### PR TITLE
fix date in preview for all day events when in toronto

### DIFF
--- a/client/utils/events.ts
+++ b/client/utils/events.ts
@@ -452,7 +452,12 @@ const getDateStringForEvent = (event, dateOnly = false, useLocal = true, withTim
     const multiDay = !isEventSameDay(start, end);
 
     if (isFullDay && !multiDay) {
-        return timezoneForEvents = start.format(dateFormat);
+        if (get(event.dates, 'all_day')) {
+            // use UTC mode to avoid any date conversion
+            return moment.utc(start).format(dateFormat);
+        }
+
+        return start.format(dateFormat);
     } else if (noEndTime && !multiDay) {
         if (withTimezone) {
             if (!useLocal) {


### PR DESCRIPTION
or any other place with negative timezone offset, that makes the events which are stored with time 00:00:00 be presented on a previous day.

SDESK-6857