### PR TITLE
[SDESK-6305] fix: Extent getErrorMessage to include errors in _issues

### DIFF
--- a/client/utils/index.ts
+++ b/client/utils/index.ts
@@ -248,6 +248,8 @@ export const getErrorMessage = (error, defaultMessage) => {
         return get(error, 'data._issues.validator exception');
     } else if (get(error, 'data._error.message')) {
         return error.data._error.message;
+    } else if (get(error, '_issues.validator exception')) {
+        return get(error, '_issues.validator exception');
     } else if (typeof error === 'string') {
         return error;
     }


### PR DESCRIPTION
The experience described in SDESK-6305 is not actually a bug but desired behaviour. The bug is actually to do with not letting the user know why they could not complete the 'Mark as Completed' action