### PR TITLE
(fix) Limit assignments in fulfil modal to the content type

### DIFF
--- a/client/utils/testData.js
+++ b/client/utils/testData.js
@@ -800,6 +800,7 @@ export const archive = [
         slugline: 'test slugline',
         headline: 'test headline',
         urgency: 2,
+        type: 'text',
     },
 ];
 

--- a/server/planning/assignments/__init__.py
+++ b/server/planning/assignments/__init__.py
@@ -90,6 +90,9 @@ def init_app(app):
     app.client_config['planning_check_for_assignment_on_publish'] = \
         app.config.get('PLANNING_CHECK_FOR_ASSIGNMENT_ON_PUBLISH', False)
 
+    app.client_config['planning_fulfil_on_publish_for_desks'] = \
+        app.config.get('PLANNING_FULFIL_ON_PUBLISH_FOR_DESKS', '').split(',')
+
     # Enhance the archive/published item resources with assigned desk/user information
     app.on_fetched_resource_archive += assignments_publish_service.on_fetched_resource_archive
     app.on_fetched_item_archive += assignments_publish_service.on_fetched_item_archive


### PR DESCRIPTION
* Add a system setting to control which desks to display the fulfil modal