### PR TITLE
fix(planning): remove planning name from editor/preview

### DIFF
--- a/client/components/Planning/PlanningEditor/index.jsx
+++ b/client/components/Planning/PlanningEditor/index.jsx
@@ -369,8 +369,8 @@ export class PlanningEditorComponent extends React.Component {
 
                     <Field
                         component={TextInput}
-                        field="name"
-                        label={gettext('Name')}
+                        field="headline"
+                        label={gettext('Headline')}
                         {...fieldProps}
                         onFocus={onFocusPlanning}
                     />

--- a/client/components/Planning/PlanningPreviewContent.jsx
+++ b/client/components/Planning/PlanningPreviewContent.jsx
@@ -82,9 +82,9 @@ export class PlanningPreviewContentComponent extends React.Component {
                     className="slugline"
                 />
                 <Row
-                    enabled={get(formProfile, 'planning.editor.name.enabled')}
-                    label={gettext('Name')}
-                    value={item.name || ''}
+                    enabled={get(formProfile, 'planning.editor.headline.enabled')}
+                    label={gettext('headline')}
+                    value={item.headline || ''}
                 />
                 <Row
                     enabled={get(formProfile, 'planning.editor.planning_date.enabled')}

--- a/client/spec/planning/planning_autosave_spec.js
+++ b/client/spec/planning/planning_autosave_spec.js
@@ -11,7 +11,6 @@ describe('planning_autosave', () => {
     beforeEach(() => {
         plan = {
             slugline: 'Plan',
-            name: 'Namer',
             planning_date: {
                 date: '12/12/2045',
                 time: '12:13',

--- a/server/planning/planning/planning_export.py
+++ b/server/planning/planning/planning_export.py
@@ -10,7 +10,7 @@ from apps.archive.common import insert_into_versions
 
 TEMPLATE = '''
 {% for item in items %}
-<p><b>{{ item.name or item.headline or item.slugline }}</b></p>
+<p><b>{{ item.headline or item.slugline }}</b></p>
 <p>{{ item.description_text }}</p>
 <p></p>
 {% if item.get('event', {}).get('location') %}


### PR DESCRIPTION
and add headline instead. there should be no name in planning item,
but we need headline for export.