### PR TITLE
[SDCP-526] Enable date field option showToBeConfirmed in events and coverages

### DIFF
--- a/client/components/fields/editor/CoverageSchedule.tsx
+++ b/client/components/fields/editor/CoverageSchedule.tsx
@@ -25,6 +25,7 @@ export class EditorFieldCoverageSchedule extends React.PureComponent<IProps> {
                 {...props}
                 field={field ?? 'scheduled'}
                 label={label ?? gettext('Due')}
+                showToBeConfirmed
             />
         );
     }

--- a/client/components/fields/editor/EndDateTime.tsx
+++ b/client/components/fields/editor/EndDateTime.tsx
@@ -7,6 +7,7 @@ import {EditorFieldDateTime} from './base/dateTime';
 interface IProps extends IEditorFieldProps {
     canClear?: boolean;
     timeField?: string;
+    showToBeConfirmed?: boolean;
 }
 
 export class EditorFieldEndDateTime extends React.PureComponent<IProps> {

--- a/client/components/fields/editor/EventSchedule.tsx
+++ b/client/components/fields/editor/EventSchedule.tsx
@@ -238,6 +238,7 @@ export class EditorFieldEventSchedule extends React.PureComponent<IProps> {
                     }
                     timeField="_startTime"
                     onChange={this.changeSchedule}
+                    showToBeConfirmed
                 />
                 <EditorFieldEndDateTime
                     {...props}
@@ -249,6 +250,7 @@ export class EditorFieldEventSchedule extends React.PureComponent<IProps> {
                     }
                     timeField="_endTime"
                     onChange={this.changeSchedule}
+                    showToBeConfirmed
                 />
                 <Row
                     flex={true}

--- a/client/components/fields/editor/StartDateTime.tsx
+++ b/client/components/fields/editor/StartDateTime.tsx
@@ -7,6 +7,7 @@ import {EditorFieldDateTime} from './base/dateTime';
 interface IProps extends IEditorFieldProps {
     canClear?: boolean;
     timeField?: string;
+    showToBeConfirmed?: boolean;
 }
 
 export class EditorFieldStartDateTime extends React.PureComponent<IProps> {


### PR DESCRIPTION
SDCP-526

It was noticed by QA when testing translations, that "to be confirmed" button was missing in events and coverages even though it was present before.