### PR TITLE
[SDESK-4529][SDESK-4534] Show current and future only assignments in the Fulfill modal

### DIFF
--- a/client/actions/assignments/notifications.js
+++ b/client/actions/assignments/notifications.js
@@ -92,23 +92,31 @@ const onAssignmentUpdated = (_e, data) => (
         );
 
         if (querySearchSettings.deskId === null ||
-                currentDesk === data.assigned_desk || currentDesk === data.original_assigned_desk) {
+            currentDesk === data.assigned_desk ||
+            currentDesk === data.original_assigned_desk
+        ) {
             dispatch(assignments.api.fetchAssignmentHistory({_id: data.item}));
             dispatch(assignments.ui.reloadAssignments([data.assignment_state]));
 
             dispatch(assignments.api.fetchAssignmentById(data.item))
                 .then((assignmentInStore) => {
-                // If assignment moved from one state to another, check if group changed
-                // And trigger reload
+                    // If assignment moved from one state to another, check if group changed
+                    // And trigger reload
                     if (assignmentInStore.assigned_to.state !== data.assignment_state) {
-                        const originalGroup = assignmentUtils.getAssignmentGroupByStates(
-                            [assignmentInStore.assigned_to.state]);
-                        const newGroup = assignmentUtils.getAssignmentGroupByStates(
-                            [data.assignment_state]);
+                        const visibleGroups = selectors.getAssignmentGroups(getState());
+                        const originalGroups = assignmentUtils.getAssignmentGroupsByStates(
+                            visibleGroups,
+                            [assignmentInStore.assigned_to.state]
+                        );
+                        const newGroups = assignmentUtils.getAssignmentGroupsByStates(
+                            visibleGroups,
+                            [data.assignment_state]
+                        );
 
-                        if (newGroup.label !== originalGroup.label) {
+                        if (newGroups[0] !== originalGroups[0]) {
                             dispatch(assignments.ui.reloadAssignments(
-                                [assignmentInStore.assigned_to.state]));
+                                [assignmentInStore.assigned_to.state])
+                            );
                         }
                     }
                 });

--- a/client/actions/assignments/tests/notification_test.js
+++ b/client/actions/assignments/tests/notification_test.js
@@ -155,7 +155,11 @@ describe('actions.assignments.notification', () => {
 
                     expect(coverage1.assigned_to.desk).toBe('desk2');
                     expect(coverage1.assigned_to.state).toBe('assigned');
-                    expect(assignmentsUi.reloadAssignments.callCount).toBe(1);
+                    expect(assignmentsUi.reloadAssignments.callCount).toBe(2);
+                    expect(assignmentsUi.reloadAssignments.args).toEqual([
+                        [['assigned']],
+                        [[undefined]],
+                    ]);
                     done();
                 })
                 .catch(done.fail);
@@ -328,7 +332,11 @@ describe('actions.assignments.notification', () => {
 
                     expect(coverage1.assigned_to.desk).toBe('desk2');
                     expect(coverage1.assigned_to.state).toBe('completed');
-                    expect(assignmentsUi.reloadAssignments.callCount).toBe(1);
+                    expect(assignmentsUi.reloadAssignments.callCount).toBe(2);
+                    expect(assignmentsUi.reloadAssignments.args).toEqual([
+                        [['completed']],
+                        [[undefined]],
+                    ]);
                     done();
                 })
                 .catch(done.fail);

--- a/client/apps/Assignments/AssignmentList.jsx
+++ b/client/apps/Assignments/AssignmentList.jsx
@@ -6,6 +6,7 @@ import {isNil} from 'lodash';
 import * as selectors from '../../selectors';
 import * as actions from '../../actions';
 import {ASSIGNMENTS} from '../../constants';
+import {gettext} from '../../utils/gettext';
 
 import {AssignmentGroupList} from '../../components/Assignments';
 
