### PR TITLE
[SDESK-2569] Add Editorial Note to the Event schema

### DIFF
--- a/client/actions/agenda.js
+++ b/client/actions/agenda.js
@@ -240,6 +240,7 @@ const _createPlanningFromEvent = (event, planningDate) => (
             subject: event.subject,
             anpa_category: event.anpa_category,
             description_text: event.definition_short,
+            ednote: event.ednote,
             agendas: [],
         }));
     }

--- a/client/actions/tests/agenda_test.js
+++ b/client/actions/tests/agenda_test.js
@@ -371,6 +371,7 @@ describe('agenda', () => {
                     state: 'Australian Capital Territory',
                     world_region: 'Oceania'
                 }];
+                events[0].ednote = 'Editorial note about this Event';
                 const action = actions.addEventToCurrentAgenda(events[0]);
 
                 return action(dispatch, getState, {
@@ -399,6 +400,7 @@ describe('agenda', () => {
                                     world_region: 'Oceania'
                                 }],
                                 internal_note: 'internal note',
+                                ednote: 'Editorial note about this Event'
                             },
                         ]);
 

--- a/client/components/AssignmentPreviewContainer/EventPreview.jsx
+++ b/client/components/AssignmentPreviewContainer/EventPreview.jsx
@@ -6,6 +6,7 @@ import * as selectors from '../../selectors';
 import {get} from 'lodash';
 import {Datetime} from '../../components';
 import {Location} from '../Location';
+import {gettext} from '../../utils';
 
 
 // eslint-disable-next-line complexity
