### PR TITLE
add compatibility fix so event templates commit can be restored

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
+    "postinstall": "node tasks/backwards-compatibility-fixes.js",
     "fix": "eslint client --ext=jsx --ext=js --ext=tsx --ext=ts --ext=spec --fix",
     "hint": "eslint client --ext=jsx --ext=js --ext=tsx --ext=ts --ext=spec",
     "lint": "eslint client --ext=jsx --ext=js --ext=tsx --ext=ts --ext=spec --quiet",

--- a/tasks/backwards-compatibility-fixes.js
+++ b/tasks/backwards-compatibility-fixes.js
@@ -1,0 +1,8 @@
+var fs = require('fs');
+var path = require('path');
+
+const filePath = path.resolve(`${__dirname}/../node_modules/superdesk-core/scripts/core/get-superdesk-api-implementation.tsx`);
+
+if (fs.existsSync(filePath) !== true) {
+    fs.writeFileSync(filePath, `export function getSuperdeskApiImplementation() {return {}; }\n`);
+}


### PR DESCRIPTION
Fixes the issue described in https://github.com/superdesk/superdesk-planning/pull/1319. @MarkLark86 can you restore event templates after this one is merged?