### PR TITLE
[EVENTS] fixed crash on missing `state_reason` + don't override reque…

### DIFF
--- a/server/planning/common.py
+++ b/server/planning/common.py
@@ -333,7 +333,9 @@ def set_ingested_event_state(updates, original):
         return
 
     # don't change status to draft when event was duplicated
-    if original.get(ITEM_STATE) == WORKFLOW_STATE.INGESTED and not updates.get('duplicate_to'):
+    if ((original.get(ITEM_STATE) == WORKFLOW_STATE.INGESTED
+         and not updates.get('duplicate_to')
+         and not updates.get(ITEM_STATE))):
         updates[ITEM_STATE] = WORKFLOW_STATE.DRAFT
 
 

--- a/server/planning/events/events.py
+++ b/server/planning/events/events.py
@@ -367,7 +367,7 @@ class EventsService(superdesk.Service):
                 new_event = get_resource_service('events').find_one(req=None,
                                                                     _id=original.get(config.ID_FIELD))
                 updates['_etag'] = new_event['_etag']
-                updates['state_reason'] = new_event['state_reason']
+                updates['state_reason'] = new_event.get('state_reason')
 
         if original.get('lock_user') and 'lock_user' in updates and updates.get('lock_user') is None:
             # when the event is unlocked by the patch.


### PR DESCRIPTION
…sted `state` update

- if an event was missing `state_reason` key, publication was crashing.
- on updates, `state` was forced to `draft` for ingested items which were
not duplicated. This is not the case anymore if a `state` change is
requested in the update.

SDNTB-568