### PR TITLE
[SDESK-6183] Allow `Reassign` or `Edit Priority` of Picture Assignments

### DIFF
--- a/client/utils/assignments.ts
+++ b/client/utils/assignments.ts
@@ -28,12 +28,16 @@ const isPictureAssignment = (assignment, contentTypes = []) => {
     return get(contentType, 'content item type', get(contentType, 'qcode')) === 'picture';
 };
 
-const canEditAssignment = (assignment, session, privileges, privilege, contentTypes) => (
-    !!privileges[privilege] &&
+function canEditPriorityOrReassignAssignment(
+    assignment: IAssignmentItem,
+    session: ISession,
+    privileges: IPrivileges,
+    privilege: string,
+) {
+    return !!privileges[privilege] &&
         self.isNotLockRestricted(assignment, session) &&
-        self.isAssignmentInEditableState(assignment) &&
-        !self.isPictureAssignment(assignment, contentTypes)
-);
+        self.isAssignmentInEditableState(assignment);
+}
 
 const canRemoveAssignment = (assignment, session, privileges, privilege) => (
     !!privileges[privilege] &&
@@ -212,11 +216,11 @@ const getAssignmentItemActions = (assignment, session, privileges, contentTypes,
 
     const actionsValidator = {
         [ASSIGNMENTS.ITEM_ACTIONS.REASSIGN.actionName]: () =>
-            self.canEditAssignment(assignment, session, privileges, PRIVILEGES.ARCHIVE, contentTypes),
+            self.canEditPriorityOrReassignAssignment(assignment, session, privileges, PRIVILEGES.ARCHIVE),
         [ASSIGNMENTS.ITEM_ACTIONS.COMPLETE.actionName]: () =>
             self.canCompleteAssignment(assignment, session, privileges),
         [ASSIGNMENTS.ITEM_ACTIONS.EDIT_PRIORITY.actionName]: () =>
-            self.canEditAssignment(assignment, session, privileges, PRIVILEGES.ARCHIVE, contentTypes),
+            self.canEditPriorityOrReassignAssignment(assignment, session, privileges, PRIVILEGES.ARCHIVE),
         [ASSIGNMENTS.ITEM_ACTIONS.START_WORKING.actionName]: () =>
             self.canStartWorking(assignment, session, privileges, contentTypes),
         [ASSIGNMENTS.ITEM_ACTIONS.REMOVE.actionName]: () =>
@@ -384,7 +388,7 @@ export function getAssignmentTypeInfo(assignment: IAssignmentItem, contentTypes:
 // eslint-disable-next-line consistent-this
 const self = {
     isNotLockRestricted,
-    canEditAssignment,
+    canEditPriorityOrReassignAssignment,
     canCompleteAssignment,
     canRemoveAssignment,
     isAssignmentInEditableState,

--- a/client/utils/tests/assignments_test.ts
+++ b/client/utils/tests/assignments_test.ts
@@ -42,7 +42,7 @@ describe('can edit assignment', () => {
         assignment, session, privileges
     );
 
-    const canRemoveAssignment = () => utils.assignmentUtils.canEditAssignment(
+    const canRemoveAssignment = () => utils.assignmentUtils.canRemoveAssignment(
         assignment, session, privileges, PRIVILEGES.PLANNING_MANAGEMENT
     );
 
@@ -50,10 +50,10 @@ describe('can edit assignment', () => {
         assignment
     );
 
-    const canReassign = () => utils.assignmentUtils.canEditAssignment(
+    const canReassign = () => utils.assignmentUtils.canEditPriorityOrReassignAssignment(
         assignment, session, privileges, PRIVILEGES.ARCHIVE
     );
-    const canEditPriority = () => utils.assignmentUtils.canEditAssignment(
+    const canEditPriority = () => utils.assignmentUtils.canEditPriorityOrReassignAssignment(
         assignment, session, privileges, PRIVILEGES.ARCHIVE
     );
     const canConfirmAvailability = () => utils.assignmentUtils.canConfirmAvailability(


### PR DESCRIPTION
This reverts the enforcement added in SDESK-5010 (https://github.com/superdesk/superdesk-planning/commit/0275d6ff2c577e8b12fe5b0a16cb9b4d8ab2cb83)

We should allow these actions on a Picture Assignment, even if the state is controlled externally (i.e. via AAP DC).
@marwoodandrew: do you see any issue here?