### PR TITLE
[SDAN-680] fix updating of events in newshub

### DIFF
--- a/server/planning/common.py
+++ b/server/planning/common.py
@@ -9,8 +9,8 @@
 # at https://www.sourcefabric.org/superdesk/license
 
 import re
+import time
 from flask import current_app as app
-from datetime import datetime, timedelta
 from collections import namedtuple
 from superdesk.resource import not_analyzed, build_custom_hateoas
 from superdesk import get_resource_service, logger
@@ -316,7 +316,7 @@ def update_returned_document(doc, item, custom_hateoas):
 
 
 def get_version_item_for_post(item):
-    version = int((datetime.utcnow() - datetime.min).total_seconds() * 100000.0)
+    version = int(time.time())
     item.setdefault(config.VERSION, version)
     item.setdefault('item_id', item['_id'])
     return version, item

--- a/server/planning/common.py
+++ b/server/planning/common.py
@@ -12,6 +12,7 @@ import re
 import time
 from flask import current_app as app
 from collections import namedtuple
+from datetime import timedelta
 from superdesk.resource import not_analyzed, build_custom_hateoas
 from superdesk import get_resource_service, logger
 from superdesk.metadata.item import ITEM_TYPE, CONTENT_STATE

--- a/server/planning/common.py
+++ b/server/planning/common.py
@@ -317,7 +317,7 @@ def update_returned_document(doc, item, custom_hateoas):
 
 
 def get_version_item_for_post(item):
-    version = int(time.time())
+    version = int(time.time() * 1000)
     item.setdefault(config.VERSION, version)
     item.setdefault('item_id', item['_id'])
     return version, item

--- a/server/planning/output_formatters/json_event.py
+++ b/server/planning/output_formatters/json_event.py
@@ -24,7 +24,7 @@ class JsonEventFormatter(Formatter):
     """
 
     remove_fields = {'lock_time', 'lock_action', 'lock_session', 'lock_user', '_etag', '_planning_schedule',
-                     'expiry', 'original_creator', '_reschedule_from_schedule'}
+                     'expiry', 'original_creator', '_reschedule_from_schedule', '_current_version'}
 
     def __init__(self):
         """

--- a/server/planning/output_formatters/json_planning.py
+++ b/server/planning/output_formatters/json_planning.py
@@ -34,7 +34,7 @@ class JsonPlanningFormatter(Formatter):
         self.can_export = False
 
     # fields to be removed from the planning item
-    remove_fields = ('lock_time', 'lock_action', 'lock_session', 'lock_user', '_etag',
+    remove_fields = ('lock_time', 'lock_action', 'lock_session', 'lock_user', '_etag', '_current_version',
                      'original_creator', 'version_creator', '_planning_schedule', 'files', '_updates_schedule')
 
     # fields to be removed from coverage


### PR DESCRIPTION
there was `_current_version` sent in ninjs
which is huge number and can't fit into elastic integer.

SDAN-680