### PR TITLE
feature(server): events, locations, and planning models

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,26 @@
 language: python
 
-python: 3.4
+python: 3.5
+
+sudo: false
+
+services:
+    - mongodb
+    - elasticsearch
+    - redis-server
+
+addons:
+  apt:
+    sources:
+    - mongodb-3.0-precise
+    packages:
+    - mongodb-org-server
+
+cache:
+  directories:
+    - $HOME/.cache/pip
+    - $HOME/.npm
+
 before_install:
     - nvm install node
     - nvm use node

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,8 @@ BACKEND_DIR = server
 VENV = `pwd`/${BACKEND_DIR}/env/bin/activate
 test:
 	flake8 ${BACKEND_DIR}
-	nosetests ${BACKEND_DIR} -v --with-timer
+	cd ${BACKEND_DIR} ; nosetests -v
+	cd ${BACKEND_DIR} ; behave
 	npm run test_all
 install:
 	virtualenv  -p python3  ${BACKEND_DIR}/env

--- a/server/behave.ini
+++ b/server/behave.ini
@@ -1,0 +1,3 @@
+[behave]
+stderr_capture=False
+stdout_capture=False

--- a/server/behave.ini
+++ b/server/behave.ini
@@ -1,3 +1,0 @@
-[behave]
-stderr_capture=False
-stdout_capture=False

--- a/server/features/coverage.feature
+++ b/server/features/coverage.feature
@@ -1,16 +1,16 @@
-Feature: Planning
+Feature: Coverage 
 
     @auth
-    Scenario: Empty planning list
-        Given empty "planning"
-        When we get "/planning"
+    Scenario: Empty coverage list
+        Given empty "coverage"
+        When we get "/coverage"
         Then we get list with 0 items
 
     @auth
     @notification
-    Scenario: Create new planning item
+    Scenario: Create new coverage item
         Given empty "users"
-        Given empty "planning"
+        Given empty "coverage"
         When we post to "users"
         """
         {"username": "foo", "email": "foo@bar.com", "is_active": true, "sign_off": "abc"}
@@ -19,18 +19,20 @@ Feature: Planning
         """
         {"_id": "#users._id#", "invisible_stages": []}
         """
-        When we post to "/planning" with success
+        When we post to "/coverage" with success
         """
         [
             {
                 "guid": "123",
                 "unique_id": "123",
                 "unique_name": "123 name",
-                "item_class": "item class value",
-                "headline": "test headline",
-                "news_coverage_set": []
+                "planning": {
+                    "ednote": "test coverage, I want 250 words",
+                    "assigned_to": "whoever wants to do it"
+                },
+                "delivery": []
             }
         ]
         """
-        When we get "/planning"
+        When we get "/coverage"
         Then we get list with 1 items

--- a/server/features/events.feature
+++ b/server/features/events.feature
@@ -26,25 +26,23 @@ Feature: Events
                 "guid": "123",
                 "unique_id": "123",
                 "unique_name": "123 name",
-                "event_details": {
-                    "description": {
-                        "definition_short": "short value",
-                        "definition_long": "long value",
-                        "note": "note value"
-                    },
-                    "relationships":{
-                        "broader": "broader value",
-                        "narrower": "narrower value",
-                        "related": "related value"
-                    },
-                    "dates": {
-                        "start": "2016-01-01",
-                        "end": "2016-01-02"
-                    },
-                    "subject": [{"qcode": "test qcaode", "name": "test name"}],
-                    "location": [{"qcode": "test qcaode", "name": "test name"}], 
-                    "contact_info": [{"qcode": "test qcaode", "name": "test name"}]  
-                }
+                "description": {
+                    "definition_short": "short value",
+                    "definition_long": "long value",
+                    "note": "note value"
+                },
+                "relationships":{
+                    "broader": "broader value",
+                    "narrower": "narrower value",
+                    "related": "related value"
+                },
+                "dates": {
+                    "start": "2016-01-01",
+                    "end": "2016-01-02"
+                },
+                "subject": [{"qcode": "test qcaode", "name": "test name"}],
+                "location": [{"qcode": "test qcaode", "name": "test name"}], 
+                "contact_info": [{"qcode": "test qcaode", "name": "test name"}]  
             }
         ]
         """

--- a/server/features/events.feature
+++ b/server/features/events.feature
@@ -5,3 +5,48 @@ Feature: Events
         Given empty "events"
         When we get "/events"
         Then we get list with 0 items
+
+    @auth
+    @notification
+    Scenario: Create new events item
+        Given empty "users"
+        Given empty "locations"
+        When we post to "users"
+        """
+        {"username": "foo", "email": "foo@bar.com", "is_active": true, "sign_off": "abc"}
+        """
+        Then we get existing resource
+        """
+        {"_id": "#users._id#", "invisible_stages": []}
+        """
+        When we post to "/events" with success
+        """
+        [
+            {
+                "guid": "123",
+                "unique_id": "123",
+                "unique_name": "123 name",
+                "event_details": {
+                    "description": {
+                        "definition_short": "short value",
+                        "definition_long": "long value",
+                        "note": "note value"
+                    },
+                    "relationships":{
+                        "broader": "broader value",
+                        "narrower": "narrower value",
+                        "related": "related value"
+                    },
+                    "dates": {
+                        "start": "2016-01-01",
+                        "end": "2016-01-02"
+                    },
+                    "subject": [{"qcode": "test qcaode", "name": "test name"}],
+                    "location": [{"qcode": "test qcaode", "name": "test name"}], 
+                    "contact_info": [{"qcode": "test qcaode", "name": "test name"}]  
+                }
+            }
+        ]
+        """
+        When we get "/events"
+        Then we get list with 1 items

--- a/server/features/locations.feature
+++ b/server/features/locations.feature
@@ -5,3 +5,45 @@ Feature: Locations
         Given empty "locations"
         When we get "/locations"
         Then we get list with 0 items
