### PR TITLE
fix(feed) - Added missing parameters

### DIFF
--- a/server/planning/feeding_services/__init__.py
+++ b/server/planning/feeding_services/__init__.py
@@ -15,11 +15,11 @@ from .event_email_service import EventEmailFeedingService
 
 
 register_feeding_service(
-    EventFileFeedingService
+    EventFileFeedingService.NAME, EventFileFeedingService(), EventFileFeedingService.ERRORS
 )
 register_feeding_service(
-    EventHTTPFeedingService
+    EventHTTPFeedingService.NAME, EventHTTPFeedingService(), EventHTTPFeedingService.ERRORS
 )
 register_feeding_service(
-    EventEmailFeedingService
+    EventEmailFeedingService.NAME, EventEmailFeedingService(), EventEmailFeedingService.ERRORS
 )


### PR DESCRIPTION
Missing parameters causes the following error: `TypeError: register_feeding_service() missing 2 required positional arguments: 'service_class' and 'errors'`