### PR TITLE
Upgrade typescript to 4.9.5

### DIFF
--- a/client/planning-extension/package-lock.json
+++ b/client/planning-extension/package-lock.json
@@ -1443,9 +1443,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.2.tgz",
-      "integrity": "sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true
     },
     "unbox-primitive": {

--- a/client/planning-extension/package.json
+++ b/client/planning-extension/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@types/angular": "1.6.50",
     "superdesk-code-style": "1.3.0",
-    "typescript": "3.7.2"
+    "typescript": "^4.9.5"
   },
   "superdeskExtension": {
     "translations-directory": "./translations"


### PR DESCRIPTION
This pull request will solve a problem that occured for us at ETC for some unknown reason last week. We started to get the following when building superdesk-planning:

```
> superdesk-planning-extension@ compile /opt/superdesk/client/node_modules/superdesk-planning/client/planning-extension
> tsc -p src

../../../@types/node/ts4.8/util.d.ts(1485,42): error TS1005: ',' expected.
../../../@types/node/ts4.8/util.d.ts(1485,44): error TS1068: Unexpected token. A constructor, method, accessor, or property was expected.
../../../@types/node/ts4.8/util.d.ts(1485,57): error TS1005: ';' expected.
../../../@types/node/ts4.8/util.d.ts(1485,65): error TS1005: ';' expected.
../../../@types/node/ts4.8/util.d.ts(1485,66): error TS1109: Expression expected.
../../../@types/node/ts4.8/util.d.ts(1485,67): error TS1109: Expression expected.
../../../@types/node/ts4.8/util.d.ts(1490,17): error TS1005: ',' expected.
../../../@types/node/ts4.8/util.d.ts(1490,26): error TS1005: ';' expected.
../../../@types/node/ts4.8/util.d.ts(1494,17): error TS1005: ',' expected.
../../../@types/node/ts4.8/util.d.ts(1494,26): error TS1005: ';' expected.
../../../@types/node/ts4.8/util.d.ts(1498,15): error TS1005: ';' expected.
../../../@types/node/ts4.8/util.d.ts(1498,41): error TS1005: '(' expected.
../../../@types/node/ts4.8/util.d.ts(1504,17): error TS1005: ',' expected.
../../../@types/node/ts4.8/util.d.ts(1504,32): error TS1005: ',' expected.
../../../@types/node/ts4.8/util.d.ts(1504,41): error TS1005: ';' expected.
../../../@types/node/ts4.8/util.d.ts(1504,47): error TS1109: Expression expected.
../../../@types/node/ts4.8/util.d.ts(1508,17): error TS1005: ';' expected.
../../../@types/node/ts4.8/util.d.ts(1508,43): error TS1005: '(' expected.
../../../@types/node/ts4.8/util.d.ts(1512,26): error TS1005: ';' expected.
../../../@types/node/ts4.8/util.d.ts(1514,1): error TS1128: Declaration or statement expected.
npm ERR! code ELIFECYCLE
npm ERR! errno 2
npm ERR! superdesk-planning-extension@ compile: `tsc -p src`
npm ERR! Exit status 2
npm ERR! 
npm ERR! Failed at the superdesk-planning-extension@ compile script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /root/.npm/_logs/2023-02-14T08_54_13_265Z-debug.log
Command failed: cd /opt/superdesk/client/node_modules/superdesk-planning/client/planning-extension && npm install --no-audit && npm run compile --if-present
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! superdesk@ build: `npx @superdesk/build-tools build-root-repo ./`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the superdesk@ build script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /root/.npm/_logs/2023-02-14T08_54_13_327Z-debug.log
ERROR: Service 'sd-frontend' failed to build: The command '/bin/sh -c npm run build' returned a non-zero code: 1
```

Some searching on the web indicated that the problem might go away if we updated typescript to a newer version. And yes, indeed, it fixed the problem.