### PR TITLE
[SDESK-3179] Exclude CustomVocabularies that don't have a schema_field

### DIFF
--- a/client/services/PlanningStoreService.js
+++ b/client/services/PlanningStoreService.js
@@ -243,7 +243,7 @@ export class PlanningStoreService {
                     contacts: data.contacts._items,
                     customVocabularies: this.metadata.cvs.filter((cv) =>
                         !isEmpty(cv.service) &&
-                        get(cv, 'schema_field', 'subject') === 'subject' &&
+                        get(cv, 'schema_field') === 'subject' &&
                         isEmpty(cv.field_type)
                     ),
                 };


### PR DESCRIPTION
@petrjasek If a vocab entry didn't have a schema field it would get into the CustomVocabularies and our subject would disappear.