### PR TITLE
Overwrite event expiry date SDESK-1167

### DIFF
--- a/server/planning/events.py
+++ b/server/planning/events.py
@@ -80,6 +80,8 @@ class EventsService(superdesk.Service):
             event['guid'] = generate_guid(type=GUID_NEWSML)
             # set the author
             set_original_creator(event)
+            # overwrite expiry date
+            overwrite_event_expiry_date(event)
             # generates events based on recurring rules
             if event['dates'].get('recurring_rule', None):
                 # generate a common id for all the events we will generate
@@ -102,6 +104,8 @@ class EventsService(superdesk.Service):
                     new_event['_id'] = new_event['guid']
                     # set the recurrence id
                     new_event['recurrence_id'] = recurrence_id
+                    # set expiry date
+                    overwrite_event_expiry_date(new_event)
                     generatedEvents.append(new_event)
                 # remove the event that contains the recurring rule. We don't need it anymore
                 docs.remove(event)
@@ -535,3 +539,8 @@ def setRecurringMode(event):
         event['dates']['recurring_rule']['until'] = None
     elif endRepeatMode == 'until':
         event['dates']['recurring_rule']['count'] = None
+
+
+def overwrite_event_expiry_date(event):
+    if 'expiry' in event:
+        event['expiry'] = event['dates']['end']

--- a/server/planning/feed_parsers/ics_2_0.py
+++ b/server/planning/feed_parsers/ics_2_0.py
@@ -135,10 +135,8 @@ class IcsTwoFeedParser(FileFeedParser):
                         item['event_lastmodified'] = component.get('last-modified').dt
                     item['firstcreated'] = utcnow()
                     item['versioncreated'] = utcnow()
-
                     items.append(item)
             original_source_ids = [_['original_source'] for _ in items if _.get('original_source', None)]
-            # existing_items = []
             existing_items = list(get_resource_service('events').get_from_mongo(req=None, lookup={
                 'original_source': {'$in': original_source_ids}
             }))

--- a/server/planning/planning.py
+++ b/server/planning/planning.py
@@ -45,6 +45,11 @@ class PlanningService(superdesk.Service):
         for doc in docs:
             doc['guid'] = generate_guid(type=GUID_NEWSML)
             set_original_creator(doc)
+            # remove event expiry if it is linked to the planning
+            if 'event_item' in doc:
+                events_service = get_resource_service('events')
+                original_event = events_service.find_one(req=None, _id=doc['event_item'])
+                events_service.update(doc['event_item'], {'expiry': None}, original_event)
 
     def on_deleted(self, doc):
         # remove the planning from agendas


### PR DESCRIPTION
Set to event ending date, and remove it when the event is linked to a planning