### PR TITLE
fix(e2e): EventTemplates fail due to search changes in GenericHttpEntityListPageComponent

### DIFF
--- a/client/actions/main.ts
+++ b/client/actions/main.ts
@@ -16,6 +16,7 @@ import {
     PLANNING_VIEW,
     IWebsocketMessageData,
     ITEM_TYPE,
+    IEventTemplate,
 } from '../interfaces';
 
 import {
@@ -174,6 +175,13 @@ const createNew = (itemType, item = null, updateUrl = true, modal = false) => (
         ...item,
     }, 'create', updateUrl, modal)
 );
+
+function createEventFromTemplate(template: IEventTemplate) {
+    return self.createNew(ITEM_TYPE.EVENT, {
+        ...template.data,
+        dates: {},
+    });
+}
 
 const unlockAndCancel = (item, ignoreSession = false) => (
     (dispatch, getState) => {
@@ -1619,6 +1627,7 @@ const self = {
     openActionModalFromEditor,
     isItemValid,
     createNew,
+    createEventFromTemplate,
     fetchById,
     fetchItemHistory,
     reloadEditor,

--- a/client/components/Main/CreateNewSubnavDropdown.tsx
+++ b/client/components/Main/CreateNewSubnavDropdown.tsx
@@ -4,7 +4,7 @@ import {connect} from 'react-redux';
 import {superdeskApi} from '../../superdeskApi';
 import {IEventTemplate} from '../../interfaces';
 
-import {PRIVILEGES, ITEM_TYPE} from '../../constants';
+import {PRIVILEGES} from '../../constants';
 import * as actions from '../../actions';
 import {eventTemplates} from '../../selectors/events';
 import {Dropdown, IDropdownItem} from '../UI/SubNav';
@@ -84,10 +84,7 @@ function mapStateToProps(state) {
 }
 
 const mapDispatchToProps = (dispatch) => ({
-    createEventFromTemplate: (template: IEventTemplate) => dispatch(actions.main.createNew(
-        ITEM_TYPE.EVENT,
-        template.data
-    ))
+    createEventFromTemplate: (template: IEventTemplate) => dispatch(actions.main.createEventFromTemplate(template)),
 });
 
 export const CreateNewSubnavDropdown = connect(

--- a/e2e/cypress/e2e/events/event_template.cy.ts
+++ b/e2e/cypress/e2e/events/event_template.cy.ts
@@ -89,7 +89,7 @@ describe('Planning.Events: event templates', () => {
         modal.element
             .find('.search-handler')
             .find('input')
-            .type('Exam');
+            .type('Exam{enter}');
 
         modal.element
             .find('[data-test-id=list-page--filters-active]')
@@ -106,7 +106,7 @@ describe('Planning.Events: event templates', () => {
         modal.element
             .find('.search-handler')
             .find('input')
-            .type('Test');
+            .type('Test{enter}');
 
         modal.element
             .find('[data-test-id=list-page--filters-active]')
@@ -121,7 +121,8 @@ describe('Planning.Events: event templates', () => {
         modal.element
             .find('.search-handler')
             .find('input')
-            .clear();
+            .clear()
+            .type('{enter}');
 
         // Open our filter and make sure the template_name is correct
         modal.element


### PR DESCRIPTION
Also remove `dates` when creating from a Template, as these aren't desired