### PR TITLE
Use a function to get assignments when translations are needed

### DIFF
--- a/client/apps/Assignments/AssignmentList.jsx
+++ b/client/apps/Assignments/AssignmentList.jsx
@@ -5,7 +5,7 @@ import {isNil} from 'lodash';
 
 import * as selectors from '../../selectors';
 import * as actions from '../../actions';
-import {ASSIGNMENTS} from '../../constants';
+import {GET_ASSIGNMENTS} from '../../constants';
 import {gettext} from '../../utils/gettext';
 
 import {AssignmentGroupList} from '../../components/Assignments';
@@ -27,6 +27,7 @@ export const AssignmentListContainer = ({
         contentTypes,
         saveSortPreferences,
     };
+    const ASSIGNMENTS = GET_ASSIGNMENTS()
 
     return (
         <div className="sd-column-box__main-column__items">

--- a/client/apps/Assignments/AssignmentList.jsx
+++ b/client/apps/Assignments/AssignmentList.jsx
@@ -27,7 +27,7 @@ export const AssignmentListContainer = ({
         contentTypes,
         saveSortPreferences,
     };
-    const ASSIGNMENTS = GET_ASSIGNMENTS()
+    const ASSIGNMENTS = GET_ASSIGNMENTS();
 
     return (
         <div className="sd-column-box__main-column__items">

--- a/client/constants/assignments.js
+++ b/client/constants/assignments.js
@@ -1,7 +1,7 @@
 import {gettext} from '../utils/gettext';
 
 // This needs to be a function, otherwise gettext won't work on top level calls
-export const GET_ASSIGNMENTS = () =>  ({
+export const GET_ASSIGNMENTS = () => ({
     ACTIONS: {
         RECEIVED_ASSIGNMENTS: 'RECEIVED_ASSIGNMENTS',
         CHANGE_LIST_SETTINGS: 'CHANGE_LIST_SETTINGS',
@@ -136,4 +136,4 @@ export const GET_ASSIGNMENTS = () =>  ({
 });
 
 // Use this constant if you don't need translations
-export const ASSIGNMENTS = GET_ASSIGNMENTS()
+export const ASSIGNMENTS = GET_ASSIGNMENTS();

--- a/client/constants/assignments.js
+++ b/client/constants/assignments.js
@@ -135,4 +135,5 @@ export const GET_ASSIGNMENTS = () =>  ({
     DEFAULT_SORT_PREFERENCE: 'assignments:default_sort',
 });
 
+// Use this constant if you don't need translations
 export const ASSIGNMENTS = GET_ASSIGNMENTS()

--- a/client/constants/assignments.js
+++ b/client/constants/assignments.js
@@ -1,6 +1,7 @@
 import {gettext} from '../utils/gettext';
 
-export const ASSIGNMENTS = {
+// This needs to be a function, otherwise gettext won't work on top level calls
+export const GET_ASSIGNMENTS = () =>  ({
     ACTIONS: {
         RECEIVED_ASSIGNMENTS: 'RECEIVED_ASSIGNMENTS',
         CHANGE_LIST_SETTINGS: 'CHANGE_LIST_SETTINGS',
@@ -132,4 +133,6 @@ export const ASSIGNMENTS = {
         ASSIGNMENT_ACCEPTED: 'accepted',
     },
     DEFAULT_SORT_PREFERENCE: 'assignments:default_sort',
-};
+});
+
+export const ASSIGNMENTS = GET_ASSIGNMENTS()

--- a/client/constants/index.js
+++ b/client/constants/index.js
@@ -3,7 +3,7 @@ import {gettext} from '../utils/gettext';
 export {PRIVILEGES} from './privileges';
 export {PLANNING} from './planning';
 export {AGENDA} from './agenda';
-export {ASSIGNMENTS} from './assignments';
+export {ASSIGNMENTS, GET_ASSIGNMENTS} from './assignments';
 export {TOOLTIPS} from './tooltips';
 export {LOCKS} from './locks';
 export {WORKSPACE} from './workspace';


### PR DESCRIPTION
SDCP-291

`gettext` doesn't work on top level code so strings like `"There are no
assignments in progress"` where not being translated in the UI.