### PR TITLE
avoid duplicates of onclusive events

### DIFF
--- a/server/planning/feed_parsers/onclusive.py
+++ b/server/planning/feed_parsers/onclusive.py
@@ -49,7 +49,7 @@ class OnclusiveFeedParser(FeedParser):
         try:
             all_events = []
             for event in content:
-                guid = "urn:onclusive:{}:{}".format(event["createdDate"], event["itemId"])
+                guid = "urn:onclusive:{}".format(event["itemId"])
 
                 item = {
                     GUID_FIELD: guid,
@@ -196,7 +196,7 @@ class OnclusiveFeedParser(FeedParser):
         if time is not None:
             parsed_time = datetime.time.fromisoformat(time)
             parsed = parsed.replace(hour=parsed_time.hour, minute=parsed_time.minute, second=parsed_time.second)
-        return parsed.astimezone(datetime.timezone.utc)
+        return parsed.replace(microsecond=0).astimezone(datetime.timezone.utc)
 
     def parse_contact_info(self, event, item):
         for contact_info in event.get("pressContacts"):

--- a/server/planning/feed_parsers/onclusive_tests.py
+++ b/server/planning/feed_parsers/onclusive_tests.py
@@ -51,7 +51,7 @@ class OnclusiveFeedParserTestCase(TestCase):
         expected_subjects.sort(key=lambda i: i["name"])
         self.assertEqual(item["subject"], expected_subjects)
 
-        self.assertEqual(item[GUID_FIELD], "urn:onclusive:2021-05-04T21:19:10.2:4112034")
+        self.assertEqual(item[GUID_FIELD], "urn:onclusive:4112034")
         self.assertEqual(item[ITEM_TYPE], CONTENT_TYPE.EVENT)
         self.assertEqual(item["state"], CONTENT_STATE.INGESTED)
         self.assertEqual(item["firstcreated"], datetime.datetime(2021, 5, 4, 21, 19, 10, tzinfo=datetime.timezone.utc))


### PR DESCRIPTION
we were using created time as part of id which produced duplicates like:

`urn:onclusive:2022-12-30T08:52:14.3070000:4757907`
`urn:onclusive:2022-12-30T08:52:14.5230000:4757907`

in general we don't need the date to be there so removing it to avoid any issues with those dates.

CPNHUB-184