### PR TITLE
(fix) Fixing elasticsearch query for filtering planning items with no agenda.

### DIFF
--- a/client/actions/planning/api.js
+++ b/client/actions/planning/api.js
@@ -88,7 +88,7 @@ const query = ({
         if (agendas) {
             must.push({ terms: { agendas: agendas } })
         } else if (noAgendaAssigned) {
-            mustNot.push({ exists: { field: 'agendas' } })
+            mustNot.push({ constant_score: { filter: { exists: { field: 'agendas' } } } })
         }
 
         switch (state) {

--- a/client/actions/planning/tests/api_test.js
+++ b/client/actions/planning/tests/api_test.js
@@ -133,15 +133,14 @@ describe('actions.planning.api', () => {
         it('by list of planning not in any agendas', (done) => (
             store.test(done, planningApi.query({ noAgendaAssigned: true }))
             .then(() => {
+                let noAgenda = { constant_score: { filter: { exists: { field: 'agendas' } } } }
                 expect(services.api('planning').query.callCount).toBe(1)
                 expect(services.api('planning').query.args[0]).toEqual([jasmine.objectContaining({
                     source: JSON.stringify({
                         query: {
                             bool: {
                                 must: [],
-                                must_not: [
-                                    { exists: { field: 'agendas' } },
-                                ],
+                                must_not: [noAgenda],
                             },
                         },
                     }),


### PR DESCRIPTION
- `exists` query is not available in elasticsearch 1.7