@@ -23,7 +24,7 @@ export const EventPreviewComponent = ({item, formProfile, createLink, streetMapU
             {get(formProfile, 'editor.name.enabled') &&
                 <div className="form__row">
                     <label className="form-label form-label--light">
-                        Name
+                        {gettext('Name')}
                     </label>
                     <p>
                         {item.name || '-'}
@@ -34,7 +35,7 @@ export const EventPreviewComponent = ({item, formProfile, createLink, streetMapU
             {get(formProfile, 'editor.definition_short.enabled') &&
                 <div className="form__row">
                     <label className="form-label form-label--light">
-                        Description
+                        {gettext('Description')}
                     </label>
                     <p>
                         {item.definition_short || '-'}
@@ -45,13 +46,13 @@ export const EventPreviewComponent = ({item, formProfile, createLink, streetMapU
             <div className="form__row form__row--flex EventDates">
                 <div className="form__row-item">
                     <label className="form-label form-label--light">
-                        From
+                        {gettext('From')}
                     </label>
                     <p><Datetime date={get(item, 'dates.start')}/></p>
                 </div>
                 <div className="form__row-item">
                     <label className="form-label form-label--light">
-                        To
+                        {gettext('To')}
                     </label>
                     <p><Datetime date={get(item, 'dates.end')}/></p>
                 </div>
@@ -59,7 +60,7 @@ export const EventPreviewComponent = ({item, formProfile, createLink, streetMapU
 
             <div className="form__row">
                 <label className="form-label form-label--light">
-                    Location
+                    {gettext('Location')}
                 </label>
                 {(locationName || formattedAddress) &&
                     <span className="addgeolookup__input-wrapper">
@@ -79,7 +80,7 @@ export const EventPreviewComponent = ({item, formProfile, createLink, streetMapU
             {get(formProfile, 'editor.definition_long.enabled') &&
                 <div className="form__row">
                     <label className="form-label form-label--light">
-                        Long Description
+                        {gettext('Long Description')}
                     </label>
                     <TextareaAutosize
                         value={item.definition_long || '-'}
@@ -88,10 +89,22 @@ export const EventPreviewComponent = ({item, formProfile, createLink, streetMapU
                 </div>
             }
 
+            {get(formProfile, 'editor.ednote.enabled') &&
+                <div className="form__row">
+                    <label className="form-label form-label--light">
+                        {gettext('Ed Note')}
+                    </label>
+                    <TextareaAutosize
+                        value={item.ednote || '-'}
+                        disabled={true}
+                    />
+                </div>
+            }
+
 
             <div className="form__row">
                 <label className="form-label form-label--light">
-                    Occurrence status
+                    {gettext('Occurrence status')}
                 </label>
                 <p>
                     {get(item.occur_status, 'label') ||
@@ -103,7 +116,7 @@ export const EventPreviewComponent = ({item, formProfile, createLink, streetMapU
             {get(formProfile, 'editor.links.enabled') &&
                 <div className="form__row">
                     <label className="form-label form-label--light">
-                        Links
+                        {gettext('Links')}
                     </label>
 
                     {get(item, 'links.length', 0) &&
@@ -128,7 +141,7 @@ export const EventPreviewComponent = ({item, formProfile, createLink, streetMapU
             {get(formProfile, 'editor.files.enabled') &&
                 <div className="form__row">
                     <label className="form-label form-label--light">
-                        Attachments
+                        {gettext('Attachments')}
                     </label>
 
                     {get(item, 'files.length', 0) &&

--- a/client/components/Events/EventEditor/index.jsx
+++ b/client/components/Events/EventEditor/index.jsx
@@ -33,6 +33,7 @@ const toggleDetails = [
     'subject',
     'definition_long',
     'internal_note',
+    'ednote'
 ];
 
 export class EventEditorComponent extends React.Component {
@@ -118,25 +119,27 @@ export class EventEditorComponent extends React.Component {
                         refNode={(node) => this.dom.slugline = node}
                         {...fieldProps}
                     />
+
                     <Field
                         component={TextInput}
                         field="name"
                         label={gettext('Name')}
                         {...fieldProps}
                     />
+
                     <Field
                         component={TextAreaInput}
                         field="definition_short"
                         label={gettext('Description')}
                         {...fieldProps}
                     />
+
                     <Field
                         component={SelectInput}
                         field="occur_status"
                         label={gettext('Occurrence Status')}
                         defaultValue={EVENTS.DEFAULT_VALUE(occurStatuses).occur_status}
                         options={occurStatuses}
-                        noMargin={true}
                         {...fieldProps}
                     />
 
@@ -211,10 +214,18 @@ export class EventEditorComponent extends React.Component {
                             label={gettext('Long Description')}
                             {...fieldProps}
                         />
+
                         <Field
                             component={TextAreaInput}
                             field="internal_note"
                             label={gettext('Internal Note')}
+                            {...fieldProps}
+                        />
+
+                        <Field
+                            component={TextAreaInput}
+                            field="ednote"
+                            label={gettext('Ed Note')}
                             noMargin={true}
                             {...fieldProps}
                         />

--- a/client/components/Events/EventPreviewContent.jsx
+++ b/client/components/Events/EventPreviewContent.jsx
@@ -229,6 +229,11 @@ export class EventPreviewContentComponent extends React.Component {
                         label={gettext('Internal Note')}
                         value={item.internal_note || ''}
                     />
+                    <Row
+                        enabled={get(formProfile, 'editor.ednote.enabled')}
+                        label={gettext('Ed Note')}
+                        value={item.ednote || ''}
+                    />
                 </ToggleBox>
                 {get(formProfile, 'editor.files.enabled') &&
                     <ToggleBox title={gettext('Attached Files')} isOpen={false}>

--- a/client/reducers/events.js
+++ b/client/reducers/events.js
@@ -219,19 +219,19 @@ const eventsReducer = createReducer(initialState, {
         let events = cloneDeep(state.events);
         let event = events[payload.event._id];
 
-        let definition = `------------------------------------------------------------
+        let ednote = `------------------------------------------------------------
 Event Postponed
 `;
 
         if (get(payload, 'reason', null) !== null) {
-            definition += `Reason: ${payload.reason}\n`;
+            ednote += `Reason: ${payload.reason}\n`;
         }
 
-        if (get(event, 'definition_long', null) !== null) {
-            definition = `${event.definition_long}\n\n${definition}`;
+        if (get(event, 'ednote', null) !== null) {
+            ednote = `${event.ednote}\n\n${ednote}`;
         }
 
-        event.definition_long = definition;
+        event.ednote = ednote;
         event.state = WORKFLOW_STATE.POSTPONED;
 
         removeLock(event);
@@ -338,19 +338,19 @@ const markEventCancelled = (events, eventId, etag, reason, occurStatus) => {
 
     let updatedEvent = events[eventId];
 
-    let definition = `------------------------------------------------------------
+    let ednote = `------------------------------------------------------------
 Event Cancelled
 `;
 
     if (reason !== null) {
-        definition += `Reason: ${reason}\n`;
+        ednote += `Reason: ${reason}\n`;
     }
 
-    if (get(updatedEvent, 'definition_long', null) !== null) {
-        definition = `${updatedEvent.definition_long}\n\n${definition}`;
+    if (get(updatedEvent, 'ednote', null) !== null) {
+        ednote = `${updatedEvent.ednote}\n\n${ednote}`;
     }
 
-    updatedEvent.definition_long = definition;
+    updatedEvent.ednote = ednote;
     updatedEvent.state = WORKFLOW_STATE.CANCELLED;
     updatedEvent.occur_status = occurStatus;
     updatedEvent._etag = etag;

--- a/client/utils/testData.js
+++ b/client/utils/testData.js
@@ -74,6 +74,8 @@ export const formsProfile = {
             internal_note: {enabled: true},
             location: {enabled: true},
             dates: {enabled: true},
+            place: {enabled: true},
+            ednote: {enabled: true},
         },
         schema: {
             files: {
@@ -161,6 +163,16 @@ export const formsProfile = {
                 type: 'string',
                 required: false,
                 maxlength: null,
+            },
+            place: {
+                mandatory_in_list: null,
+                schema: null,
+                type: 'list',
+                required: false,
+            },
+            ednote: {
+                type: 'string',
+                required: false,
             },
         },
     },

--- a/client/validators/index.js
+++ b/client/validators/index.js
@@ -109,6 +109,7 @@ export const validators = {
         occur_status: [formProfile],
         slugline: [formProfile],
         dates: [eventValidators.validateDates],
+        ednote: [formProfile],
     },
     planning: {
         planning_date: [formProfile],

--- a/server/features/events_cancel.feature
+++ b/server/features/events_cancel.feature
@@ -370,7 +370,7 @@ Feature: Events Cancel
                 "end": "2029-11-21T14:00:00.000Z",
                 "tz": "Australia/Sydney"
             },
-            "definition_long":  "An event with exciting things",
+            "ednote":  "An event with exciting things",
             "occur_status": {
                 "qcode": "eocstat:eos5",
                 "name": "Planned, occurs certainly"
@@ -421,7 +421,7 @@ Feature: Events Cancel
         {"_items":[{
             "_id": "event1",
             "state": "cancelled",
-            "definition_long": "An event with exciting things\n\n------------------------------------------------------------\nEvent Cancelled\nReason: Not happening anymore!\n",
+            "ednote": "An event with exciting things\n\n------------------------------------------------------------\nEvent Cancelled\nReason: Not happening anymore!\n",
             "occur_status": {"qcode": "eocstat:eos6"},
             "lock_user": null,
             "lock_session": null,

--- a/server/features/events_postpone.feature
+++ b/server/features/events_postpone.feature
@@ -336,7 +336,7 @@ Feature: Events Postpone
                 "end": "2029-11-21T14:00:00.000Z",
                 "tz": "Australia/Sydney"
             },
-            "definition_long":  "An event with exciting things",
+            "ednote":  "An event with exciting things",
             "occur_status": {
                 "qcode": "eocstat:eos5",
                 "name": "Planned, occurs certainly"
@@ -387,7 +387,7 @@ Feature: Events Postpone
         {"_items":[{
             "_id": "event1",
             "state": "postponed",
-            "definition_long": "An event with exciting things\n\n------------------------------------------------------------\nEvent Postponed\nReason: Not happening anymore!\n"
+            "ednote": "An event with exciting things\n\n------------------------------------------------------------\nEvent Postponed\nReason: Not happening anymore!\n"
         }]}
         """
         When we get "/planning"
@@ -526,7 +526,7 @@ Feature: Events Postpone
                 "end": "2029-11-21T14:00:00.000Z",
                 "tz": "Australia/Sydney"
             },
-            "definition_long":  "An event with exciting things",
+            "ednote":  "An event with exciting things",
             "occur_status": {
                 "qcode": "eocstat:eos5",
                 "name": "Planned, occurs certainly"
@@ -608,7 +608,7 @@ Feature: Events Postpone
         {"_items":[{
             "_id": "event1",
             "state": "postponed",
-            "definition_long": "An event with exciting things\n\n------------------------------------------------------------\nEvent Postponed\nReason: Not happening anymore!\n",
+            "ednote": "An event with exciting things\n\n------------------------------------------------------------\nEvent Postponed\nReason: Not happening anymore!\n",
             "pubstatus": "usable"
 
         }]}

--- a/server/features/events_reschedule.feature
+++ b/server/features/events_reschedule.feature
@@ -10,7 +10,7 @@ Feature: Events Reschedule
             "_id": "event1",
             "guid": "event1",
             "name": "TestEvent",
-            "definition_long": "Something happening.",
+            "ednote": "Something happening.",
             "dates": {
                 "start": "2029-11-21T12:00:00.000Z",
                 "end": "2029-11-21T14:00:00.000Z",
@@ -80,7 +80,7 @@ Feature: Events Reschedule
                 "end": "2029-11-21T14:00:00+0000",
                 "tz": "Australia/Sydney"
             },
-            "definition_long": "Something happening.\n\n------------------------------------------------------------\nEvent Rescheduled\nReason: Changed to the next day!\n"
+            "ednote": "Something happening.\n\n------------------------------------------------------------\nEvent Rescheduled\nReason: Changed to the next day!\n"
         }
         """
         When we get "/events_history"
@@ -302,7 +302,7 @@ Feature: Events Reschedule
                     "end": "2099-11-21T14:00:00+0000"
                 },
                 "recurrence_id": "#EVENT1.recurrence_id#",
-                "definition_long": "------------------------------------------------------------\nEvent Rescheduled\nReason: Changed to the next day!\n"
+                "ednote": "------------------------------------------------------------\nEvent Rescheduled\nReason: Changed to the next day!\n"
             },
             {
                 "_id": "#EVENT2._id#",
@@ -934,22 +934,22 @@ Feature: Events Reschedule
             {
                 "_id": "#EVENT1._id#",
                 "state": "postponed",
-                "definition_long": "------------------------------------------------------------\nEvent Postponed\n"
+                "ednote": "------------------------------------------------------------\nEvent Postponed\n"
             },
             {
                 "_id": "#EVENT2._id#",
                 "state": "postponed",
-                "definition_long": "------------------------------------------------------------\nEvent Postponed\n"
+                "ednote": "------------------------------------------------------------\nEvent Postponed\n"
             },
             {
                 "_id": "#EVENT3._id#",
                 "state": "postponed",
-                "definition_long": "------------------------------------------------------------\nEvent Postponed\n"
+                "ednote": "------------------------------------------------------------\nEvent Postponed\n"
             },
             {
                 "_id": "#EVENT4._id#",
                 "state": "postponed",
-                "definition_long": "------------------------------------------------------------\nEvent Postponed\n"
+                "ednote": "------------------------------------------------------------\nEvent Postponed\n"
             }
         ]}
         """
@@ -1025,7 +1025,7 @@ Feature: Events Reschedule
                     }
                 },
                 "state": "draft",
-                "definition_long": "------------------------------------------------------------\nEvent Postponed\n\n\n------------------------------------------------------------\nEvent Rescheduled\nReason: Event back on at original date and time\n"
+                "ednote": "------------------------------------------------------------\nEvent Postponed\n\n\n------------------------------------------------------------\nEvent Rescheduled\nReason: Event back on at original date and time\n"
             },
             {
                 "name": "Friday Club",
@@ -1042,7 +1042,7 @@ Feature: Events Reschedule
                     }
                 },
                 "state": "draft",
-                "definition_long": "------------------------------------------------------------\nEvent Postponed\n\n\n------------------------------------------------------------\nEvent Rescheduled\nReason: Event back on at original date and time\n"
+                "ednote": "------------------------------------------------------------\nEvent Postponed\n\n\n------------------------------------------------------------\nEvent Rescheduled\nReason: Event back on at original date and time\n"
             },
             {
                 "name": "Friday Club",
@@ -1059,7 +1059,7 @@ Feature: Events Reschedule
                     }
                 },
                 "state": "draft",
-                "definition_long": "------------------------------------------------------------\nEvent Postponed\n\n\n------------------------------------------------------------\nEvent Rescheduled\nReason: Event back on at original date and time\n"
+                "ednote": "------------------------------------------------------------\nEvent Postponed\n\n\n------------------------------------------------------------\nEvent Rescheduled\nReason: Event back on at original date and time\n"
             },
             {
                 "name": "Friday Club",
@@ -1076,7 +1076,7 @@ Feature: Events Reschedule
                     }
                 },
                 "state": "scheduled",
-                "definition_long": "------------------------------------------------------------\nEvent Postponed\n\n\n------------------------------------------------------------\nEvent Rescheduled\nReason: Event back on at original date and time\n"
+                "ednote": "------------------------------------------------------------\nEvent Postponed\n\n\n------------------------------------------------------------\nEvent Rescheduled\nReason: Event back on at original date and time\n"
             }
         ]}
         """
@@ -1228,7 +1228,7 @@ Feature: Events Reschedule
             "_id": "event1",
             "guid": "event1",
             "name": "TestEvent",
-            "definition_long": "Something happening.",
+            "ednote": "Something happening.",
             "dates": {
                 "start": "2029-11-21T12:00:00.000Z",
                 "end": "2029-11-21T14:00:00.000Z",
@@ -1319,7 +1319,7 @@ Feature: Events Reschedule
                 "end": "2029-11-21T14:00:00+0000",
                 "tz": "Australia/Sydney"
             },
-            "definition_long": "Something happening.\n\n------------------------------------------------------------\nEvent Rescheduled\nReason: Changed to the next day!\n"
+            "ednote": "Something happening.\n\n------------------------------------------------------------\nEvent Rescheduled\nReason: Changed to the next day!\n"
         }
         """
         When we get "publish_queue"

--- a/server/planning/events/events_cancel.py
+++ b/server/planning/events/events_cancel.py
@@ -113,19 +113,19 @@ class EventsCancelService(EventsBaseService):
 
         reason = updates.get('reason', None)
 
-        definition = '''------------------------------------------------------------
+        ednote = '''------------------------------------------------------------
 Event Cancelled
 '''
         if reason is not None:
-            definition += 'Reason: {}\n'.format(reason)
+            ednote += 'Reason: {}\n'.format(reason)
 
-        if 'definition_long' in original:
-            definition = original['definition_long'] + '\n\n' + definition
+        if 'ednote' in original:
+            ednote = original['ednote'] + '\n\n' + ednote
 
         remove_lock_information(updates)
         updates.update({
             'state': WORKFLOW_STATE.CANCELLED,
-            'definition_long': definition,
+            'ednote': ednote,
             'occur_status': occur_cancel_state
         })
 

--- a/server/planning/events/events_postpone.py
+++ b/server/planning/events/events_postpone.py
@@ -94,20 +94,20 @@ class EventsPostponeService(EventsBaseService):
     def _set_event_postponed(updates, original):
         reason = updates.get('reason', None)
 
-        definition = '''------------------------------------------------------------
+        ednote = '''------------------------------------------------------------
 Event Postponed
 '''
         if reason is not None:
-            definition += 'Reason: {}\n'.format(reason)
+            ednote += 'Reason: {}\n'.format(reason)
 
-        if 'definition_long' in original:
-            definition = original['definition_long'] + '\n\n' + definition
+        if 'ednote' in original:
+            ednote = original['ednote'] + '\n\n' + ednote
 
         remove_lock_information(updates)
 
         updates.update({
             'state': WORKFLOW_STATE.POSTPONED,
-            'definition_long': definition
+            'ednote': ednote
         })
 
     def update_recurring_events(self, updates, original, update_method):

--- a/server/planning/events/events_reschedule.py
+++ b/server/planning/events/events_reschedule.py
@@ -63,21 +63,22 @@ class EventsRescheduleService(EventsBaseService):
 
     @staticmethod
     def _mark_event_rescheduled(updates, original, keep_dates=False):
-        definition = '''------------------------------------------------------------
+        ednote = '''------------------------------------------------------------
 Event Rescheduled
 '''
 
         reason = updates.get('reason', None)
-        if reason is not None:
-            definition += 'Reason: {}\n'.format(reason)
 
-        if 'definition_long' in original:
-            definition = original['definition_long'] + '\n\n' + definition
+        if reason is not None:
+            ednote += 'Reason: {}\n'.format(reason)
+
+        if 'ednote' in original:
+            ednote = original['ednote'] + '\n\n' + ednote
 
         # Update the workflow state and definition of the original Event
         updates.update({
             'state': WORKFLOW_STATE.RESCHEDULED,
-            'definition_long': definition
+            'ednote': ednote
         })
 
         # We don't want to update the schedule of this current event

--- a/server/planning/events/events_schema.py
+++ b/server/planning/events/events_schema.py
@@ -313,4 +313,5 @@ events_schema = {
     'reschedule_to': event_type,
 
     'place': metadata_schema['place'],
+    'ednote': metadata_schema['ednote'],
 }  # end events_schema

--- a/server/planning/planning/planning_types.py
+++ b/server/planning/planning/planning_types.py
@@ -78,6 +78,7 @@ class EventSchema(BaseSchema):
     files = schema.ListField()
     links = schema.ListField()
     dates = schema.DictField(required=True)
+    ednote = schema.StringField()
 
 
 class PlanningSchema(BaseSchema):
@@ -143,6 +144,7 @@ DEFAULT_EDITOR = [{
             'enabled': True,
             'default_duration_on_change': 1
         },
+        'ednote': {'enabled': True}
     },
     'schema': dict(EventSchema)
 }, {


### PR DESCRIPTION
* Use 'ednote' instead of 'description_long' for action reasons (i.e. from Postpone/Reschedule/Cancel actions)
* Planning item also inherits ednote from the Event