### PR TITLE
[SDESK-6174] fix(ui): Planning goes blank after adding scheduled update (#1660)

### DIFF
--- a/client/components/Coverages/CoverageEditor/CoverageForm.tsx
+++ b/client/components/Coverages/CoverageEditor/CoverageForm.tsx
@@ -61,6 +61,12 @@ interface IProps {
         scheduledUpdate: any,
         scheduledUpdateIndex: number
     ): void;
+    onCancelCoverage(
+        coverage: IPlanningCoverageItem,
+        index: number,
+        scheduledUpdate?: ICoverageScheduledUpdate,
+        scheduledUpdateIndex?: number
+    ): void;
     uploadFiles(files: Array<Array<File>>): Promise<Array<IFile>>;
     createUploadLink(file: IFile): void;
     removeFile(file: IFile): Promise<void>;
@@ -80,7 +86,7 @@ interface IProps {
 }
 
 interface IState {
-    openScheduledUpdates: Array<any>;
+    openScheduledUpdates: Array<ICoverageScheduledUpdate['scheduled_update_id']>;
     uploading: boolean;
 }
 
@@ -424,9 +430,18 @@ export class CoverageFormComponent extends React.Component<IProps, IState> {
                 onScheduledUpdateClose: this.onScheduledUpdateClose,
                 onScheduledUpdateOpen: this.onScheduledUpdateOpen,
                 onAddScheduledUpdate: this.onAddScheduledUpdate,
-                canCreateScheduledUpdate: this.props.addNewsItemToPlanning == null &&
-                    !get(this.props.diff, `${this.props.field}.flags.no_content_linking`),
-                enabled: this.props.includeScheduledUpdates,
+                canCreateScheduledUpdate: (
+                    this.props.addNewsItemToPlanning == null &&
+                    !get(this.props.diff, `${this.props.field}.flags.no_content_linking`)
+                ),
+                onCancelCoverage: this.props.onCancelCoverage,
+                index: this.props.index,
+                openScheduledUpdates: this.state.openScheduledUpdates,
+                planning: this.props.diff,
+                enabled: (
+                    this.props.includeScheduledUpdates &&
+                    this.props.value.planning?.g2_content_type === 'text'
+                ),
             },
         };
 

--- a/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx
+++ b/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {connect} from 'react-redux';
 import {get} from 'lodash';
 
-import {IPlanningCoverageItem} from '../../../interfaces';
+import {IPlanningCoverageItem, ICoverageScheduledUpdate} from '../../../interfaces';
 import {IArticle, IDesk, IUser} from 'superdesk-api';
 
 import {getCreator, getItemInArrayById, gettext, planningUtils, onEventCapture} from '../../../utils';
