### PR TITLE
(fix): Update enzyme-adapter-react-16

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "devDependencies": {
     "btoa": "^1.1.2",
     "enzyme": "~3.3.0",
-    "enzyme-adapter-react-16": "~1.1.1",
+    "enzyme-adapter-react-16": "^1.1.1",
     "istanbul-instrumenter-loader": "0.2.0",
     "jasmine": "^2.99.0",
     "jasmine-reporters": "^2.3.0",


### PR DESCRIPTION
This fixes the issues with unit tests failing after upgrading to React v16.8.x