@@ -14,31 +15,11 @@ export const AssignmentListContainer = ({
     changeAssignmentListSingleGroupView,
     setMaxHeight,
     hideItemActions,
-    loadAssignments,
     loadMoreAssignments,
-    filterBy,
-    searchQuery,
-    orderByField,
-    orderDirection,
-    filterByType,
-    filterByPriority,
-    selectedDeskId,
     contentTypes,
+    listGroups,
 }) => {
-    const loadAssignmentsForGroup = (groupKey) =>
-        loadAssignments(
-            filterBy,
-            searchQuery,
-            orderByField,
-            orderDirection,
-            ASSIGNMENTS.LIST_GROUPS[groupKey].states,
-            filterByType,
-            filterByPriority,
-            selectedDeskId
-        );
-
     const listProps = {
-        loadAssignmentsForGroup,
         loadMoreAssignments,
         setMaxHeight,
         hideItemActions,
@@ -48,10 +29,13 @@ export const AssignmentListContainer = ({
     return (
         <div className="sd-column-box__main-column__items">
             {isNil(assignmentListSingleGroupView) ? (
-                Object.keys(ASSIGNMENTS.LIST_GROUPS).map((groupKey) => (
+                listGroups.map((groupKey) => (
                     <AssignmentGroupList
                         key={groupKey}
                         groupKey={groupKey}
+                        groupLabel={gettext(ASSIGNMENTS.LIST_GROUPS[groupKey].label)}
+                        groupStates={ASSIGNMENTS.LIST_GROUPS[groupKey].states}
+                        groupEmptyMessage={ASSIGNMENTS.LIST_GROUPS[groupKey].emptyMessage}
                         changeAssignmentListSingleGroupView={
                             changeAssignmentListSingleGroupView.bind(null, groupKey)
                         }
@@ -61,6 +45,9 @@ export const AssignmentListContainer = ({
             ) : (
                 <AssignmentGroupList
                     groupKey={assignmentListSingleGroupView}
+                    groupLabel={gettext(ASSIGNMENTS.LIST_GROUPS[assignmentListSingleGroupView].label)}
+                    groupStates={ASSIGNMENTS.LIST_GROUPS[assignmentListSingleGroupView].states}
+                    groupEmptyMessage={ASSIGNMENTS.LIST_GROUPS[assignmentListSingleGroupView].emptyMessage}
                     changeAssignmentListSingleGroupView={
                         changeAssignmentListSingleGroupView.bind(this, assignmentListSingleGroupView)
                     }
@@ -75,54 +62,27 @@ AssignmentListContainer.propTypes = {
     assignmentListSingleGroupView: PropTypes.string,
     changeAssignmentListSingleGroupView: PropTypes.func,
     setMaxHeight: PropTypes.bool,
-    loadAssignments: PropTypes.func.isRequired,
     loadMoreAssignments: PropTypes.func.isRequired,
-    filterBy: PropTypes.string,
-    filterByType: PropTypes.string,
-    filterByPriority: PropTypes.string,
-    searchQuery: PropTypes.string,
-    orderByField: PropTypes.string,
-    orderDirection: PropTypes.string,
     hideItemActions: PropTypes.bool,
-    selectedDeskId: PropTypes.string,
     contentTypes: PropTypes.array,
+    listGroups: PropTypes.arrayOf(PropTypes.string),
 };
 
 AssignmentListContainer.defaultProps = {setMaxHeight: true};
 
 const mapStateToProps = (state) => ({
     assignmentListSingleGroupView: selectors.getAssignmentListSingleGroupView(state),
-    filterBy: selectors.getFilterBy(state),
-    filterByType: selectors.getAssignmentFilterByType(state),
-    filterByPriority: selectors.getAssignmentFilterByPriority(state),
-    searchQuery: selectors.getSearchQuery(state),
-    orderByField: selectors.getOrderByField(state),
-    orderDirection: selectors.getOrderDirection(state),
-    selectedDeskId: selectors.getSelectedDeskId(state),
     contentTypes: selectors.general.contentTypes(state),
+    listGroups: selectors.getAssignmentGroups(state),
 });
 
 const mapDispatchToProps = (dispatch) => ({
     changeAssignmentListSingleGroupView: (groupKey) => dispatch(
         actions.assignments.ui.changeAssignmentListSingleGroupView(groupKey)
     ),
-    loadMoreAssignments: (states) => dispatch(
-        actions.assignments.ui.loadMoreAssignments(states)
+    loadMoreAssignments: (groupKey) => dispatch(
+        actions.assignments.ui.loadMoreAssignments(groupKey)
     ),
-    loadAssignments: (
-        filterBy,
-        searchQuery,
-        orderByField,
-        orderDirection,
-        filterByState,
-        filterByType,
-        filterByPriority,
-        selectedDeskId
-    ) =>
-        dispatch(actions.assignments.ui.loadAssignments(
-            filterBy, searchQuery, orderByField, orderDirection,
-            filterByState, filterByType, filterByPriority, selectedDeskId)
-        ),
 });
 
 export const AssignmentList = connect(

--- a/client/apps/Assignments/FulfilAssignmentUi.jsx
+++ b/client/apps/Assignments/FulfilAssignmentUi.jsx
@@ -15,13 +15,11 @@ export const FulfilAssignmentUi = ({previewOpen, newsItem}) => (
         SubNavPanel={AssignmentsSubNav}
         subNavProps={{
             archiveItem: newsItem,
-            onlyTodoAssignments: true,
             withArchiveItem: true,
         }}
 
         ListPanel={AssignmentList}
         listProps={{
-            setMaxHeight: false,
             hideItemActions: true,
         }}
 

--- a/client/components/Assignments/AssignmentItem/index.jsx
+++ b/client/components/Assignments/AssignmentItem/index.jsx
@@ -110,6 +110,9 @@ export class AssignmentItem extends React.Component {
         const assignedDeskName = get(assignedDesk, 'name') || '-';
         const genre = get(assignment, 'planning.genre.name');
 
+        const isOverdue = assignmentUtils.isDue(assignment);
+        const clockIconClass = isOverdue ? 'label-icon label-icon--warning' : 'label-icon';
+
         return (
             <Item
                 shadow={3}
@@ -159,10 +162,11 @@ export class AssignmentItem extends React.Component {
                                 marginRight={true}
                                 marginLeft={true}
                             />
-                            <span data-sd-tooltip={gettext('Due Date')} data-flow="right">
+                            <span data-sd-tooltip={gettext('Due Date')}
+                                data-flow="right"
+                                className={clockIconClass}
+                            >
                                 <i className="icon-time" />
-                            </span>
-                            <span className="sd-overflow-ellipsis sd-list-item--element-grow">
                                 {planningSchedule ? (
                                     <AbsoluteDate
                                         date={moment(planningSchedule).format()}
@@ -170,6 +174,7 @@ export class AssignmentItem extends React.Component {
                                 ) : (
                                     <span>{gettext('\'not scheduled yet\'')}</span>
                                 )}
+                                {isOverdue && <span className="label label--warning label--hollow">due</span>}
                             </span>
                         </span>
                         <div className="sd-list-item__element-lm-10">

--- a/client/components/Assignments/SubNavBar.jsx
+++ b/client/components/Assignments/SubNavBar.jsx
@@ -13,10 +13,9 @@ export const SubNavBar = ({
     assignmentListSingleGroupView,
     changeAssignmentListSingleGroupView,
     totalCountInListView,
-    onlyTodoAssignments,
 }) => (
     <SubNav>
-        {!onlyTodoAssignments && assignmentListSingleGroupView &&
+        {assignmentListSingleGroupView &&
             <div className="Assignments-list-container__header__backButton">
                 <div className="navbtn" title="Back to group list view">
                     <button
@@ -51,5 +50,4 @@ SubNavBar.propTypes = {
     assignmentListSingleGroupView: PropTypes.string,
     changeAssignmentListSingleGroupView: PropTypes.func,
     totalCountInListView: PropTypes.number,
-    onlyTodoAssignments: PropTypes.bool,
 };

--- a/client/constants/assignments.js
+++ b/client/constants/assignments.js
@@ -20,6 +20,11 @@ export const ASSIGNMENTS = {
         REMOVE_ASSIGNMENT: 'REMOVE_ASSIGNMENT',
         RECEIVE_ASSIGNMENT_HISTORY: 'RECEIVE_ASSIGNMENT_HISTORY',
         SET_BASE_QUERY: 'SET_BASE_ASSIGNMENT_QUERY',
+
+        SET_LIST_PAGE: 'SET_ASSIGNMENT_LIST_PAGE',
+        SET_LIST_ITEMS: 'SET_ASSIGNMENT_LIST_ITEMS',
+        ADD_LIST_ITEMS: 'ADD_ASSIGNMENT_LIST_ITEMS',
+        SET_GROUP_KEYS: 'SET_ASSIGNMENT_GROUP_KEYS',
     },
     WORKFLOW_STATE: {
         ASSIGNED: 'assigned',
@@ -67,18 +72,46 @@ export const ASSIGNMENTS = {
     DEFAULT_PRIORITY: 2,
     LIST_GROUPS: {
         TODO: {
+            id: 'TODO',
             label: gettext('To Do'),
             states: ['assigned', 'submitted'],
+            emptyMessage: gettext('There are no assignments to do'),
         },
         IN_PROGRESS: {
+            id: 'IN_PROGRESS',
             label: gettext('In Progress'),
             states: ['in_progress'],
+            emptyMessage: gettext('There are no assignments in progress'),
         },
         COMPLETED: {
+            id: 'COMPLETED',
             label: gettext('Completed'),
             states: ['completed', 'cancelled'],
+            emptyMessage: gettext('There are no assignments completed'),
+        },
+        CURRENT: {
+            id: 'CURRENT',
+            label: gettext('Current Assignments'),
+            states: ['assigned', 'submitted'],
+            emptyMessage: gettext('There are no current assignments'),
+            dateFilter: 'current',
+        },
+        TODAY: {
+            id: 'TODAY',
+            label: gettext('Todays Assignments'),
+            states: ['assigned', 'submitted'],
+            emptyMessage: gettext('There are no assignments for today'),
+            dateFilter: 'today',
+        },
+        FUTURE: {
+            id: 'FUTURE',
+            label: gettext('Future Assignments'),
+            states: ['assigned', 'submitted'],
+            emptyMessage: gettext('There are no future assignments'),
+            dateFilter: 'future',
         },
     },
+    DEFAULT_LIST_GROUPS: ['TODO', 'IN_PROGRESS', 'COMPLETED'],
     HISTORY_OPERATIONS: {
         CREATE: 'create',
         ADD_TO_WORKFLOW: 'add_to_workflow',

--- a/client/controllers/FulfilAssignmentController.js
+++ b/client/controllers/FulfilAssignmentController.js
@@ -5,7 +5,7 @@ import {Provider} from 'react-redux';
 import {ModalsContainer} from '../components';
 import {get} from 'lodash';
 import {registerNotifications} from '../utils';
-import {WORKSPACE, ASSIGNMENTS, MODALS} from '../constants';
+import {WORKSPACE, MODALS, ASSIGNMENTS} from '../constants';
 import {getErrorMessage} from '../utils/index';
 
 export class FulFilAssignmentController {
@@ -20,7 +20,8 @@ export class FulFilAssignmentController {
         userList,
         api,
         $timeout,
-        superdeskFlags
+        superdeskFlags,
+        desks
     ) {
         this.$element = $element;
         this.$scope = $scope;
@@ -32,6 +33,7 @@ export class FulFilAssignmentController {
         this.api = api;
         this.$timeout = $timeout;
         this.superdeskFlags = superdeskFlags;
+        this.desks = desks;
 
         this.render = this.render.bind(this);
         this.loadWorkspace = this.loadWorkspace.bind(this);
@@ -67,9 +69,6 @@ export class FulFilAssignmentController {
     }
 
     render() {
-        this.store.dispatch(
-            actions.assignments.ui.changeAssignmentListSingleGroupView('TODO')
-        );
         this.store.dispatch(actions.main.closePublishQueuePreviewOnWorkspaceChange());
 
         ReactDOM.render(
@@ -100,16 +99,14 @@ export class FulFilAssignmentController {
             .then((newsItem) => {
                 this.newsItem = newsItem;
                 registerNotifications(this.$scope, this.store);
-                return this.store.dispatch(
-                    actions.assignments.ui.loadAssignments(
-                        'Desk',
-                        null,
-                        'Scheduled',
-                        'Asc',
-                        [ASSIGNMENTS.WORKFLOW_STATE.ASSIGNED],
-                        this.newsItem.type,
-                        null,
-                        get(this.item, 'task.desk')
+
+                return store.dispatch(
+                    actions.assignments.ui.loadFulfillModal(
+                        this.newsItem,
+                        [
+                            ASSIGNMENTS.LIST_GROUPS.CURRENT.id,
+                            ASSIGNMENTS.LIST_GROUPS.FUTURE.id,
+                        ]
                     )
                 );
             });
@@ -233,4 +230,5 @@ FulFilAssignmentController.$inject = [
     'api',
     '$timeout',
     'superdeskFlags',
+    'desks',
 ];

--- a/client/reducers/tests/assignment_test.js
+++ b/client/reducers/tests/assignment_test.js
@@ -1,160 +1,120 @@
-import assignment from '../assignment';
 import moment from 'moment';
+import {cloneDeep} from 'lodash';
+
+import assignment from '../assignment';
+import * as testData from '../../utils/testData';
 
 describe('assignment', () => {
     let initialState;
-    let stateTest;
+    let state;
+    let assignments;
 
     beforeEach(() => {
-        stateTest = {
-            archive: {},
-            assignmentListSingleGroupView: null,
-            assignments: {},
-            assignmentsInCompletedList: [],
-            assignmentsInInProgressList: [],
-            assignmentsInTodoList: [],
-            baseQuery: {must: []},
-            completedListLastLoadedPage: null,
-            completedListTotal: 0,
-            currentAssignmentId: null,
-            filterBy: 'Desk',
-            filterByPriority: null,
-            filterByType: null,
-            inProgressListLastLoadedPage: null,
-            inProgressListTotal: 0,
-            myAssignmentsTotal: 0,
-            orderByField: 'Scheduled',
-            orderDirection: 'Asc',
-            previewOpened: false,
-            readOnly: false,
-            searchQuery: null,
-            selectedDeskId: '',
-            todoListLastLoadedPage: null,
-            todoListTotal: 0,
-        };
+        initialState = cloneDeep(testData.assignmentInitialState);
+        state = assignment({}, {type: null});
+        assignments = cloneDeep(testData.assignments);
     });
 
-    describe('load reducers', () => {
-        beforeEach(() => {
-            stateTest.assignments = {
+    it('initialState load', () => {
+        expect(state).toEqual(initialState);
+    });
+
+    it('RECEIVED_ASSIGNMENTS', () => {
+        let result = assignment(state, {
+            type: 'RECEIVED_ASSIGNMENTS',
+            payload: [
+                assignments[0],
+                assignments[1],
+            ],
+        });
+
+        expect(result).toEqual({
+            ...initialState,
+            assignments: {
                 as1: {
-                    _id: 'as1',
-                    _created: '2017-07-13T13:55:41+0000',
-                    _updated: '2017-07-28T11:16:36+0000',
-                    planning: {scheduled: moment('2017-07-28T11:16:36+0000')},
-                    assigned_to: {
-                        assigned_date: '2017-07-28T11:16:36+0000',
-                        desk: 'desk1',
+                    ...assignments[0],
+                    planning: {
+                        ...assignments[0].planning,
+                        scheduled: moment(assignments[0].planning.scheduled),
                     },
                 },
                 as2: {
-                    _id: 'as2',
-                    _created: '2017-07-13T14:55:41+0000',
-                    _updated: '2017-07-28T13:16:36+0000',
-                    planning: {scheduled: moment('2017-07-28T13:16:36+0000')},
+                    ...assignments[1],
+                    planning: {
+                        ...assignments[1].planning,
+                        scheduled: moment(assignments[1].planning.scheduled),
+                    },
+                },
+            },
+        });
+
+        result = assignment(result, {
+            type: 'RECEIVED_ASSIGNMENTS',
+            payload: [
+                {
+                    ...assignments[1],
+                    planning: {
+                        ...assignments[1].planning,
+                        slugline: 'test',
+                    },
+                },
+                {
+                    _id: 'as3',
+                    _created: '2017-07-13T15:55:41+0000',
+                    _updated: '2017-07-28T14:16:36+0000',
+                    planning: {scheduled: '2017-07-28T14:16:36+0000'},
                     assigned_to: {
-                        assigned_date: '2017-07-28T13:16:36+0000',
-                        desk: 'desk2',
+                        assigned_date: '2017-07-28T14:16:36+0000',
+                        desk: 'desk3',
                     },
                 },
-            };
+            ],
         });
 
-        beforeEach(() => {
-            initialState = assignment(stateTest, {type: null});
-        });
-
-        it('initialState load', () => {
-            expect(initialState).toEqual(stateTest);
-        });
-
-        it('RECEIVED_ASSIGNMENTS', () => {
-            const result = assignment(initialState, {
-                type: 'RECEIVED_ASSIGNMENTS',
-                payload: [
-                    {
-                        _id: 'as2',
-                        _created: '2017-07-13T14:55:41+0000',
-                        _updated: '2017-07-28T13:16:36+0000',
-                        planning: {
-                            scheduled: '2017-07-28T13:16:36+0000',
-                            slugline: 'test',
-                        },
-                        assigned_to: {
-                            assigned_date: '2017-07-28T13:16:36+0000',
-                            desk: 'desk2',
-                        },
-                    },
-                    {
-                        _id: 'as3',
-                        _created: '2017-07-13T15:55:41+0000',
-                        _updated: '2017-07-28T14:16:36+0000',
-                        planning: {scheduled: '2017-07-28T14:16:36+0000'},
-                        assigned_to: {
-                            assigned_date: '2017-07-28T14:16:36+0000',
-                            desk: 'desk3',
-                        },
-                    },
-                ],
-            });
-
-            expect(result).toEqual({
-                ...stateTest,
-                assignments: {
-                    as1: {
-                        _id: 'as1',
-                        _created: '2017-07-13T13:55:41+0000',
-                        _updated: '2017-07-28T11:16:36+0000',
-                        planning: {scheduled: moment('2017-07-28T11:16:36+0000')},
-                        assigned_to: {
-                            assigned_date: '2017-07-28T11:16:36+0000',
-                            desk: 'desk1',
-                        },
-                    },
-                    as2: {
-                        _id: 'as2',
-                        _created: '2017-07-13T14:55:41+0000',
-                        _updated: '2017-07-28T13:16:36+0000',
-                        planning: {
-                            scheduled: moment('2017-07-28T13:16:36+0000'),
-                            slugline: 'test',
-                        },
-                        assigned_to: {
-                            assigned_date: '2017-07-28T13:16:36+0000',
-                            desk: 'desk2',
-                        },
-                    },
-                    as3: {
-                        _id: 'as3',
-                        _created: '2017-07-13T15:55:41+0000',
-                        _updated: '2017-07-28T14:16:36+0000',
-                        planning: {scheduled: moment('2017-07-28T14:16:36+0000')},
-                        assigned_to: {
-                            assigned_date: '2017-07-28T14:16:36+0000',
-                            desk: 'desk3',
-                        },
+        expect(result).toEqual({
+            ...initialState,
+            assignments: {
+                as1: {
+                    ...assignments[0],
+                    planning: {
+                        ...assignments[0].planning,
+                        scheduled: moment(assignments[0].planning.scheduled),
                     },
                 },
-            });
+                as2: {
+                    ...assignments[1],
+                    planning: {
+                        ...assignments[1].planning,
+                        scheduled: moment(assignments[1].planning.scheduled),
+                        slugline: 'test',
+                    },
+                },
+                as3: {
+                    _id: 'as3',
+                    _created: '2017-07-13T15:55:41+0000',
+                    _updated: '2017-07-28T14:16:36+0000',
+                    planning: {scheduled: moment('2017-07-28T14:16:36+0000')},
+                    assigned_to: {
+                        assigned_date: '2017-07-28T14:16:36+0000',
+                        desk: 'desk3',
+                    },
+                },
+            },
         });
     });
 
     describe('list setting reducers', () => {
         beforeEach(() => {
-            stateTest = {
-                ...stateTest,
+            state = {
+                ...state,
                 searchQuery: 'test',
                 orderByField: 'Updated',
                 orderDirection: 'Desc',
             };
         });
 
-        beforeEach(() => {
-            initialState = assignment(stateTest, {type: null});
-        });
-
         it('CHANGE_LIST_SETTINGS MY ASSIGNMENTS', () => {
-            const result = assignment(initialState, {
+            const result = assignment(state, {
                 type: 'CHANGE_LIST_SETTINGS',
                 payload: {
                     filterBy: 'User',
@@ -164,7 +124,8 @@ describe('assignment', () => {
             });
 
             expect(result).toEqual({
-                ...stateTest,
+                ...initialState,
+                searchQuery: 'test',
                 filterBy: 'User',
                 orderByField: 'Created',
                 orderDirection: 'Asc',
@@ -172,7 +133,7 @@ describe('assignment', () => {
         });
 
         it('CHANGE_LIST_SETTINGS DESK ASSIGNMENTS', () => {
-            const result = assignment(initialState, {
+            const result = assignment(state, {
                 type: 'CHANGE_LIST_SETTINGS',
                 payload: {
                     filterBy: 'Desk',
@@ -183,7 +144,8 @@ describe('assignment', () => {
             });
 
             expect(result).toEqual({
-                ...stateTest,
+                ...initialState,
+                searchQuery: 'test',
                 orderByField: 'Created',
                 orderDirection: 'Asc',
                 selectedDeskId: '1',
@@ -193,188 +155,211 @@ describe('assignment', () => {
 
     describe('list group reducers', () => {
         beforeEach(() => {
-            stateTest.assignments = {
-                as1: {
-                    _id: 'as1',
-                    _created: '2017-07-13T13:55:41+0000',
-                    _updated: '2017-07-28T11:16:36+0000',
-                    planning: {scheduled: moment('2017-07-28T11:16:36+0000')},
-                    assigned_to: {
-                        assigned_date: '2017-07-28T11:16:36+0000',
-                        desk: 'desk1',
-                    },
-                },
-                as2: {
-                    _id: 'as2',
-                    _created: '2017-07-13T14:55:41+0000',
-                    _updated: '2017-07-28T13:16:36+0000',
-                    planning: {scheduled: moment('2017-07-28T13:16:36+0000')},
-                    assigned_to: {
-                        assigned_date: '2017-07-28T13:16:36+0000',
-                        desk: 'desk2',
-                    },
-                },
-            };
-        });
-
-        beforeEach(() => {
-            initialState = assignment(stateTest, {type: null});
-        });
-
-        it('initialState list setting', () => {
-            expect(initialState).toEqual(stateTest);
+            state = assignment(state, {
+                type: 'RECEIVED_ASSIGNMENTS',
+                payload: [
+                    assignments[0],
+                    assignments[1],
+                ],
+            });
+            initialState = cloneDeep(state);
         });
 
         it('SET_TODO_LIST', () => {
-            const result = assignment(initialState, {
-                type: 'SET_TODO_LIST',
+            const result = assignment(state, {
+                type: 'SET_ASSIGNMENT_LIST_ITEMS',
                 payload: {
+                    list: 'TODO',
                     ids: ['1', '2'],
                     total: 4,
                 },
             });
 
             expect(result).toEqual({
-                ...stateTest,
-                assignmentsInTodoList: ['1', '2'],
-                todoListTotal: 4,
-                todoListLastLoadedPage: 1,
+                ...initialState,
+                lists: {
+                    ...initialState.lists,
+                    TODO: {
+                        assignmentIds: ['1', '2'],
+                        total: 4,
+                        lastPage: 1,
+                    },
+                },
             });
         });
 
         it('SET_IN_PROGRESS_LIST', () => {
-            const result = assignment(initialState, {
-                type: 'SET_IN_PROGRESS_LIST',
+            const result = assignment(state, {
+                type: 'SET_ASSIGNMENT_LIST_ITEMS',
                 payload: {
+                    list: 'IN_PROGRESS',
                     ids: ['1', '2'],
                     total: 4,
                 },
             });
 
             expect(result).toEqual({
-                ...stateTest,
-                assignmentsInInProgressList: ['1', '2'],
-                inProgressListTotal: 4,
-                inProgressListLastLoadedPage: 1,
+                ...initialState,
+                lists: {
+                    ...initialState.lists,
+                    IN_PROGRESS: {
+                        assignmentIds: ['1', '2'],
+                        total: 4,
+                        lastPage: 1,
+                    },
+                },
             });
         });
 
         it('SET_COMPLETED_LIST', () => {
-            const result = assignment(initialState, {
-                type: 'SET_COMPLETED_LIST',
+            const result = assignment(state, {
+                type: 'SET_ASSIGNMENT_LIST_ITEMS',
                 payload: {
+                    list: 'COMPLETED',
                     ids: ['1', '2'],
                     total: 4,
                 },
             });
 
             expect(result).toEqual({
-                ...stateTest,
-                assignmentsInCompletedList: ['1', '2'],
-                completedListTotal: 4,
-                completedListLastLoadedPage: 1,
+                ...initialState,
+                lists: {
+                    ...initialState.lists,
+                    COMPLETED: {
+                        assignmentIds: ['1', '2'],
+                        total: 4,
+                        lastPage: 1,
+                    },
+                },
             });
         });
 
         it('ADD_TO_TODO_LIST', () => {
-            initialState.assignmentsInTodoList = ['1', '2'];
-            const result = assignment(initialState, {
-                type: 'ADD_TO_TODO_LIST',
+            let result = assignment(state, {
+                type: 'SET_ASSIGNMENT_LIST_ITEMS',
                 payload: {
+                    list: 'TODO',
+                    ids: ['1', '2'],
+                    total: 4,
+                },
+            });
+
+            result = assignment(result, {
+                type: 'ADD_ASSIGNMENT_LIST_ITEMS',
+                payload: {
+                    list: 'TODO',
                     ids: ['3'],
                     total: 3,
                 },
             });
 
             expect(result).toEqual({
-                ...stateTest,
-                assignmentsInTodoList: ['1', '2', '3'],
-                todoListTotal: 3,
+                ...initialState,
+                lists: {
+                    ...initialState.lists,
+                    TODO: {
+                        assignmentIds: ['1', '2', '3'],
+                        total: 3,
+                        lastPage: 1,
+                    },
+                },
             });
         });
 
         it('ADD_TO_IN_PROGRESS_LIST', () => {
-            initialState.assignmentsInInProgressList = ['1', '2'];
-
-            const result = assignment(initialState, {
-                type: 'ADD_TO_IN_PROGRESS_LIST',
+            let result = assignment(state, {
+                type: 'SET_ASSIGNMENT_LIST_ITEMS',
                 payload: {
+                    list: 'IN_PROGRESS',
+                    ids: ['1', '2'],
+                    total: 4,
+                },
+            });
+
+            result = assignment(result, {
+                type: 'ADD_ASSIGNMENT_LIST_ITEMS',
+                payload: {
+                    list: 'IN_PROGRESS',
                     ids: ['3'],
                     total: 3,
                 },
             });
 
             expect(result).toEqual({
-                ...stateTest,
-                assignmentsInInProgressList: ['1', '2', '3'],
-                inProgressListTotal: 3,
+                ...initialState,
+                lists: {
+                    ...initialState.lists,
+                    IN_PROGRESS: {
+                        assignmentIds: ['1', '2', '3'],
+                        total: 3,
+                        lastPage: 1,
+                    },
+                },
             });
         });
 
         it('ADD_TO_COMPLETED_LIST', () => {
-            initialState.assignmentsInCompletedList = ['1', '2'];
-
-            const result = assignment(initialState, {
-                type: 'ADD_TO_COMPLETED_LIST',
+            let result = assignment(state, {
+                type: 'SET_ASSIGNMENT_LIST_ITEMS',
                 payload: {
+                    list: 'COMPLETED',
+                    ids: ['1', '2'],
+                    total: 4,
+                },
+            });
+
+            result = assignment(result, {
+                type: 'ADD_ASSIGNMENT_LIST_ITEMS',
+                payload: {
+                    list: 'COMPLETED',
                     ids: ['3'],
                     total: 3,
                 },
             });
 
             expect(result).toEqual({
-                ...stateTest,
-                assignmentsInCompletedList: ['1', '2', '3'],
-                completedListTotal: 3,
+                ...initialState,
+                lists: {
+                    ...initialState.lists,
+                    COMPLETED: {
+                        assignmentIds: ['1', '2', '3'],
+                        total: 3,
+                        lastPage: 1,
+                    },
+                },
             });
         });
 
         it('CHANGE_LIST_VIEW_MODE', () => {
-            const result = assignment(initialState, {
+            const result = assignment(state, {
                 type: 'CHANGE_LIST_VIEW_MODE',
                 payload: 'TODO',
             });
 
             expect(result).toEqual({
-                ...stateTest,
+                ...initialState,
                 assignmentListSingleGroupView: 'TODO',
             });
         });
     });
 
-    describe('preview&edit assignment reducers', () => {
+    describe('preview & edit assignment reducers', () => {
         beforeEach(() => {
-            stateTest.assignments = {
-                as1: {
-                    _id: 'as1',
-                    _created: '2017-07-13T15:55:41+0000',
-                    _updated: '2017-07-28T14:16:36+0000',
-                    planning: {
-                        assigned_to: {
-                            assigned_date: '2017-07-28T14:16:36+0000',
-                            desk: 'desk3',
-                        },
-                    },
-                },
-            };
-        });
-
-        beforeEach(() => {
-            initialState = assignment(stateTest, {type: null});
-        });
-
-        it('initialState preview&edit assignment', () => {
-            expect(initialState).toEqual(stateTest);
+            state = assignment(state, {
+                type: 'RECEIVED_ASSIGNMENTS',
+                payload: [assignments[0]],
+            });
+            initialState = cloneDeep(state);
         });
 
         it('PREVIEW_ASSIGNMENT', () => {
-            const result = assignment(initialState, {
+            const result = assignment(state, {
                 type: 'PREVIEW_ASSIGNMENT',
                 payload: 'as1',
             });
 
             expect(result).toEqual({
-                ...stateTest,
+                ...initialState,
                 previewOpened: true,
                 currentAssignmentId: 'as1',
                 readOnly: true,
@@ -382,123 +367,202 @@ describe('assignment', () => {
         });
 
         it('CLOSE_PREVIEW_ASSIGNMENT', () => {
-            const result = assignment(initialState, {type: 'CLOSE_PREVIEW_ASSIGNMENT'});
+            const result = assignment(state, {type: 'CLOSE_PREVIEW_ASSIGNMENT'});
 
             expect(result).toEqual({
-                ...stateTest,
+                ...initialState,
                 readOnly: true,
             });
         });
 
         describe('REMOVE_ASSIGNMENT', () => {
             beforeEach(() => {
-                initialState = assignment(undefined, {type: null});
+                state = assignment(undefined, {type: null});
+                initialState = cloneDeep(state);
             });
 
             it('REMOVE_ASSIGNMENT returns if Assignment not loaded', () => {
-                const result = assignment(initialState, {
+                const result = assignment(state, {
                     type: 'REMOVE_ASSIGNMENT',
-                    payload: {assignment: 'a1'},
+                    payload: {assignment: 'as1'},
                 });
 
                 expect(result).toEqual(initialState);
             });
 
             it('REMOVE_ASSIGNMENT removes the assignment from view lists', () => {
-                // Checks to see if assignmentsInInProgressList is set back to empty list
-                let result = assignment(
-                    {
-                        ...initialState,
-                        assignments: {a1: {_id: 'a1'}},
-                        assignmentsInInProgressList: ['a1'],
-                        inProgressListTotal: 1,
-                    },
-                    {
-                        type: 'REMOVE_ASSIGNMENT',
-                        payload: {assignment: 'a1'},
-                    }
-                );
+                // Checks to see if IN_PROGRESS list is set back to empty
+                let result = assignment(initialState, {
+                    type: 'RECEIVED_ASSIGNMENTS',
+                    payload: [assignments[0]],
+                });
 
-                expect(result).toEqual(initialState);
+                result = assignment(result, {
+                    type: 'SET_ASSIGNMENT_LIST_ITEMS',
+                    payload: {list: 'IN_PROGRESS', ids: ['as1'], total: 1},
+                });
 
-                // Checks to see if assignmentsInTodoList is set back to empty list
-                result = assignment(
-                    {
-                        ...initialState,
-                        assignments: {a1: {_id: 'a1'}},
-                        assignmentsInTodoList: ['a1'],
-                        todoListTotal: 1,
-                    },
-                    {
-                        type: 'REMOVE_ASSIGNMENT',
-                        payload: {assignment: 'a1'},
-                    }
-                );
-                expect(result).toEqual(initialState);
+                result = assignment(result, {
+                    type: 'REMOVE_ASSIGNMENT',
+                    payload: {assignment: 'as1'},
+                });
 
-                // Checks to see if assignmentsInCompletedList is set back to empty list
-                result = assignment(
-                    {
-                        ...initialState,
-                        assignments: {a1: {_id: 'a1'}},
-                        assignmentsInCompletedList: ['a1'],
-                        completedListTotal: 1,
-                    },
-                    {
-                        type: 'REMOVE_ASSIGNMENT',
-                        payload: {assignment: 'a1'},
-                    }
-                );
-                expect(result).toEqual(initialState);
-            });
+                expect(result.lists.IN_PROGRESS).toEqual({
+                    assignmentIds: [],
+                    total: 0,
+                    lastPage: 1,
+                });
 
-            it('REMOVE_ASSIGNMENT closes preview viewing the removed Assignment', () => {
-                // Closes the preview and sets currentAssignmentId to null
-                let result = assignment(
-                    {
-                        ...initialState,
-                        assignments: {a1: {_id: 'a1'}},
-                        assignmentsInInProgressList: ['a1'],
-                        inProgressListTotal: 1,
-                        previewOpened: true,
-                        currentAssignmentId: 'a1',
-                    },
-                    {
-                        type: 'REMOVE_ASSIGNMENT',
-                        payload: {assignment: 'a1'},
-                    }
-                );
+                // Checks to see if TO_DO list is set back to empty
+                result = assignment(initialState, {
+                    type: 'RECEIVED_ASSIGNMENTS',
+                    payload: [assignments[0]],
+                });
 
-                expect(result).toEqual(initialState);
+                result = assignment(result, {
+                    type: 'SET_ASSIGNMENT_LIST_ITEMS',
+                    payload: {list: 'TODO', ids: ['as1'], total: 1},
+                });
 
-                // Removes the assignment from the store, but keeps the preview open
-                result = assignment(
-                    {
-                        ...initialState,
-                        assignments: {
-                            a1: {_id: 'a1'},
-                            a2: {_id: 'a2'},
-                        },
-                        assignmentsInInProgressList: ['a1', 'a2'],
-                        inProgressListTotal: 2,
-                        previewOpened: true,
-                        currentAssignmentId: 'a2',
-                    },
-                    {
-                        type: 'REMOVE_ASSIGNMENT',
-                        payload: {assignment: 'a1'},
-                    }
-                );
+                result = assignment(result, {
+                    type: 'REMOVE_ASSIGNMENT',
+                    payload: {assignment: 'as1'},
+                });
 
-                expect(result).toEqual({
-                    ...initialState,
-                    assignments: {a2: {_id: 'a2'}},
-                    assignmentsInInProgressList: ['a2'],
-                    inProgressListTotal: 1,
-                    previewOpened: true,
-                    currentAssignmentId: 'a2',
+                expect(result.lists.TODO).toEqual({
+                    assignmentIds: [],
+                    total: 0,
+                    lastPage: 1,
+                });
+
+                // Checks to see if COMPLETED list is set back to empty
+                result = assignment(initialState, {
+                    type: 'RECEIVED_ASSIGNMENTS',
+                    payload: [assignments[0]],
+                });
+
+                result = assignment(result, {
+                    type: 'SET_ASSIGNMENT_LIST_ITEMS',
+                    payload: {list: 'COMPLETED', ids: ['as1'], total: 1},
+                });
+
+                result = assignment(result, {
+                    type: 'REMOVE_ASSIGNMENT',
+                    payload: {assignment: 'as1'},
+                });
+
+                expect(result.lists.COMPLETED).toEqual({
+                    assignmentIds: [],
+                    total: 0,
+                    lastPage: 1,
                 });
             });
+
+            it('REMOVE_ASSIGNMENT closes the preview', () => {
+                let result = assignment(initialState, {
+                    type: 'RECEIVED_ASSIGNMENTS',
+                    payload: [assignments[0]],
+                });
+
+                result = assignment(result, {
+                    type: 'SET_ASSIGNMENT_LIST_ITEMS',
+                    payload: {list: 'IN_PROGRESS', ids: ['as1'], total: 1},
+                });
+
+                result = assignment(result, {
+                    type: 'PREVIEW_ASSIGNMENT',
+                    payload: 'as1',
+                });
+
+                result = assignment(result, {
+                    type: 'REMOVE_ASSIGNMENT',
+                    payload: {assignment: 'as1'},
+                });
+
+                expect(result).toEqual(jasmine.objectContaining({
+                    previewOpened: false,
+                    currentAssignmentId: null,
+                }));
+            });
+
+            it('REMOVE_ASSIGNMENT doesnt close the preview if not viewing', () => {
+                let result = assignment(initialState, {
+                    type: 'RECEIVED_ASSIGNMENTS',
+                    payload: [assignments[0]],
+                });
+
+                result = assignment(result, {
+                    type: 'SET_ASSIGNMENT_LIST_ITEMS',
+                    payload: {list: 'IN_PROGRESS', ids: ['as1'], total: 1},
+                });
+
+                result = assignment(result, {
+                    type: 'PREVIEW_ASSIGNMENT',
+                    payload: 'as2',
+                });
+
+                result = assignment(result, {
+                    type: 'REMOVE_ASSIGNMENT',
+                    payload: {assignment: 'as1'},
+                });
+
+                expect(result).toEqual(jasmine.objectContaining({
+                    previewOpened: true,
+                    currentAssignmentId: 'as2',
+                }));
+            });
         });
+    });
+
+    it('SET_LIST_ITEMS and ADD_LIST_ITEMS', () => {
+        let result = assignment(initialState, {
+            type: 'SET_ASSIGNMENT_LIST_ITEMS',
+            payload: {
+                list: 'TODO',
+                ids: ['as1', 'as2'],
+                total: 2,
+            },
+        });
+
+        expect(result.lists).toEqual(jasmine.objectContaining({
+            TODO: {
+                assignmentIds: ['as1', 'as2'],
+                total: 2,
+                lastPage: 1,
+            },
+        }));
+
+        result = assignment(result, {
+            type: 'ADD_ASSIGNMENT_LIST_ITEMS',
+            payload: {
+                list: 'TODO',
+                ids: ['as3'],
+                total: 3,
+            },
+        });
+
+        expect(result.lists).toEqual(jasmine.objectContaining({
+            TODO: {
+                assignmentIds: ['as1', 'as2', 'as3'],
+                total: 3,
+                lastPage: 1,
+            },
+        }));
+
+        result = assignment(result, {
+            type: 'SET_ASSIGNMENT_LIST_PAGE',
+            payload: {
+                list: 'TODO',
+                page: 2,
+            },
+        });
+
+        expect(result.lists).toEqual(jasmine.objectContaining({
+            TODO: {
+                assignmentIds: ['as1', 'as2', 'as3'],
+                total: 3,
+                lastPage: 2,
+            },
+        }));
     });
 });

--- a/client/selectors/assignments.js
+++ b/client/selectors/assignments.js
@@ -1,18 +1,116 @@
 import {get} from 'lodash';
+import {createSelector} from 'reselect';
+
 import {storedEvents} from './events';
 import {storedPlannings} from './planning';
 import {currentDeskId, currentUserId, currentWorkspace} from './general';
-import {createSelector} from 'reselect';
 import {getItemsById} from '../utils';
+import {ASSIGNMENTS} from '../constants';
 
 export const getStoredAssignments = (state) => get(state, 'assignment.assignments', {});
 export const getStoredArchiveItems = (state) => get(state, 'assignment.archive', {});
-export const getAssignmentsInTodoList = (state) => get(state,
-    'assignment.assignmentsInTodoList', []);
-export const getAssignmentsInInProgressList = (state) => get(state,
-    'assignment.assignmentsInInProgressList', []);
-export const getAssignmentsInCompletedList = (state) => get(state,
-    'assignment.assignmentsInCompletedList', []);
+
+export const getAssignmentGroups = (state) => get(
+    state,
+    'assignment.groupKeys',
+    [
+        ASSIGNMENTS.LIST_GROUPS.TODO.id,
+        ASSIGNMENTS.LIST_GROUPS.IN_PROGRESS.id,
+        ASSIGNMENTS.LIST_GROUPS.COMPLETED.id,
+    ]
+);
+
+const getList = (state, list) => get(state, `assignment.lists.${list}`, {
+    assignmentIds: [],
+    total: 0,
+    lastPage: 1,
+});
+
+const getListIds = (list) => get(list, 'assignmentIds', []);
+const getListCount = (list) => get(list, 'total', 0);
+const getListLastPage = (list) => get(list, 'lastPage', 1);
+const getListItems = (list, storedAssignments) => getItemsById(
+    getListIds(list),
+    storedAssignments
+);
+
+// TO DO Assignments
+export const getAssignmentsTodo = (state) => getList(state, ASSIGNMENTS.LIST_GROUPS.TODO.id);
+export const getAssignmentsInTodoList = createSelector([getAssignmentsTodo], getListIds);
+export const getAssignmentsToDoListCount = createSelector([getAssignmentsTodo], getListCount);
+export const getAssignmentTodoListPage = createSelector([getAssignmentsTodo], getListLastPage);
+export const getTodoAssignments = createSelector(
+    [getAssignmentsTodo, getStoredAssignments],
+    getListItems
+);
+
+// IN PROGRESS Assignments
+export const getAssignmentsInProgress = (state) => getList(state, ASSIGNMENTS.LIST_GROUPS.IN_PROGRESS.id);
+export const getAssignmentsInInProgressList = createSelector([getAssignmentsInProgress], getListIds);
+export const getAssignmentsInProgressListCount = createSelector([getAssignmentsInProgress], getListCount);
+export const getAssignmentInProgressPage = createSelector([getAssignmentsInProgress], getListLastPage);
+export const getInProgressAssignments = createSelector(
+    [getAssignmentsInProgress, getStoredAssignments],
+    getListItems
+);
+
+// COMPLETED Assignments
+export const getAssignmentsCompleted = (state) => getList(state, ASSIGNMENTS.LIST_GROUPS.COMPLETED.id);
+export const getAssignmentsInCompletedList = createSelector([getAssignmentsCompleted], getListIds);
+export const getAssignmentsCompletedListCount = createSelector([getAssignmentsCompleted], getListCount);
+export const getAssignmentCompletedPage = createSelector([getAssignmentsCompleted], getListLastPage);
+export const getCompletedAssignments = createSelector(
+    [getAssignmentsCompleted, getStoredAssignments],
+    getListItems
+);
+
+// TO DO / CURRENT Assignments
+export const getAssignmentsCurrent = (state) => getList(state, ASSIGNMENTS.LIST_GROUPS.CURRENT.id);
+export const getAssignmentsCurrentList = createSelector([getAssignmentsCurrent], getListIds);
+export const getAssignmentsCurrentListCount = createSelector([getAssignmentsCurrent], getListCount);
+export const getAssignmentCurrentPage = createSelector([getAssignmentsCurrent], getListLastPage);
+export const getCurrentAssignments = createSelector(
+    [getAssignmentsCurrent, getStoredAssignments],
+    getListItems
+);
+
+// TO DO / TODAY Assignments
+export const getAssignmentsToday = (state) => getList(state, ASSIGNMENTS.LIST_GROUPS.TODAY.id);
+export const getAssignmentsTodayList = createSelector([getAssignmentsToday], getListIds);
+export const getAssignmentsTodayListCount = createSelector([getAssignmentsToday], getListCount);
+export const getAssignmentTodayPage = createSelector([getAssignmentsToday], getListLastPage);
+export const getTodayAssignments = createSelector(
+    [getAssignmentsToday, getStoredAssignments],
+    getListItems
+);
+
+// TO DO / FUTURE Assignments
+export const getAssignmentsFuture = (state) => getList(state, ASSIGNMENTS.LIST_GROUPS.FUTURE.id);
+export const getAssignmentsFutureList = createSelector([getAssignmentsFuture], getListIds);
+export const getAssignmentsFutureListCount = createSelector([getAssignmentsFuture], getListCount);
+export const getAssignmentFuturePage = createSelector([getAssignmentsFuture], getListLastPage);
+export const getFutureAssignments = createSelector(
+    [getAssignmentsFuture, getStoredAssignments],
+    getListItems
+);
+
+export const getAssignmentGroupCounts = createSelector([
+    getAssignmentsToDoListCount,
+    getAssignmentsInProgressListCount,
+    getAssignmentsCompletedListCount,
+    getAssignmentsCurrentListCount,
+    getAssignmentsTodayListCount,
+    getAssignmentsFutureListCount,
+],
+(todo, inProgress, completed, current, today, future) => ({
+    [ASSIGNMENTS.LIST_GROUPS.TODO.id]: todo,
+    [ASSIGNMENTS.LIST_GROUPS.IN_PROGRESS.id]: inProgress,
+    [ASSIGNMENTS.LIST_GROUPS.COMPLETED.id]: completed,
+    [ASSIGNMENTS.LIST_GROUPS.CURRENT.id]: current,
+    [ASSIGNMENTS.LIST_GROUPS.TODAY.id]: today,
+    [ASSIGNMENTS.LIST_GROUPS.FUTURE.id]: future,
+}));
+
 export const getFilterBy = (state) => get(state, 'assignment.filterBy', 'Desk');
 export const getSearchQuery = (state) => get(state, 'assignment.searchQuery', null);
 export const getOrderByField = (state) => get(state, 'assignment.orderByField', 'Scheduled');
@@ -22,12 +120,7 @@ export const getAssignmentFilterByType = (state) => get(state, 'assignment.filte
 export const getSelectedDeskId = (state) => get(state, 'assignment.selectedDeskId', '');
 export const getAssignmentFilterByPriority = (state) =>
     get(state, 'assignment.filterByPriority', null);
-export const getAssignmentTodoListPage = (state) => get(state,
-    'assignment.todoListLastLoadedPage', 1);
-export const getAssignmentInProgressPage = (state) => get(state,
-    'assignment.inProgressListLastLoadedPage', 1);
-export const getAssignmentCompletedPage = (state) => get(state,
-    'assignment.completedListLastLoadedPage', 1);
+
 export const getAssignmentListSettings = (state) => ({
     filterBy: getFilterBy(state),
     searchQuery: getSearchQuery(state),
@@ -38,11 +131,7 @@ export const getAssignmentListSettings = (state) => ({
     filterByPriority: getAssignmentFilterByPriority(state),
     selectedDeskId: getSelectedDeskId(state),
 });
-export const getAssignmentsToDoListCount = (state) => (get(state, 'assignment.todoListTotal', 0));
-export const getAssignmentsInProgressListCount = (state) => (get(state,
-    'assignment.inProgressListTotal', 0));
-export const getAssignmentsCompletedListCount = (state) => (get(state,
-    'assignment.completedListTotal', 0));
+
 export const getAssignmentListSingleGroupView = (state) => get(state,
     'assignment.assignmentListSingleGroupView', null);
 
@@ -55,21 +144,6 @@ export const getAssignmentHistory = (state) => get(state, 'assignment.assignment
 
 export const getMyAssignmentsCount = (state) => (get(state, 'assignment.myAssignmentsTotal', 0));
 export const getBaseAssignmentQuery = (state) => get(state, 'assignment.baseQuery', {must: []});
-
-export const getTodoAssignments = createSelector(
-    [getAssignmentsInTodoList, getStoredAssignments],
-    (assignmentIds, storedAssignments) => (getItemsById(assignmentIds, storedAssignments))
-);
-
-export const getInProgressAssignments = createSelector(
-    [getAssignmentsInInProgressList, getStoredAssignments],
-    (assignmentIds, storedAssignments) => (getItemsById(assignmentIds, storedAssignments))
-);
-
-export const getCompletedAssignments = createSelector(
-    [getAssignmentsInCompletedList, getStoredAssignments],
-    (assignmentIds, storedAssignments) => (getItemsById(assignmentIds, storedAssignments))
-);
 
 export const getCurrentAssignment = createSelector(
     [getCurrentAssignmentId, getStoredAssignments],
@@ -90,7 +164,7 @@ export const getAssignmentSearch = createSelector(
             searchDeskId = get(listSettings, 'selectedDeskId', null);
         }
 
-        const assignmentSearch = {
+        return {
             deskId: searchDeskId,
             userId: (get(listSettings, 'filterBy') === 'User') ? currentUserId : null,
             searchQuery: get(listSettings, 'searchQuery', ''),
@@ -101,8 +175,6 @@ export const getAssignmentSearch = createSelector(
             type: filterByType,
             priority: filterByPriority,
         };
-
-        return assignmentSearch;
     }
 );
 
@@ -130,3 +202,42 @@ export const getCurrentAssignmentArchiveItem = createSelector(
         assignmentId ? get(storedItems, assignmentId, null) : null
     )
 );
+
+export const getAssignmentGroupSelectors = {
+    [ASSIGNMENTS.LIST_GROUPS.TODO.id]: {
+        assignmentsSelector: getTodoAssignments,
+        countSelector: getAssignmentsToDoListCount,
+        page: getAssignmentTodoListPage,
+        assignmentIds: getAssignmentsInTodoList,
+    },
+    [ASSIGNMENTS.LIST_GROUPS.IN_PROGRESS.id]: {
+        assignmentsSelector: getInProgressAssignments,
+        countSelector: getAssignmentsInProgressListCount,
+        page: getAssignmentInProgressPage,
+        assignmentIds: getAssignmentsInInProgressList,
+    },
+    [ASSIGNMENTS.LIST_GROUPS.COMPLETED.id]: {
+        assignmentsSelector: getCompletedAssignments,
+        countSelector: getAssignmentsCompletedListCount,
+        page: getAssignmentCompletedPage,
+        assignmentIds: getAssignmentsInCompletedList,
+    },
+    [ASSIGNMENTS.LIST_GROUPS.CURRENT.id]: {
+        assignmentsSelector: getCurrentAssignments,
+        countSelector: getAssignmentsCurrentListCount,
+        page: getAssignmentCurrentPage,
+        assignmentIds: getAssignmentsCurrentList,
+    },
+    [ASSIGNMENTS.LIST_GROUPS.TODAY.id]: {
+        assignmentsSelector: getTodayAssignments,
+        countSelector: getAssignmentsTodayListCount,
+        page: getAssignmentTodayPage,
+        assignmentIds: getAssignmentsTodayList,
+    },
+    [ASSIGNMENTS.LIST_GROUPS.FUTURE.id]: {
+        assignmentsSelector: getFutureAssignments,
+        countSelector: getAssignmentsFutureListCount,
+        page: getAssignmentFuturePage,
+        assignmentIds: getAssignmentsFutureList,
+    },
+};

--- a/client/selectors/tests/assignments_test.js
+++ b/client/selectors/tests/assignments_test.js
@@ -173,40 +173,34 @@ describe('selectors', () => {
         });
     });
 
-    it('getAssignmentTodoListPage', () => {
-        const page = selectors.getAssignmentTodoListPage(state);
+    describe('TODO', () => {
+        it('getAssignmentTodoListPage', () => {
+            expect(selectors.getAssignmentTodoListPage(state)).toBe(1);
+        });
 
-        expect(page).toBe(1);
+        it('getAssignmentsToDoListCount', () => {
+            expect(selectors.getAssignmentsToDoListCount(state)).toBe(0);
+        });
     });
 
-    it('getAssignmentInProgressPage', () => {
-        const page = selectors.getAssignmentInProgressPage(state);
+    describe('IN_PROGRESS', () => {
+        it('getAssignmentInProgressPage', () => {
+            expect(selectors.getAssignmentInProgressPage(state)).toBe(1);
+        });
 
-        expect(page).toBe(1);
+        it('getAssignmentsInProgressListCount', () => {
+            expect(selectors.getAssignmentsInProgressListCount(state)).toBe(0);
+        });
     });
 
-    it('getAssignmentCompletedPage', () => {
-        const page = selectors.getAssignmentCompletedPage(state);
+    describe('COMPLETED', () => {
+        it('getAssignmentCompletedPage', () => {
+            expect(selectors.getAssignmentCompletedPage(state)).toBe(1);
+        });
 
-        expect(page).toBe(1);
-    });
-
-    it('getAssignmentsToDoListCount', () => {
-        const count = selectors.getAssignmentsToDoListCount(state);
-
-        expect(count).toBe(0);
-    });
-
-    it('getAssignmentsInProgressListCount', () => {
-        const count = selectors.getAssignmentsInProgressListCount(state);
-
-        expect(count).toBe(0);
-    });
-
-    it('getAssignmentsCompletedListCount', () => {
-        const count = selectors.getAssignmentsCompletedListCount(state);
-
-        expect(count).toBe(0);
+        it('getAssignmentsCompletedListCount', () => {
+            expect(selectors.getAssignmentsCompletedListCount(state)).toBe(0);
+        });
     });
 
     it('getAssignmentListSingleGroupView', () => {

--- a/client/services/AssignmentsService.js
+++ b/client/services/AssignmentsService.js
@@ -4,65 +4,69 @@ import {Provider} from 'react-redux';
 
 import {gettext} from '../utils';
 
-import planningUtils from '../utils/planning';
-import {WORKSPACE, MODALS} from '../constants';
+import {WORKSPACE, MODALS, ASSIGNMENTS} from '../constants';
 import {ModalsContainer} from '../components';
 import * as actions from '../actions';
 
 export class AssignmentsService {
-    constructor(api, notify, modal, sdPlanningStore, deployConfig, desks) {
+    constructor(api, notify, modal, sdPlanningStore, deployConfig, desks, config) {
         this.api = api;
         this.notify = notify;
         this.modal = modal;
         this.sdPlanningStore = sdPlanningStore;
         this.deployConfig = deployConfig;
         this.desks = desks;
+        this.config = config;
 
         this.onPublishFromAuthoring = this.onPublishFromAuthoring.bind(this);
     }
 
     getAssignmentQuery(slugline, contentType) {
-        return {
-            must: [
-                {term: {'assigned_to.state': 'assigned'}},
-                {query_string: {
-                    query: `planning.slugline.phrase:("${slugline}")`,
-                    lenient: false,
-                }},
-                {term: {'planning.g2_content_type': contentType}},
-            ],
-        };
+        return actions.assignments.api.constructQuery({
+            systemTimezone: this.config.defaultTimezone,
+            searchQuery: `planning.slugline.phrase:("${slugline}")`,
+            states: ['assigned'],
+            type: contentType,
+            dateFilter: 'today',
+        });
     }
 
     onPublishFromAuthoring(item) {
         // Get the complete item from a new query
         return this.api.find('archive', item._id)
-            .then((archiveTtem) => {
+            .then((archiveItem) => {
                 // If the archive item is already linked to an Assignment
                 // then return now (nothing needs to be done)
-                if (get(archiveTtem, 'assignment_id')) {
+                if (get(archiveItem, 'assignment_id')) {
                     return Promise.resolve();
                 }
 
-                const fulfilFromDesks = get(this.deployConfig, 'config.planning_fulfil_on_publish_for_desks', []);
+                const fulfilFromDesks = get(
+                    this.deployConfig,
+                    'config.planning_fulfil_on_publish_for_desks',
+                    []
+                );
                 const currentDesk = get(this.desks, 'active.desk');
+                const selectedDeskId = get(archiveItem, 'task.desk') ?
+                    archiveItem.task.desk :
+                    currentDesk;
 
-                if (fulfilFromDesks.length > 0 && fulfilFromDesks.indexOf(currentDesk) < 0) {
+                if (fulfilFromDesks.length > 0 && fulfilFromDesks.indexOf(selectedDeskId) < 0) {
                     return Promise.resolve();
                 }
 
                 // Otherwise attempt to get an open Assignment (state==assigned)
                 // based on the slugline of the archive item
                 return new Promise((resolve, reject) => {
-                    this.getBySlugline(get(archiveTtem, 'slugline'), get(archiveTtem, 'type'))
-                        .then((assignments) => {
+                    this.getBySlugline(get(archiveItem, 'slugline'), get(archiveItem, 'type'))
+                        .then((data) => {
                             // If no Assignments were found, then there is nothing to do
-                            if (!Array.isArray(assignments) || assignments.length === 0) {
+                            if (get(data, '_meta.total', 0) < 1) {
                                 return resolve();
                             }
 
                             // Show the LinkToAssignment modal for further user decisions
-                            return this.showLinkAssignmentModal(archiveTtem, assignments, resolve, reject);
+                            return this.showLinkAssignmentModal(archiveItem, resolve, reject);
                         })
                         .catch(() => {
                             // If the API call failed, allow the publishing to continue
@@ -81,25 +85,15 @@ export class AssignmentsService {
     getBySlugline(slugline, contentType) {
         return this.api('assignments').query({
             source: JSON.stringify({
-                query: {
-                    bool: this.getAssignmentQuery(slugline, contentType),
-                },
+                query: this.getAssignmentQuery(slugline, contentType),
+                size: 0,
             }),
-        })
-            .then(
-                (data) => {
-                    if (get(data, '_items.length', 0) > 0) {
-                        data._items.forEach(planningUtils.modifyForClient);
-                        return Promise.resolve(data._items);
-                    }
-
-                    return Promise.resolve([]);
-                },
-                (error) => Promise.reject(error)
-            );
+            page: 1,
+            sort: '[("planning.scheduled", 1)]',
+        });
     }
 
-    showLinkAssignmentModal(item, assignments, resolve, reject) {
+    showLinkAssignmentModal(item, resolve, reject) {
         let store;
 
         this.sdPlanningStore.initWorkspace(WORKSPACE.AUTHORING, (newStore) => {
@@ -115,49 +109,54 @@ export class AssignmentsService {
                             </Provider>
                         );
 
-                        store.dispatch(
-                            actions.assignments.ui.changeAssignmentListSingleGroupView('TODO')
-                        );
-                        store.dispatch(actions.assignments.api.setBaseQuery(
-                            this.getAssignmentQuery(get(item, 'slugline'), get(item, 'type'))
-                        ));
-                        store.dispatch(actions.assignments.ui.preview(assignments[0]));
+                        store.dispatch(actions.assignments.ui.loadFulfillModal(
+                            item,
+                            [
+                                ASSIGNMENTS.LIST_GROUPS.TODAY.id,
+                                ASSIGNMENTS.LIST_GROUPS.FUTURE.id,
+                            ]
+                        ))
+                            .then(() => {
+                                store.dispatch(
+                                    actions.assignments.ui.previewFirstInListGroup(
+                                        ASSIGNMENTS.LIST_GROUPS.CURRENT.id
+                                    )
+                                );
 
-                        const onCancel = () => {
-                            closeModal();
-                            reject();
-                        };
+                                const onUnload = () => {
+                                    closeModal();
+                                    store.dispatch(actions.resetStore());
+                                };
 
-                        const onIgnore = () => {
-                            closeModal();
-                            resolve();
-                        };
+                                const $scope = {
+                                    resolve: () => {
+                                        onUnload();
+                                        resolve();
+                                    },
+                                    reject: () => {
+                                        onUnload();
+                                        reject();
+                                    },
+                                };
 
-                        const $scope = {
-                            resolve: () => {
-                                closeModal();
-                                resolve();
-                            },
-                            reject: reject,
-                        };
-
-                        store.dispatch(actions.showModal({
-                            modalType: MODALS.FULFIL_ASSIGNMENT,
-                            modalProps: {
-                                newsItem: item,
-                                fullscreen: true,
-                                $scope: $scope, // Required by actions dispatches
-                                onCancel: onCancel,
-                                onIgnore: onIgnore,
-                                showCancel: false,
-                                showIgnore: true,
-                                ignoreText: gettext('Don\'t Fulfil Assignment'),
-                                title: gettext('Fulfil Assignment with this item?'),
-                            },
-                        }));
+                                store.dispatch(actions.showModal({
+                                    modalType: MODALS.FULFIL_ASSIGNMENT,
+                                    modalProps: {
+                                        newsItem: item,
+                                        fullscreen: true,
+                                        $scope: $scope, // Required by actions dispatches
+                                        onCancel: $scope.resolve,
+                                        onIgnore: $scope.resolve,
+                                        showCancel: false,
+                                        showIgnore: true,
+                                        ignoreText: gettext('Don\'t Fulfil Assignment'),
+                                        title: gettext('Fulfil Assignment with this item?'),
+                                    },
+                                }));
+                            });
                     });
             });
     }
 }
 
-AssignmentsService.$inject = ['api', 'notify', 'modal', 'sdPlanningStore', 'deployConfig', 'desks'];
+AssignmentsService.$inject = ['api', 'notify', 'modal', 'sdPlanningStore', 'deployConfig', 'desks', 'config'];

--- a/client/styles/index.scss
+++ b/client/styles/index.scss
@@ -21,9 +21,20 @@
 
 .AssignmentItem {
     .sd-list-item__time__schedule {
-        color: #005b7f !important;
+        color: $sd-blueDark !important;
         font-weight: 500;
         vertical-align: text-top;
+        padding-left: 0;
+    }
+
+    .label-icon--warning {
+        .sd-list-item__time__schedule {
+            color: $orange !important;
+        }
+
+        .label {
+            margin-left: 0.75rem;
+        }
     }
 }
 

--- a/client/utils/testData.js
+++ b/client/utils/testData.js
@@ -491,15 +491,55 @@ export const agendaInitialState = {
 };
 
 export const assignmentInitialState = {
-    assignments: {},
-    filterBy: 'Desk',
-    previewOpened: false,
-    assignmentsInInProgressList: [],
-    assignmentsInTodoList: [],
-    assignmentsInCompletedList: [],
-    assignmentListSingleGroupView: null,
-    currentAssignmentId: null,
     archive: {},
+    assignments: {},
+    baseQuery: {must: []},
+    currentAssignmentId: null,
+    filterBy: 'Desk',
+    filterByPriority: null,
+    filterByType: null,
+    myAssignmentsTotal: 0,
+    orderByField: 'Scheduled',
+    orderDirection: 'Asc',
+    previewOpened: false,
+    readOnly: false,
+    searchQuery: null,
+    selectedDeskId: '',
+    assignmentListSingleGroupView: null,
+
+    groupKeys: ['TODO', 'IN_PROGRESS', 'COMPLETED'],
+    lists: {
+        TODO: {
+            assignmentIds: [],
+            total: 0,
+            lastPage: null,
+        },
+        IN_PROGRESS: {
+            assignmentIds: [],
+            total: 0,
+            lastPage: null,
+        },
+        COMPLETED: {
+            assignmentIds: [],
+            total: 0,
+            lastPage: null,
+        },
+        CURRENT: {
+            assignmentIds: [],
+            total: 0,
+            lastPage: null,
+        },
+        TODAY: {
+            assignmentIds: [],
+            total: 0,
+            lastPage: null,
+        },
+        FUTURE: {
+            assignmentIds: [],
+            total: 0,
+            lastPage: null,
+        },
+    },
 };
 
 export const modal = {
@@ -801,6 +841,7 @@ export const archive = [
         headline: 'test headline',
         urgency: 2,
         type: 'text',
+        task: {desk: 'desk2'},
     },
 ];
 

--- a/client/utils/tests/assignments_test.js
+++ b/client/utils/tests/assignments_test.js
@@ -1,5 +1,5 @@
 import * as utils from '../index';
-import {PRIVILEGES} from '../../constants';
+import {PRIVILEGES, ASSIGNMENTS} from '../../constants';
 
 describe('can edit assignment', () => {
     let privileges;
@@ -184,5 +184,61 @@ describe('can edit assignment', () => {
 
         assignment.item_ids = ['item1', 'item2'];
         expect(assignmentHasContent()).toBe(true);
+    });
+
+    describe('getAssignmentGroupsByStates', () => {
+        it('returns an empty array if no states provided', () => {
+            let groups;
+
+            groups = utils.assignmentUtils.getAssignmentGroupsByStates([], []);
+            expect(groups).toEqual([]);
+
+            groups = utils.assignmentUtils.getAssignmentGroupsByStates();
+            expect(groups).toEqual([]);
+        });
+
+        it('returns groups that are associated with the assignment state', () => {
+            let groups;
+
+            groups = utils.assignmentUtils.getAssignmentGroupsByStates(
+                Object.keys(ASSIGNMENTS.LIST_GROUPS),
+                ['assigned']
+            );
+            expect(groups).toEqual(['TODO', 'CURRENT', 'TODAY', 'FUTURE']);
+
+            groups = utils.assignmentUtils.getAssignmentGroupsByStates(
+                Object.keys(ASSIGNMENTS.LIST_GROUPS),
+                ['submitted']
+            );
+            expect(groups).toEqual(['TODO', 'CURRENT', 'TODAY', 'FUTURE']);
+
+            groups = utils.assignmentUtils.getAssignmentGroupsByStates(
+                Object.keys(ASSIGNMENTS.LIST_GROUPS),
+                ['in_progress']
+            );
+            expect(groups).toEqual(['IN_PROGRESS']);
+
+            groups = utils.assignmentUtils.getAssignmentGroupsByStates(
+                Object.keys(ASSIGNMENTS.LIST_GROUPS),
+                ['completed']
+            );
+            expect(groups).toEqual(['COMPLETED']);
+
+            groups = utils.assignmentUtils.getAssignmentGroupsByStates(
+                Object.keys(ASSIGNMENTS.LIST_GROUPS),
+                ['cancelled']
+            );
+            expect(groups).toEqual(['COMPLETED']);
+        });
+
+        it('returns groups that are associated with any state in the array', () => {
+            let groups;
+
+            groups = utils.assignmentUtils.getAssignmentGroupsByStates(
+                Object.keys(ASSIGNMENTS.LIST_GROUPS),
+                ['assigned', 'in_progress']
+            );
+            expect(groups).toEqual(['TODO', 'CURRENT', 'TODAY', 'FUTURE', 'IN_PROGRESS']);
+        });
     });
 });

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "hint": "eslint client --ext=jsx --ext=js --ext=tsx --ext=ts --ext=spec",
     "lint": "eslint client --ext=jsx --ext=js --ext=tsx --ext=ts --ext=spec --quiet",
     "unit_test": "karma start karma.conf.js --log-level debug --display-error-details --single-run",
-    "karma": "karma start karma.conf.js",
+    "karma": "node --max-old-space-size=8192 ./node_modules/.bin/karma start karma.conf.js",
     "test": "npm run hint && npm run unit_test"
   },
   "author": "Edouard Richard",


### PR DESCRIPTION
* (fix): Use items desk not the selected desk when determining if to fulfill assignment on publish