### PR TITLE
Open an Empty Agenda

### DIFF
--- a/client/actions/agenda.js
+++ b/client/actions/agenda.js
@@ -354,8 +354,16 @@ const _unspikeAgenda = (agenda) => (
 const fetchSelectedAgendaPlannings = () => (
     (dispatch, getState) => {
         const agenda = selectors.getCurrentAgenda(getState())
-        if (!agenda || !agenda.planning_items) return Promise.resolve()
-        return dispatch(planning.api.fetch({ ids: agenda.planning_items }))
+        return new Promise((resolve) => {
+            if (!agenda || !agenda.planning_items) {
+                resolve([])
+            } else {
+                resolve(dispatch(planning.api.fetch({ ids: agenda.planning_items })))
+            }
+        })
+        .then((items) => (dispatch(planning.api.setInList(
+            items.map((p) => p._id)
+        ))))
     }
 )
 

--- a/client/actions/planning/api.js
+++ b/client/actions/planning/api.js
@@ -11,13 +11,12 @@ import moment from 'moment'
  */
 const spike = (item) => (
     (dispatch, getState, { api }) => (
-        api.update('planning_spike', item, {})
+        api.update('planning_spike', { ...item }, {})
         .then(() => {
             dispatch({
                 type: PLANNING.ACTIONS.SPIKE_PLANNING,
                 payload: item,
             })
-            return dispatch(self.fetch())
         }, (error) => (Promise.reject(error)))
     )
 )
@@ -29,13 +28,12 @@ const spike = (item) => (
  */
 const unspike = (item) => (
     (dispatch, getState, { api }) => (
-        api.update('planning_unspike', item, {})
+        api.update('planning_unspike', { ...item }, {})
         .then(() => {
             dispatch({
                 type: PLANNING.ACTIONS.UNSPIKE_PLANNING,
                 payload: item,
             })
-            return dispatch(self.fetch())
         }, (error) => (Promise.reject(error)))
     )
 )
@@ -132,15 +130,10 @@ const fetch = (params={}) => (
             dispatch(self.fetchPlanningsEvents(items))
             .then(() => {
                 dispatch(self.receivePlannings(items))
-                dispatch(self.setInList(items.map((p) => p._id)))
                 return Promise.resolve(items)
             }, (error) => {
                 dispatch(self.receivePlannings([]))
                 return Promise.reject(error)
-            })
-            .catch((error) => {
-                expect(error).toBe(null)
-                expect(error.stack).toBe(null)
             })
         ), (error) => {
             dispatch(self.receivePlannings([]))

--- a/client/actions/planning/tests/api_test.js
+++ b/client/actions/planning/tests/api_test.js
@@ -61,7 +61,6 @@ describe('actions.planning.api', () => {
                     payload: data.plannings[1],
                 }])
 
-                expect(planningApi.fetch.callCount).toBe(1)
                 done()
             })
         ))
@@ -92,7 +91,6 @@ describe('actions.planning.api', () => {
                     payload: data.plannings[1],
                 }])
 
-                expect(planningApi.fetch.callCount).toBe(1)
                 done()
             })
         ))

--- a/client/components/PlanningList/index.jsx
+++ b/client/components/PlanningList/index.jsx
@@ -104,7 +104,7 @@ const mapDispatchToProps = (dispatch) => ({
         dispatch(actions.showModal({
             modalType: 'CONFIRMATION',
             modalProps: {
-                body: `Are you sure you want to spike the planning item ${item.slugline} ?`,
+                body: `Are you sure you want to spike the planning item ${item.headline} ?`,
                 action: () => dispatch(actions.planning.ui.spike(item)),
             },
         }))
@@ -113,7 +113,7 @@ const mapDispatchToProps = (dispatch) => ({
         dispatch(actions.showModal({
             modalType: 'CONFIRMATION',
             modalProps: {
-                body: `Are you sure you want to unspike the planning item ${item.slugline} ?`,
+                body: `Are you sure you want to unspike the planning item ${item.headline} ?`,
                 action: () => dispatch(actions.planning.ui.unspike(item)),
             },
         }))

--- a/client/components/PlanningPanelContainer/_test.jsx
+++ b/client/components/PlanningPanelContainer/_test.jsx
@@ -227,7 +227,7 @@ describe('planning', () => {
 
                 const item = {
                     _id: 'planning1',
-                    slugline: 'Plan1',
+                    headline: 'Plan1',
                 }
 
                 const wrapper = mount(
@@ -263,7 +263,7 @@ describe('planning', () => {
 
                 const item = {
                     _id: 'planning1',
-                    slugline: 'Plan1',
+                    headline: 'Plan1',
                 }
 
                 const wrapper = mount(


### PR DESCRIPTION
This fix a bug that was preventing to refresh the planning list when the selected agenda was empty.

SDESK-1616