### PR TITLE
[SDESK-4273] Use exact slugline match in Fulfil Assignment on Publish

### DIFF
--- a/client/services/AssignmentsService.js
+++ b/client/services/AssignmentsService.js
@@ -26,7 +26,7 @@ export class AssignmentsService {
             must: [
                 {term: {'assigned_to.state': 'assigned'}},
                 {query_string: {
-                    query: `planning.slugline.phrase('${slugline}')`,
+                    query: `planning.slugline.phrase:("${slugline}")`,
                     lenient: false,
                 }},
                 {term: {'planning.g2_content_type': contentType}},

--- a/client/services/tests/AssignmentsService_test.js
+++ b/client/services/tests/AssignmentsService_test.js
@@ -61,7 +61,7 @@ describe('assignments service', () => {
                                     must: [
                                         {term: {'assigned_to.state': 'assigned'}},
                                         {query_string: {
-                                            query: 'planning.slugline.phrase(\'test slugline\')',
+                                            query: 'planning.slugline.phrase:("test slugline")',
                                             lenient: false,
                                         }},
                                         {term: {'planning.g2_content_type': 'text'}},
@@ -105,7 +105,7 @@ describe('assignments service', () => {
                         must: [
                             {term: {'assigned_to.state': 'assigned'}},
                             {query_string: {
-                                query: 'planning.slugline.phrase(\'test slugline\')',
+                                query: 'planning.slugline.phrase:("test slugline")',
                                 lenient: false,
                             }},
                             {term: {'planning.g2_content_type': 'text'}},
@@ -180,7 +180,7 @@ describe('assignments service', () => {
                             must: [
                                 {term: {'assigned_to.state': 'assigned'}},
                                 {query_string: {
-                                    query: 'planning.slugline.phrase(\'test slugline\')',
+                                    query: 'planning.slugline.phrase:("test slugline")',
                                     lenient: false,
                                 }},
                                 {term: {'planning.g2_content_type': 'text'}},

--- a/server/planning/assignments/__init__.py
+++ b/server/planning/assignments/__init__.py
@@ -90,8 +90,11 @@ def init_app(app):
     app.client_config['planning_check_for_assignment_on_publish'] = \
         app.config.get('PLANNING_CHECK_FOR_ASSIGNMENT_ON_PUBLISH', False)
 
-    app.client_config['planning_fulfil_on_publish_for_desks'] = \
-        app.config.get('PLANNING_FULFIL_ON_PUBLISH_FOR_DESKS', '').split(',')
+    if len(app.config.get('PLANNING_FULFIL_ON_PUBLISH_FOR_DESKS', '')) == 0:
+        app.client_config['planning_fulfil_on_publish_for_desks'] = []
+    else:
+        app.client_config['planning_fulfil_on_publish_for_desks'] = \
+            app.config.get('PLANNING_FULFIL_ON_PUBLISH_FOR_DESKS', '').split(',')
 
     # Enhance the archive/published item resources with assigned desk/user information
     app.on_fetched_resource_archive += assignments_publish_service.on_fetched_resource_archive


### PR DESCRIPTION
* Fix bug with 'PLANNING_FULFIL_ON_PUBLISH_FOR_DESKS' config if the config is an empty string