### PR TITLE
[SDESK-1563] Use scheduled date(s) of Coverage(s) for time filtering planning views

### DIFF
--- a/client/actions/agenda.js
+++ b/client/actions/agenda.js
@@ -251,19 +251,12 @@ const _createPlanningFromEvent = (event) => (
 const fetchSelectedAgendaPlannings = () => (
     (dispatch, getState) => {
         const agendaId = selectors.getCurrentAgendaId(getState())
-
         if (!agendaId) {
             dispatch(planning.ui.clearList())
             return Promise.resolve()
         }
 
-        const agenda = selectors.getCurrentAgenda(getState())
-        const params = {
-            noAgendaAssigned: agendaId === AGENDA.FILTER.NO_AGENDA_ASSIGNED,
-            agendas: agenda ? [agenda._id] : null,
-            page: 1,
-        }
-
+        const params = selectors.getPlanningFilterParams(getState())
         return dispatch(planning.ui.fetchToList(params))
     }
 )

--- a/client/actions/tests/agenda_test.js
+++ b/client/actions/tests/agenda_test.js
@@ -77,7 +77,10 @@ describe('agenda', () => {
                     agendas,
                     currentAgendaId: 'a2',
                 },
-                planning: { plannings },
+                planning: {
+                    plannings,
+                    search: { currentSearch: undefined },
+                },
                 events: { events },
                 privileges: {
                     planning: 1,
@@ -330,11 +333,17 @@ describe('agenda', () => {
                     expect(services.$location.search.args[0]).toEqual(['agenda', 'a1'])
 
                     expect(planningUi.fetchToList.callCount).toBe(1)
-                    expect(planningUi.fetchToList.args[0]).toEqual([{
-                        noAgendaAssigned: false,
-                        agendas: ['a1'],
-                        page: 1,
-                    }])
+                    expect(planningUi.fetchToList.args[0]).toEqual([
+                        {
+                            noAgendaAssigned: false,
+                            agendas: ['a1'],
+                            page: 1,
+                            advancedSearch: undefined,
+                            state: 'active',
+                            fulltext: undefined,
+                            onlyFuture: true,
+                        },
+                    ])
 
                     done()
                 })
@@ -478,6 +487,10 @@ describe('agenda', () => {
                         noAgendaAssigned: false,
                         agendas: ['a1'],
                         page: 1,
+                        advancedSearch: undefined,
+                        state: 'active',
+                        fulltext: undefined,
+                        onlyFuture: true,
                     }])
                     done()
                 })
@@ -493,6 +506,10 @@ describe('agenda', () => {
                         noAgendaAssigned: true,
                         agendas: null,
                         page: 1,
+                        advancedSearch: undefined,
+                        state: 'active',
+                        fulltext: undefined,
+                        onlyFuture: true,
                     }])
                     done()
                 })

--- a/client/components/PlanningItem/index.jsx
+++ b/client/components/PlanningItem/index.jsx
@@ -4,7 +4,7 @@ import { ListItem, TimePlanning, DueDate, tooltips } from '../index'
 import { OverlayTrigger, Tooltip } from 'react-bootstrap'
 import { ITEM_STATE } from '../../constants'
 import classNames from 'classnames'
