### PR TITLE
[SDESK-6504] fix: Ignore unlock ws notification if already unlocked

### DIFF
--- a/client/actions/events/tests/notifications_test.ts
+++ b/client/actions/events/tests/notifications_test.ts
@@ -516,6 +516,7 @@ describe('actions.events.notifications', () => {
         beforeEach(() => {
             store.initialState.events.events.e1.lock_user = 'ident1';
             store.initialState.events.events.e1.lock_session = 'session1';
+            store.initialState.events.events.e1.lock_time = '2022-06-15T13:01:11+0000';
             sinon.stub(main, 'changeEditorAction').callsFake(() => Promise.resolve());
         });
 
@@ -577,6 +578,7 @@ describe('actions.events.notifications', () => {
                 {
                     item: 'e1',
                     user: 'ident2',
+                    lock_session: 'session1',
                     etag: 'e123',
                 }
             ))

--- a/client/actions/planning/notifications.ts
+++ b/client/actions/planning/notifications.ts
@@ -1,7 +1,7 @@
 import {get} from 'lodash';
 import planning from './index';
 import assignments from '../assignments/index';
-import {gettext} from '../../utils';
+import {gettext, lockUtils} from '../../utils';
 import * as selectors from '../../selectors';
 import {events, fetchAgendas} from '../index';
 import main from '../main';
@@ -136,7 +136,14 @@ const onPlanningLocked = (e, data) => (
 const onPlanningUnlocked = (_e, data) => (
     (dispatch, getState) => {
         if (get(data, 'item')) {
-            let planningItem = selectors.planning.storedPlannings(getState())[data.item];
+            const state = getState();
+            let planningItem = selectors.planning.storedPlannings(state)[data.item];
+            const isCurrentlyLocked = lockUtils.isItemLocked(planningItem, selectors.locks.getLockedItems(state));
+
+            if (!isCurrentlyLocked && planningItem?.lock_session == null) {
+                // No need to announce an unlock, as we have already done so
+                return Promise.resolve();
+            }
 
             dispatch(main.onItemUnlocked(data, planningItem, ITEM_TYPE.PLANNING));
 

--- a/client/actions/planning/tests/notifications_test.ts
+++ b/client/actions/planning/tests/notifications_test.ts
@@ -244,6 +244,7 @@ describe('actions.planning.notifications', () => {
             store.initialState.planning.currentPlanningId = 'p1';
             store.initialState.planning.plannings.p1.lock_user = 'ident1';
             store.initialState.planning.plannings.p1.lock_session = 'session1';
+            store.initialState.planning.plannings.p1.lock_time = '2022-06-15T13:01:11+0000';
             sinon.stub(main, 'changeEditorAction').callsFake(() => Promise.resolve());
         });
 
@@ -301,6 +302,7 @@ describe('actions.planning.notifications', () => {
                 {
                     item: 'p1',
                     user: 'ident2',
+                    lock_session: 'session1',
                     etag: 'e123',
                 }))
                 .then(() => {

--- a/client/api/events.ts
+++ b/client/api/events.ts
@@ -110,15 +110,12 @@ export function getEventByIds(
 }
 
 export function getLockedEvents(): Promise<Array<IEventItem>> {
-    return searchEvents({
+    return searchEventsGetAll({
         lock_state: LOCK_STATE.LOCKED,
         directly_locked: true,
         only_future: false,
-    })
-        .then(modifyResponseForClient)
-        .then((response) => (
-            response._items
-        ));
+        include_killed: true,
+    });
 }
 
 function getEventEditorProfile() {

--- a/client/api/planning.ts
+++ b/client/api/planning.ts
@@ -125,13 +125,12 @@ export function getPlanningByIds(
 }
 
 export function getLockedPlanningItems(): Promise<Array<IPlanningItem>> {
-    return searchPlanning({
+    return searchPlanningGetAll({
         lock_state: LOCK_STATE.LOCKED,
         directly_locked: true,
         only_future: false,
-    })
-        .then(modifyResponseForClient)
-        .then((response) => response._items);
+        include_killed: true,
+    });
 }
 
 export function getLockedFeaturedPlanning(): Promise<Array<IFeaturedPlanningLock>> {

--- a/client/interfaces.ts
+++ b/client/interfaces.ts
@@ -751,7 +751,7 @@ export interface IAssignmentItem extends IBaseRestApiResponse {
     version_creator: string;
     firstcreated: string;
     versioncreated: string;
-    type: string;
+    type: 'assignment';
     lock_user: string;
     lock_time: string | Date | moment.Moment;
     lock_session: string;

--- a/client/utils/events.ts
+++ b/client/utils/events.ts
@@ -4,7 +4,7 @@ import {get, map, isNil, sortBy, cloneDeep, omitBy, find, isEqual, pickBy, flatt
 import {IMenuItem} from 'superdesk-ui-framework/react/components/Menu';
 
 import {appConfig} from 'appConfig';
-import {IEventItem} from '../interfaces';
+import {IEventItem, ISession, ILockedItems} from '../interfaces';
 
 import {
     PRIVILEGES,
@@ -67,15 +67,16 @@ const isEventSameDay = (startingDate, endingDate) => (
 
 const eventHasPlanning = (event) => get(event, 'planning_ids', []).length > 0;
 
-const isEventLocked = (event, locks) =>
-    !isNil(event) && locks && (
-        event._id in locks.event ||
-        get(event, 'recurrence_id') in locks.recurring
-    );
+function isEventLocked(event: IEventItem, locks: ILockedItems): boolean {
+    return lockUtils.getLock(event, locks) != null;
+}
 
-const isEventLockRestricted = (event, session, locks) =>
-    isEventLocked(event, locks) &&
-    !lockUtils.isItemLockedInThisSession(event, session, locks);
+function isEventLockRestricted(event: IEventItem, session: ISession, locks: ILockedItems): boolean {
+    return (
+        isEventLocked(event, locks) &&
+        !lockUtils.isItemLockedInThisSession(event, session, locks)
+    );
+}
 
 const isEventCompleted = (event) => (get(event, 'completed'));
 

--- a/client/utils/planning.ts
+++ b/client/utils/planning.ts
@@ -10,6 +10,8 @@ import {
     IPlanningCoverageItem,
     IPlanningNewsCoverageStatus,
     IG2ContentType,
+    ISession,
+    ILockedItems,
 } from '../interfaces';
 import {stripHtmlRaw} from 'superdesk-core/scripts/apps/authoring/authoring/helpers';
 
@@ -202,16 +204,16 @@ const canAddCoverages = (planning, event, privileges, session, locks) => (
         !isItemExpired(planning)
 );
 
-const isPlanningLocked = (plan, locks) =>
-    !isNil(plan) && (
-        plan._id in locks.planning ||
-        get(plan, 'event_item') in locks.event ||
-        get(plan, 'recurrence_id') in locks.recurring
-    );
+function isPlanningLocked(plan: IPlanningItem, locks: ILockedItems): boolean {
+    return lockUtils.getLock(plan, locks) != null;
+}
 
-const isPlanningLockRestricted = (plan, session, locks) =>
-    isPlanningLocked(plan, locks) &&
-        !lockUtils.isItemLockedInThisSession(plan, session, locks);
+function isPlanningLockRestricted(plan: IPlanningItem, session: ISession, locks: ILockedItems): boolean {
+    return (
+        isPlanningLocked(plan, locks) &&
+        !lockUtils.isItemLockedInThisSession(plan, session, locks)
+    );
+}
 
 /**
  * Get the array of coverage content type and color base on the scheduled date

--- a/client/utils/testApi.ts
+++ b/client/utils/testApi.ts
@@ -29,6 +29,7 @@ Object.assign(superdeskApi, {
     },
     utilities: {
         querySelectorParent: querySelectorParent,
+        dateToServerString: (date) => date.toISOString().slice(0, 19) + '+0000',
     },
     privileges: {
         hasPrivilege: (privilege: string) => privileges[privilege] === 1

--- a/client/utils/tests/events_test.ts
+++ b/client/utils/tests/events_test.ts
@@ -23,6 +23,7 @@ describe('EventUtils', () => {
                     currentUser: {
                         currentSession: {
                             _id: 'e1',
+                            type: 'event',
                             lock_user: 'ident1',
                             lock_session: 'session1',
                             lock_action: 'edit',
@@ -30,6 +31,7 @@ describe('EventUtils', () => {
                         },
                         otherSession: {
                             _id: 'e2',
+                            type: 'event',
                             lock_user: 'ident1',
                             lock_session: 'session2',
                             lock_action: 'edit',
@@ -38,17 +40,22 @@ describe('EventUtils', () => {
                     },
                     otherUser: {
                         _id: 'e3',
+                        type: 'event',
                         lock_user: 'ident2',
                         lock_session: 'session3',
                         lock_action: 'edit',
                         lock_time: '2099-10-15T14:30+0000',
                     },
-                    notLocked: {_id: 'e4'},
+                    notLocked: {
+                        _id: 'e4',
+                        type: 'event',
+                    },
                 },
                 recurring: {
                     currentUser: {
                         currentSession: {
                             _id: 'e5',
+                            type: 'event',
                             recurrence_id: 'r1',
                             lock_user: 'ident1',
                             lock_session: 'session1',
@@ -57,6 +64,7 @@ describe('EventUtils', () => {
                         },
                         otherSession: {
                             _id: 'e6',
+                            type: 'event',
                             recurrence_id: 'r2',
                             lock_user: 'ident1',
                             lock_session: 'session2',
@@ -66,6 +74,7 @@ describe('EventUtils', () => {
                     },
                     otherUser: {
                         _id: 'e7',
+                        type: 'event',
                         recurrence_id: 'r3',
                         lock_user: 'ident2',
                         lock_session: 'session3',
@@ -74,22 +83,26 @@ describe('EventUtils', () => {
                     },
                     notLocked: {
                         _id: 'e8',
+                        type: 'event',
                         recurrence_id: 'r4',
                     },
                 },
                 associated: {
                     standalone: {
                         _id: 'e9',
+                        type: 'event',
                         planning_ids: ['p1'],
                     },
                     recurring: {
                         direct: {
                             _id: 'e10',
+                            type: 'event',
                             recurrence_id: 'r5',
                             planning_ids: ['p2'],
                         },
                         indirect: {
                             _id: 'e11',
+                            type: 'event',
                             recurrence_id: 'r6',
                         },
                     },
@@ -98,6 +111,7 @@ describe('EventUtils', () => {
             plans: {
                 standalone: {
                     _id: 'p1',
+                    type: 'planning',
                     event_item: 'e9',
                     lock_user: 'ident1',
                     lock_session: 'session1',
@@ -107,6 +121,7 @@ describe('EventUtils', () => {
                 recurring: {
                     direct: {
                         _id: 'p2',
+                        type: 'planning',
                         event_item: 'e10',
                         recurrence_id: 'r5',
                         lock_user: 'ident1',
@@ -116,6 +131,7 @@ describe('EventUtils', () => {
                     },
                     indirect: {
                         _id: 'p3',
+                        type: 'planning',
                         event_item: 'e12',
                         recurrence_id: 'r6',
                         lock_user: 'ident1',
@@ -359,6 +375,7 @@ describe('EventUtils', () => {
             // Base condition where assign to calendar is available
             event = {
                 _id: 'e1',
+                type: 'event',
                 state: WORKFLOW_STATE.DRAFT,
             };
             expectActions(getActions(), ['Assign to calendar']);

--- a/client/utils/tests/planning_test.ts
+++ b/client/utils/tests/planning_test.ts
@@ -25,6 +25,7 @@ describe('PlanningUtils', () => {
                     currentUser: {
                         currentSession: {
                             _id: 'p1',
+                            type: 'planning',
                             lock_user: 'ident1',
                             lock_session: 'session1',
                             lock_action: 'edit',
@@ -32,6 +33,7 @@ describe('PlanningUtils', () => {
                         },
                         otherSession: {
                             _id: 'p2',
+                            type: 'planning',
                             lock_user: 'ident1',
                             lock_session: 'session2',
                             lock_action: 'edit',
@@ -40,6 +42,7 @@ describe('PlanningUtils', () => {
                     },
                     otherUser: {
                         _id: 'p3',
+                        type: 'planning',
                         lock_user: 'ident2',
                         lock_session: 'session3',
                         lock_action: 'edit',
@@ -51,6 +54,7 @@ describe('PlanningUtils', () => {
                     currentUser: {
                         currentSession: {
                             _id: 'p5',
+                            type: 'planning',
                             event_item: 'e1',
                             lock_user: 'ident1',
                             lock_session: 'session1',
@@ -59,6 +63,7 @@ describe('PlanningUtils', () => {
                         },
                         otherSession: {
                             _id: 'p6',
+                            type: 'planning',
                             event_item: 'e2',
                             lock_user: 'ident1',
                             lock_session: 'session2',
@@ -68,6 +73,7 @@ describe('PlanningUtils', () => {
                     },
                     otherUser: {
                         _id: 'p7',
+                        type: 'planning',
                         event_item: 'e3',
                         lock_user: 'ident2',
                         lock_session: 'session3',
@@ -76,6 +82,7 @@ describe('PlanningUtils', () => {
                     },
                     notLocked: {
                         _id: 'p8',
+                        type: 'planning',
                         event_item: 'e4',
                     },
                 },
@@ -83,6 +90,7 @@ describe('PlanningUtils', () => {
                     currentUser: {
                         currentSession: {
                             _id: 'p9',
+                            type: 'planning',
                             event_item: 'e5',
                             recurrence_id: 'r1',
                             lock_user: 'ident1',
@@ -92,6 +100,7 @@ describe('PlanningUtils', () => {
                         },
                         otherSession: {
                             _id: 'p10',
+                            type: 'planning',
                             event_item: 'e6',
                             recurrence_id: 'r2',
                             lock_user: 'ident1',
@@ -102,6 +111,7 @@ describe('PlanningUtils', () => {
                     },
                     otherUser: {
                         _id: 'p11',
+                        type: 'planning',
                         event_item: 'e7',
                         recurrence_id: 'r3',
                         lock_user: 'ident2',
@@ -111,6 +121,7 @@ describe('PlanningUtils', () => {
                     },
                     notLocked: {
                         _id: 'p12',
+                        type: 'planning',
                         event_item: 'e8',
                         recurrence_id: 'r4',
                     },
@@ -118,16 +129,19 @@ describe('PlanningUtils', () => {
                 associated: {
                     standalone: {
                         _id: 'p13',
+                        type: 'planning',
                         event_item: 'e9',
                     },
                     recurring: {
                         direct: {
                             _id: 'p14',
+                            type: 'planning',
                             event_item: 'e10',
                             recurrence_id: 'r5',
                         },
                         indirect: {
                             _id: 'p15',
+                            type: 'planning',
                             event_item: 'e11',
                             recurrence_id: 'r5',
                         },
@@ -137,6 +151,7 @@ describe('PlanningUtils', () => {
             events: {
                 standalone: {
                     _id: 'e9',
+                    type: 'event',
                     lock_user: 'ident1',
                     lock_session: 'session1',
                     lock_action: 'edit',
@@ -144,6 +159,7 @@ describe('PlanningUtils', () => {
                 },
                 recurring: {
                     _id: 'e10',
+                    type: 'event',
                     recurrence_id: 'r5',
                     lock_user: 'ident1',
                     lock_session: 'session1',
@@ -551,6 +567,7 @@ describe('PlanningUtils', () => {
             event = null;
             planning = {
                 _id: 'plan1',
+                type: 'planning',
                 state: 'draft',
                 coverages: [],
             };

--- a/client/utils/time.ts
+++ b/client/utils/time.ts
@@ -1,6 +1,7 @@
 import moment from 'moment-timezone';
 
 import {appConfig} from 'appConfig';
+import {superdeskApi} from '../superdeskApi';
 import {IEventItem} from '../interfaces';
 
 import {TIME_COMPARISON_GRANULARITY} from '../constants';
@@ -163,6 +164,16 @@ function getDateForVersionInList(date: moment.Moment | string, tz?: string): str
     return localDate.format(dateFormat + ' @ ' + shortTimeFormat);
 }
 
+function getDateAsString(value: string | Date | moment.Moment): string {
+    if (typeof value === 'string') {
+        return value;
+    } else if (value instanceof Date) {
+        return superdeskApi.utilities.dateToServerString(value);
+    } else {
+        return superdeskApi.utilities.dateToServerString(value.toDate());
+    }
+}
+
 // eslint-disable-next-line consistent-this
 const self = {
     getStartOfNextWeek,
@@ -175,6 +186,7 @@ const self = {
     getLocalDate,
     getTimeZoneAbbreviation,
     getDateForVersionInList,
+    getDateAsString,
 };
 
 export default self;

--- a/e2e/cypress/integration/events/event_action_create_planning.spec.ts
+++ b/e2e/cypress/integration/events/event_action_create_planning.spec.ts
@@ -15,7 +15,7 @@ describe('Planning.Events: create planning action', () => {
     const expectedValues = {
         slugline: 'Original',
         'planning_date.date': '12/12/2045',
-        'planning_date.time': '00:00',
+        'planning_date.time': '01:00',
         description_text: 'Desc.',
         ednote: 'Ed. Note',
         anpa_category: ['Finance'],


### PR DESCRIPTION
Cherry-picked #1694

* [SDESK-6504] fix: Ignore unlock ws notification if already unlocked
This was causing the Editor to act as if the Event/Planning item was not locked for editing

* Iterate pagination when getting item locks

* Fallback to getting lock directly from item

* Fix unit tests

* Include killed Events when getting locks

[SDESK-6504]: https://sofab.atlassian.net/browse/SDESK-6504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