+
+    @auth
+    @notification
+    Scenario: Create new location
+        Given empty "users"
+        Given empty "locations"
+        When we post to "users"
+        """
+        {"username": "foo", "email": "foo@bar.com", "is_active": true, "sign_off": "abc"}
+        """
+        Then we get existing resource
+        """
+        {"_id": "#users._id#", "invisible_stages": []}
+        """
+        When we post to "/locations"
+        """
+        {
+            "unique_name": "Test Location",
+            "location_details": {
+                "name": "Test Location",
+                "related": {
+                    "qcode": "test_qcode"
+                    "name": "test_name"
+                },
+                "poi_details": {},
+                
+            }
+        }
+        """
+        And we get "/locations/#locations._id#"
+        Then we get existing resource
+        """
+        {
+            "unique_name": "Test Location",
+            "location_details": {
+                "name": "Test Location",
+                "related": {"test_qcode": "test_name"},
+                "poi_details": {},
+                
+            }
+        }
+        """

--- a/server/features/locations.feature
+++ b/server/features/locations.feature
@@ -19,31 +19,19 @@ Feature: Locations
         """
         {"_id": "#users._id#", "invisible_stages": []}
         """
-        When we post to "/locations"
+        When we post to "/locations" with success
         """
-        {
-            "unique_name": "Test Location",
-            "location_details": {
-                "name": "Test Location",
-                "related": {
-                    "qcode": "test_qcode"
-                    "name": "test_name"
-                },
-                "poi_details": {},
-                
+        [
+            {
+                "guid": "123",
+                "unique_id": "123",
+                "unique_name": "123 name",
+                "location_details": {
+                    "name": "Test Location",
+                    "poi_details": {}
+                }
             }
-        }
+        ]
         """
-        And we get "/locations/#locations._id#"
-        Then we get existing resource
-        """
-        {
-            "unique_name": "Test Location",
-            "location_details": {
-                "name": "Test Location",
-                "related": {"test_qcode": "test_name"},
-                "poi_details": {},
-                
-            }
-        }
-        """
+        When we get "/locations"
+        Then we get list with 1 items

--- a/server/features/planning.feature
+++ b/server/features/planning.feature
@@ -5,3 +5,49 @@ Feature: Planning
         Given empty "planning"
         When we get "/planning"
         Then we get list with 0 items
+
+    @auth
+    @notification
+    Scenario: Create new planning item
+        Given empty "users"
+        Given empty "locations"
+        When we post to "users"
+        """
+        {"username": "foo", "email": "foo@bar.com", "is_active": true, "sign_off": "abc"}
+        """
+        Then we get existing resource
+        """
+        {"_id": "#users._id#", "invisible_stages": []}
+        """
+        When we post to "/planning" with success
+        """
+        [
+            {
+                "guid": "123",
+                "unique_id": "123",
+                "unique_name": "123 name",
+                "planning_item": {
+                    "item_meta": {"item_class": "item class value"},
+                    "content_meta": {"qcode": "test qcaode", "name": "test name"},
+                    "news_coverage_set": [
+                        {
+                            "planning": {
+                                "assigned_to": "assigned to value",
+                                "ed_note": "editors note",
+                                "slugline": [{"qcode": "test qcaode", "name": "test name"}],
+                                "subject": [{"qcode": "test qcaode", "name": "test name"}]
+                            },  
+                            "delivery": [
+                                {
+                                    "rel": "relationship id",
+                                    "content_type": "photo"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        ]
+        """
+        When we get "/planning"
+        Then we get list with 1 items

--- a/server/features/planning.feature
+++ b/server/features/planning.feature
@@ -27,8 +27,7 @@ Feature: Planning
                 "unique_id": "123",
                 "unique_name": "123 name",
                 "item_class": "item class value",