@@ -14,7 +14,7 @@ import * as actions from '../../../actions';
 
 interface IProps {
     field: string;
-    value: IPlanningCoverageItem;
+    value: IPlanningCoverageItem | ICoverageScheduledUpdate;
     users: Array<IUser>;
     desks: Array<IDesk>;
     readOnly?: boolean;
@@ -22,15 +22,15 @@ interface IProps {
     onChange(field: string, value: any): void;
     onFocus?(): void;
     onRemoveAssignment?(): void;
-    setCoverageDefaultDesk(coverage: IPlanningCoverageItem): void;
+    setCoverageDefaultDesk(coverage: IPlanningCoverageItem | ICoverageScheduledUpdate): void;
     showEditCoverageAssignmentModal(props: {
         field: string;
-        value: IPlanningCoverageItem;
+        value: IPlanningCoverageItem | ICoverageScheduledUpdate;
         disableDeskSelection: boolean;
         disableUserSelection: boolean;
         priorityPrefix: string;
         onChange(field: string, value: any): void;
-        setCoverageDefaultDesk(coverage: IPlanningCoverageItem): void;
+        setCoverageDefaultDesk(coverage: IPlanningCoverageItem | ICoverageScheduledUpdate): void;
     }): void;
 }
 

--- a/client/components/Coverages/ScheduledUpdate/index.tsx
+++ b/client/components/Coverages/ScheduledUpdate/index.tsx
@@ -1,8 +1,19 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import {get} from 'lodash';
+import moment from 'moment';
 
-import {ContactsPreviewList} from '../../Contacts/index';
+import {IArticle, IDesk, IUser} from 'superdesk-api';
+import {
+    IAssignmentPriority,
+    ICoverageProvider, ICoverageScheduledUpdate,
+    IGenre,
+    IPlanningCoverageItem,
+    IPlanningItem,
+    IPlanningNewsCoverageStatus
+} from '../../../interfaces';
+import {superdeskApi} from '../../../superdeskApi';
+
+import {ContactsPreviewList} from '../../Contacts';
 import {Row as PreviewRow} from '../../UI/Preview';
 import {ItemActionsMenu} from '../../index';
 import {CollapseBox} from '../../UI';
@@ -11,172 +22,261 @@ import {ScheduledUpdateForm} from './ScheduledUpdateForm';
 import {CoverageFormHeader} from '../CoverageEditor/CoverageFormHeader';
 import {CoveragePreviewTopBar} from '../CoveragePreview/CoveragePreviewTopBar';
 
-import {planningUtils, gettext, stringUtils, assignmentUtils} from '../../../utils';
+import {planningUtils, stringUtils, assignmentUtils} from '../../../utils';
 import {PLANNING, COVERAGES} from '../../../constants';
 
-export const ScheduledUpdate = ({
-    diff,
-    index,
-    field,
-    value,
-    users,
-    desks,
-    onRemove,
-    contentTypes,
-    genres,
-    newsCoverageStatus,
-    onChange,
-    coverageProviders,
-    priorities,
-    onRemoveAssignment,
-    readOnly,
-    addNewsItemToPlanning,
-    popupContainer,
-    onPopupOpen,
-    onPopupClose,
-    setCoverageDefaultDesk,
-    openCoverageIds,
-    autoAssignToWorkflow,
-    onFocus,
-    forPreview,
-    onScheduleChanged,
-    coverageIndex,
-    openScheduledUpdates,
-    onOpen,
-    onClose,
-    message,
-    onAddScheduledUpdateToWorkflow,
-    onCancelCoverage,
-    testId,
-    ...props
-}) => {
-    const coverage = get(diff, `coverages[${coverageIndex}]`);
-    // Coverage item actions
-    let itemActions = [];
+interface IProps {
+    diff: IPlanningCoverageItem;
+    planning: IPlanningItem;
+    index: number;
+    field: string;
+    value: ICoverageScheduledUpdate;
+    users: Array<IUser>;
+    desks: Array<IDesk>;
+    genres: Array<IGenre>;
+    newsCoverageStatus: Array<IPlanningNewsCoverageStatus>;
+    coverageProviders: Array<ICoverageProvider>;
+    priorities: Array<IAssignmentPriority>;
+    readOnly: boolean;
+    addNewsItemToPlanning?: IArticle;
+    openCoverageIds: Array<IPlanningCoverageItem['coverage_id']>;
+    autoAssignToWorkflow: boolean;
+    forPreview: boolean;
+    coverageIndex: number;
+    openScheduledUpdates: Array<ICoverageScheduledUpdate['scheduled_update_id']>;
+    message: {[key: string]: string};
+    testId: string;
 
-    if (!readOnly && !addNewsItemToPlanning) {
-        // To be done in the next iteration
-        if (planningUtils.canCancelCoverage(value, diff, 'scheduled_update_id')) {
-            itemActions.push({
-                ...COVERAGES.ITEM_ACTIONS.CANCEL_COVERAGE,
-                label: gettext('Cancel Scheduled Update'),
-                callback: onCancelCoverage.bind(null, coverage, coverageIndex, value, index),
-            });
-        }
+    onRemove(): void;
+    onChange(field: string, value: any): void;
+    onRemoveAssignment(
+        coverage: IPlanningCoverageItem,
+        coverageIndex: number,
+        scheduledUpdate: ICoverageScheduledUpdate,
+        scheduledIndex: number
+    ): void;
+    popupContainer?(): HTMLElement;
+    onPopupOpen?(): void;
+    onPopupClose?(): void;
+    setCoverageDefaultDesk(coverage: IPlanningCoverageItem): void;
+    onFocus?(): void;
+    onScheduleChanged(field: string, value: moment.Moment | undefined, coverage: ICoverageScheduledUpdate): void;
+    onOpen?(coverage: ICoverageScheduledUpdate): void;
+    onClose?(coverage: ICoverageScheduledUpdate): void;
+    onAddScheduledUpdateToWorkflow(
+        coverage: IPlanningCoverageItem,
+        coverageIndex: number,
+        scheduledUpdate: ICoverageScheduledUpdate,
+        scheduledIndex: number
+    ): void;
+    onCancelCoverage(
+        coverage: IPlanningCoverageItem,
+        coverageIndex: number,
+        scheduledUpdate: ICoverageScheduledUpdate,
+        scheduledIndex: number
+    ): void;
+}
 
-        if (planningUtils.canAddScheduledUpdateToWorkflow(value, autoAssignToWorkflow, diff, coverage)) {
-            itemActions.push({
-                id: 'addToWorkflow',
-                label: gettext('Add to workflow'),
-                icon: 'icon-assign',
-                callback: onAddScheduledUpdateToWorkflow.bind(null, coverage, coverageIndex, value, index),
-            });
-        }
+export class ScheduledUpdate extends React.PureComponent<IProps> {
+    static defaultProps = {
+        openScheduledUpdates: [],
+    };
 
-        if (planningUtils.canRemoveCoverage(value, diff)) {
-            itemActions.push({
-                label: gettext('Remove Scheduled Update'),
-                icon: 'icon-trash',
-                callback: onRemove,
-            });
-        }
+    constructor(props: IProps) {
+        super(props);
+
+        this.cancelCoverage = this.cancelCoverage.bind(this);
+        this.addScheduledUpdateToWorkflow = this.addScheduledUpdateToWorkflow.bind(this);
+        this.onOpen = this.onOpen.bind(this);
+        this.onClose = this.onClose.bind(this);
     }
 
-    const componentInvalid = get(message, `scheduled_updates.${index}`);
-    const itemActionComponent = get(itemActions, 'length', 0) > 0 ?
-        (
-            <div className="side-panel__top-tools-right">
-                <ItemActionsMenu
-                    field={field}
-                    actions={itemActions}
-                    onOpen={onFocus}
-                />
-            </div>
-        ) :
-        null;
-    const fieldName = `${field}.scheduled_updates[${index}]`;
+    cancelCoverage() {
+        this.props.onCancelCoverage(
+            this.props.diff,
+            this.props.coverageIndex,
+            this.props.value,
+            this.props.index
+        );
+    }
 
-    const coverageItem = (
-        <CoverageItem
-            item={diff}
-            index={index}
-            coverage={value}
-            itemActionComponent={itemActionComponent}
-            readOnly={readOnly}
-            isPreview={forPreview}
-            workflowStateReasonPrefix={`coverages[${coverageIndex}].scheduled_updates[${index}]`}
-        />
-    );
+    addScheduledUpdateToWorkflow() {
+        this.props.onAddScheduledUpdateToWorkflow(
+            this.props.diff,
+            this.props.coverageIndex,
+            this.props.value,
+            this.props.index
+        );
+    }
 
-    const coverageTopBar = forPreview ? (
-        <CoveragePreviewTopBar
-            item={diff}
-            coverage={value}
-            users={users}
-            desks={desks}
-            newsCoverageStatus={newsCoverageStatus}
-        />
-    ) :
-        (
+    onOpen() {
+        this.props.onOpen(this.props.value);
+    }
+
+    onClose() {
+        this.props.onClose(this.props.value);
+    }
+
+    render() {
+        const {gettext} = superdeskApi.localization;
+        const {
+            diff,
+            planning,
+            index,
+            field,
+            value,
+            users,
+            desks,
+            onRemove,
+            genres,
+            newsCoverageStatus,
+            onChange,
+            coverageProviders,
+            priorities,
+            onRemoveAssignment,
+            readOnly,
+            addNewsItemToPlanning,
+            popupContainer,
+            onPopupOpen,
+            onPopupClose,
+            setCoverageDefaultDesk,
+            openCoverageIds,
+            autoAssignToWorkflow,
+            onFocus,
+            forPreview,
+            onScheduleChanged,
+            coverageIndex,
+            openScheduledUpdates,
+            onOpen,
+            onClose,
+            message,
+            onAddScheduledUpdateToWorkflow,
+            onCancelCoverage,
+            testId,
+            ...props
+        } = this.props;
+
+        // Coverage item actions
+        let itemActions = [];
+
+        if (!readOnly && !addNewsItemToPlanning) {
+            // To be done in the next iteration
+            if (planningUtils.canCancelCoverage(value, planning, 'scheduled_update_id')) {
+                itemActions.push({
+                    ...COVERAGES.ITEM_ACTIONS.CANCEL_COVERAGE,
+                    label: gettext('Cancel Scheduled Update'),
+                    callback: this.cancelCoverage,
+                });
+            }
+
+            if (planningUtils.canAddScheduledUpdateToWorkflow(value, autoAssignToWorkflow, planning, diff)) {
+                itemActions.push({
+                    id: 'addToWorkflow',
+                    label: gettext('Add to workflow'),
+                    icon: 'icon-assign',
+                    callback: this.addScheduledUpdateToWorkflow,
+                });
+            }
+
+            if (planningUtils.canRemoveCoverage(value, planning)) {
+                itemActions.push({
+                    label: gettext('Remove Scheduled Update'),
+                    icon: 'icon-trash',
+                    callback: onRemove,
+                });
+            }
+        }
+
+        const componentInvalid = get(message, `scheduled_updates.${index}`)?.length > 0;
+        const itemActionComponent = itemActions.length > 0 ?
+            (
+                <div className="side-panel__top-tools-right">
+                    <ItemActionsMenu
+                        field={field}
+                        actions={itemActions}
+                        onOpen={onFocus}
+                    />
+                </div>
+            ) :
+            null;
+        const fieldName = `scheduled_updates[${index}]`;
+
+        const coverageItem = (
+            <CoverageItem
+                item={planning}
+                index={index}
+                coverage={value}
+                itemActionComponent={itemActionComponent}
+                readOnly={readOnly}
+                isPreview={forPreview}
+                workflowStateReasonPrefix={`coverages[${coverageIndex}].scheduled_updates[${index}]`}
+            />
+        );
+
+        const coverageTopBar = forPreview ? (
+            <CoveragePreviewTopBar
+                item={planning}
+                coverage={value}
+                users={users}
+                desks={desks}
+                newsCoverageStatus={newsCoverageStatus}
+            />
+        ) : (
             <CoverageFormHeader
                 field={fieldName}
                 value={value}
                 onChange={onChange}
                 users={users}
                 desks={desks}
-                readOnly={forPreview ? true : readOnly}
+                readOnly={readOnly}
                 addNewsItemToPlanning={addNewsItemToPlanning}
                 onRemoveAssignment={!onRemoveAssignment ? null :
-                    onRemoveAssignment.bind(null, coverage, coverageIndex, value, index)}
+                    onRemoveAssignment.bind(null, diff, coverageIndex, value, index)}
                 setCoverageDefaultDesk={setCoverageDefaultDesk}
-                {...props}
             />
         );
 
-    const coverageStatus = get(value, 'news_coverage_status.qcode', '') ===
+        const coverageStatus = get(value, 'news_coverage_status.qcode', '') ===
         PLANNING.NEWS_COVERAGE_CANCELLED_STATUS.qcode ? PLANNING.NEWS_COVERAGE_CANCELLED_STATUS :
-        newsCoverageStatus.find((s) => s.qcode === get(value, 'news_coverage_status.qcode', '')) || {};
+            newsCoverageStatus.find((s) => s.qcode === get(value, 'news_coverage_status.qcode', '')) || {};
 
-    const openItem = forPreview ? (
-        <div>
-            <PreviewRow label={assignmentUtils.getContactLabel(coverage)}>
-                <ContactsPreviewList
-                    contactIds={get(value, 'planning.contact_info.length', 0) > 0 ?
-                        [value.planning.contact_info] : []}
-                    scrollInView={true}
-                    scrollIntoViewOptions={{block: 'center'}}
+        const openItem = forPreview ? (
+            <div>
+                <PreviewRow label={assignmentUtils.getContactLabel(value)}>
+                    <ContactsPreviewList
+                        contactIds={get(value, 'planning.contact_info.length', 0) > 0 ?
+                            [value.planning.contact_info] : []}
+                        scrollInView={true}
+                        scrollIntoViewOptions={{block: 'center'}}
+                    />
+                </PreviewRow>
+                <PreviewRow
+                    label={gettext('Genre')}
+                    value={get(value, 'planning.genre.name')}
                 />
-            </PreviewRow>
-            <PreviewRow
-                label={gettext('Genre')}
-                value={get(value, 'planning.genre.name')}
-            />
-            <PreviewRow
-                label={gettext('Internal Note')}
-                value={stringUtils.convertNewlineToBreak(
-                    value.planning.internal_note || ''
-                )}
-            />
-            <PreviewRow
-                label={gettext('Coverage Status')}
-                value={coverageStatus.label || ''}
-            />
-            <PreviewRow
-                label={gettext('Due')}
-                value={planningUtils.getCoverageDateText(value)}
-            />
-        </div>
-    ) :
-        (
+                <PreviewRow
+                    label={gettext('Internal Note')}
+                    value={stringUtils.convertNewlineToBreak(
+                        value.planning.internal_note || ''
+                    )}
+                />
+                <PreviewRow
+                    label={gettext('Coverage Status')}
+                    value={coverageStatus.label || ''}
+                />
+                <PreviewRow
+                    label={gettext('Due')}
+                    value={planningUtils.getCoverageDateText(value)}
+                />
+            </div>
+        ) : (
             <ScheduledUpdateForm
                 field={fieldName}
                 value={value}
                 diff={diff}
                 index={index}
                 coverageIndex={coverageIndex}
-                onChange={onChange}
                 newsCoverageStatus={newsCoverageStatus}
-                contentTypes={contentTypes}
                 genres={genres}
                 readOnly={readOnly}
                 invalid={componentInvalid}
@@ -187,68 +287,25 @@ export const ScheduledUpdate = ({
                 onPopupClose={onPopupClose}
                 onScheduleChanged={onScheduleChanged}
                 {...props}
+                onChange={onChange}
             />
         );
 
-    return (
-        <CollapseBox
-            testId={testId}
-            collapsedItem={coverageItem}
-            openItem={openItem}
-            openItemTopBar={coverageTopBar}
-            tools={itemActionComponent}
-            invalid={componentInvalid}
-            onClose={onClose ? onClose.bind(null, value) : null}
-            onOpen={onOpen ? onOpen.bind(null, value) : null}
-            entityId={value.scheduled_update_id}
-            isOpen={openScheduledUpdates.includes(value.scheduled_update_id)}
-            tabEnabled
-            scrollInView
-        />
-    );
-};
-
-ScheduledUpdate.propTypes = {
-    testId: PropTypes.string,
-    field: PropTypes.string,
-    value: PropTypes.object,
-    onChange: PropTypes.func,
-    users: PropTypes.array,
-    desks: PropTypes.array,
-    newsCoverageStatus: PropTypes.array,
-    onRemove: PropTypes.func,
-    contentTypes: PropTypes.array,
-    genres: PropTypes.array,
-    coverageProviders: PropTypes.array,
-    priorities: PropTypes.array,
-    readOnly: PropTypes.bool,
-    item: PropTypes.object,
-    diff: PropTypes.object,
-    formProfile: PropTypes.object,
-    addNewsItemToPlanning: PropTypes.object,
-    onRemoveAssignment: PropTypes.func,
-    index: PropTypes.number,
-    popupContainer: PropTypes.func,
-    setCoverageDefaultDesk: PropTypes.func,
-    onPopupOpen: PropTypes.func,
-    onPopupClose: PropTypes.func,
-    openCoverageIds: PropTypes.arrayOf(PropTypes.string),
-    autoAssignToWorkflow: PropTypes.bool,
-    onFocus: PropTypes.func,
-    forPreview: PropTypes.bool,
-    onScheduleChanged: PropTypes.func,
-    coverageIndex: PropTypes.number,
-    openScheduledUpdates: PropTypes.array,
-    onOpen: PropTypes.func,
-    onClose: PropTypes.func,
-    message: PropTypes.oneOfType([
-        PropTypes.string,
-        PropTypes.object,
-    ]),
-    onAddScheduledUpdateToWorkflow: PropTypes.func,
-    onCancelCoverage: PropTypes.func,
-};
-
-ScheduledUpdate.defaultProps = {
-    openScheduledUpdates: [],
-};
+        return (
+            <CollapseBox
+                testId={testId}
+                collapsedItem={coverageItem}
+                openItem={openItem}
+                openItemTopBar={coverageTopBar}
+                tools={itemActionComponent}
+                invalid={componentInvalid}
+                onClose={onClose ? this.onClose : null}
+                onOpen={onOpen ? this.onOpen : null}
+                entityId={value.scheduled_update_id}
+                isOpen={openScheduledUpdates.includes(value.scheduled_update_id)}
+                tabEnabled
+                scrollInView
+            />
+        );
+    }
+}

--- a/client/components/Planning/PlanningEditor/index.tsx
+++ b/client/components/Planning/PlanningEditor/index.tsx
@@ -516,6 +516,7 @@ class PlanningEditorComponent extends React.Component<IProps, IState> {
                             planningApi.editor(this.props.editorType)
                                 .item.planning.getCoverageFieldDomRef(value.coverage_id)
                         ),
+                        includeScheduledUpdates: true,
                     },
                 }}
             />

--- a/client/components/fields/editor/ScheduledUpdates.tsx
+++ b/client/components/fields/editor/ScheduledUpdates.tsx
@@ -3,12 +3,14 @@ import {connect} from 'react-redux';
 import {get} from 'lodash';
 import moment from 'moment';
 
+import {IDesk, IUser} from 'superdesk-api';
 import {
     ICoverageScheduledUpdate,
     IEditorFieldProps,
     IG2ContentType,
     IGenre,
     IPlanningCoverageItem,
+    IPlanningItem,
     IPlanningNewsCoverageStatus
 } from '../../../interfaces';
 import {superdeskApi} from '../../../superdeskApi';
@@ -25,14 +27,23 @@ interface IProps extends IEditorFieldProps {
     newsCoverageStatus: Array<IPlanningNewsCoverageStatus>;
     contentTypes: Array<IG2ContentType>;
     genres: Array<IGenre>;
-    openScheduledUpdates: Array<any>;
+    users: Array<IUser>;
+    desks: Array<IDesk>;
+    openScheduledUpdates: Array<ICoverageScheduledUpdate['scheduled_update_id']>;
     canCreateScheduledUpdate?: boolean;
+    planning: IPlanningItem;
 
     onRemoveAssignment(
         coverage: IPlanningCoverageItem,
         index: number,
         scheduledUpdate: any,
         scheduledUpdateIndex: number
+    ): void;
+    onCancelCoverage(
+        coverage: IPlanningCoverageItem,
+        index: number,
+        scheduledUpdate?: ICoverageScheduledUpdate,
+        scheduledUpdateIndex?: number
     ): void;
     setCoverageDefaultDesk(coverage: IPlanningCoverageItem): void;
     onRemoveScheduledUpdate(indexToRemove: number): void;
@@ -46,6 +57,8 @@ const mapStateToProps = (state) => ({
     newsCoverageStatus: selectors.general.newsCoverageStatus(state),
     contentTypes: selectors.general.contentTypes(state),
     genres: state.genres,
+    users: selectors.general.users(state),
+    desks: selectors.general.desks(state),
 });
 
 class EditorFieldScheduledUpdatesComponent extends React.PureComponent<IProps> {
@@ -53,6 +66,10 @@ class EditorFieldScheduledUpdatesComponent extends React.PureComponent<IProps> {
         const {gettext} = superdeskApi.localization;
         const field = this.props.field ?? 'scheduled_updates';
         const value = get(this.props.item, field, []);
+
+        if (!this.props.canCreateScheduledUpdate && !value.length) {
+            return null;
+        }
 
         return (
             <Row testId={this.props.testId}>
@@ -64,7 +81,8 @@ class EditorFieldScheduledUpdatesComponent extends React.PureComponent<IProps> {
                         {...this.props}
                         testId={`${this.props.testId}[${index}]`}
                         diff={this.props.item}
-                        key={index}
+                        planning={this.props.planning}
+                        key={s.scheduled_update_id}
                         value={s}
                         field={field}
                         coverageIndex={this.props.index}

--- a/client/utils/planning.ts
+++ b/client/utils/planning.ts
@@ -617,8 +617,8 @@ const modifyCoverageForClient = (coverage) => {
         if (s.planning.scheduled) {
             s.planning.scheduled = moment(s.planning.scheduled);
             s.planning._scheduledTime = moment(s.planning.scheduled);
-            modifyGenre(s);
         }
+        modifyGenre(s);
     });
 
     return coverage;

--- a/e2e/cypress/integration/events/event_action_create_planning.spec.ts
+++ b/e2e/cypress/integration/events/event_action_create_planning.spec.ts
@@ -15,7 +15,7 @@ describe('Planning.Events: create planning action', () => {
     const expectedValues = {
         slugline: 'Original',
         'planning_date.date': '12/12/2045',
-        'planning_date.time': '01:00',
+        'planning_date.time': '00:00',
         description_text: 'Desc.',
         ednote: 'Ed. Note',
         anpa_category: ['Finance'],

--- a/e2e/server/settings.py
+++ b/e2e/server/settings.py
@@ -1,6 +1,6 @@
 import os
 from pathlib import Path
-from superdesk.default_settings import INSTALLED_APPS
+from superdesk.default_settings import INSTALLED_APPS, SECRET_KEY
 
 
 def env(variable, fallback_value=None):
@@ -51,8 +51,6 @@ REDIS_URL = env('REDIS_URL', 'redis://localhost:6379')
 if env('REDIS_PORT'):
     REDIS_URL = env('REDIS_PORT').replace('tcp:', 'redis:')
 BROKER_URL = env('CELERY_BROKER_URL', REDIS_URL)
-
-SECRET_KEY = env('SECRET_KEY', '')
 
 MONGO_DBNAME = 'e2e_superdesk'
 MONGO_URI = 'mongodb://localhost/%s' % MONGO_DBNAME


### PR DESCRIPTION
**<cherry picked from hotfix/2.3.2 branch>**

* fix: Update coverage profile with scheduled_updates field

* fix: Pass required params to scheduled_update field

* fix: Modify scheduled_update genre regardless of scheduled date/time