### PR TITLE
[SDESK-2795] (fix) Don't attempt delete autosave on unlock if autosave doesn't exist

### DIFF
--- a/client/actions/locks.js
+++ b/client/actions/locks.js
@@ -76,7 +76,11 @@ const unlock = (item) => (
             break;
         }
 
-        return promise.then(() => dispatch(autosave.removeById(currentLock.item_type, currentLock.item_id)));
+        return promise.then(() => dispatch(autosave.removeById(
+            currentLock.item_type,
+            currentLock.item_id,
+            false // Don't attempt to get the autosave from the server
+        )));
     }
 );
 

--- a/client/actions/tests/autosave_test.js
+++ b/client/actions/tests/autosave_test.js
@@ -111,7 +111,7 @@ describe('actions.autosave', () => {
         it('fetchById without trying the server', (done) => (
             store.test(done, autosave.fetchById('event', 'e2', false))
                 .then((autosaveItem) => {
-                    expect(autosaveItem).toEqual({});
+                    expect(autosaveItem).toEqual(null);
                     expect(services.api('event_autosave').getById.callCount).toBe(0);
 
                     done();

--- a/client/components/Autosave/index.jsx
+++ b/client/components/Autosave/index.jsx
@@ -66,7 +66,7 @@ export class Autosave extends React.Component {
 
         return this.props.load(props.formName, id)
             .then((changes) => {
-                this.changeValues(changes, props);
+                this.changeValues(changes || {}, props);
 
                 return Promise.resolve(changes);
             });


### PR DESCRIPTION
* Removed error when creating an Event (failed to save autosave item because '_planning_item' cannot be null)