### PR TITLE
[SDAAP-52] Speed up the response of the Events Post endpoint

### DIFF
--- a/server/planning/events/events.py
+++ b/server/planning/events/events.py
@@ -340,7 +340,7 @@ class EventsService(superdesk.Service):
 
                 duplicate_ids = parent_event.get("duplicate_to", [])
                 duplicate_ids.append(event_id)
-                self.patch(parent_id, {"duplicate_to": duplicate_ids})
+                self.patch(parent_id, {"duplicate_to": duplicate_ids, config.ID_FIELD: parent_id})
 
             event_type = "events:created"
             user_id = str(doc.get("original_creator", ""))


### PR DESCRIPTION
Duplicating recuring events updates the original events with the "duplicate_to" field, the event update called _enhance_event_item on each event without passing an _id in the update. A query on the planning collection with event_item : null was made.