-import { getCoverageIcon, isItemPublic } from '../../utils/index'
+import { getCoverageIcon, isItemPublic, planningUtils } from '../../utils/index'
 import './style.scss'
 
 const PlanningItem = ({
@@ -22,8 +22,8 @@ const PlanningItem = ({
         onAgendaClick,
     }) => {
     const location = get(event, 'location[0].name')
-    const dueDates = get(item, 'coverages', []).map((c) => (get(c, 'planning.scheduled'))).filter(d => (d))
-    const coveragesTypes = get(item, 'coverages', []).map((c) => get(c, 'planning.g2_content_type'))
+    const dueDates = get(item, '_coverages', []).map((c) => (get(c, 'scheduled'))).filter(d => (d))
+    const coveragesTypes = planningUtils.mapCoverageByDate(get(item, 'coverages', []))
 
     const itemSpiked = item && get(item, 'state', 'active') === ITEM_STATE.SPIKED
     const eventSpiked = event ? get(event, 'state', 'active') === ITEM_STATE.SPIKED : false
@@ -79,11 +79,11 @@ const PlanningItem = ({
                             <OverlayTrigger
                                 placement="bottom"
                                 overlay={
-                                    <Tooltip id={`${i}${c}`}>
-                                        {capitalize(c).replace(/_/g, ' ')}
+                                    <Tooltip id={`${i}${c.g2_content_type}`}>
+                                        {capitalize(c.g2_content_type).replace(/_/g, ' ')}
                                     </Tooltip>
                                 }>
-                                <i className={getCoverageIcon(c)}/>
+                                <i className={getCoverageIcon(c.g2_content_type) + ` ${c.iconColor}`}/>
                             </OverlayTrigger>
                             &nbsp;
                         </span>

--- a/client/components/PlanningItem/style.scss
+++ b/client/components/PlanningItem/style.scss
@@ -1,8 +1,18 @@
+@import '~superdesk-core/styles/sass/variables.scss';
+
 .PlanningItem{
 	&__dueDate, &__event {
     	i { margin: 0 5px;}
 	}
 	&--locked {
-		border-left: 4px solid #e51c23;
+		border-left: 4px solid $red;
 	}
+}
+
+.icon--green {
+	color: $green;
+}
+
+.icon--red {
+	color: $red;
 }

--- a/client/components/PlanningPanelContainer/_test.jsx
+++ b/client/components/PlanningPanelContainer/_test.jsx
@@ -148,6 +148,11 @@ describe('planning', () => {
                                 agendas: ['agenda1'],
                             }],
                         }),
+                        apiGetById: () => ({
+                            _id: 'RefreshedplanningId',
+                            slugline: 'coucou',
+                            agendas: ['agenda1'],
+                        }),
                     },
                     initialState,
                 })

