### PR TITLE
[SDESK-6612] Due date for coverages is not being set correctly if lon…

### DIFF
--- a/client/utils/planning.ts
+++ b/client/utils/planning.ts
@@ -1140,7 +1140,7 @@ const defaultCoverageValues = (
                     to: eventItem?.dates?.end
                 });
 
-                if (duration > appConfig.long_event_duration_threshold) {
+                if (duration.hours() > appConfig.long_event_duration_threshold) {
                     delete newCoverage.planning.scheduled;
                     delete newCoverage.planning._scheduledTime;
                 }


### PR DESCRIPTION
…g_event_duration_threshold is set.