### PR TITLE
[NHUB-269] fix: Default MAX_MULTI_DAY_EVENT_DURATION to 1 year

### DIFF
--- a/e2e/server/requirements.txt
+++ b/e2e/server/requirements.txt
@@ -1,4 +1,4 @@
 gunicorn==19.7.1
 honcho==1.0.1
-git+https://github.com/superdesk/superdesk-core.git@hotfix/2.6.1#egg=superdesk-core
+git+https://github.com/superdesk/superdesk-core.git@hotfix/2.6.3#egg=superdesk-core
 -e ../../

--- a/server/features/autosave.feature
+++ b/server/features/autosave.feature
@@ -62,9 +62,9 @@ Feature: Events Autosave
         {"user_type": "user", "email": "foo.bar@foobar.org"}
         """
         When we get "/event_autosave"
-        Then we get list with 2 items
+        Then we get list with 1 items
         """
-        {"_items": [{"_id": "event2"}, {"_id": "event3"}]}
+        {"_items": [{"_id": "event3"}]}
         """
 
     @auth
@@ -147,9 +147,9 @@ Feature: Events Autosave
         {"user_type": "user", "email": "foo.bar@foobar.org"}
         """
         When we get "/planning_autosave"
-        Then we get list with 2 items
+        Then we get list with 1 items
         """
-        {"_items": [{"_id": "plan2"}, {"_id": "plan3"}]}
+        {"_items": [{"_id": "plan3"}]}
         """
 
     @auth

--- a/server/features/events_spike.feature
+++ b/server/features/events_spike.feature
@@ -136,7 +136,7 @@ Feature: Events Spike
             "name": "TestEvent",
             "dates": {
                 "start": "2016-01-01",
-                "end": "2017-01-01"
+                "end": "2016-01-02"
             }
         }]
         """

--- a/server/planning/common.py
+++ b/server/planning/common.py
@@ -425,8 +425,8 @@ def get_start_of_next_week(date=None, start_of_week=0):
 def get_event_max_multi_day_duration(current_app=None):
     """Get the max multi day duration"""
     if current_app is not None:
-        return int(current_app.config.get(MAX_MULTI_DAY_EVENT_DURATION, 0))
-    return int(app.config.get(MAX_MULTI_DAY_EVENT_DURATION, 0))
+        return int(current_app.config.get(MAX_MULTI_DAY_EVENT_DURATION, 365))
+    return int(app.config.get(MAX_MULTI_DAY_EVENT_DURATION, 365))
 
 
 def set_original_creator(doc):

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -19,4 +19,4 @@ pytest-env
 
 -e .
 # Install in editable state so we get feature fixtures
--e git+https://github.com/superdesk/superdesk-core.git@hotfix/2.6.1#egg=superdesk-core
+-e git+https://github.com/superdesk/superdesk-core.git@hotfix/2.6.3#egg=superdesk-core


### PR DESCRIPTION
We need to place a maximum default value, as event duration can cause performance issues if the duration is too long