--- a/client/components/PlanningPanelContainer/index.jsx
+++ b/client/components/PlanningPanelContainer/index.jsx
@@ -67,8 +67,8 @@ class PlanningPanel extends React.Component {
                         <div className="Planning-panel__searchbar subnav">
                             <SearchBar value={null} onSearch={handleSearch}/>
                             <label>
-                                Only future
-                                <Toggle value={onlyFuture} onChange={onFutureToggleChange}/>
+                                Only Future
+                                <Toggle value={onlyFuture} onChange={onFutureToggleChange} />
                             </label>
                             <label>
                                 Spiked
@@ -146,6 +146,7 @@ const mapStateToProps = (state) => ({
     onlyFuture: state.planning.onlyFuture,
     onlySpiked: state.planning.onlySpiked,
     privileges: selectors.getPrivileges(state),
+    filterPlanningTimeline: state.planning.filterPlanningTimeline,
 })
 
 const mapDispatchToProps = (dispatch) => ({

--- a/client/components/SearchBar/index.jsx
+++ b/client/components/SearchBar/index.jsx
@@ -60,7 +60,7 @@ export default class SearchBar extends React.Component {
                     </label>
                     <DebounceInput
                         minLength={minLength}
-                        debounceTimeout={500}
+                        debounceTimeout={800}
                         value={this.state.searchInputValue}
                         onChange={this.onSearchChange.bind(this)}
                         id={uniqueId}

--- a/client/constants/planning.js
+++ b/client/constants/planning.js
@@ -10,6 +10,7 @@ export const PLANNING = {
         SET_ONLY_FUTURE: 'SET_ONLY_FUTURE',
         SET_ONLY_SPIKED: 'SET_ONLY_SPIKED',
         PLANNING_FILTER_BY_KEYWORD: 'PLANNING_FILTER_BY_KEYWORD',
+        PLANNING_FILTER_BY_TIMELINE: 'PLANNING_FILTER_BY_TIMELINE',
         RECEIVE_COVERAGE: 'RECEIVE_COVERAGE',
         COVERAGE_DELETED: 'COVERAGE_DELETED',
         RECEIVE_PLANNING_HISTORY: 'RECEIVE_PLANNING_HISTORY',
@@ -21,4 +22,9 @@ export const PLANNING = {
     // because url length must stay short
     // chunk size must be lower than page limit (25)
     FETCH_IDS_CHUNK_SIZE: 25,
+    PLANNING_FILTER_TIMELINE: {
+        FUTURE: 'FUTURE',
+        PAST: 'PAST',
+        NOT_SCHEDULED: 'NOT_SCHEDULED',
+    },
 }

--- a/client/reducers/planning.js
+++ b/client/reducers/planning.js
@@ -15,6 +15,7 @@ const initialState  = {
     readOnly: true,
     planningHistoryItems: [],
     lastRequestParams: { page: 1 },
+    search: { currentSearch: undefined },
 }
 
 let plannings
@@ -147,6 +148,10 @@ const planningReducer = createReducer(initialState, {
         {
             ...state,
             onlyFuture: payload,
+            search: {
+                ...state.search,
+                currentSearch: payload,
+            },
         }
     ),
 

--- a/client/reducers/tests/planning_test.js
+++ b/client/reducers/tests/planning_test.js
@@ -32,6 +32,7 @@ describe('planning', () => {
                 readOnly: true,
                 planningHistoryItems: [],
                 lastRequestParams: { page: 1 },
+                search: { currentSearch: undefined },
             })
         })
 

--- a/client/selectors/tests/index_test.js
+++ b/client/selectors/tests/index_test.js
@@ -122,11 +122,6 @@ describe('selectors', () => {
         const _getPlanningItems = () => (selectors.getFilteredPlanningList(newState))
         beforeEach(() => { newState = cloneDeep(state) })
 
-        it('show all except spiked', () => {
-            result = _getPlanningItems()
-            expect(result).toEqual([newState.planning.plannings.a, newState.planning.plannings.b])
-        })
-
         it('without a selected agenda', () => {
             delete newState.agenda.currentAgendaId
             newState.planning.planningsInList = []
@@ -139,81 +134,6 @@ describe('selectors', () => {
             newState.planning.planningsInList = ['c', 'e']
             result = _getPlanningItems()
             expect(result).toEqual([newState.planning.plannings.c, newState.planning.plannings.e])
-        })
-
-        it('empty list when all items are spiked', () => {
-            newState.planning.plannings.a.state = 'spiked'
-            newState.planning.plannings.b.state = 'spiked'
-            result = _getPlanningItems()
-            expect(result).toEqual([])
-        })
-
-        it('only future items', () => {
-            // a and b have no coverage due date or event ending date, so they appear
-            newState.planning.onlyFuture = true
-            result = _getPlanningItems()
-            expect(result).toEqual([
-                newState.planning.plannings.a,
-                newState.planning.plannings.b,
-            ])
-
-            // a appears because it has a linked event with a future ending date
-            newState = cloneDeep(state)
-            newState.planning.onlyFuture = true
-            const future = '2045-10-19T13:01:50+0000'
-            const past = '1900-10-19T13:01:50+0000'
-            newState.events.events.event1.dates = { end: moment(future) }
-            newState.planning.plannings.b.coverages = [{ planning: { scheduled: past } }]
-            result = selectors.getFilteredPlanningList(newState)
-            expect(result).toEqual([newState.planning.plannings.a])
-
-            // b appears because it has a future due date
-            newState = cloneDeep(state)
-            newState.planning.onlyFuture = true
-            newState.events.events.event1.dates = { end: moment(past) }
-            newState.planning.plannings.b.coverages = [{ planning: { scheduled: future } }]
-            result = selectors.getFilteredPlanningList(newState)
-            expect(result).toEqual([newState.planning.plannings.b])
-        })
-
-        it('only spiked items', () => {
-            newState.planning.onlySpiked = true
-            result = _getPlanningItems()
-            expect(result).toEqual([newState.planning.plannings.d])
-        })
-
-        it('only future spiked items', () => {
-            // a and d have no coverage due date or event ending date, so they appear
-            newState.planning.onlySpiked = true
-            newState.planning.onlyFuture = true
-            newState.planning.plannings.a.state = 'spiked'
-            result = _getPlanningItems()
-            expect(result).toEqual([
-                newState.planning.plannings.a,
-                newState.planning.plannings.d,
-            ])
-
-            // a appears because it has a linked event with a future ending date
-            newState = cloneDeep(state)
-            newState.planning.onlySpiked = true
-            newState.planning.onlyFuture = true
-            newState.planning.plannings.a.state = 'spiked'
-            const future = '2045-10-19T13:01:50+0000'
-            const past = '1900-10-19T13:01:50+0000'
-            newState.events.events.event1.dates = { end: moment(future) }
-            newState.planning.plannings.d.coverages = [{ planning: { scheduled: past } }]
-            result = selectors.getFilteredPlanningList(newState)
-            expect(result).toEqual([newState.planning.plannings.a])
-
-            // d appears because it has a future due date
-            newState = cloneDeep(state)
-            newState.planning.onlySpiked = true
-            newState.planning.onlyFuture = true
-            newState.planning.plannings.a.state = 'spiked'
-            newState.events.events.event1.dates = { end: moment(past) }
-            newState.planning.plannings.d.coverages = [{ planning: { scheduled: future } }]
-            result = selectors.getFilteredPlanningList(newState)
-            expect(result).toEqual([newState.planning.plannings.d])
         })
     })
 

--- a/client/utils/index.js
+++ b/client/utils/index.js
@@ -319,3 +319,9 @@ export const isItemPublic = (pubstatus) =>
 export const isItemSpiked = (item) => item ?
     getItemState(item) === WORKFLOW_STATE.SPIKED : false
 
+/**
+ * Get the timezone offset
+ * @param {Array} coverages
+ * @returns {Array}
+ */
+export const getTimeZoneOffset = () => (moment().format('Z'))

--- a/client/utils/planning.js
+++ b/client/utils/planning.js
@@ -1,5 +1,7 @@
+import moment from 'moment-timezone'
 import { getItemState } from './index'
 import { WORKFLOW_STATE } from '../constants/index'
+import { get } from 'lodash'
 
 const canSavePlanning = (planning, event) => (
     getItemState(planning) !== WORKFLOW_STATE.SPIKED &&
@@ -34,11 +36,33 @@ const canEditPlanning = (
         !lockedUser
 )
 
+/**
+ * Get the array of coverage content type and color base on the scheduled date
+ * @param {Array} coverages
+ * @returns {Array}
+ */
+export const mapCoverageByDate = (coverages) => (
+    coverages.map((c) => {
+        let coverage = {
+            g2_content_type: c.planning.g2_content_type || '',
+            iconColor: '',
+        }
+
+        if (get(c, 'planning.scheduled')) {
+            const isAfter = moment(get(c, 'planning.scheduled')).isAfter(moment())
+            coverage.iconColor = isAfter ? 'icon--green' : 'icon--red'
+        }
+
+        return coverage
+    })
+)
+
 const self = {
     canSavePlanning,
     canPublishPlanning,
     canUnpublishPlanning,
     canEditPlanning,
+    mapCoverageByDate,
 }
 
 export default self

--- a/client/utils/testUtils.js
+++ b/client/utils/testUtils.js
@@ -209,6 +209,7 @@ export const getTestActionStore = () => {
                     noAgendaAssigned: false,
                     page: 1,
                 },
+                search: { currentSearch: undefined },
             },
             events: {
                 events: {},
@@ -277,7 +278,6 @@ export const getTestActionStore = () => {
 
         test: (done, action) => {
             if (!store.ready) store.init()
-
             return action(store.dispatch, store.getState, store.services)
             .catch((error) => {
                 // If this is from a Promise.reject, then pass that on

--- a/server/features/coverage.feature
+++ b/server/features/coverage.feature
@@ -44,7 +44,7 @@ Feature: Coverage
         ]
         """
         When we get "/coverage"
-        Then we get list with 2 items
+        Then we get list with 1 items
         """
             {"_items": [{
                 "guid": "__any_value__",
@@ -60,7 +60,7 @@ Feature: Coverage
             }]}
         """
         When we get "/coverage_history"
-        Then we get a list with 2 items
+        Then we get a list with 1 items
         """
             {"_items": [{"operation": "create", "coverage_id": "#coverage._id#", "update": {
                 "planning_item": "#planning._id#"
@@ -105,7 +105,7 @@ Feature: Coverage
         ]
         """
         When we get "/coverage"
-        Then we get list with 2 items
+        Then we get list with 1 items
         """
             {"_items": [{
                 "guid": "__any_value__",
@@ -256,7 +256,7 @@ Feature: Coverage
         """
         Then we get OK response
         When we get "/coverage_history"
-        Then we get a list with 3 items
+        Then we get a list with 2 items
         """
             {"_items": [{
                 "coverage_id":  "#coverage._id#",
@@ -288,7 +288,7 @@ Feature: Coverage
             ]}
         """
         When we get "/planning_history?where=planning_id==%22#planning._id#%22"
-        Then we get list with 4 items
+        Then we get list with 3 items
         """
             {"_items": [
                 {"operation": "create"},
@@ -300,7 +300,7 @@ Feature: Coverage
         """
         When we delete "/coverage/#coverage._id#"
         When we get "/planning_history?where=planning_id==%22#planning._id#%22"
-        Then we get list with 5 items
+        Then we get list with 4 items
         """
             {"_items": [
                 {"operation": "create"},
@@ -311,4 +311,175 @@ Feature: Coverage
                 {"operation": "coverage deleted",
                     "update": {"coverage_id": "#coverage._id#"}}
             ]}
+        """
+    @auth
+    @notification
+    Scenario: Create or update coverage - sync coverage information to planning
+        Given empty "users"
+        Given empty "coverage"
+        Given empty "planning"
+        When we post to "planning"
+        """
+        [{
+            "slugline": "planning 1"
+        }]
+        """
+        Then we get OK response
+        Then we store "planning_date" with value "#planning._planning_date#" to context
+        When we post to "/coverage"
+        """
+        [
+            {
+                "guid": "123",
+                "planning": {
+                    "ednote": "test coverage, I want 250 words",
+                    "g2_content_type": "text",
+                    "assigned_to": {
+                        "desk": "Politic Desk",
+                        "user": "507f191e810c19729de860ea"
+                    }
+                },
+                "planning_item": "#planning._id#",
+                "delivery": []
+            }
+        ]
+        """
+        Then we get OK response
+        Then we store "coverage1" with value "#coverage._id#" to context
+        When we get "/coverage"
+        Then we get list with 1 items
+        """
+            {"_items": [{
+                "guid": "__any_value__",
+                "original_creator": "__any_value__",
+                "planning": {
+                    "ednote": "test coverage, I want 250 words",
+                    "g2_content_type": "text",
+                    "assigned_to": {
+                        "desk": "Politic Desk",
+                        "user": "507f191e810c19729de860ea"
+                    }
+                },
+                "delivery": []
+            }]}
+        """
+        When we get "/planning/#planning._id#"
+        Then we get existing resource
+        """
+        {
+            "slugline": "planning 1",
+            "coverages": [{
+                "planning": {
+                    "ednote": "test coverage, I want 250 words",
+                    "g2_content_type": "text",
+                    "assigned_to": {
+                        "desk": "Politic Desk",
+                        "user": "507f191e810c19729de860ea",
+                        "assigned_by": "#CONTEXT_USER_ID#",
+                        "assigned_date": "__any_value__"
+                    }
+                },
+                "planning_item": "#planning._id#",
+                "delivery": []
+            }],
+            "_coverages": [
+                {
+                    "coverage_id" : null,
+                    "scheduled" : "__any_value__",
+                    "g2_content_type": null
+                },
+                {
+                    "coverage_id" : "#coverage._id#",
+                    "scheduled" : null,
+                    "g2_content_type": "text"
+                }
+            ]
+        }
+        """
+        When we patch "/coverage/#coverage._id#"
+        """
+        {"planning": { "scheduled": "#DATE+1#", "g2_content_type": "text" }}
+        """
+        Then we get updated response
+        When we get "/planning/#planning._id#"
+        Then we get existing resource
+        """
+        {
+            "slugline": "planning 1",
+            "coverages": [{
+                "planning": {
+                    "ednote": "test coverage, I want 250 words",
+                    "g2_content_type": "text",
+                    "assigned_to": {
+                        "desk": "Politic Desk",
+                        "user": "507f191e810c19729de860ea",
+                        "assigned_by": "#CONTEXT_USER_ID#",
+                        "assigned_date": "__any_value__"
+                    }
+                },
+                "planning_item": "#planning._id#",
+                "delivery": []
+            }],
+            "_coverages": [
+                {
+                    "coverage_id": "#coverage._id#",
+                    "scheduled": "__any_value__",
+                    "g2_content_type": "text"
+                }
+            ]
+        }
+        """
+        When we post to "/coverage"
+        """
+        [
+            {
+                "guid": "456",
+                "planning": {
+                    "ednote": "test coverage, I want 250 words",
+                    "g2_content_type": "video",
+                    "assigned_to": {
+                        "desk": "Politic Desk",
+                        "user": "507f191e810c19729de860ea"
+                    },
+                    "scheduled": "#DATE+3#"
+                },
+                "planning_item": "#planning._id#",
+                "delivery": []
+            }
+        ]
+        """
+        Then we get OK response
+        Then we store "coverage2" with value "#coverage._id#" to context
+        When we get "/planning/#planning._id#"
+        Then we get existing resource
+        """
+        {
+            "slugline": "planning 1",
+            "coverages": [{
+                "planning": {
+                    "ednote": "test coverage, I want 250 words",
+                    "g2_content_type": "text",
+                    "assigned_to": {
+                        "desk": "Politic Desk",
+                        "user": "507f191e810c19729de860ea",
+                        "assigned_by": "#CONTEXT_USER_ID#",
+                        "assigned_date": "__any_value__"
+                    }
+                },
+                "planning_item": "#planning._id#",
+                "delivery": []
+            }],
+            "_coverages": [
+                {
+                    "coverage_id": "#coverage1#",
+                    "scheduled": "__any_value__",
+                    "g2_content_type": "text"
+                },
+                {
+                    "coverage_id": "#coverage2#",
+                    "scheduled": "__any_value__",
+                    "g2_content_type": "video"
+                }
+            ]
+        }
         """

--- a/server/features/planning_spike.feature
+++ b/server/features/planning_spike.feature
@@ -51,16 +51,12 @@ Feature: Planning Spike
         }
         """
         When we get "/planning_history?where=planning_id==%22#planning._id#%22"
-        Then we get list with 2 items
+        Then we get list with 1 items
         """
         {"_items": [{
             "planning_id": "#planning._id#",
             "operation": "spiked",
-            "update": {"state" : "spiked", "revert_state": "in_progress"}},
-            {
-            "planning_id": "#planning._id#",
-            "operation": "coverage created"
-            }
+            "update": {"state" : "spiked", "revert_state": "in_progress"}}
             ]}
         """
 
@@ -97,16 +93,13 @@ Feature: Planning Spike
         }
         """
         When we get "/planning_history?where=planning_id==%22#planning._id#%22"
-        Then we get list with 2 items
+        Then we get list with 1 items
         """
         {"_items": [{
             "planning_id": "#planning._id#",
             "operation": "unspiked",
-            "update": {"state" : "in_progress"}},
-            {
-            "planning_id": "#planning._id#",
-            "operation": "coverage created"
-            }]}
+            "update": {"state" : "in_progress"}}
+        ]}
         """
 
     @auth

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -11,4 +11,4 @@ icalendar==3.11.1
 coverage==4.3.4
 coveralls
 mock
--e git://github.com/superdesk/superdesk-core.git@e67645736#egg=Superdesk_Core
+-e git://github.com/superdesk/superdesk-core.git@f986cfee4#egg=Superdesk_Core


### PR DESCRIPTION
- Includes no default coverage when Planning Item is created
- Schedule date of coverage is not compulsory.
- If coverage date is not available on any of the coverages then `planning item date`  is used for sorting and filtering.
- `planning item date` is `event start date` for planning items created from associated event and for ad-hoc planning item the `planning item date` is current date time.