### PR TITLE
Revert "Fix buggy behaviour when trying to remove subjects from event and planning item"

### DIFF
--- a/client/components/UI/Form/SelectMetaTermsInput/index.jsx
+++ b/client/components/UI/Form/SelectMetaTermsInput/index.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import {SelectFieldPopup} from './SelectFieldPopup';
-import {differenceBy} from 'lodash';
+import {differenceBy, cloneDeep} from 'lodash';
 
 import {LineInput, Label} from '../';
 import {TermsList} from '../../';
@@ -37,13 +37,12 @@ export class SelectMetaTermsInput extends React.Component {
         this.addBtn.focus();
     }
 
-    removeValue(index, term) {
+    removeValue(index) {
         const {value, field, onChange} = this.props;
+        let newValue = cloneDeep(value);
 
-        onChange(
-            field,
-            value.filter(({scheme, qcode}) => !(term.scheme === scheme && term.qcode === qcode))
-        );
+        newValue.splice(index, 1);
+        onChange(field, newValue);
     }
 
     removeValuesFromOptions() {

--- a/client/components/UI/TermsList.jsx
+++ b/client/components/UI/TermsList.jsx
@@ -15,7 +15,7 @@ const TermsList = ({terms, displayField, onClick, readOnly}) => (
     )}>
         <ul>
             {terms.map((term, index) => (
-                <li key={index} onClick={(!readOnly && onClick) ? onClick.bind(null, index, term) : null}>
+                <li key={index} onClick={(!readOnly && onClick) ? onClick.bind(null, index) : null}>
                     {(!readOnly && onClick) && <i className="icon-close-small"/>}
                     {get(term, displayField) || term}
                 </li>


### PR DESCRIPTION
Reverts superdesk/superdesk-planning#1373

A submodule for `superdesk` was added again and breaks the build. Please ensure when you create a PR that it does not include the submodule.