### PR TITLE
SDBELGA-262 [EVENT FILES] Save additional file information.

### DIFF
--- a/server/features/publish.feature
+++ b/server/features/publish.feature
@@ -107,7 +107,7 @@ Feature: Publish
                     "type": "event",
                     "published_item": {
                         "_id": "#events._id#",
-                        "files": [{"_id": "#FILE._id#", "media": {"_id": "#FILE.filemeta.media_id#"}}]
+                        "files": [{"_id": "#FILE._id#", "media": {"_id": "#FILE.media._id#"}}]
                     }
                 }
             ]

--- a/server/planning/events/events_files.py
+++ b/server/planning/events/events_files.py
@@ -8,10 +8,11 @@
 
 """Superdesk Files"""
 
+import logging
+from flask import current_app as app
 import superdesk
 from superdesk import get_resource_service
 from superdesk.errors import SuperdeskApiError
-import logging
 
 logger = logging.getLogger(__name__)
 
@@ -45,7 +46,15 @@ class EventsFilesService(superdesk.Service):
     def on_create(self, docs):
         for doc in docs:
             # save the media id to retrieve the file later
-            doc['filemeta'] = {'media_id': doc['media']}
+            if 'media' in doc:
+                _file = app.media.get(doc['media'])
+                if _file:
+                    doc['filemeta'] = {
+                        'media_id': doc['media'],
+                        'content_type': _file.content_type,
+                        'filename': _file.filename,
+                        'length': _file.length
+                    }
 
     def on_created(self, docs):
         for doc in docs:


### PR DESCRIPTION
In mongo:
<img width="568" alt="Screenshot 2020-01-17 at 16 28 41" src="https://user-images.githubusercontent.com/4199922/72620554-32be9200-3948-11ea-9cd1-e44730c586a4.png">

Production API response:
<img width="747" alt="Screenshot 2020-01-17 at 16 38 51" src="https://user-images.githubusercontent.com/4199922/72620578-3d792700-3948-11ea-97b7-fd95e8968c8e.png">
