### PR TITLE
Keep events in only one place in store.events

### DIFF
--- a/client/components/EventsList/_test.jsx
+++ b/client/components/EventsList/_test.jsx
@@ -49,7 +49,7 @@ describe('<EventsList />', () => {
                 plannings: {
                     planning1: {
                         _id: 'planning1',
-                        event_item: { _id: '5800d71930627218866f1e80' },
+                        event_item: '5800d71930627218866f1e80',
                     },
                 },
             },

--- a/client/components/PlanningItem.jsx
+++ b/client/components/PlanningItem.jsx
@@ -3,10 +3,10 @@ import moment from 'moment'
 import { get } from 'lodash'
 import { ListItem } from './index'
 
-export const PlanningItem = ({ item, onClick, active, onDelete }) => {
-    const location = get(item, 'event_item.location[0].name')
-    const eventTime = get(item, 'event_item.dates.start') ?
-        moment(get(item, 'event_item.dates.start')).format('LL HH:mm') : null
+export const PlanningItem = ({ item, event, onClick, active, onDelete }) => {
+    const location = get(event, 'location[0].name')
+    const eventTime = get(event, 'dates.start') ?
+        moment(get(event, 'dates.start')).format('LL HH:mm') : null
     return (
         <ListItem item={item} onClick={onClick.bind(null, item)} active={active}>
             <div className="line">
@@ -30,6 +30,7 @@ export const PlanningItem = ({ item, onClick, active, onDelete }) => {
 
 PlanningItem.propTypes = {
     item: PropTypes.object.isRequired,
+    event: PropTypes.object,
     active: PropTypes.bool,
     onClick: PropTypes.func,
     onDelete: PropTypes.func,

--- a/client/containers/EditPlanningPanelContainer/index.jsx
+++ b/client/containers/EditPlanningPanelContainer/index.jsx
@@ -15,10 +15,9 @@ class EditPlanningPanel extends React.Component {
     }
 
     render() {
-        const { closePlanningEditor, planning } = this.props
+        const { closePlanningEditor, planning, event } = this.props
         const creationDate = get(planning, '_created')
         const author = get(planning, 'original_creator.username')
-        const event = get(planning, 'event_item')
         return (
             <div className="Planning__edit-planning">
                 <header>
@@ -50,9 +49,13 @@ class EditPlanningPanel extends React.Component {
 EditPlanningPanel.propTypes = {
     closePlanningEditor: React.PropTypes.func.isRequired,
     planning: React.PropTypes.object,
+    event: React.PropTypes.object,
 }
 
-const mapStateToProps = (state) => ({ planning: selectors.getCurrentPlanning(state) })
+const mapStateToProps = (state) => ({
+    planning: selectors.getCurrentPlanning(state),
+    event: selectors.getCurrentPlanningEvent(state),
+})
 
 const mapDispatchToProps = (dispatch) => ({ closePlanningEditor: () => dispatch(actions.closePlanningEditor()) })
 

--- a/client/containers/PlanningPanelContainer/index.jsx
+++ b/client/containers/PlanningPanelContainer/index.jsx
@@ -45,6 +45,7 @@ class PlanningPanel extends React.Component {
             currentAgenda,
             handlePlanningDeletion,
             createPlanning,
+            planningsEvents,
             currentPlanning,
             planningsAreLoading,
             editPlanningViewOpen,
@@ -89,6 +90,7 @@ class PlanningPanel extends React.Component {
                                     key={planning._id}
                                     active={currentPlanning && currentPlanning._id === planning._id}
                                     item={planning}
+                                    event={planningsEvents[planning._id]}
                                     onDelete={handlePlanningDeletion}
                                     onClick={openPlanningEditor.bind(null, planning._id)} />
                             ))}
@@ -119,6 +121,7 @@ class PlanningPanel extends React.Component {
 PlanningPanel.propTypes = {
     currentAgenda: React.PropTypes.object,
     currentPlanning: React.PropTypes.object,
+    planningsEvents: React.PropTypes.object,
     fetchAgendas: React.PropTypes.func.isRequired,
     openCreateAgenda: React.PropTypes.func.isRequired,
     planningList: React.PropTypes.array.isRequired,
@@ -136,6 +139,7 @@ const mapStateToProps = (state) => ({
     planningList: selectors.getCurrentAgendaPlannings(state),
     planningsAreLoading: state.planning.agendasAreLoading || state.planning.planningsAreLoading,
     editPlanningViewOpen: state.planning.editorOpened,
+    planningsEvents: selectors.getCurrentAgendaPlanningsEvents(state),
 })
 
 const mapDispatchToProps = (dispatch) => ({

--- a/client/containers/tests/SelectAgenda_test.jsx
+++ b/client/containers/tests/SelectAgenda_test.jsx
@@ -34,7 +34,7 @@ describe('<SelectAgendaComponent />', () => {
         const initialState = {
             planning: {
                 plannings: {
-                    3: {
+                    '3': {
                         _id: '3',
                         slugline: 'planning 3',
                     },
@@ -61,6 +61,7 @@ describe('<SelectAgendaComponent />', () => {
             // check if selection is registered in the store
             expect(store.getState().planning.currentAgendaId)
             .toEqual('2')
+            // expect(selectors.getCurrentAgenda(store.getState())._id).toEqual('2')
             // must be not empty any more
             expect(selectors.getCurrentAgendaPlannings(store.getState()))
             .toEqual([initialState.planning.plannings['3']])

--- a/client/selectors/tests/index_test.js
+++ b/client/selectors/tests/index_test.js
@@ -14,7 +14,7 @@ describe('selectors', () => {
             plannings: {
                 a: {
                     name: 'name a',
-                    event_item: { _id: 'event1' },
+                    event_item: 'event1',
                 },
                 b: { name: 'name b' },
             },


### PR DESCRIPTION
and use another selector to retrieve events when needed without
modifying the planning object structure.