### PR TITLE
[SDESK-4766] UX improvements for coverage provider contact

### DIFF
--- a/client/components/Assignments/AssignmentEditor.jsx
+++ b/client/components/Assignments/AssignmentEditor.jsx
@@ -105,6 +105,19 @@ export class AssignmentEditorComponent extends React.Component {
         }
     }
 
+    componentDidUpdate(prevProps, prevState) {
+        const currentContactType = get(this.state, 'contactType') || {};
+        const prevContactType = get(prevState, 'contactType') || {};
+
+        if (currentContactType.qcode !== prevContactType.qcode) {
+            if (currentContactType.assignable) {
+                this.onChange(this.FIELDS.USER, null);
+            } else {
+                this.onChange(this.FIELDS.CONTACT, null);
+            }
+        }
+    }
+
     onChange(field, value, state = {}) {
         const errors = cloneDeep(this.state.errors);
         const combinedState = {
@@ -266,7 +279,7 @@ export class AssignmentEditorComponent extends React.Component {
 
                 {this.state.contactType && this.state.contactType.assignable ? (
                     <Row>
-                        <Label text={gettext('External Contact')} />
+                        <Label text={gettext('Assigned Provider')} />
                         {this.state.contactId && (
                             <ContactsPreviewList
                                 contactIds={[this.state.contactId]}
@@ -278,6 +291,8 @@ export class AssignmentEditorComponent extends React.Component {
                             value={this.state.contactId ? [this.state.contactId] : []}
                             onChange={this.onContactChange}
                             contactType={this.state.contactType.qcode}
+                            minLengthPopup={0}
+                            placeholder={gettext('Search provider contacts')}
                         />
                     </Row>
                 ) : (

--- a/client/components/Assignments/AssignmentPreviewContainer/AssignmentPreview.jsx
+++ b/client/components/Assignments/AssignmentPreviewContainer/AssignmentPreview.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {get} from 'lodash';
 
-import {gettext, stringUtils} from '../../../utils';
+import {gettext, stringUtils, assignmentUtils} from '../../../utils';
 
 import {InternalNoteLabel} from '../../';
 import {ContactsPreviewList} from '../../Contacts/index';
@@ -33,15 +33,15 @@ export const AssignmentPreview = ({
     const subjectText = get(planningItem, 'subject.length', 0) > 0 ?
         planningItem.subject.map((s) => s.name).join(', ') : '-';
 
-    const contactIds = get(assignment, 'assigned_to.contact') ?
-        [assignment.assigned_to.contact] :
-        get(planning, 'contact_info', []);
+    const contactId = get(assignment, 'assigned_to.contact') ?
+        assignment.assigned_to.contact :
+        get(planning, 'contact_info');
 
     return (
         <div>
-            <Row label={gettext('Coverage Provider Contact')}>
+            <Row label={assignmentUtils.getContactLabel(assignment)}>
                 <ContactsPreviewList
-                    contactIds={contactIds}
+                    contactIds={contactId ? [contactId] : []}
                     scrollInView={true}
                     scrollIntoViewOptions={{block: 'center'}}
                     tabEnabled={true}

--- a/client/components/Contacts/ContactLabel.jsx
+++ b/client/components/Contacts/ContactLabel.jsx
@@ -17,7 +17,7 @@ export const ContactLabel = ({contact}) => (
             <div>
                 <span className="sd-list-item__text-strong sd-overflow-ellipsis">
                     {contact.first_name ?
-                        `${contact.last_name}, ${contact.first_name} ` :
+                        `${contact.first_name} ${contact.last_name} ` :
                         `${contact.organisation} `
                     }
                     {(contact.first_name && contact.job_title && contact.organisation) && (

--- a/client/components/Contacts/SelectSearchContactsField/SelectListPopup.jsx
+++ b/client/components/Contacts/SelectSearchContactsField/SelectListPopup.jsx
@@ -99,7 +99,7 @@ export class SelectListPopupComponent extends React.Component {
     }
 
     filterSearchResults(val) {
-        if (!val) {
+        if (this.props.minLength > 0 && (!val || get(val, 'length') < this.props.minLength)) {
             this.setState({
                 search: false,
                 filteredList: this.getFilteredOptionList(),
@@ -108,7 +108,7 @@ export class SelectListPopupComponent extends React.Component {
             return;
         }
 
-        const valueNoCase = val.toLowerCase();
+        const valueNoCase = (val || '').toLowerCase();
 
         this.getSearchResult(valueNoCase);
         this.setState({
@@ -118,7 +118,9 @@ export class SelectListPopupComponent extends React.Component {
     }
 
     openSearchList(event) {
-        if (event && get(event.target, 'value.length') > 1) {
+        if (event && get(event.target, 'value.length') >= this.props.minLength) {
+            this.filterSearchResults(event.target.value);
+
             if (!this.state.openFilterList) {
                 this.setState({
                     filteredList: this.getFilteredOptionList(),
@@ -160,7 +162,8 @@ export class SelectListPopupComponent extends React.Component {
                 ref={(node) => this.dom.searchField = node}
                 onFocus={this.props.onFocus}
                 readOnly={this.props.readOnly}
-                placeholder={gettext('Search for a contact')}
+                placeholder={this.props.placeholder || gettext('Search for a contact')}
+                autoComplete={false}
             />
             {this.state.openFilterList && (
                 <Popup
@@ -225,7 +228,11 @@ SelectListPopupComponent.propTypes = {
     onPopupOpen: PropTypes.func,
     onPopupClose: PropTypes.func,
     contactType: PropTypes.string,
+    minLength: PropTypes.number,
+    placeholder: PropTypes.string,
 };
+
+SelectListPopupComponent.defaultProps = {minLength: 1};
 
 const mapDispatchToProps = (dispatch) => ({
     searchContacts: (text, contactType) => dispatch(

--- a/client/components/Contacts/SelectSearchContactsField/index.jsx
+++ b/client/components/Contacts/SelectSearchContactsField/index.jsx
@@ -25,7 +25,18 @@ export class SelectSearchContactsField extends React.Component {
     }
 
     render() {
-        const {label, value, onAdd, onAddText, onFocus, readOnly, contactType, ...props} = this.props;
+        const {
+            label,
+            value,
+            onAdd,
+            onAddText,
+            onFocus,
+            readOnly,
+            contactType,
+            minLengthPopup,
+            placeholder,
+            ...props
+        } = this.props;
 
         return (
             <LineInput readOnly={readOnly} {...props}>
@@ -43,6 +54,8 @@ export class SelectSearchContactsField extends React.Component {
                     onPopupOpen={props.onPopupOpen}
                     onPopupClose={props.onPopupClose}
                     contactType={contactType}
+                    minLength={minLengthPopup}
+                    placeholder={placeholder}
                 />
             </LineInput>
         );
@@ -60,9 +73,12 @@ SelectSearchContactsField.propTypes = {
     onAddText: PropTypes.string,
     onFocus: PropTypes.func,
     contactType: PropTypes.string,
+    minLengthPopup: PropTypes.number,
+    placeholder: PropTypes.string,
 };
 
 SelectSearchContactsField.defaultProps = {
     required: false,
     readOnly: false,
+    minLengthPopup: 1,
 };

--- a/client/components/Coverages/CoverageEditor/CoverageForm.jsx
+++ b/client/components/Coverages/CoverageEditor/CoverageForm.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {get} from 'lodash';
-import {getItemInArrayById, gettext, planningUtils, generateTempId} from '../../../utils';
+import {getItemInArrayById, gettext, planningUtils, generateTempId, assignmentUtils} from '../../../utils';
 import moment from 'moment';
 import {WORKFLOW_STATE, DEFAULT_DATE_FORMAT, DEFAULT_TIME_FORMAT, TO_BE_CONFIRMED_FIELD} from '../../../constants';
 import {Button} from '../../UI';
@@ -206,11 +206,13 @@ export class CoverageForm extends React.Component {
         const canCreateScheduledUpdate = !addNewsItemToPlanning &&
             !get(diff, `${field}.flags.no_content_linking`);
 
+        const contactLabel = assignmentUtils.getContactLabel(get(diff, field));
+
         return (
             <div className="coverage-editor">
                 {get(diff, `${field}.assigned_to.contact`) ? (
                     <Row className="coverage-editor__contact">
-                        <Label row={true} text={gettext('Coverage Provider Contact')} />
+                        <Label row={true} text={contactLabel} />
                         <ContactsPreviewList
                             contactIds={[get(diff, `${field}.assigned_to.contact`)]}
                             scrollInView={true}
@@ -222,7 +224,7 @@ export class CoverageForm extends React.Component {
                         component={ContactField}
                         field={`${field}.planning.contact_info`}
                         profileName="contact_info"
-                        label={gettext('Coverage Provider Contact')}
+                        label={contactLabel}
                         defaultValue={[]}
                         {...fieldProps}
                         readOnly={readOnly}

--- a/client/components/Coverages/CoveragePreview/index.jsx
+++ b/client/components/Coverages/CoveragePreview/index.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import {Row as PreviewRow} from '../../UI/Preview';
 import {CollapseBox} from '../../UI';
 import {get} from 'lodash';
-import {gettext, stringUtils, planningUtils} from '../../../utils';
+import {gettext, stringUtils, planningUtils, assignmentUtils} from '../../../utils';
 import {ContactsPreviewList} from '../../Contacts/index';
 import {PLANNING, WORKFLOW_STATE, DEFAULT_DATE_FORMAT, DEFAULT_TIME_FORMAT} from '../../../constants';
 import {CoverageItem} from '../';
@@ -73,7 +73,10 @@ export const CoveragePreview = ({
     const coverageInDetail = (
         <div className="coverage-preview__detail">
             {contactId && (
-                <PreviewRow label={gettext('Coverage Provider Contact')} className="coverage-preview__contact">
+                <PreviewRow
+                    label={assignmentUtils.getContactLabel(coverage)}
+                    className="coverage-preview__contact"
+                >
                     <ContactsPreviewList
                         contactIds={contactId ? [contactId] : []}
                         scrollInView={true}

--- a/client/components/Coverages/ScheduledUpdate/ScheduledUpdateForm.jsx
+++ b/client/components/Coverages/ScheduledUpdate/ScheduledUpdateForm.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {gettext, planningUtils} from '../../../utils';
+import {get} from 'lodash';
+
+import {gettext, planningUtils, assignmentUtils} from '../../../utils';
 import {WORKFLOW_STATE, DEFAULT_DATE_FORMAT, DEFAULT_TIME_FORMAT} from '../../../constants';
 import {
     TextAreaInput,
@@ -83,7 +85,21 @@ export class ScheduledUpdateForm extends React.Component {
                     showText
                     stateField= {value.workflow_status === WORKFLOW_STATE.CANCELLED ?
                         `coverages[${coverageIndex}].scheduled_updates[${index}].workflow_status` : 'state'}
-                    className="form__row" />
+                    className="form__row"
+                />
+
+                <Field
+                    component={ContactField}
+                    field={`${field}.planning.contact_info`}
+                    profileName="contact_info"
+                    label={assignmentUtils.getContactLabel(get(diff, field))}
+                    defaultValue={[]}
+                    {...fieldProps}
+                    onPopupOpen={onPopupOpen}
+                    onPopupClose={onPopupClose}
+                    singleValue={true}
+                    readOnly={readOnly}
+                />
 
                 <Field
                     component={SelectInput}
@@ -105,18 +121,6 @@ export class ScheduledUpdateForm extends React.Component {
                     {...fieldProps}
                     refNode={(ref) => this.dom.internalNote = ref}
                 />
-
-                <Field
-                    component={ContactField}
-                    field={`${field}.planning.contact_info`}
-                    profileName="contact_info"
-                    label={gettext('Coverage Provider Contact')}
-                    defaultValue={[]}
-                    {...fieldProps}
-                    onPopupOpen={onPopupOpen}
-                    onPopupClose={onPopupClose}
-                    singleValue={true}
-                    readOnly={readOnly} />
 
                 <Field
                     component={SelectInput}

--- a/client/components/Coverages/ScheduledUpdate/index.jsx
+++ b/client/components/Coverages/ScheduledUpdate/index.jsx
@@ -11,7 +11,7 @@ import {ScheduledUpdateForm} from './ScheduledUpdateForm';
 import {CoverageFormHeader} from '../CoverageEditor/CoverageFormHeader';
 import {CoveragePreviewTopBar} from '../CoveragePreview/CoveragePreviewTopBar';
 
-import {planningUtils, gettext, stringUtils} from '../../../utils';
+import {planningUtils, gettext, stringUtils, assignmentUtils} from '../../../utils';
 import {PLANNING, COVERAGES, DEFAULT_DATE_FORMAT, DEFAULT_TIME_FORMAT} from '../../../constants';
 
 export const ScheduledUpdate = ({
@@ -138,6 +138,14 @@ export const ScheduledUpdate = ({
         newsCoverageStatus.find((s) => s.qcode === get(value, 'news_coverage_status.qcode', '')) || {};
 
     const openItem = forPreview ? (<div>
+        <PreviewRow label={assignmentUtils.getContactLabel(coverage)}>
+            <ContactsPreviewList
+                contactIds={get(value, 'planning.contact_info.length', 0) > 0 ?
+                    [value.planning.contact_info] : []}
+                scrollInView={true}
+                scrollIntoViewOptions={{block: 'center'}}
+            />
+        </PreviewRow>
         <PreviewRow
             label={gettext('Genre')}
             value={get(value, 'planning.genre.name')}
@@ -148,14 +156,6 @@ export const ScheduledUpdate = ({
                 value.planning.internal_note || ''
             )}
         />
-        <PreviewRow label={gettext('Coverage Provider Contact')}>
-            <ContactsPreviewList
-                contactIds={get(value, 'planning.contact_info.length', 0) > 0 ?
-                    [value.planning.contact_info] : []}
-                scrollInView={true}
-                scrollIntoViewOptions={{block: 'center'}}
-            />
-        </PreviewRow>
         <PreviewRow
             label={gettext('Coverage Status')}
             value={coverageStatus.label || ''}

--- a/client/components/Events/tests/EventPreviewContent_test.jsx
+++ b/client/components/Events/tests/EventPreviewContent_test.jsx
@@ -125,7 +125,7 @@ describe('<EventPreviewContent />', () => {
         let contacts = wrapper.find('.contact-info');
 
         expect(contacts.find('span').first()
-            .text()).toBe(`${storeContact.last_name}, ${storeContact.first_name} `);
+            .text()).toBe(`${storeContact.first_name} ${storeContact.last_name} `);
 
         let files = wrapper.find('.toggle-box').at(1);
 

--- a/client/components/UI/SearchField/index.jsx
+++ b/client/components/UI/SearchField/index.jsx
@@ -19,6 +19,10 @@ export default class SearchField extends React.Component {
             searchInputValue: this.props.value || '',
             uniqueId: uniqueId('SearchField'),
         };
+
+        this.onSearchChange = this.onSearchChange.bind(this);
+        this.onSearchClick = this.onSearchClick.bind(this);
+        this.onKeyDown = this.onKeyDown.bind(this);
     }
 
     /** Reset the field value, close the search bar and load events */
@@ -41,7 +45,16 @@ export default class SearchField extends React.Component {
     }
 
     onSearchClick(event) {
-        this.setState(() => this.props.onSearchClick());
+        if (this.props.onSearchClick) {
+            this.props.onSearchClick(event);
+        }
+    }
+
+    onKeyDown(event) {
+        if (event.keyCode === KEYCODES.ENTER) {
+            onEventCapture(event);
+            this.onSearchClick();
+        }
     }
 
     render() {
@@ -53,20 +66,17 @@ export default class SearchField extends React.Component {
                 minLength={minLength}
                 debounceTimeout={800}
                 value={this.state.searchInputValue}
-                onChange={this.onSearchChange.bind(this)}
-                onClick={this.onSearchClick.bind(this)}
+                onChange={this.onSearchChange}
+                onClick={this.onSearchClick}
                 id={uniqueId}
                 placeholder={this.props.placeholder || gettext('Search')}
                 className="sd-line-input__input"
                 type="text"
-                onKeyDown={(event) => {
-                    if (event.keyCode === KEYCODES.ENTER) {
-                        onEventCapture(event);
-                        this.onSearchClick();
-                    }
-                }}
+                onKeyDown={this.onKeyDown}
                 onFocus={this.props.onFocus}
-                disabled={this.props.readOnly} />
+                disabled={this.props.readOnly}
+                autoComplete={this.props.autoComplete ? 'on' : 'off'}
+            />
         );
     }
 }
@@ -79,4 +89,7 @@ SearchField.propTypes = {
     onFocus: PropTypes.func,
     readOnly: PropTypes.bool,
     placeholder: PropTypes.string,
+    autoComplete: PropTypes.bool,
 };
+
+SearchField.defaultProps = {autoComplete: true};

--- a/client/utils/assignments.js
+++ b/client/utils/assignments.js
@@ -89,6 +89,12 @@ const isAssignedToProvider = (assignment) => (
     get(assignment, 'assigned_to.coverage_provider.qcode')
 );
 
+const getContactLabel = (assignment) => (
+    isAssignedToProvider(assignment) ?
+        gettext('Assigned Provider') :
+        gettext('Coverage Contact')
+);
+
 const getAssignmentActions = (assignment, session, privileges, lockedItems, contentTypes, callBacks) => {
     if (!isExistingItem(assignment) || lockUtils.isLockRestricted(assignment, session, lockedItems)) {
         return [];
@@ -349,6 +355,7 @@ const self = {
     getCurrentSelectedDeskId,
     getCurrentSelectedDesk,
     isAssignedToProvider,
+    getContactLabel,
 };
 
 export default self;


### PR DESCRIPTION
* External Contact on the Coverage Assignment Details modal should be a prepopulated drop list search as for Desk and User
* Change the label from 'External Contact' to 'Assigned Provider'
* Change the hint text to 'Search provider contacts'
* The Coverage Provider Contact tile persists (as read only) if the assignee type is reverted from Coverage Provider to user