### PR TITLE
Fix event duplicate.

### DIFF
--- a/client/actions/tests/autosave_test.js
+++ b/client/actions/tests/autosave_test.js
@@ -132,6 +132,7 @@ describe('actions.autosave', () => {
                     const expectedItem = {
                         ...data.events[1],
                         _id: 'tempId-e4',
+                        duplicate_from: 'e1',
                         lock_action: 'create',
                         lock_user: store.initialState.session.identity._id,
                         lock_session: store.initialState.session.sessionId,

--- a/client/constants/autosave.js
+++ b/client/constants/autosave.js
@@ -7,5 +7,5 @@ export const AUTOSAVE = {
     INTERVAL: 3000,
     IGNORE_FIELDS: ['planning_ids', 'reason', 'update_method', 'expired', 'version', 'previous_recurrence_id',
         'versioncreated', 'event_lastmodified', 'relationships', 'expiry', 'duplicate_to', 'original_creator',
-        'revert_state', 'version_creator', 'duplicate_from', 'unique_id'],
+        'revert_state', 'version_creator', 'unique_id'],
 };

--- a/client/utils/testData.js
+++ b/client/utils/testData.js
@@ -546,6 +546,7 @@ export const events = [
     },
     {
         _id: 'e2',
+        duplicate_from: 'e1',
         type: 'event',
         slugline: 'test slugline 2',
         name: 'Event 2',


### PR DESCRIPTION
When you duplicate an event, autosave does not send `duplicate_from` which brakes a relation between events.

SDNTB-599