### PR TITLE
fix(slack) change deprecated slack API call

### DIFF
--- a/server/planning/planning_notifications.py
+++ b/server/planning/planning_notifications.py
@@ -328,7 +328,7 @@ def _send_to_slack_user(sc, user_id, message):
     user_token = _get_slack_user_id(sc, user)
     # Need to open a direct IM channel to the target user
     if user_token:
-        im = sc.api_call('im.open', user=user_token, return_im=True)
+        im = sc.api_call('conversations.open', users=user_token, return_im=True)
         if im.get('ok', False):
             sent = sc.api_call('chat.postMessage', as_user=False, channel=im.get('channel', {}).get('id'),
                                text=message, link_names=True)

--- a/server/planning/planning_notifications_test.py
+++ b/server/planning/planning_notifications_test.py
@@ -29,7 +29,7 @@ class MockSlack():
             return {'ok': True}
         elif method == 'users.list':
             return {'ok': True, 'members': [{'name': 'foo', 'id': 'ABCD'}]}
-        elif method == 'im.open':
+        elif method == 'conversations.open':
             return {'ok': True, 'channel': {'id': 'EFGH'}}
 
 


### PR DESCRIPTION
See [details here](https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api?utm_medium=email&utm_source=newsletter&utm_campaign=fy21-Q205-changelog)