-                "headline": "test headline",
-                "news_coverage_set": []
+                "headline": "test headline"
             }
         ]
         """

--- a/server/planning/__init__.py
+++ b/server/planning/__init__.py
@@ -13,6 +13,7 @@
 import superdesk
 from .events import EventsResource, EventsService
 from .planning import PlanningResource, PlanningService
+from .coverage import CoverageResource, CoverageService
 from .locations import LocationsResource, LocationsService
 
 
@@ -24,6 +25,9 @@ def init_app(app):
     planning_search_service = PlanningService('planning', backend=superdesk.get_backend())
     PlanningResource('planning', app=app, service=planning_search_service)
 
+    coverage_search_service = CoverageService('coverage', backend=superdesk.get_backend())
+    CoverageResource('coverage', app=app, service=coverage_search_service)
+
     events_search_service = EventsService('events', backend=superdesk.get_backend())
     EventsResource('events', app=app, service=events_search_service)
 
@@ -32,6 +36,6 @@ def init_app(app):
 
     superdesk.privilege(
         name='planning',
-        label='Events',
+        label='Planning',
         description='Create, update, and delete  events, planning items, and coverages'
     )

--- a/server/planning/coverage.py
+++ b/server/planning/coverage.py
@@ -1,0 +1,234 @@
+# -*- coding: utf-8; -*-
+#
+# This file is part of Superdesk.
+#
+#  Copyright 2013, 2014 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+
+"""Superdesk Coverage"""
+
+import superdesk
+import logging
+from superdesk.metadata.utils import generate_guid
+from superdesk.metadata.item import GUID_NEWSML
+
+logger = logging.getLogger(__name__)
+
+not_analyzed = {'type': 'string', 'index': 'not_analyzed'}
+not_indexed = {'type': 'string', 'index': 'no'}
+
+
+class CoverageService(superdesk.Service):
+    """Service class for the coverage model."""
+
+    def on_create(self, docs):
+        """Set default metadata."""
+
+        for doc in docs:
+            doc['guid'] = generate_guid(type=GUID_NEWSML)
+
+coverage_schema = {
+    # Identifiers
+    'guid': {
+        'type': 'string',
+        'unique': True,
+        'mapping': not_analyzed
+    },
+    'unique_id': {
+        'type': 'integer',
+        'unique': True,
+    },
+    'unique_name': {
+        'type': 'string',
+        'unique': True,
+        'mapping': not_analyzed
+    },
+    'version': {
+        'type': 'integer'
+    },
+    'ingest_id': {
+        'type': 'string',
+        'mapping': not_analyzed
+    },
+
+    # Audit Information
+    'original_creator': superdesk.Resource.rel('users'),
+    'version_creator': superdesk.Resource.rel('users'),
+    'firstcreated': {
+        'type': 'datetime'
+    },
+    'versioncreated': {
+        'type': 'datetime'
+    },
+
+    # Ingest Details
+    'ingest_provider': superdesk.Resource.rel('ingest_providers'),
+    'source': {     # The value is copied from the ingest_providers vocabulary
+        'type': 'string',
+        'mapping': not_analyzed
+    },
+    'original_source': {    # This value is extracted from the ingest
+        'type': 'string',
+        'mapping': not_analyzed
+    },
+    'ingest_provider_sequence': {
+        'type': 'string',
+        'mapping': not_analyzed
+    },
+
+    # Reference to Planning Item
+    'planning_item': superdesk.Resource.rel('planning'),
+
+    # News Coverage Details
+    # See IPTC-G2-Implementation_Guide 16.4
+    'planning': {
+        'type': 'dict',
+        'schema': {
+            'ednote': {'type': 'string'},
+            'g2_content_type': {'type': 'string'},
+            'item_class': {'type': 'string'},
+            'item_count': {'type': 'string'},
+            'scheduled': {'type': 'datetime'},
+            'service': {
+                'type': 'list',
+                'mapping': {
+                    'properties': {
+                        'qcode': not_analyzed,
+                        'name': not_analyzed
+                    }
+                }
+            },
+            'assigned_to': {'type': 'string'},
+            'news_content_characteristics': {
+                'type': 'list',
+                'mapping': {
+                    'properties': {
+                        'name': not_analyzed,
+                        'value': not_analyzed
+                    }
+                }
+            },
+            'planning_ext_property': {
+                'type': 'list',
+                'mapping': {
+                    'properties': {
+                        'qcode': not_analyzed,
+                        'name': not_analyzed
+                    }
+                }
+            },
+            # Metadata hints.  See IPTC-G2-Implementation_Guide 16.5.1.1
+            'by': {
+                'type': 'list',
+                'mapping': {
+                    'type': 'string'
+                }
+            },
+            'credit_line': {
+                'type': 'list',
+                'mapping': {
+                    'type': 'string'
+                }
+            },
+            'dateline': {
+                'type': 'list',
+                'mapping': {
+                    'type': 'string'
+                }
+            },
+            'description': {
+                'type': 'list',
+                'mapping': {
+                    'type': 'string'
+                }
+            },
+            'genre': {
+                'type': 'list',
+                'mapping': {
+                    'properties': {
+                        'qcode': not_analyzed,
+                        'name': not_analyzed
+                    }
+                }
+            },
+            'headline': {
+                'type': 'list',
+                'mapping': {
+                    'type': 'string'
+                }
+            },
+            'keyword': {
+                'type': 'list',
+                'mapping': {
+                    'type': 'string'
+                }
+            },
+            'language': {
+                'type': 'list',
+                'mapping': {
+                    'type': 'string'
+                }
+            },
+            'slugline': {
+                'type': 'list',
+                'mapping': {
+                    'type': 'string'
+                }
+            },
+            'subject': {
+                'type': 'list',
+                'mapping': {
+                    'properties': {
+                        'qcode': not_analyzed,
+                        'name': not_analyzed
+                    }
+                }
+            }
+        }  # end planning dict schema
+    },  # end planning
+
+    # See IPTC-G2-Implementation_Guide 16.6
+    'delivery': {
+        'type': 'list',
+        'schema': {
+            'type': 'dict',
+            'schema': {
+                # Delivered Item Ref See IPTC-G2-Implementation_Guide 16.7
+                'rel': {'type': 'string'},
+                'href': {'type': 'string'},
+                'residref': {'type': 'string'},
+                'version': {'type': 'string'},
+                'content_type': {'type': 'string'},
+                'format': {'type': 'string'},
+                'size': {'type': 'string'},
+                'persistent_id_ref': {'type': 'string'},
+                'valid_from': {'type': 'datetime'},
+                'valid_to': {'type': 'datetime'},
+                'creator': {'type': 'string'},
+                'modified': {'type': 'datetime'},
+                'xml_lang': {'type': 'string'},
+                'dir': {'type': 'string'},
+                'rank': {'type': 'integer'}
+            }
+        }
+    }
+}  # end coverage_schema
+
+
+class CoverageResource(superdesk.Resource):
+    """Resource for coverage data model
+
+    See IPTC-G2-Implementation_Guide (version 2.21) Section 16.5 for schema details
+    """
+
+    url = 'coverage'
+    schema = coverage_schema
+    resource_methods = ['GET', 'POST']
+    item_methods = ['GET', 'PATCH', 'PUT', 'DELETE']
+    public_methods = ['GET']
+    privileges = {'POST': 'planning',
+                  'PATCH': 'planning',
+                  'DELETE': 'planning'}

--- a/server/planning/events.py
+++ b/server/planning/events.py
@@ -100,167 +100,162 @@ events_schema = {
 
     # Event Details
     # NewsML-G2 Event properties See IPTC-G2-Implementation_Guide 15.2
-    # probably can skip this subsection, although its documented in iptc impl guide this way
-    'event_details': {
+    'description': {
         'type': 'dict',
         'schema': {
-            'description': {
+            'definition_short': {'type': 'string'},
+            'definition_long': {'type': 'string'},
+            'related': {'type': 'string'},
+            'note': {'type': 'string'}
+        },
+    },
+    'relationships': {
+        'type': 'dict',
+        'schema': {
+            'broader': {'type': 'string'},
+            'narrower': {'type': 'string'},
+            'related': {'type': 'string'}
+        },
+    },
+
+    # NewsML-G2 Event properties See IPTC-G2-Implementation_Guide 15.4.3
+    'dates': {
+        'type': 'dict',
+        'schema': {
+            'start': {'type': 'datetime'},
+            'end': {'type': 'datetime'},
+            'duration': {'type': 'string'},
+            'confirmation': {'type': 'string'},
+            'recurring_date': {
+                'type': 'list',
+                'nullable': True,
+                'mapping': {
+                    'type': 'datetime'
+                }
+            },
+            'recurring_rule': {
                 'type': 'dict',
                 'schema': {
-                    'definition_short': {'type': 'string'},
-                    'definition_long': {'type': 'string'},
-                    'related': {'type': 'string'},
-                    'note': {'type': 'string'}
-                },
+                    'frequency': {'type': 'string'},
+                    'interval': {'type': 'string'},
+                    'until': {'type': 'datetime'},
+                    'count': {'type': 'integer'},
+                    'bymonth': {'type': 'string'},
+                    'byday': {'type': 'string'},
+                    'byhour': {'type': 'string'},
+                    'byminute': {'type': 'string'}
+                }
             },
-            'relationships': {
+            'ex_date': {
+                'type': 'list',
+                'mapping': {
+                    'type': 'datetime'
+                }
+            },
+            'ex_rule': {
                 'type': 'dict',
                 'schema': {
-                    'broader': {'type': 'string'},
-                    'narrower': {'type': 'string'},
-                    'related': {'type': 'string'}
-                },
-            },
-            # NewsML-G2 Event properties See IPTC-G2-Implementation_Guide 15.4.3
-            'dates': {
-                'type': 'dict',
-                'schema': {
-                    'start': {'type': 'datetime'},
-                    'end': {'type': 'datetime'},
-                    'duration': {'type': 'string'},
-                    'confirmation': {'type': 'string'},
-                    'recurring_date': {
-                        'type': 'list',
-                        'nullable': True,
-                        'mapping': {
-                            'type': 'datetime'
-                        }
-                    },
-                    'recurring_rule': {
-                        'type': 'dict',
-                        'schema': {
-                            'frequency': {'type': 'string'},
-                            'interval': {'type': 'string'},
-                            'until': {'type': 'datetime'},
-                            'count': {'type': 'integer'},
-                            'bymonth': {'type': 'string'},
-                            'byday': {'type': 'string'},
-                            'byhour': {'type': 'string'},
-                            'byminute': {'type': 'string'}
-                        }
-                    },
-                    'ex_date': {
-                        'type': 'list',
-                        'mapping': {
-                            'type': 'datetime'
-                        }
-                    },
-                    'ex_rule': {
-                        'type': 'dict',
-                        'schema': {
-                            'frequency': {'type': 'string'},
-                            'interval': {'type': 'string'},
-                            'until': {'type': 'datetime'},
-                            'count': {'type': 'integer'},
-                            'bymonth': {'type': 'string'},
-                            'byday': {'type': 'string'},
-                            'byhour': {'type': 'string'},
-                            'byminute': {'type': 'string'}
-                        }
-                    }
-                }
-            },  # end dates
-            'occur_status': {
-                'type': 'dict',
-                'schema': {
-                    'qcode': {'type': 'string'},
-                    'name': {'type': 'string'}
-                }
-            },
-            'news_coverage_status': {
-                'type': 'dict',
-                'schema': {
-                    'qcode': {'type': 'string'},
-                    'name': {'type': 'string'}
-                }
-            },
-            'registration': {
-                'type': 'string'
-            },
-            'access_status': {
-                'type': 'list',
-                'mapping': {
-                    'properties': {
-                        'qcode': not_analyzed,
-                        'name': not_analyzed
-                    }
-                }
-            },
-            'subject': {
-                'type': 'list',
-                'mapping': {
-                    'properties': {
-                        'qcode': not_analyzed,
-                        'name': not_analyzed
-                    }
-                }
-            },
-            'location': {  # TODO: this is only placeholder schema
-                'type': 'list',
-                'mapping': {
-                    'properties': {
-                        'qcode': not_analyzed,
-                        'name': not_analyzed
-                    }
-                }
-            },
-            'participant': {
-                'type': 'list',
-                'mapping': {
-                    'properties': {
-                        'qcode': not_analyzed,
-                        'name': not_analyzed
-                    }
-                }
-            },
-            'participant_requirement': {
-                'type': 'list',
-                'mapping': {
-                    'properties': {
-                        'qcode': not_analyzed,
-                        'name': not_analyzed
-                    }
-                }
-            },
-            'organizer': {  # TODO: this is only placeholder schema
-                'type': 'list',
-                'mapping': {
-                    'properties': {
-                        'qcode': not_analyzed,
-                        'name': not_analyzed
-                    }
-                }
-            },
-            'contact_info': {  # TODO: this is only placeholder schema
-                'type': 'list',
-                'mapping': {
-                    'properties': {
-                        'qcode': not_analyzed,
-                        'name': not_analyzed
-                    }
-                }
-            },
-            'language': {  # TODO: this is only placeholder schema
-                'type': 'list',
-                'mapping': {
-                    'properties': {
-                        'qcode': not_analyzed,
-                        'name': not_analyzed
-                    }
+                    'frequency': {'type': 'string'},
+                    'interval': {'type': 'string'},
+                    'until': {'type': 'datetime'},
+                    'count': {'type': 'integer'},
+                    'bymonth': {'type': 'string'},
+                    'byday': {'type': 'string'},
+                    'byhour': {'type': 'string'},
+                    'byminute': {'type': 'string'}
                 }
             }
-        }  # end event_details schema
-    }  # end event_details
+        }
+    },  # end dates
+    'occur_status': {
+        'type': 'dict',
+        'schema': {
+            'qcode': {'type': 'string'},
+            'name': {'type': 'string'}
+        }
+    },
+    'news_coverage_status': {
+        'type': 'dict',
+        'schema': {
+            'qcode': {'type': 'string'},
+            'name': {'type': 'string'}
+        }
+    },
+    'registration': {
+        'type': 'string'
+    },
+    'access_status': {
+        'type': 'list',
+        'mapping': {
+            'properties': {
+                'qcode': not_analyzed,
+                'name': not_analyzed
+            }
+        }
+    },
+    'subject': {
+        'type': 'list',
+        'mapping': {
+            'properties': {
+                'qcode': not_analyzed,
+                'name': not_analyzed
+            }
+        }
+    },
+    'location': {  # TODO: this is only placeholder schema
+        'type': 'list',
+        'mapping': {
+            'properties': {
+                'qcode': not_analyzed,
+                'name': not_analyzed
+            }
+        }
+    },
+    'participant': {
+        'type': 'list',
+        'mapping': {
+            'properties': {
+                'qcode': not_analyzed,
+                'name': not_analyzed
+            }
+        }
+    },
+    'participant_requirement': {
+        'type': 'list',
+        'mapping': {
+            'properties': {
+                'qcode': not_analyzed,
+                'name': not_analyzed
+            }
+        }
+    },
+    'organizer': {  # TODO: this is only placeholder schema
+        'type': 'list',
+        'mapping': {
+            'properties': {
+                'qcode': not_analyzed,
+                'name': not_analyzed
+            }
+        }
+    },
+    'contact_info': {  # TODO: this is only placeholder schema
+        'type': 'list',
+        'mapping': {
+            'properties': {
+                'qcode': not_analyzed,
+                'name': not_analyzed
+            }
+        }
+    },
+    'language': {  # TODO: this is only placeholder schema
+        'type': 'list',
+        'mapping': {
+            'properties': {
+                'qcode': not_analyzed,
+                'name': not_analyzed
+            }
+        }
+    }
 }  # end events_schema
 
 

--- a/server/planning/events.py
+++ b/server/planning/events.py
@@ -11,8 +11,11 @@
 """Superdesk Events"""
 
 import superdesk
+import logging
 from superdesk.metadata.utils import generate_guid
+from superdesk.metadata.item import GUID_NEWSML
 
+logger = logging.getLogger(__name__)
 
 not_analyzed = {'type': 'string', 'index': 'not_analyzed'}
 not_indexed = {'type': 'string', 'index': 'no'}
@@ -43,7 +46,7 @@ class EventsService(superdesk.Service):
         """Set default metadata."""
 
         for doc in docs:
-            # TODO: generate GUID here
+            doc['guid'] = generate_guid(type=GUID_NEWSML)
 
 
 events_schema = {

--- a/server/planning/events.py
+++ b/server/planning/events.py
@@ -39,7 +39,11 @@ occurrence_statuses = {
 class EventsService(superdesk.Service):
     """Service class for the events model."""
 
-    pass
+    def on_create(self, docs):
+        """Set default metadata."""
+
+        for doc in docs:
+            # TODO: generate GUID here
 
 
 events_schema = {

--- a/server/planning/events.py
+++ b/server/planning/events.py
@@ -11,7 +11,7 @@
 """Superdesk Events"""
 
 import superdesk
-from superdesk.metadata.utils import item_url
+from superdesk.metadata.utils import generate_guid
 
 
 not_analyzed = {'type': 'string', 'index': 'not_analyzed'}
@@ -268,7 +268,6 @@ class EventsResource(superdesk.Resource):
     resource_methods = ['GET', 'POST']
     item_methods = ['GET', 'PATCH', 'PUT', 'DELETE']
     public_methods = ['GET']
-    item_url = item_url
     privileges = {'POST': 'planning',
                   'PATCH': 'planning',
                   'DELETE': 'planning'}

--- a/server/planning/locations.py
+++ b/server/planning/locations.py
@@ -11,6 +11,7 @@
 import superdesk
 import logging
 from superdesk.metadata.utils import generate_guid
+from superdesk.metadata.item import GUID_NEWSML
 
 logger = logging.getLogger(__name__)
 
@@ -27,7 +28,7 @@ class LocationsService(superdesk.Service):
         """Set default metadata."""
 
         for doc in docs:
-            # TODO: generate GUID here
+            doc['guid'] = generate_guid(type=GUID_NEWSML)
 
 
 locations_schema = {
@@ -151,6 +152,7 @@ locations_schema = {
         },
     },
 }
+
 
 class LocationsResource(superdesk.Resource):
     """Resource for locations data model

