### PR TITLE
Fix buggy behaviour when trying to remove subjects from event and planning item

### DIFF
--- a/client/components/UI/Form/SelectMetaTermsInput/index.jsx
+++ b/client/components/UI/Form/SelectMetaTermsInput/index.jsx
@@ -37,12 +37,13 @@ export class SelectMetaTermsInput extends React.Component {
         this.addBtn.focus();
     }
 
-    removeValue(index) {
+    removeValue(index, term) {
         const {value, field, onChange} = this.props;
-        let newValue = cloneDeep(value);
 
-        newValue.splice(index, 1);
-        onChange(field, newValue);
+        onChange(
+            field,
+            value.filter(({scheme, qcode}) => !(term.scheme === scheme && term.qcode === qcode)),
+        );
     }
 
     removeValuesFromOptions() {

--- a/client/components/UI/Form/SelectMetaTermsInput/index.jsx
+++ b/client/components/UI/Form/SelectMetaTermsInput/index.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import {SelectFieldPopup} from './SelectFieldPopup';
-import {differenceByS} from 'lodash';
+import {differenceBy} from 'lodash';
 
 import {LineInput, Label} from '../';
 import {TermsList} from '../../';

--- a/client/components/UI/Form/SelectMetaTermsInput/index.jsx
+++ b/client/components/UI/Form/SelectMetaTermsInput/index.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import {SelectFieldPopup} from './SelectFieldPopup';
-import {differenceBy, cloneDeep} from 'lodash';
+import {differenceByS} from 'lodash';
 
 import {LineInput, Label} from '../';
 import {TermsList} from '../../';
@@ -42,7 +42,7 @@ export class SelectMetaTermsInput extends React.Component {
 
         onChange(
             field,
-            value.filter(({scheme, qcode}) => !(term.scheme === scheme && term.qcode === qcode)),
+            value.filter(({scheme, qcode}) => !(term.scheme === scheme && term.qcode === qcode))
         );
     }
 

--- a/client/components/UI/TermsList.jsx
+++ b/client/components/UI/TermsList.jsx
@@ -15,7 +15,7 @@ const TermsList = ({terms, displayField, onClick, readOnly}) => (
     )}>
         <ul>
             {terms.map((term, index) => (
-                <li key={index} onClick={(!readOnly && onClick) ? onClick.bind(null, index) : null}>
+                <li key={index} onClick={(!readOnly && onClick) ? onClick.bind(null, index, term) : null}>
                     {(!readOnly && onClick) && <i className="icon-close-small"/>}
                     {get(term, displayField) || term}
                 </li>


### PR DESCRIPTION
SDNTB-613

Values from the same array are used both for subject and category fields thus removing items by index can't be used.

![category-subject](https://user-images.githubusercontent.com/2076953/67845567-faa17300-faff-11e9-8cc1-7ed0c9cda671.gif)
