### PR TITLE
fix(events): make occur status nullable

### DIFF
--- a/server/planning/events/events_schema.py
+++ b/server/planning/events/events_schema.py
@@ -175,6 +175,7 @@ events_schema = {
         }
     },
     'occur_status': {
+        'nullable': True,
         'type': 'dict',
         'schema': {
             'qcode': {'type': 'string'},


### PR DESCRIPTION
when there are not enough values in cv it's set to null,
but then it can't be saved.

SDESK-3759