### PR TITLE
[SDESK-2181] (fix) Ensure all affected event times are updated in the recurring series

### DIFF
--- a/client/actions/events/api.js
+++ b/client/actions/events/api.js
@@ -660,6 +660,19 @@ const publishEvent = (event) => (
     )
 );
 
+const updateEventTime = (event) => (
+    (dispatch, getState, {api}) => (
+        api.update(
+            'events_update_time',
+            event,
+            {
+                update_method: get(event, 'update_method.value', EventUpdateMethods[0].value),
+                dates: event.dates,
+            }
+        )
+    )
+);
+
 const markEventCancelled = (event, reason, occurStatus) => ({
     type: EVENTS.ACTIONS.MARK_EVENT_CANCELLED,
     payload: {
@@ -871,6 +884,7 @@ const self = {
     markEventCancelled,
     markEventHasPlannings,
     rescheduleEvent,
+    updateEventTime,
     markEventPostponed,
     postponeEvent,
     loadEventDataForAction,

--- a/client/actions/events/notifications.js
+++ b/client/actions/events/notifications.js
@@ -185,18 +185,12 @@ const onEventCancelled = (e, data) => (
     }
 );
 
-const onEventRescheduled = (e, data) => (
+const onEventScheduleChanged = (e, data) => (
     (dispatch) => {
         if (get(data, 'item')) {
             dispatch(eventsUi.scheduleRefetch());
             dispatch(eventsPlanning.ui.scheduleRefetch());
-            dispatch(eventsApi.getEvent(data.item, false))
-                .then((event) => (
-                    dispatch({
-                        type: EVENTS.ACTIONS.UNLOCK_EVENT,
-                        payload: {event},
-                    })
-                ));
+            dispatch(eventsApi.getEvent(data.item, false));
         }
     }
 );
@@ -278,7 +272,7 @@ const self = {
     onEventSpiked,
     onEventUnspiked,
     onEventCancelled,
-    onEventRescheduled,
+    onEventScheduleChanged,
     onEventPostponed,
     onEventPublishChanged,
     onRecurringEventSpiked,
@@ -291,11 +285,14 @@ self.events = {
     'events:spiked': () => (self.onEventSpiked),
     'events:unspiked': () => (self.onEventUnspiked),
     'events:cancelled': () => (self.onEventCancelled),
-    'events:rescheduled': () => (self.onEventRescheduled),
+    'events:reschedule': () => (self.onEventScheduleChanged),
+    'events:reschedule:recurring': () => (self.onEventScheduleChanged),
     'events:postponed': () => (self.onEventPostponed),
     'events:published': () => (self.onEventPublishChanged),
     'events:unpublished': () => (self.onEventPublishChanged),
     'events:spiked:recurring': () => (self.onRecurringEventSpiked),
+    'events:update_time': () => (self.onEventScheduleChanged),
+    'events:update_time:recurring': () => (self.onEventScheduleChanged),
 };
 
 export default self;

--- a/client/actions/events/tests/notifications_test.js
+++ b/client/actions/events/tests/notifications_test.js
@@ -34,7 +34,7 @@ describe('actions.events.notifications', () => {
                 () => (Promise.resolve())
             );
 
-            sinon.stub(eventsNotifications, 'onEventRescheduled').callsFake(
+            sinon.stub(eventsNotifications, 'onEventScheduleChanged').callsFake(
                 () => (Promise.resolve())
             );
 
@@ -56,7 +56,7 @@ describe('actions.events.notifications', () => {
             restoreSinonStub(eventsNotifications.onEventUnlocked);
             restoreSinonStub(eventsNotifications.onEventSpiked);
             restoreSinonStub(eventsNotifications.onEventUnspiked);
-            restoreSinonStub(eventsNotifications.onEventRescheduled);
+            restoreSinonStub(eventsNotifications.onEventScheduleChanged);
             restoreSinonStub(eventsNotifications.onEventPublishChanged);
             restoreSinonStub(eventsNotifications.onRecurringEventSpiked);
         });
@@ -105,12 +105,45 @@ describe('actions.events.notifications', () => {
             }, delay);
         });
 
-        it('`events:rescheduled` calls onEventRescheduled', (done) => {
-            $rootScope.$broadcast('events:rescheduled', {item: 'e1'});
+        it('`events:reschedule` calls onEventScheduleChanged', (done) => {
+            $rootScope.$broadcast('events:reschedule', {item: 'e1'});
 
             setTimeout(() => {
-                expect(eventsNotifications.onEventRescheduled.callCount).toBe(1);
-                expect(eventsNotifications.onEventRescheduled.args[0][1]).toEqual({item: 'e1'});
+                expect(eventsNotifications.onEventScheduleChanged.callCount).toBe(1);
+                expect(eventsNotifications.onEventScheduleChanged.args[0][1]).toEqual({item: 'e1'});
+
+                done();
+            }, delay);
+        });
+
+        it('`events:reschedule:recurring` calls onEventScheduleChanged', (done) => {
+            $rootScope.$broadcast('events:reschedule:recurring', {item: 'e1'});
+
+            setTimeout(() => {
+                expect(eventsNotifications.onEventScheduleChanged.callCount).toBe(1);
+                expect(eventsNotifications.onEventScheduleChanged.args[0][1]).toEqual({item: 'e1'});
+
+                done();
+            }, delay);
+        });
+
+        it('`events:update_time` calls onEventScheduleChanged', (done) => {
+            $rootScope.$broadcast('events:update_time', {item: 'e1'});
+
+            setTimeout(() => {
+                expect(eventsNotifications.onEventScheduleChanged.callCount).toBe(1);
+                expect(eventsNotifications.onEventScheduleChanged.args[0][1]).toEqual({item: 'e1'});
+
+                done();
+            }, delay);
+        });
+
+        it('`events:update_time:recurring` calls onEventScheduleChanged', (done) => {
+            $rootScope.$broadcast('events:update_time:recurring', {item: 'e1'});
+
+            setTimeout(() => {
+                expect(eventsNotifications.onEventScheduleChanged.callCount).toBe(1);
+                expect(eventsNotifications.onEventScheduleChanged.args[0][1]).toEqual({item: 'e1'});
 
                 done();
             }, delay);

--- a/client/actions/events/tests/ui_test.js
+++ b/client/actions/events/tests/ui_test.js
@@ -154,7 +154,7 @@ describe('actions.events.ui', () => {
                 expect(eventsUi._openActionModal.args[0]).toEqual([
                     data.events[1],
                     'Reschedule',
-                    'reschedule_event',
+                    'reschedule',
                     true,
                     false,
                     true,

--- a/client/actions/events/ui.js
+++ b/client/actions/events/ui.js
@@ -450,6 +450,25 @@ const rescheduleEvent = (event) => (
     )
 );
 
+const updateEventTime = (event) => (
+    (dispatch, getState, {notify}) => (
+        dispatch(eventsApi.updateEventTime(event))
+            .then(() => {
+                dispatch(hideModal());
+                notify.success('Event time has been update');
+                return Promise.resolve();
+            }, (error) => {
+                dispatch(hideModal());
+
+                notify.error(
+                    getErrorMessage(error, 'Failed to update the Event time!')
+                );
+
+                return Promise.reject(error);
+            })
+    )
+);
+
 const saveAndPublish = (event, save = true, publish = false) => (
     (dispatch) => {
         if (!save) {
@@ -761,7 +780,8 @@ const self = {
     unpublish,
     loadMore,
     addToList,
-    requestEvents
+    requestEvents,
+    updateEventTime
 };
 
 export default self;

--- a/client/components/ItemActionConfirmation/forms/updateTimeForm.jsx
+++ b/client/components/ItemActionConfirmation/forms/updateTimeForm.jsx
@@ -80,8 +80,8 @@ export class UpdateTimeComponent extends React.Component {
             relatedEvents: relatedEvents,
         });
 
-        if (
-            isEqual(diff.dates, this.props.initialValues.dates) ||
+        if ((isEqual(diff.dates, this.props.initialValues.dates) &&
+                diff.update_method.value === EventUpdateMethods[0].value) ||
             !isEqual(errors, {})
         ) {
             this.props.disableSaveInModal();
@@ -218,24 +218,12 @@ const mapStateToProps = (state) => ({
 });
 
 const mapDispatchToProps = (dispatch) => ({
-    onSubmit: (event) => dispatch(actions.events.ui.saveAndPublish(
-        event,
-        get(event, '_save', true),
-        get(event, '_publish', false)
-    ))
-        .then(() => {
-            dispatch({
-                type: EVENTS.ACTIONS.UNLOCK_EVENT,
-                payload: {event},
-            });
-        }),
-
+    onSubmit: (event) => dispatch(actions.events.ui.updateEventTime(event)),
     onHide: (event) => {
         if (event.lock_action === EVENTS.ITEM_ACTIONS.UPDATE_TIME.lock_action) {
             dispatch(actions.events.api.unlock(event));
         }
     },
-
     onValidate: (item, profile, errors) => dispatch(validateItem('events', item, profile, errors, ['dates']))
 });
 

--- a/client/constants/events.js
+++ b/client/constants/events.js
@@ -69,7 +69,7 @@ export const EVENTS = {
             label: gettext('Reschedule'),
             icon: 'icon-calendar',
             actionName: 'onRescheduleEvent',
-            lock_action: 'reschedule_event',
+            lock_action: 'reschedule',
         },
         POSTPONE_EVENT: {
             label: gettext('Mark as Postponed'),

--- a/server/features/events_update_time.feature
+++ b/server/features/events_update_time.feature
@@ -1,0 +1,524 @@
+Feature: Events Update Time
+
+    @auth
+    @notification
+    Scenario: Update time of single event
+        Given we have sessions "/sessions"
+        Given "events"
+        """
+        [{
+            "_id": "event1",
+            "guid": "event1",
+            "dates": {
+                "start": "2029-11-21T12:00:00.000Z",
+                "end": "2029-11-21T14:00:00.000Z",
+                "tz": "Australia/Sydney"
+            },
+            "lock_user": "#CONTEXT_USER_ID#",
+            "lock_session": "#SESSION_ID#",
+            "lock_action": "update_time",
+            "lock_time": "#DATE#"
+        }]
+        """
+        When we reset notifications
+        When we perform update_time on events "event1"
+        """
+        {
+            "dates": {
+                "start": "2029-11-21T02:00:00.000Z",
+                "end": "2029-11-21T04:00:00.000Z",
+                "tz": "Australia/Sydney"
+            }
+        }
+        """
+        Then we get OK response
+        And we get notifications
+        """
+        [{
+            "event": "events:unlock",
+            "extra": {"item": "event1", "user": "#CONTEXT_USER_ID#"}
+        }, {
+            "event": "events:update_time",
+            "extra": {
+                "item": "event1",
+                "user": "#CONTEXT_USER_ID#"
+            }
+        }]
+        """
+        When we get "/events/event1"
+        Then we get existing resource
+        """
+        {
+            "_id": "event1",
+            "guid": "event1",
+            "dates": {
+                "start": "2029-11-21T02:00:00+0000",
+                "end": "2029-11-21T04:00:00+0000",
+                "tz": "Australia/Sydney"
+            },
+            "lock_user": null,
+            "lock_session": null,
+            "lock_action": null,
+            "lock_time": null
+        }
+        """
+
+    @auth
+    Scenario: Event must be locked to update the time
+        Given we have sessions "/sessions"
+        Given "events"
+        """
+        [{
+            "_id": "event1",
+            "guid": "event1",
+            "dates": {
+                "start": "2029-11-21T12:00:00.000Z",
+                "end": "2029-11-21T14:00:00.000Z",
+                "tz": "Australia/Sydney"
+            }
+        }, {
+            "_id": "event2",
+            "guid": "event2",
+            "dates": {
+                "start": "2029-11-21T12:00:00.000Z",
+                "end": "2029-11-21T14:00:00.000Z",
+                "tz": "Australia/Sydney"
+            },
+            "lock_user": "#CONTEXT_USER_ID#",
+            "lock_session": "session123",
+            "lock_action": "update_time",
+            "lock_time": "#DATE#"
+        }, {
+            "_id": "event3",
+            "guid": "event3",
+            "dates": {
+                "start": "2029-11-21T12:00:00.000Z",
+                "end": "2029-11-21T14:00:00.000Z",
+                "tz": "Australia/Sydney"
+            },
+            "lock_user": "user123",
+            "lock_session": "session456",
+            "lock_action": "update_time",
+            "lock_time": "#DATE#"
+        }, {
+            "_id": "event4",
+            "guid": "event4",
+            "dates": {
+                "start": "2029-11-21T12:00:00.000Z",
+                "end": "2029-11-21T14:00:00.000Z",
+                "tz": "Australia/Sydney"
+            },
+            "lock_user": "#CONTEXT_USER_ID#",
+            "lock_session": "#SESSION_ID#",
+            "lock_action": "edit",
+            "lock_time": "#DATE#"
+        }]
+        """
+        When we perform update_time on events "event1"
+        """
+        {
+            "dates": {
+                "start": "2029-11-21T02:00:00.000Z",
+                "end": "2029-11-21T04:00:00.000Z",
+                "tz": "Australia/Sydney"
+            }
+        }
+        """
+        Then we get error 400
+        """
+        {"_issues": {"validator exception": "403: The event must be locked"}, "_status": "ERR"}
+        """
+        When we perform update_time on events "event2"
+        """
+        {
+            "dates": {
+                "start": "2029-11-21T02:00:00.000Z",
+                "end": "2029-11-21T04:00:00.000Z",
+                "tz": "Australia/Sydney"
+            }
+        }
+        """
+        Then we get error 400
+        """
+        {"_issues": {"validator exception": "403: The event is locked by you in another session"}, "_status": "ERR"}
+        """
+        When we perform update_time on events "event3"
+        """
+        {
+            "dates": {
+                "start": "2029-11-21T02:00:00.000Z",
+                "end": "2029-11-21T04:00:00.000Z",
+                "tz": "Australia/Sydney"
+            }
+        }
+        """
+        Then we get error 400
+        """
+        {"_issues": {"validator exception": "403: The event is locked by another user"}, "_status": "ERR"}
+        """
+        When we perform update_time on events "event4"
+        """
+        {
+            "dates": {
+                "start": "2029-11-21T02:00:00.000Z",
+                "end": "2029-11-21T04:00:00.000Z",
+                "tz": "Australia/Sydney"
+            }
+        }
+        """
+        Then we get error 400
+        """
+        {"_issues": {"validator exception": "403: The lock must be for the `update time` action"}, "_status": "ERR"}
+        """
+
+    @auth
+    @notification
+    Scenario: Update time of a all events in a series of recurring events
+        Given we have sessions "/sessions"
+        When we post to "events"
+        """
+        [{
+            "name": "Friday Club",
+            "dates": {
+                "start": "2029-11-21T12:00:00.000Z",
+                "end": "2029-11-21T14:00:00.000Z",
+                "tz": "Australia/Sydney",
+                "recurring_rule": {
+                    "frequency": "DAILY",
+                    "interval": 1,
+                    "count": 4,
+                    "endRepeatMode": "count"
+                }
+            },
+            "state": "draft"
+        }]
+        """
+        Then we get OK response
+        Then we store "EVENT1" with first item
+        Then we store "EVENT2" with 2 item
+        Then we store "EVENT3" with 3 item
+        Then we store "EVENT4" with 4 item
+        When we post to "/events/#EVENT2._id#/lock" with success
+        """
+        {"lock_action": "update_time"}
+        """
+        When we reset notifications
+        When we perform update_time on events "#EVENT2._id#"
+        """
+        {
+            "dates": {
+                "start": "2029-11-22T02:00:00.000Z",
+                "end": "2029-11-22T04:00:00.000Z",
+                "tz": "Australia/Sydney"
+            },
+            "update_method": "all"
+        }
+        """
+        Then we get OK response
+        And we get notifications
+        """
+        [{
+            "event": "events:unlock",
+            "extra": {"item": "#EVENT2._id#", "user": "#CONTEXT_USER_ID#"}
+        }, {
+            "event": "events:update_time:recurring",
+            "extra": {
+                "item": "#EVENT2._id#",
+                "user": "#CONTEXT_USER_ID#",
+                "session": "#SESSION_ID#",
+                "recurrence_id": "#EVENT2.recurrence_id#"
+            }
+        }]
+        """
+        When we get "events"
+        Then we get list with 4 items
+        """
+        {"_items": [{
+            "_id": "#EVENT1._id#",
+            "dates": {
+                "start": "2029-11-21T02:00:00+0000",
+                "end": "2029-11-21T04:00:00+0000",
+                "tz": "Australia/Sydney",
+                "recurring_rule": {
+                    "frequency": "DAILY",
+                    "interval": 1,
+                    "count": 4,
+                    "endRepeatMode": "count"
+                }
+            }
+        }, {
+            "_id": "#EVENT2._id#",
+            "dates": {
+                "start": "2029-11-22T02:00:00+0000",
+                "end": "2029-11-22T04:00:00+0000",
+                "tz": "Australia/Sydney",
+                "recurring_rule": {
+                    "frequency": "DAILY",
+                    "interval": 1,
+                    "count": 4,
+                    "endRepeatMode": "count"
+                }
+            }
+        }, {
+            "_id": "#EVENT3._id#",
+            "dates": {
+                "start": "2029-11-23T02:00:00+0000",
+                "end": "2029-11-23T04:00:00+0000",
+                "tz": "Australia/Sydney",
+                "recurring_rule": {
+                    "frequency": "DAILY",
+                    "interval": 1,
+                    "count": 4,
+                    "endRepeatMode": "count"
+                }
+            }
+        }, {
+            "_id": "#EVENT4._id#",
+            "dates": {
+                "start": "2029-11-24T02:00:00+0000",
+                "end": "2029-11-24T04:00:00+0000",
+                "tz": "Australia/Sydney",
+                "recurring_rule": {
+                    "frequency": "DAILY",
+                    "interval": 1,
+                    "count": 4,
+                    "endRepeatMode": "count"
+                }
+            }
+        }]}
+        """
+
+    @auth
+    @notification
+    Scenario: Update time of a all future events in a series of recurring events
+        Given we have sessions "/sessions"
+        When we post to "events"
+        """
+        [{
+            "name": "Friday Club",
+            "dates": {
+                "start": "2029-11-21T12:00:00.000Z",
+                "end": "2029-11-21T14:00:00.000Z",
+                "tz": "Australia/Sydney",
+                "recurring_rule": {
+                    "frequency": "DAILY",
+                    "interval": 1,
+                    "count": 4,
+                    "endRepeatMode": "count"
+                }
+            },
+            "state": "draft"
+        }]
+        """
+        Then we get OK response
+        Then we store "EVENT1" with first item
+        Then we store "EVENT2" with 2 item
+        Then we store "EVENT3" with 3 item
+        Then we store "EVENT4" with 4 item
+        When we post to "/events/#EVENT2._id#/lock" with success
+        """
+        {"lock_action": "update_time"}
+        """
+        When we reset notifications
+        When we perform update_time on events "#EVENT2._id#"
+        """
+        {
+            "dates": {
+                "start": "2029-11-22T02:00:00.000Z",
+                "end": "2029-11-22T04:00:00.000Z",
+                "tz": "Australia/Sydney"
+            },
+            "update_method": "future"
+        }
+        """
+        Then we get OK response
+        And we get notifications
+        """
+        [{
+            "event": "events:unlock",
+            "extra": {"item": "#EVENT2._id#", "user": "#CONTEXT_USER_ID#"}
+        }, {
+            "event": "events:update_time:recurring",
+            "extra": {
+                "item": "#EVENT2._id#",
+                "user": "#CONTEXT_USER_ID#",
+                "session": "#SESSION_ID#",
+                "recurrence_id": "#EVENT2.recurrence_id#"
+            }
+        }]
+        """
+        When we get "events"
+        Then we get list with 4 items
+        """
+        {"_items": [{
+            "_id": "#EVENT1._id#",
+            "dates": {
+                "start": "2029-11-21T12:00:00+0000",
+                "end": "2029-11-21T14:00:00+0000",
+                "tz": "Australia/Sydney",
+                "recurring_rule": {
+                    "frequency": "DAILY",
+                    "interval": 1,
+                    "count": 4,
+                    "endRepeatMode": "count"
+                }
+            }
+        }, {
+            "_id": "#EVENT2._id#",
+            "dates": {
+                "start": "2029-11-22T02:00:00+0000",
+                "end": "2029-11-22T04:00:00+0000",
+                "tz": "Australia/Sydney",
+                "recurring_rule": {
+                    "frequency": "DAILY",
+                    "interval": 1,
+                    "count": 4,
+                    "endRepeatMode": "count"
+                }
+            }
+        }, {
+            "_id": "#EVENT3._id#",
+            "dates": {
+                "start": "2029-11-23T02:00:00+0000",
+                "end": "2029-11-23T04:00:00+0000",
+                "tz": "Australia/Sydney",
+                "recurring_rule": {
+                    "frequency": "DAILY",
+                    "interval": 1,
+                    "count": 4,
+                    "endRepeatMode": "count"
+                }
+            }
+        }, {
+            "_id": "#EVENT4._id#",
+            "dates": {
+                "start": "2029-11-24T02:00:00+0000",
+                "end": "2029-11-24T04:00:00+0000",
+                "tz": "Australia/Sydney",
+                "recurring_rule": {
+                    "frequency": "DAILY",
+                    "interval": 1,
+                    "count": 4,
+                    "endRepeatMode": "count"
+                }
+            }
+        }]}
+        """
+
+    @auth
+    @notification
+    Scenario: Update time of a single event in a series of recurring events
+        Given we have sessions "/sessions"
+        When we post to "events"
+        """
+        [{
+            "name": "Friday Club",
+            "dates": {
+                "start": "2029-11-21T12:00:00.000Z",
+                "end": "2029-11-21T14:00:00.000Z",
+                "tz": "Australia/Sydney",
+                "recurring_rule": {
+                    "frequency": "DAILY",
+                    "interval": 1,
+                    "count": 4,
+                    "endRepeatMode": "count"
+                }
+            },
+            "state": "draft"
+        }]
+        """
+        Then we get OK response
+        Then we store "EVENT1" with first item
+        Then we store "EVENT2" with 2 item
+        Then we store "EVENT3" with 3 item
+        Then we store "EVENT4" with 4 item
+        When we post to "/events/#EVENT2._id#/lock" with success
+        """
+        {"lock_action": "update_time"}
+        """
+        When we reset notifications
+        When we perform update_time on events "#EVENT2._id#"
+        """
+        {
+            "dates": {
+                "start": "2029-11-22T02:00:00.000Z",
+                "end": "2029-11-22T04:00:00.000Z",
+                "tz": "Australia/Sydney"
+            },
+            "update_method": "single"
+        }
+        """
+        Then we get OK response
+
+        And we get notifications
+        """
+        [{
+            "event": "events:unlock",
+            "extra": {"item": "#EVENT2._id#", "user": "#CONTEXT_USER_ID#"}
+        }, {
+            "event": "events:update_time:recurring",
+            "extra": {
+                "item": "#EVENT2._id#",
+                "user": "#CONTEXT_USER_ID#",
+                "session": "#SESSION_ID#",
+                "recurrence_id": "#EVENT2.recurrence_id#"
+            }
+        }]
+        """
+        When we get "events"
+        Then we get list with 4 items
+        """
+        {"_items": [{
+            "_id": "#EVENT1._id#",
+            "dates": {
+                "start": "2029-11-21T12:00:00+0000",
+                "end": "2029-11-21T14:00:00+0000",
+                "tz": "Australia/Sydney",
+                "recurring_rule": {
+                    "frequency": "DAILY",
+                    "interval": 1,
+                    "count": 4,
+                    "endRepeatMode": "count"
+                }
+            }
+        }, {
+            "_id": "#EVENT2._id#",
+            "dates": {
+                "start": "2029-11-22T02:00:00+0000",
+                "end": "2029-11-22T04:00:00+0000",
+                "tz": "Australia/Sydney",
+                "recurring_rule": {
+                    "frequency": "DAILY",
+                    "interval": 1,
+                    "count": 4,
+                    "endRepeatMode": "count"
+                }
+            }
+        }, {
+            "_id": "#EVENT3._id#",
+            "dates": {
+                "start": "2029-11-23T12:00:00+0000",
+                "end": "2029-11-23T14:00:00+0000",
+                "tz": "Australia/Sydney",
+                "recurring_rule": {
+                    "frequency": "DAILY",
+                    "interval": 1,
+                    "count": 4,
+                    "endRepeatMode": "count"
+                }
+            }
+        }, {
+            "_id": "#EVENT4._id#",
+            "dates": {
+                "start": "2029-11-24T12:00:00+0000",
+                "end": "2029-11-24T14:00:00+0000",
+                "tz": "Australia/Sydney",
+                "recurring_rule": {
+                    "frequency": "DAILY",
+                    "interval": 1,
+                    "count": 4,
+                    "endRepeatMode": "count"
+                }
+            }
+        }]}
+        """

--- a/server/planning/events/__init__.py
+++ b/server/planning/events/__init__.py
@@ -19,6 +19,7 @@ from .events_publish import EventsPublishService, EventsPublishResource
 from .events_cancel import EventsCancelService, EventsCancelResource
 from .events_reschedule import EventsRescheduleService, EventsRescheduleResource
 from .events_postpone import EventsPostponeService, EventsPostponeResource
+from .events_update_time import EventsUpdateTimeService, EventsUpdateTimeResource
 
 
 def init_app(app):
@@ -74,6 +75,16 @@ def init_app(app):
 
     events_duplicate_service = EventsDuplicateService('events_duplicate', backend=superdesk.get_backend())
     EventsDuplicateResource('events_duplicate', app=app, service=events_duplicate_service)
+
+    events_update_time_service = EventsUpdateTimeService(
+        EventsUpdateTimeResource.endpoint_name,
+        backend=superdesk.get_backend()
+    )
+    EventsUpdateTimeResource(
+        EventsUpdateTimeResource.endpoint_name,
+        app=app,
+        service=events_update_time_service
+    )
 
     app.on_updated_events += events_history_service.on_item_updated
     app.on_inserted_events += events_history_service.on_item_created

--- a/server/planning/events/events_base_service.py
+++ b/server/planning/events/events_base_service.py
@@ -1,0 +1,193 @@
+# -*- coding: utf-8; -*-
+#
+# This file is part of Superdesk.
+#
+# Copyright 2013, 2014, 2015, 2016, 2017, 2018 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+
+from superdesk.errors import SuperdeskApiError
+from superdesk.services import BaseService
+from superdesk.notification import push_notification
+from superdesk.utc import utcnow
+from apps.auth import get_user_id
+from apps.archive.common import get_auth
+
+from planning.common import UPDATE_SINGLE
+from planning.item_lock import LOCK_USER, LOCK_SESSION, LOCK_ACTION
+
+from eve.utils import config, ParsedRequest
+from flask import json
+
+
+class EventsBaseService(BaseService):
+    """
+    Base class for Event action endpoints
+
+    Provides common functionality to be used for event actions.
+    Implement `update_single_event` and `update_recurring_events` based on the
+    type of event that is being actioned against.
+    """
+
+    ACTION = ''
+
+    def on_update(self, updates, original):
+        """
+        Process the action on the event provided
+
+        Automatically sets the `version_creator`, then calls the appropriate method
+        for single event (`update_single_event`) or a series of events (`update_recurring_events`)
+        """
+        user_id = get_user_id()
+        if user_id:
+            updates['version_creator'] = user_id
+
+        # If `skip_on_update` is provided in the updates
+        # Then return here so no further processing is performed on this event.
+        if 'skip_on_update' in updates:
+            return
+
+        # We only validate the original event,
+        # not the events that are automatically updated by the system
+        self._validate(updates, original)
+
+        # Run the specific method based on if the original is a single or a series of recurring events
+        # Or if the 'update_method' is 'UPDATE_SINGLE'
+        update_method = updates.pop('update_method', UPDATE_SINGLE)
+        if not original.get('dates', {}).get('recurring_rule', None) or update_method == UPDATE_SINGLE:
+            self.update_single_event(updates, original)
+        else:
+            self.update_recurring_events(updates, original, update_method)
+
+    def update(self, id, updates, original):
+        """
+        Save the changes to the backend.
+
+        If `_deleted` is in the updates, then don't save the changes for this item.
+        This is used when updating a series of events where the selected Event is
+        deleted and a new series is generated
+        """
+        # If this Event has been deleted, then do not perform the update
+        if '_deleted' in updates:
+            return
+
+        updates.pop('skip_on_update', None)
+        return self.backend.update(self.datasource, id, updates, original)
+
+    def on_updated(self, updates, original):
+        # Because we require the original item being actioned against to be locked
+        # then we can check the lock information of original and updates to check if this
+        # event was the original event.
+        if original.get('lock_user') and 'lock_user' in updates and updates.get('lock_user') is None:
+            # when the event is unlocked by the patch.
+            push_notification(
+                'events:unlock',
+                item=str(original.get(config.ID_FIELD)),
+                user=str(get_user_id()),
+                lock_session=str(get_auth().get('_id')),
+                etag=updates.get('_etag')
+            )
+
+            self.push_notification(
+                self.ACTION,
+                updates,
+                original
+            )
+
+    def update_single_event(self, updates, original):
+        raise NotImplementedError('BaseService._update_single_event not implemented')
+
+    def update_recurring_events(self, updates, original, update_method):
+        raise NotImplementedError('BaseService._update_recurring_events not implemented')
+
+    def _validate(self, updates, original):
+        """
+        Generic validation for event actions
+
+        A lock must be held by the user in their current session
+        As well as the lock must solely be for the action being processed,
+        i.e. lock_action='update_time'
+        """
+        if not original:
+            raise SuperdeskApiError.notFoundError()
+
+        user_id = get_user_id()
+        session_id = get_auth().get(config.ID_FIELD, None)
+
+        lock_user = original.get(LOCK_USER, None)
+        lock_session = original.get(LOCK_SESSION, None)
+        lock_action = original.get(LOCK_ACTION, None)
+
+        if not lock_user:
+            raise SuperdeskApiError.forbiddenError(message='The event must be locked')
+        elif str(lock_user) != str(user_id):
+            raise SuperdeskApiError.forbiddenError(message='The event is locked by another user')
+        elif str(lock_session) != str(session_id):
+            raise SuperdeskApiError.forbiddenError(message='The event is locked by you in another session')
+        elif str(lock_action) != self.ACTION:
+            raise SuperdeskApiError.forbiddenError(
+                message='The lock must be for the `{}` action'.format(self.ACTION.lower().replace('_', ' '))
+            )
+
+    @staticmethod
+    def set_planning_schedule(event):
+        if event and event.get('dates') and event['dates'].get('start'):
+            event['_planning_schedule'] = [
+                {'scheduled': event['dates']['start']}
+            ]
+
+    @staticmethod
+    def push_notification(name, updates, original):
+        session = get_auth().get(config.ID_FIELD, '')
+
+        data = {
+            'item': str(original.get(config.ID_FIELD)),
+            'user': str(updates.get('version_creator', '')),
+            'session': str(session)
+        }
+
+        if original.get('dates', {}).get('recurring_rule', None):
+            data['recurrence_id'] = str(updates.get('recurrence_id', original.get('recurrence_id', '')))
+            name += ':recurring'
+
+        push_notification(
+            'events:' + name,
+            **data
+        )
+
+    def get_recurring_timeline(self, selected):
+        """Utility method to get all events in the series
+
+        This splits up the series of events into 3 separate arrays.
+        Historic: event.dates.start < utcnow()
+        Past: utcnow() < event.dates.start < selected.dates.start
+        Future: event.dates.start > selected.dates.start
+        """
+        historic = []
+        past = []
+        future = []
+
+        selected_start = selected.get('dates', {}).get('start', utcnow())
+
+        req = ParsedRequest()
+        req.sort = '[("dates.start", 1)]'
+        req.where = json.dumps({
+            '$and': [
+                {'recurrence_id': selected['recurrence_id']},
+                {'_id': {'$ne': selected[config.ID_FIELD]}}
+            ]
+        })
+
+        for event in list(self.get_from_mongo(req, {})):
+            end = event['dates']['end']
+            start = event['dates']['start']
+            if end < utcnow():
+                historic.append(event)
+            elif start < selected_start:
+                past.append(event)
+            elif start > selected_start:
+                future.append(event)
+
+        return historic, past, future

--- a/server/planning/events/events_schema.py
+++ b/server/planning/events/events_schema.py
@@ -1,0 +1,311 @@
+# -*- coding: utf-8; -*-
+#
+# This file is part of Superdesk.
+#
+# Copyright 2013, 2014 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+
+from superdesk import Resource
+from superdesk.resource import not_analyzed
+from superdesk.metadata.item import metadata_schema, ITEM_TYPE
+from copy import deepcopy
+
+from planning.common import WORKFLOW_STATE_SCHEMA, PUBLISHED_STATE_SCHEMA, UPDATE_METHODS
+
+event_type = deepcopy(Resource.rel('events', type='string'))
+event_type['mapping'] = not_analyzed
+
+events_schema = {
+    # Identifiers
+    '_id': metadata_schema['_id'],
+    'guid': metadata_schema['guid'],
+    'unique_id': metadata_schema['unique_id'],
+    'unique_name': metadata_schema['unique_name'],
+    'version': metadata_schema['version'],
+    'ingest_id': metadata_schema['ingest_id'],
+    'recurrence_id': {
+        'type': 'string',
+        'mapping': not_analyzed,
+        'nullable': True,
+    },
+
+    # This is used when recurring series are split
+    'previous_recurrence_id': {
+        'type': 'string',
+        'mapping': not_analyzed,
+        'nullable': True
+    },
+
+    # Audit Information
+    'original_creator': metadata_schema['original_creator'],
+    'version_creator': metadata_schema['version_creator'],
+    'firstcreated': metadata_schema['firstcreated'],
+    'versioncreated': metadata_schema['versioncreated'],
+
+    # Ingest Details
+    'ingest_provider': metadata_schema['ingest_provider'],
+    'source': metadata_schema['source'],
+    'original_source': metadata_schema['original_source'],
+    'ingest_provider_sequence': metadata_schema['ingest_provider_sequence'],
+
+    'event_created': {
+        'type': 'datetime'
+    },
+    'event_lastmodified': {
+        'type': 'datetime'
+    },
+    # Event Details
+    # NewsML-G2 Event properties See IPTC-G2-Implementation_Guide 15.2
+    'name': {
+        'type': 'string',
+        'required': True,
+    },
+    'definition_short': {'type': 'string'},
+    'definition_long': {'type': 'string'},
+    'internal_note': {'type': 'string'},
+    'anpa_category': metadata_schema['anpa_category'],
+    'files': {
+        'type': 'list',
+        'nullable': True,
+        'schema': Resource.rel('events_files'),
+        'mapping': not_analyzed,
+    },
+    'relationships': {
+        'type': 'dict',
+        'schema': {
+            'broader': {'type': 'string'},
+            'narrower': {'type': 'string'},
+            'related': {'type': 'string'}
+        },
+    },
+    'links': {
+        'type': 'list',
+        'nullable': True
+    },
+
+    # NewsML-G2 Event properties See IPTC-G2-Implementation_Guide 15.4.3
+    'dates': {
+        'type': 'dict',
+        'schema': {
+            'start': {'type': 'datetime'},
+            'end': {'type': 'datetime'},
+            'tz': {'type': 'string'},
+            'duration': {'type': 'string'},
+            'confirmation': {'type': 'string'},
+            'recurring_date': {
+                'type': 'list',
+                'nullable': True,
+                'mapping': {
+                    'type': 'date'
+                }
+            },
+            'recurring_rule': {
+                'type': 'dict',
+                'schema': {
+                    'frequency': {'type': 'string'},
+                    'interval': {'type': 'integer'},
+                    'endRepeatMode': {
+                        'type': 'string',
+                        'allowed': ['count', 'until']
+                    },
+                    'until': {'type': 'datetime', 'nullable': True},
+                    'count': {'type': 'integer', 'nullable': True},
+                    'bymonth': {'type': 'string', 'nullable': True},
+                    'byday': {'type': 'string', 'nullable': True},
+                    'byhour': {'type': 'string', 'nullable': True},
+                    'byminute': {'type': 'string', 'nullable': True},
+                },
+                'nullable': True
+            },
+            'occur_status': {
+                'nullable': True,
+                'type': 'dict',
+                'mapping': {
+                    'properties': {
+                        'qcode': not_analyzed,
+                        'name': not_analyzed
+                    }
+                },
+                'schema': {
+                    'qcode': {'type': 'string'},
+                    'name': {'type': 'string'},
+                }
+            },
+            'ex_date': {
+                'type': 'list',
+                'mapping': {
+                    'type': 'date'
+                }
+            },
+            'ex_rule': {
+                'type': 'dict',
+                'schema': {
+                    'frequency': {'type': 'string'},
+                    'interval': {'type': 'string'},
+                    'until': {'type': 'datetime', 'nullable': True},
+                    'count': {'type': 'integer', 'nullable': True},
+                    'bymonth': {'type': 'string', 'nullable': True},
+                    'byday': {'type': 'string', 'nullable': True},
+                    'byhour': {'type': 'string', 'nullable': True},
+                    'byminute': {'type': 'string', 'nullable': True}
+                }
+            }
+        }
+    },  # end dates
+    # This is a extra field so that we can sort in the combined view of events and planning.
+    # It will store the dates.start of the event.
+    '_planning_schedule': {
+        'type': 'list',
+        'mapping': {
+            'type': 'nested',
+            'properties': {
+                'scheduled': {'type': 'date'},
+            }
+        }
+    },
+    'occur_status': {
+        'type': 'dict',
+        'schema': {
+            'qcode': {'type': 'string'},
+            'name': {'type': 'string'},
+            'label': {'type': 'string'}
+        }
+    },
+    'news_coverage_status': {
+        'type': 'dict',
+        'schema': {
+            'qcode': {'type': 'string'},
+            'name': {'type': 'string'}
+        }
+    },
+    'registration': {
+        'type': 'string'
+    },
+    'access_status': {
+        'type': 'list',
+        'mapping': {
+            'properties': {
+                'qcode': not_analyzed,
+                'name': not_analyzed
+            }
+        }
+    },
+
+    # Content metadata
+    'subject': metadata_schema['subject'],
+    'slugline': metadata_schema['slugline'],
+
+    # Item metadata
+    'location': {
+        'type': 'list',
+        'mapping': {
+            'properties': {
+                'qcode': {'type': 'string'},
+                'name': {'type': 'string'},
+                'address': {'type': 'object'},
+                'geo': {'type': 'string'},
+                'location': {'type': 'geo_point'},
+            }
+        },
+        'nullable': True
+    },
+    'participant': {
+        'type': 'list',
+        'mapping': {
+            'properties': {
+                'qcode': not_analyzed,
+                'name': not_analyzed
+            }
+        }
+    },
+    'participant_requirement': {
+        'type': 'list',
+        'mapping': {
+            'properties': {
+                'qcode': not_analyzed,
+                'name': not_analyzed
+            }
+        }
+    },
+    'organizer': {
+        'type': 'list',
+        'mapping': {
+            'properties': {
+                'qcode': not_analyzed,
+                'name': not_analyzed
+            }
+        }
+    },
+    'event_contact_info': {
+        'type': 'list',
+        'schema': Resource.rel('contacts'),
+        'mapping': not_analyzed
+    },
+    'event_language': {  # TODO: this is only placeholder schema
+        'type': 'list',
+        'mapping': {
+            'properties': {
+                'qcode': not_analyzed,
+                'name': not_analyzed
+            }
+        }
+    },
+
+    # These next two are for spiking/unspiking and purging events
+    'state': WORKFLOW_STATE_SCHEMA,
+    'expiry': {
+        'type': 'datetime',
+        'nullable': True
+    },
+    # says if the event is for internal usage or published
+    'pubstatus': PUBLISHED_STATE_SCHEMA,
+
+    'lock_user': metadata_schema['lock_user'],
+    'lock_time': metadata_schema['lock_time'],
+    'lock_session': metadata_schema['lock_session'],
+    'lock_action': metadata_schema['lock_action'],
+
+    # The update method used for recurring events
+    'update_method': {
+        'type': 'string',
+        'allowed': UPDATE_METHODS,
+        'mapping': not_analyzed,
+        'nullable': True
+    },
+
+    # Item type used by superdesk publishing
+    ITEM_TYPE: {
+        'type': 'string',
+        'mapping': not_analyzed,
+        'default': 'event',
+    },
+
+    # Named Calendars
+    'calendars': {
+        'type': 'list',
+        'nullable': True,
+        'mapping': {
+            'type': 'object',
+            'properties': {
+                'qcode': not_analyzed,
+                'name': not_analyzed,
+            }
+        }
+    },
+
+    # The previous state the item was in before for example being spiked,
+    # when un-spiked it will revert to this state
+    'revert_state': metadata_schema['revert_state'],
+
+    # Used when duplicating/rescheduling of Events
+    'duplicate_from': event_type,
+    'duplicate_to': {
+        'type': 'list',
+        'nullable': True,
+        'schema': Resource.rel('events', type='string'),
+        'mapping': not_analyzed
+    }
+}  # end events_schema

--- a/server/planning/events/events_update_time.py
+++ b/server/planning/events/events_update_time.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8; -*-
+#
+# This file is part of Superdesk.
+#
+# Copyright 2013, 2014 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+
+from superdesk import get_resource_service
+from superdesk.errors import SuperdeskApiError
+from flask import current_app as app
+from eve.utils import config
+from copy import deepcopy
+
+from .events import EventsResource, events_schema
+from planning.common import remove_lock_information, UPDATE_FUTURE
+from .events_base_service import EventsBaseService
+
+
+class EventsUpdateTimeResource(EventsResource):
+    url = 'events/update_time'
+    resource_title = endpoint_name = 'events_update_time'
+
+    datasource = {'source': 'events'}
+
+    resource_methods = []
+    item_methods = ['PATCH']
+    privileges = {'PATCH': 'planning_event_management'}
+
+    schema = events_schema
+
+
+class EventsUpdateTimeService(EventsBaseService):
+    ACTION = 'update_time'
+
+    def update_single_event(self, updates, original):
+        # Release the Lock on the selected Event
+        remove_lock_information(updates)
+
+        # Set '_planning_schedule' on the Event item
+        self.set_planning_schedule(updates)
+
+    def update_recurring_events(self, updates, original, update_method):
+        events_service = get_resource_service('events')
+        historic, past, future = events_service.get_recurring_timeline(original)
+
+        # Determine if the selected event is the first one, if so then
+        # act as if we're changing future events
+        if len(historic) == 0 and len(past) == 0:
+            update_method = UPDATE_FUTURE
+
+        if update_method == UPDATE_FUTURE:
+            new_series = [original] + future
+        else:
+            new_series = past + [original] + future
+
+        # Release the Lock on the selected Event
+        remove_lock_information(updates)
+
+        # Calculate the delta between the original date/time and the updated date/time
+        start_delta = updates['dates']['start'] - original['dates']['start']
+        end_delta = updates['dates']['end'] - original['dates']['end']
+
+        for event in new_series:
+            if not event.get(config.ID_FIELD):
+                continue
+
+            new_updates = {'dates': deepcopy(event['dates'])}
+
+            # Add the delta to the events original date/time
+            new_updates['dates']['start'] = event['dates']['start'] + start_delta
+            new_updates['dates']['end'] = event['dates']['end'] + end_delta
+
+            # Set '_planning_schedule' on the Event item
+            self.set_planning_schedule(new_updates)
+
+            if event.get(config.ID_FIELD) != original.get(config.ID_FIELD):
+                new_updates['skip_on_update'] = True
+                self.patch(event[config.ID_FIELD], new_updates)
+                app.on_updated_events_update_time(new_updates, {'_id': event[config.ID_FIELD]})
+
+    def _validate(self, updates, original):
+        super()._validate(updates, original)
+
+        if not updates.get('dates'):
+            raise SuperdeskApiError.badRequestError('No new time was provided')
+        elif not updates['dates'].get('start'):
+            raise SuperdeskApiError.badRequestError('No start time was provided')
+        elif not updates['dates'].get('end'):
+            raise SuperdeskApiError.badRequestError('No end time was provided')


### PR DESCRIPTION


* Moved 'update_time' action to a dedicated endpoint
* Created a base class for all Event action endpoints to use
* Removed code for the deprecated action of removing recurring rules from an Event