### PR TITLE
Update packages following "superdesk-client-core" updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,12 +32,12 @@
     "whatwg-fetch": "^2.0.3"
   },
   "devDependencies": {
-    "enzyme": "~2.8.0",
-    "eslint-plugin-jasmine": "~2.4.0",
+    "enzyme": "~2.9.1",
+    "eslint-plugin-jasmine": "~2.8.4",
     "istanbul-instrumenter-loader": "0.2.0",
-    "jasmine": "2.7.0",
+    "jasmine": "2.8.0",
     "jscs": "^3.0.7",
-    "karma": "1.7.0",
+    "karma": "1.7.1",
     "karma-cli": "^1.0.1",
     "karma-chrome-launcher": "2.2.0",
     "karma-coverage": "1.1.1",
@@ -46,10 +46,10 @@
     "karma-sourcemap-loader": "~0.3.7",
     "karma-verbose-reporter": "0.0.6",
     "karma-webpack": "2.0.4",
-    "react-addons-test-utils": "~15.5.1",
-    "react-test-renderer": "~15.5.1",
+    "react-addons-test-utils": "~15.6.0",
+    "react-test-renderer": "~15.6.1",
     "simulant": "^0.2.2",
-    "sinon": "~2.1.0",
+    "sinon": "~3.3.0",
     "superdesk-core": "superdesk/superdesk-client-core#42959f5"
   }
 }


### PR DESCRIPTION
Following https://github.com/superdesk/superdesk-client-core/pull/1847

But there are still some outdated packages
```
(env) root@sd:/opt/superdesk/planning# npm outdated
Package                          Current      Wanted       Latest  Location
istanbul-instrumenter-loader       0.2.0       0.2.0        3.0.0  superdesk-planning
react-addons-shallow-compare      15.5.2      15.5.2       15.6.0  superdesk-planning
react-bootstrap                  0.30.10     0.30.10       0.31.3  superdesk-planning
react-datepicker                  0.41.1      0.41.1       0.55.0  superdesk-planning
react-debounce-input               2.4.2       2.4.2        3.0.1  superdesk-planning
react-select                  1.0.0-rc.5  1.0.0-rc.5  1.0.0-rc.10  superdesk-planning
redux-form                         6.8.0       6.8.0        7.0.4  superdesk-planning
redux-logger                      2.10.2      2.10.2        3.0.6  superdesk-planning
reselect                           2.5.4       2.5.4        3.0.1  superdesk-planning
superdesk-core                1.9.0-rc.1         git          git  superdesk-planning
```
Probably someone should update them too, with proper checks...