### PR TITLE
(fix) Last day of the multi-day event was not visible in the events list.

### DIFF
--- a/client/selectors/tests/events_test.js
+++ b/client/selectors/tests/events_test.js
@@ -81,6 +81,33 @@ describe('selectors', () => {
             expect(events['2017-01-16'].events[1]._id).toBe('event2');
         });
 
+        it('all events with max start date on 2017-01-17', () => {
+            const state = getState();
+
+            state.events.events.event2.dates.start = moment('2017-01-17T08:00:00', dateFormat);
+            state.events.events.event2.dates.end = moment('2017-01-17T14:00:00', dateFormat);
+            setAdvancedSearchDates(state, '2017-01-10T00:00:00');
+            const events = keyBy(selectors.events.orderedEvents(state), 'date');
+
+            expect(Object.keys(events)).toEqual([
+                '2017-01-14',
+                '2017-01-15',
+                '2017-01-16',
+                '2017-01-17',
+            ]);
+
+            expect(events['2017-01-14'].events.length).toBe(1);
+            expect(events['2017-01-14'].events[0]._id).toBe('event3');
+            expect(events['2017-01-15'].events.length).toBe(2);
+            expect(events['2017-01-15'].events[0]._id).toBe('event3');
+            expect(events['2017-01-15'].events[1]._id).toBe('event1');
+            expect(events['2017-01-16'].events.length).toBe(1);
+            expect(events['2017-01-16'].events[0]._id).toBe('event3');
+            expect(events['2017-01-17'].events.length).toBe(2);
+            expect(events['2017-01-17'].events[0]._id).toBe('event3');
+            expect(events['2017-01-17'].events[1]._id).toBe('event2');
+        });
+
         it('for today 2017-01-15', () => {
             const state = getState();
 

--- a/client/utils/events.js
+++ b/client/utils/events.js
@@ -665,7 +665,7 @@ const getEventsByDate = (events, startDate, endDate) => {
     sortedEvents.forEach((event) => {
         // compute the number of days of the event
         if (!event.dates.start.isSame(event.dates.end, 'day')) {
-            let deltaDays = Math.max(event.dates.end.diff(event.dates.start, 'days'), 1);
+            let deltaDays = Math.max(Math.ceil(event.dates.end.diff(event.dates.start, 'days', true)), 1);
             // if the event happens during more that one day, add it to every day
             // add the event to the other days
 
@@ -675,7 +675,7 @@ const getEventsByDate = (events, startDate, endDate) => {
 
                 newDate.add(i, 'days');
 
-                if (maxStartDate.isSameOrAfter(newDate, 'day')) {
+                if (maxStartDate.isSameOrAfter(newDate, 'day') && newDate.isSameOrBefore(event.dates.end, 'day')) {
                     addEventToDate(event, newDate);
                 }
             }
@@ -716,6 +716,7 @@ const modifyForClient = (event) => {
 
     return event;
 };
+
 
 const modifyForServer = (event, removeNullLinks = false) => {
     event.location = event.location ?


### PR DESCRIPTION
`moment.diff` truncates the result to zero decimal places and an integer. Hence the last day of the multi-day event is not visible.