### PR TITLE
[SDESK-850] Added time__short class to event item's time field as it can be visible when advanced search pane is opened

### DIFF
--- a/client/components/EventItem/index.jsx
+++ b/client/components/EventItem/index.jsx
@@ -19,7 +19,7 @@ export const EventItem = ({ event, onClick }) => {
             <div className="line">
                 <span className="keyword">{event.name}</span>
                 <span className="item-heading">{event.definition_short}</span>
-                <time title={time}>{time}</time>
+                <time className="time__short" title={time}>{time}</time>
             </div>
             <div className="line">
                 <span className="container">


### PR DESCRIPTION
Depends on client-core: https://github.com/superdesk/superdesk-client-core/pull/1426