### PR TITLE
[SDESK-5223] Replace React hooks with Class for ExpandableText component

### DIFF
--- a/client/components/PlanningDetailsWidget.tsx
+++ b/client/components/PlanningDetailsWidget.tsx
@@ -47,7 +47,7 @@ class PlanningDetailsWidget extends React.Component<IProps, IState> {
         }
 
         return (
-            <div className="widget">
+            <div className="widget sd-padding-all--2">
                 <Provider store={this.state.store}>
                     <PlanningPreviewContent item={this.state.planning} />
                 </Provider>

--- a/client/components/UI/Preview/ExpandableText.jsx
+++ b/client/components/UI/Preview/ExpandableText.jsx
@@ -1,4 +1,4 @@
-import React, {useRef, useState} from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import {get} from 'lodash';
 
@@ -6,47 +6,61 @@ import {gettext} from '../../../utils';
 
 import './style.scss';
 
-export function ExpandableText({value, className, expandAt}) {
-    const valueRef = useRef();
-    const [expanded, setExpanded] = useState(false);
-
-    const toggleExpanded = () => {
-        setExpanded(!expanded);
-        if (valueRef.current && valueRef.current.parentNode) {
-            valueRef.current.parentNode.scrollIntoView();
-        }
-    };
-
-    if (!value) {
-        return null;
+export class ExpandableText extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {expanded: false};
+        this.dom = {parent: null};
+        this.toggleExpanded = this.toggleExpanded.bind(this);
+        this.setDomRef = this.setDomRef.bind(this);
     }
 
-    let text = value.replace(/\r/g, '')
-        .split('\n');
+    toggleExpanded(expanded) {
+        this.setState({expanded: !this.state.expanded});
+        if (this.dom.parent && this.dom.parent.parentNode) {
+            this.dom.parent.parentNode.scrollIntoView();
+        }
+    }
 
-    if (get(text, 'length', 0) > expandAt) {
-        if (!expanded) {
-            text = text.slice(0, expandAt);
+    setDomRef(ref) {
+        this.dom.parent = ref;
+    }
+
+    render() {
+        const {value, className, expandAt} = this.props;
+        const {expanded} = this.state;
+
+        if (!value) {
+            return null;
         }
 
-        const linkText = expanded ?
-            gettext('Show less') :
-            gettext('Show all');
+        let text = value.replace(/\r/g, '')
+            .split('\n');
 
-        text.push(
-            <a className="sd-text__expandable-link" onClick={toggleExpanded}>
-                ... {linkText}
-            </a>
+        if (get(text, 'length', 0) > expandAt) {
+            if (!expanded) {
+                text = text.slice(0, expandAt);
+            }
+
+            const linkText = expanded ?
+                gettext('Show less') :
+                gettext('Show all');
+
+            text.push(
+                <a className="sd-text__expandable-link" onClick={this.toggleExpanded}>
+                    ... {linkText}
+                </a>
+            );
+        }
+
+        return (
+            <p className={className} ref={this.setDomRef}>
+                {text.map((item, key) => (
+                    <span key={key}>{item}<br/></span>
+                ))}
+            </p>
         );
     }
-
-    return (
-        <p className={className} ref={valueRef}>
-            {text.map((item, key) => (
-                <span key={key}>{item}<br/></span>
-            ))}
-        </p>
-    );
 }
 
 ExpandableText.propTypes = {

--- a/client/components/UI/Preview/ExpandableText.jsx
+++ b/client/components/UI/Preview/ExpandableText.jsx
@@ -15,7 +15,7 @@ export class ExpandableText extends React.Component {
         this.setDomRef = this.setDomRef.bind(this);
     }
 
-    toggleExpanded(expanded) {
+    toggleExpanded() {
         this.setState({expanded: !this.state.expanded});
         if (this.dom.parent && this.dom.parent.parentNode) {
             this.dom.parent.parentNode.scrollIntoView();


### PR DESCRIPTION
PlanningDetails widget threw the React error code https://reactjs.org/docs/error-decoder.html/?invariant=321
This may be happening because Superdesk has React 16.9 while UI-Framework has 16.8
as the UI-Framework is bundling React inside its dist/superdesk-ui.bundle.js

Also added padding for this widget (SDESK-4327)