--- a/server/planning/locations.py
+++ b/server/planning/locations.py
@@ -9,7 +9,10 @@
 """Superdesk Locations"""
 
 import superdesk
+import logging
 from superdesk.metadata.utils import generate_guid
+
+logger = logging.getLogger(__name__)
 
 not_analyzed = {'type': 'string', 'index': 'not_analyzed'}
 not_indexed = {'type': 'string', 'index': 'no'}
@@ -20,7 +23,11 @@ venue_types = {
 class LocationsService(superdesk.Service):
     """Service class for the events model."""
 
-    pass
+    def on_create(self, docs):
+        """Set default metadata."""
+
+        for doc in docs:
+            # TODO: generate GUID here
 
 
 locations_schema = {
@@ -144,7 +151,6 @@ locations_schema = {
         },
     },
 }
-
 
 class LocationsResource(superdesk.Resource):
     """Resource for locations data model

--- a/server/planning/locations.py
+++ b/server/planning/locations.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8; -*-
-#
 # This file is part of Superdesk.
 #
 # Copyright 2013, 2014 Sourcefabric z.u. and contributors.
@@ -11,7 +9,7 @@
 """Superdesk Locations"""
 
 import superdesk
-from superdesk.metadata.utils import item_url
+from superdesk.metadata.utils import generate_guid
 
 not_analyzed = {'type': 'string', 'index': 'not_analyzed'}
 not_indexed = {'type': 'string', 'index': 'no'}
@@ -109,12 +107,12 @@ locations_schema = {
                             'line': {
                                 'type': 'list',
                                 'mapping': {'type': 'string'}
-                            }
+                            },
+                            'locality': {'type': 'string'},
+                            'area': {'type': 'string'},
+                            'country': {'type': 'string'},
+                            'postal_code': {'type': 'string'}
                         },
-                        'locality': {'type': 'string'},
-                        'area': {'type': 'string'},
-                        'country': {'type': 'string'},
-                        'postal_code': {'type': 'string'}
                     },
                     'open_hours': {'type': 'string'},
                     'capacity': {'type': 'string'},
@@ -139,8 +137,8 @@ locations_schema = {
                             'type': 'string'
                         }
                     },
-                    'created': {'type': 'datestring'},
-                    'ceased_to_exist': {'type': 'datestring'}
+                    'created': {'type': 'datetime'},
+                    'ceased_to_exist': {'type': 'datetime'}
                 },
             },
         },
@@ -159,7 +157,6 @@ class LocationsResource(superdesk.Resource):
     resource_methods = ['GET', 'POST']
     item_methods = ['GET', 'PATCH', 'PUT', 'DELETE']
     public_methods = ['GET']
-    item_url = item_url
     privileges = {'POST': 'planning',
                   'PATCH': 'planning',
                   'DELETE': 'planning'}

--- a/server/planning/planning.py
+++ b/server/planning/planning.py
@@ -9,7 +9,7 @@
 # at https://www.sourcefabric.org/superdesk/license
 
 import superdesk
-from superdesk.metadata.utils import item_url
+from superdesk.metadata.utils import generate_guid
 
 not_analyzed = {'type': 'string', 'index': 'not_analyzed'}
 
@@ -71,10 +71,26 @@ planning_schema = {
     # Planning Details
     # NewsML-G2 Event properties See IPTC-G2-Implementation_Guide 16.5.1
     # probably can skip this subsection, although its documented in iptc impl guide this way
-    'planning_details': {
+    'planning_item': {
         'type': 'dict',
         'schema': {
             # TODO: fill in from NewsML-G2 version 2.21 spec
+            'item_meta': {
+                'type': 'dict',
+                'schema': {
+                    'item_class': 'plinat:newscoverage'
+                }
+            },
+            'content_meta': {
+                'type': 'dict',
+                'schema': {
+                }
+            },
+            'news_coverage_set': {
+                'type': 'dict',
+                'schema': {
+                }
+            }
         }
     }  # end planning_details
 }  # end planning_schema
@@ -91,7 +107,6 @@ class PlanningResource(superdesk.Resource):
     resource_methods = ['GET', 'POST']
     item_methods = ['GET', 'PATCH', 'PUT', 'DELETE']
     public_methods = ['GET']
-    item_url = item_url
     privileges = {'POST': 'planning',
                   'PATCH': 'planning',
                   'DELETE': 'planning'}

--- a/server/planning/planning.py
+++ b/server/planning/planning.py
@@ -80,6 +80,9 @@ planning_schema = {
         'mapping': not_analyzed
     },
 
+    # Event Item
+    'event_item': superdesk.Resource.rel('events'),
+
     # Planning Details
     # NewsML-G2 Event properties See IPTC-G2-Implementation_Guide 16
 
@@ -189,14 +192,7 @@ planning_schema = {
     'description_text': {
         'type': 'string',
         'nullable': True
-    },
-
-    # See IPTC-G2-Implementation_Guide 16.3
-    'news_coverage_set': {
-        'type': 'list',
-        # See IPTC-G2-Implementation_Guide 16.4 (newsCoverage)
-        'schema': Resource.rel('coverage', True)
-    }  # end news_coverage_set
+    }
 
 }  # end planning_schema
 

--- a/server/planning/planning.py
+++ b/server/planning/planning.py
@@ -69,29 +69,161 @@ planning_schema = {
     },
 
     # Planning Details
-    # NewsML-G2 Event properties See IPTC-G2-Implementation_Guide 16.5.1
+    # NewsML-G2 Event properties See IPTC-G2-Implementation_Guide 16
     # probably can skip this subsection, although its documented in iptc impl guide this way
     'planning_item': {
         'type': 'dict',
         'schema': {
-            # TODO: fill in from NewsML-G2 version 2.21 spec
+            # See IPTC-G2-Implementation_Guide 16.1
             'item_meta': {
                 'type': 'dict',
                 'schema': {
-                    'item_class': 'plinat:newscoverage'
+                    'item_class': {'type': 'string'}
                 }
             },
+            # See IPTC-G2-Implementation_Guide 16.2
             'content_meta': {
                 'type': 'dict',
                 'schema': {
+                    'qcode': {'type': 'string'},
+                    'name': {'type': 'string'}
                 }
             },
+            # See IPTC-G2-Implementation_Guide 16.3
             'news_coverage_set': {
-                'type': 'dict',
+                'type': 'list',
+                # See IPTC-G2-Implementation_Guide 16.4 (newsCoverage)
                 'schema': {
-                }
-            }
-        }
+                    'type': 'dict',
+                    'schema': {
+                        # See IPTC-G2-Implementation_Guide 16.5
+                        'planning': {
+                            'type': 'dict',
+                            'schema': {
+                                'ed_note': {'type': 'string'},
+                                'g2_content_type': {'type': 'string'},
+                                'item_class': {'type': 'string'},
+                                'item_count': {'type': 'string'},
+                                'scheduled': {'type': 'datetime'},
+                                'service': {
+                                    'type': 'list',
+                                    'mapping': {
+                                        'properties': {
+                                            'qcode': not_analyzed,
+                                            'name': not_analyzed
+                                        }
+                                    }
+                                },
+                                'assigned_to': {'type': 'string'},
+                                'news_content_characteristics': {
+                                    'type': 'list',
+                                    'mapping': {
+                                        'properties': {
+                                            'name': not_analyzed,
+                                            'value': not_analyzed
+                                        }
+                                    }
+                                },
+                                'planning_ext_property': {
+                                    'type': 'list',
+                                    'mapping': {
+                                        'properties': {
+                                            'qcode': not_analyzed,
+                                            'name': not_analyzed
+                                        }
+                                    }
+                                },
+                                # Metadata hints.  See IPTC-G2-Implementation_Guide 16.5.1.1
+                                'by': {'type': 'string'},
+                                'credit_line': {'type': 'string'},
+                                'dateline': {
+                                    'type': 'list',
+                                    'mapping': {
+                                        'type': 'string'
+                                    }
+                                },
+                                'description': {
+                                    'type': 'list',
+                                    'mapping': {
+                                        'type': 'string'
+                                    }
+                                },
+                                'genre': {
+                                    'type': 'list',
+                                    'mapping': {
+                                        'properties': {
+                                            'qcode': not_analyzed,
+                                            'name': not_analyzed
+                                        }
+                                    }
+                                },
+                                'headline': {
+                                    'type': 'list',
+                                    'mapping': {
+                                        'type': 'string'
+                                    }
+                                },
+                                'keyword': {
+                                    'type': 'list',
+                                    'mapping': {
+                                        'type': 'string'
+                                    }
+                                },
+                                'language': {
+                                    'type': 'list',
+                                    'mapping': {
+                                        'type': 'string'
+                                    }
+                                },
+                                'slugline': {
+                                    'type': 'list',
+                                    'mapping': {
+                                        'type': 'string'
+                                    }
+                                },
+                                'subject': {
+                                    'type': 'list',
+                                    'mapping': {
+                                        'properties': {
+                                            'qcode': not_analyzed,
+                                            'name': not_analyzed
+                                        }
+                                    }
+                                }
+                            } # end planning dict schema
+                        }, # end planning
+
+                        # See IPTC-G2-Implementation_Guide 16.6
+                        'delivery': {
+                            'type': 'list',
+                            'schema': {
+                                'type': 'dict',
+                                'schema': {
+                                    # Delivered Item Ref See IPTC-G2-Implementation_Guide 16.7
+                                    'rel': {'type': 'string'},
+                                    'href': {'type': 'string'},
+                                    'residref': {'type': 'string'},
+                                    'version': {'type': 'string'},
+                                    'content_type': {'type': 'string'},
+                                    'format': {'type': 'string'},
+                                    'size': {'type': 'string'},
+                                    'persistent_id_ref': {'type': 'string'},
+                                    'valid_from': {'type': 'datetime'},
+                                    'valid_to': {'type': 'datetime'},
+                                    'creator': {'type': 'string'},
+                                    'modified': {'type': 'datetime'},
+                                    'xml_lang': {'type': 'string'},
+                                    'dir': {'type': 'string'},
+                                    'rank': {'type': 'integer'}
+                                    
+                                }
+                            }
+                        }
+                    }
+                } # end news_coverage schema 
+            } # end news_coverage_set list
+        } # end news_coverage_set
+
     }  # end planning_details
 }  # end planning_schema
 

--- a/server/planning/planning.py
+++ b/server/planning/planning.py
@@ -11,7 +11,11 @@
 """Superdesk Planning"""
 
 import superdesk
+import logging
 from superdesk.metadata.utils import generate_guid
+from superdesk.metadata.item import GUID_NEWSML
+
+logger = logging.getLogger(__name__)
 
 not_analyzed = {'type': 'string', 'index': 'not_analyzed'}
 not_indexed = {'type': 'string', 'index': 'no'}
@@ -24,7 +28,7 @@ class PlanningService(superdesk.Service):
         """Set default metadata."""
 
         for doc in docs:
-            # TODO: generate GUID here
+            doc['guid'] = generate_guid(type=GUID_NEWSML)
 
 planning_schema = {
     # Identifiers
@@ -197,8 +201,8 @@ planning_schema = {
                                         }
                                     }
                                 }
-                            } # end planning dict schema
-                        }, # end planning
+                            }  # end planning dict schema
+                        },  # end planning
                         # See IPTC-G2-Implementation_Guide 16.6
                         'delivery': {
                             'type': 'list',
@@ -225,9 +229,9 @@ planning_schema = {
                             }
                         }
                     }
-                } # end news_coverage schema 
-            } # end news_coverage_set list
-        } # end news_coverage_set
+                }  # end news_coverage schema
+            }  # end news_coverage_set list
+        }  # end news_coverage_set
     }  # end planning_details
 }  # end planning_schema
 

--- a/server/planning/planning.py
+++ b/server/planning/planning.py
@@ -12,7 +12,6 @@
 
 import superdesk
 import logging
-from superdesk.resource import Resource
 from superdesk.metadata.utils import generate_guid
 from superdesk.metadata.item import GUID_NEWSML
 

--- a/server/planning/planning.py
+++ b/server/planning/planning.py
@@ -8,16 +8,23 @@
 # AUTHORS and LICENSE files distributed with this source code, or
 # at https://www.sourcefabric.org/superdesk/license
 
+"""Superdesk Planning"""
+
 import superdesk
 from superdesk.metadata.utils import generate_guid
 
 not_analyzed = {'type': 'string', 'index': 'not_analyzed'}
+not_indexed = {'type': 'string', 'index': 'no'}
 
 
 class PlanningService(superdesk.Service):
     """Service class for the planning model."""
 
-    pass
+    def on_create(self, docs):
+        """Set default metadata."""
+
+        for doc in docs:
+            # TODO: generate GUID here
 
 planning_schema = {
     # Identifiers
@@ -192,7 +199,6 @@ planning_schema = {
                                 }
                             } # end planning dict schema
                         }, # end planning
-
                         # See IPTC-G2-Implementation_Guide 16.6
                         'delivery': {
                             'type': 'list',
@@ -215,7 +221,6 @@ planning_schema = {
                                     'xml_lang': {'type': 'string'},
                                     'dir': {'type': 'string'},
                                     'rank': {'type': 'integer'}
-                                    
                                 }
                             }
                         }
@@ -223,7 +228,6 @@ planning_schema = {
                 } # end news_coverage schema 
             } # end news_coverage_set list
         } # end news_coverage_set
-
     }  # end planning_details
 }  # end planning_schema
 

--- a/server/planning/planning.py
+++ b/server/planning/planning.py
@@ -12,6 +12,7 @@
 
 import superdesk
 import logging
+from superdesk.resource import Resource
 from superdesk.metadata.utils import generate_guid
 from superdesk.metadata.item import GUID_NEWSML
 
@@ -81,158 +82,122 @@ planning_schema = {
 
     # Planning Details
     # NewsML-G2 Event properties See IPTC-G2-Implementation_Guide 16
-    # probably can skip this subsection, although its documented in iptc impl guide this way
-    'planning_item': {
-        'type': 'dict',
-        'schema': {
-            # See IPTC-G2-Implementation_Guide 16.1
-            'item_meta': {
-                'type': 'dict',
-                'schema': {
-                    'item_class': {'type': 'string'}
+
+    # Item Metadata - See IPTC-G2-Implementation_Guide 16.1
+    'item_class': {
+        'type': 'string',
+        'default': 'plinat:newscoverage'
+    },
+    'ednote': {
+        'type': 'string',
+        'nullable': True,
+    },
+    'description_text': {
+        'type': 'string',
+        'nullable': True
+    },
+    'anpa_category': {
+        'type': 'list',
+        'nullable': True,
+        'mapping': {
+            'type': 'object',
+            'properties': {
+                'qcode': not_analyzed,
+                'name': not_analyzed,
+            }
+        }
+    },
+    'subject': {
+        'type': 'list',
+        'mapping': {
+            'properties': {
+                'qcode': not_analyzed,
+                'name': not_analyzed
+            }
+        }
+    },
+    'genre': {
+        'type': 'list',
+        'nullable': True,
+        'mapping': {
+            'type': 'object',
+            'properties': {
+                'name': not_analyzed,
+                'qcode': not_analyzed
+            }
+        }
+    },
+    'company_codes': {
+        'type': 'list',
+        'mapping': {
+            'type': 'object',
+            'properties': {
+                'qcode': not_analyzed,
+                'name': not_analyzed,
+                'security_exchange': not_analyzed
+            }
+        }
+    },
+
+    # Content Metadata - See IPTC-G2-Implementation_Guide 16.2
+    'language': {
+        'type': 'string',
+        'mapping': not_analyzed,
+        'nullable': True,
+    },
+    'abstract': {
+        'type': 'string',
+        'nullable': True,
+    },
+    'headline': {
+        'type': 'string'
+    },
+    'slugline': {
+        'type': 'string',
+        'mapping': {
+            'type': 'string',
+            'fields': {
+                'phrase': {
+                    'type': 'string',
+                    'analyzer': 'phrase_prefix_analyzer',
+                    'search_analyzer': 'phrase_prefix_analyzer'
                 }
-            },
-            # See IPTC-G2-Implementation_Guide 16.2
-            'content_meta': {
-                'type': 'dict',
-                'schema': {
-                    'qcode': {'type': 'string'},
-                    'name': {'type': 'string'}
-                }
-            },
-            # See IPTC-G2-Implementation_Guide 16.3
-            'news_coverage_set': {
-                'type': 'list',
-                # See IPTC-G2-Implementation_Guide 16.4 (newsCoverage)
-                'schema': {
-                    'type': 'dict',
-                    'schema': {
-                        # See IPTC-G2-Implementation_Guide 16.5
-                        'planning': {
-                            'type': 'dict',
-                            'schema': {
-                                'ed_note': {'type': 'string'},
-                                'g2_content_type': {'type': 'string'},
-                                'item_class': {'type': 'string'},
-                                'item_count': {'type': 'string'},
-                                'scheduled': {'type': 'datetime'},
-                                'service': {
-                                    'type': 'list',
-                                    'mapping': {
-                                        'properties': {
-                                            'qcode': not_analyzed,
-                                            'name': not_analyzed
-                                        }
-                                    }
-                                },
-                                'assigned_to': {'type': 'string'},
-                                'news_content_characteristics': {
-                                    'type': 'list',
-                                    'mapping': {
-                                        'properties': {
-                                            'name': not_analyzed,
-                                            'value': not_analyzed
-                                        }
-                                    }
-                                },
-                                'planning_ext_property': {
-                                    'type': 'list',
-                                    'mapping': {
-                                        'properties': {
-                                            'qcode': not_analyzed,
-                                            'name': not_analyzed
-                                        }
-                                    }
-                                },
-                                # Metadata hints.  See IPTC-G2-Implementation_Guide 16.5.1.1
-                                'by': {'type': 'string'},
-                                'credit_line': {'type': 'string'},
-                                'dateline': {
-                                    'type': 'list',
-                                    'mapping': {
-                                        'type': 'string'
-                                    }
-                                },
-                                'description': {
-                                    'type': 'list',
-                                    'mapping': {
-                                        'type': 'string'
-                                    }
-                                },
-                                'genre': {
-                                    'type': 'list',
-                                    'mapping': {
-                                        'properties': {
-                                            'qcode': not_analyzed,
-                                            'name': not_analyzed
-                                        }
-                                    }
-                                },
-                                'headline': {
-                                    'type': 'list',
-                                    'mapping': {
-                                        'type': 'string'
-                                    }
-                                },
-                                'keyword': {
-                                    'type': 'list',
-                                    'mapping': {
-                                        'type': 'string'
-                                    }
-                                },
-                                'language': {
-                                    'type': 'list',
-                                    'mapping': {
-                                        'type': 'string'
-                                    }
-                                },
-                                'slugline': {
-                                    'type': 'list',
-                                    'mapping': {
-                                        'type': 'string'
-                                    }
-                                },
-                                'subject': {
-                                    'type': 'list',
-                                    'mapping': {
-                                        'properties': {
-                                            'qcode': not_analyzed,
-                                            'name': not_analyzed
-                                        }
-                                    }
-                                }
-                            }  # end planning dict schema
-                        },  # end planning
-                        # See IPTC-G2-Implementation_Guide 16.6
-                        'delivery': {
-                            'type': 'list',
-                            'schema': {
-                                'type': 'dict',
-                                'schema': {
-                                    # Delivered Item Ref See IPTC-G2-Implementation_Guide 16.7
-                                    'rel': {'type': 'string'},
-                                    'href': {'type': 'string'},
-                                    'residref': {'type': 'string'},
-                                    'version': {'type': 'string'},
-                                    'content_type': {'type': 'string'},
-                                    'format': {'type': 'string'},
-                                    'size': {'type': 'string'},
-                                    'persistent_id_ref': {'type': 'string'},
-                                    'valid_from': {'type': 'datetime'},
-                                    'valid_to': {'type': 'datetime'},
-                                    'creator': {'type': 'string'},
-                                    'modified': {'type': 'datetime'},
-                                    'xml_lang': {'type': 'string'},
-                                    'dir': {'type': 'string'},
-                                    'rank': {'type': 'integer'}
-                                }
-                            }
-                        }
-                    }
-                }  # end news_coverage schema
-            }  # end news_coverage_set list
-        }  # end news_coverage_set
-    }  # end planning_details
+            }
+        }
+    },
+    'keywords': {
+        'type': 'list',
+        'mapping': {
+            'type': 'string'
+        }
+    },
+    'word_count': {
+        'type': 'integer'
+    },
+    'priority': {
+        'type': 'integer',
+        'nullable': True
+    },
+    'urgency': {
+        'type': 'integer',
+        'nullable': True
+    },
+    'profile': {
+        'type': 'string',
+        'nullable': True
+    },
+    'description_text': {
+        'type': 'string',
+        'nullable': True
+    },
+
+    # See IPTC-G2-Implementation_Guide 16.3
+    'news_coverage_set': {
+        'type': 'list',
+        # See IPTC-G2-Implementation_Guide 16.4 (newsCoverage)
+        'schema': Resource.rel('coverage', True)
+    }  # end news_coverage_set
+
 }  # end planning_schema
 
 

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -6,4 +6,4 @@ flake8-docstrings
 wooper
 requests
 requests-mock
--e git://github.com/superdesk/superdesk-core.git@a5fa622de31362822672508414d27358e789cade#egg=Superdesk_Core
+-e git://github.com/superdesk/superdesk-core.git@v1.3.2#egg=Superdesk_Core


### PR DESCRIPTION
Implementing schema only based on:

IPTC-G2-Implementation_Guide version 2.21
(https://www.iptc.org/std/NewsML-G2/latest/IPTC-G2-Implementation_Guide)
Section 15 (EventsML-G2) - 16 (Editorial Planning)


What is included in this update, and please review for:

- All necessary fields are represented, and using appropriate field types for Planning Items,  which subsequently include coverage sets and coverage items (Locations and Events were added in previous PRs).  
- Any additional internal fields (like guid, unique_name, etc) are present.
- Behave test for basic GETs and POSTs

What is NOT included in this update:

- GUID generate functions (this will come in a separate PR later)
- Detailed behave testing for GETs, POSTs, PUTs, UPDATEs
- Predefined lookup values
- Additional validators for specific field values (like occurance_statuses and organizer_rols, etc)

