### PR TITLE
fix date filtering for all day events

### DIFF
--- a/client/api/search.ts
+++ b/client/api/search.ts
@@ -2,6 +2,7 @@ import {ISearchAPIParams, ISearchParams} from '../interfaces';
 import {superdeskApi} from '../superdeskApi';
 import {IRestApiResponse} from 'superdesk-api';
 import {getDateTimeElasticFormat, getTimeZoneOffset} from '../utils';
+import {default as timeUtils} from '../utils/time';
 
 
 export function cvsToString(items?: Array<{[key: string]: any}>, field: string = 'qcode'): string {
@@ -48,6 +49,7 @@ export function convertCommonParams(params: ISearchParams): Partial<ISearchAPIPa
         sort_order: params.sort_order,
         sort_field: params.sort_field,
         tz_offset: params.date_filter ? getTimeZoneOffset() : null,
+        time_zone: timeUtils.localTimeZone(),
     };
 }
 

--- a/client/apps/Planning/SubNavDatePicker.tsx
+++ b/client/apps/Planning/SubNavDatePicker.tsx
@@ -4,7 +4,7 @@ import moment from 'moment-timezone';
 import {SUBNAV_VIEW_SIZE} from './PlanningListSubNav';
 
 import {DateInputPopup} from '../../components/UI/Form/DateInput/DateInputPopup';
-import {timeUtils, gettext} from '../../utils';
+import {gettext, timeUtils} from '../../utils';
 import {Button} from 'superdesk-ui-framework/react';
 
 interface IProps {

--- a/client/components/Events/EventDateTime.tsx
+++ b/client/components/Events/EventDateTime.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import moment from 'moment';
 
 import {superdeskApi} from '../../superdeskApi';
 import {IEventItem} from '../../interfaces';
@@ -20,8 +19,8 @@ export class EventDateTime extends React.PureComponent<IProps> {
     render() {
         const {gettext} = superdeskApi.localization;
         const {item, ignoreAllDay, displayLocalTimezone} = this.props;
-        const start = moment(item.dates.start);
-        const end = moment(item.dates.end);
+        const start = eventUtils.getStartDate(item);
+        const end = eventUtils.getEndDate(item);
         const isAllDay = eventUtils.isEventAllDay(start, end);
         const multiDay = !eventUtils.isEventSameDay(start, end);
         const isRemoteTimeZone = timeUtils.isEventInDifferentTimeZone(item);

--- a/client/interfaces.ts
+++ b/client/interfaces.ts
@@ -1259,6 +1259,7 @@ export interface ISearchParams {
     item_ids?: Array<string>;
     name?: string;
     tz_offset?: string;
+    time_zone?: string;
     full_text?: string;
     anpa_category?: Array<IANPACategory>;
     subject?: Array<ISubject>;
@@ -1319,6 +1320,7 @@ export interface ISearchAPIParams {
     item_ids?: string;
     name?: string;
     tz_offset?: string;
+    time_zone?: string;
     full_text?: string;
     anpa_category?: string;
     subject?: string;

--- a/client/utils/index.ts
+++ b/client/utils/index.ts
@@ -672,9 +672,18 @@ export const onEventCapture = (event) => {
     }
 };
 
-export const isDateInRange = (inputDate, startDate, endDate) => {
+export const isDateInRange = (inputDate, startDate, endDate, allDay = false) => {
     if (!inputDate) {
         return false;
+    }
+
+    if (allDay) {
+        // if passed as string so inBetween will convert those to local dates
+        // from utc dates which are used for all day events
+        const startDay = startDate.format('YYYY-MM-DD');
+        const endDay = (endDate || inputDate).format('YYYY-MM-DD');
+
+        return moment(inputDate).isBetween(startDay, endDay, 'day', '[]');
     }
 
     if (startDate && moment(inputDate).isBefore(startDate, 'millisecond') ||
@@ -945,6 +954,7 @@ export const sortBasedOnTBC = (days) => {
     }
 
     pushEventsForTheDay(days);
+
     return sortBy(sortable, [(e) => (e.date)]);
 };
 

--- a/client/utils/search.ts
+++ b/client/utils/search.ts
@@ -13,7 +13,7 @@ import {
     SORT_ORDER,
 } from '../interfaces';
 import {MAIN} from '../constants';
-import {getTimeZoneOffset} from './index';
+import {getTimeZoneOffset, timeUtils} from './index';
 
 function commonParamsToSearchParams(params: ICommonSearchParams<IEventOrPlanningItem>): ISearchParams {
     return {
@@ -29,6 +29,7 @@ function commonParamsToSearchParams(params: ICommonSearchParams<IEventOrPlanning
         lock_state: params.lock_state,
         directly_locked: params.directly_locked,
         tz_offset: params.timezoneOffset ?? getTimeZoneOffset(),
+        time_zone: timeUtils.localTimeZone(),
         anpa_category: params.advancedSearch?.anpa_category,
         date_filter: params.advancedSearch?.dates?.range,
         start_date: params.advancedSearch?.dates?.start,

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,9 +31,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.20.15",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.15.tgz",
-      "integrity": "sha512-DI4a1oZuf8wC+oAJA9RW6ga3Zbe8RZFt7kD9i4qAspz3I/yHet1VvC3DiSy/fsUvv5pvJuNPh0LPOdCcqinDPg==",
+      "version": "7.21.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.21.3.tgz",
+      "integrity": "sha512-lobG0d7aOfQRXh8AyklEAgZGvA4FShxo6xQbUrrT/cNBPUdIDojlokwJsQyCC/eKia7ifqM0yP+2DRZ4WKw2RQ==",
       "dev": true
     },
     "@babel/runtime": {
@@ -204,9 +204,9 @@
       }
     },
     "@types/jasmine": {
-      "version": "3.10.6",
-      "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-3.10.6.tgz",
-      "integrity": "sha512-twY9adK/vz72oWxCWxzXaxoDtF9TpfEEsxvbc1ibjF3gMD/RThSuSud/GKUTR3aJnfbivAbC/vLqhY+gdWCHfA==",
+      "version": "3.10.7",
+      "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-3.10.7.tgz",
+      "integrity": "sha512-brLuHhITMz4YV2IxLstAJtyRJgtWfLqFKiqiJFvFWMSmydpAmn42CE4wfw7ywkSk02UrufhtzipTcehk8FctoQ==",
       "dev": true
     },
     "@types/json-schema": {
@@ -222,9 +222,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.13.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.13.0.tgz",
-      "integrity": "sha512-gC3TazRzGoOnoKAhUx+Q0t8S9Tzs74z7m0ipwGpSqQrleP14hKxP4/JUeEQcD3W1/aIpnWl8pHowI7WokuZpXg==",
+      "version": "18.15.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.11.tgz",
+      "integrity": "sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q==",
       "dev": true
     },
     "@types/prop-types": {
@@ -356,9 +356,9 @@
       }
     },
     "@xmldom/xmldom": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.6.tgz",
-      "integrity": "sha512-HHXP9hskkFQHy8QxxUXkS7946FFIhYVfGqsk0WLwllmexN9x/+R4UBLvurHEuyXRfVEObVR8APuQehykLviwSQ==",
+      "version": "0.8.6",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.6.tgz",
+      "integrity": "sha512-uRjjusqpoqfmRkTaNuLJ2VohVr67Q5YwDATW3VU7PfzTj6IRaihGrYI7zckGZjxQPBIp63nfvJbM+Yu5ICh0Bg==",
       "dev": true
     },
     "@yarnpkg/lockfile": {
@@ -1291,9 +1291,9 @@
           }
         },
         "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "version": "3.6.2",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+          "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
           "dev": true,
           "requires": {
             "inherits": "^2.0.3",
@@ -1541,14 +1541,14 @@
       }
     },
     "array.prototype.find": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.2.0.tgz",
-      "integrity": "sha512-sn40qmUiLYAcRb/1HsIQjTTZ1kCy8II8VtZJpMn2Aoen9twULhbWXisfh3HimGqMlHGUul0/TfKCnXg42LuPpQ==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.2.1.tgz",
+      "integrity": "sha512-I2ri5Z9uMpMvnsNrHre9l3PaX+z9D0/z6F7Yt2u15q7wt0I62g5kX6xUKR1SJiefgG+u2/gJUmM8B47XRvQR6w==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.4",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
         "es-shim-unscopables": "^1.0.0"
       }
     },
@@ -2245,9 +2245,9 @@
       },
       "dependencies": {
         "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "version": "3.6.2",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+          "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
           "dev": true,
           "requires": {
             "inherits": "^2.0.3",
@@ -2483,9 +2483,9 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30001452",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30001452.tgz",
-      "integrity": "sha512-W+sJxuU8qlfQ8o5zwrBjgPahjIlxbL3F0G7NkqYelskQF1Y4OHb15fuL8LwR1VYX1KBzqo64Z9lB3h2e61mvEA==",
+      "version": "1.0.30001473",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30001473.tgz",
+      "integrity": "sha512-Acmbmkrm6HlPiDcOn/Qlxga6jXGix9/y3vwzu8zHwcRCwAqAc5zPkuxjqpoi+JOlG6fY85phdVLdCE1gK1n2yA==",
       "dev": true
     },
     "caseless": {
@@ -4144,9 +4144,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.4.296",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.296.tgz",
-      "integrity": "sha512-i/6Q+Y9bluDa2a0NbMvdtG5TuS/1Fr3TKK8L+7UUL9QjRS5iFJzCC3r70xjyOnLiYG8qGV4/mMpe6HuAbdJW4w==",
+      "version": "1.4.345",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.345.tgz",
+      "integrity": "sha512-znGhOQK2TUYLICgS25uaM0a7pHy66rSxbre7l762vg9AUoCcJK+Bu+HCPWpjL/U/kK8/Hf+6E0szAUJSyVYb3Q==",
       "dev": true
     },
     "elliptic": {
@@ -4347,34 +4347,46 @@
       }
     },
     "enzyme-adapter-react-16": {
-      "version": "1.15.6",
-      "resolved": "https://registry.npmjs.org/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.15.6.tgz",
-      "integrity": "sha512-yFlVJCXh8T+mcQo8M6my9sPgeGzj85HSHi6Apgf1Cvq/7EL/J9+1JoJmJsRxZgyTvPMAqOEpRSu/Ii/ZpyOk0g==",
+      "version": "1.15.7",
+      "resolved": "https://registry.npmjs.org/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.15.7.tgz",
+      "integrity": "sha512-LtjKgvlTc/H7adyQcj+aq0P0H07LDL480WQl1gU512IUyaDo/sbOaNDdZsJXYW2XaoPqrLLE9KbZS+X2z6BASw==",
       "dev": true,
       "requires": {
-        "enzyme-adapter-utils": "^1.14.0",
-        "enzyme-shallow-equal": "^1.0.4",
+        "enzyme-adapter-utils": "^1.14.1",
+        "enzyme-shallow-equal": "^1.0.5",
         "has": "^1.0.3",
-        "object.assign": "^4.1.2",
-        "object.values": "^1.1.2",
-        "prop-types": "^15.7.2",
+        "object.assign": "^4.1.4",
+        "object.values": "^1.1.5",
+        "prop-types": "^15.8.1",
         "react-is": "^16.13.1",
         "react-test-renderer": "^16.0.0-0",
         "semver": "^5.7.0"
+      },
+      "dependencies": {
+        "enzyme-shallow-equal": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/enzyme-shallow-equal/-/enzyme-shallow-equal-1.0.5.tgz",
+          "integrity": "sha512-i6cwm7hN630JXenxxJFBKzgLC3hMTafFQXflvzHgPmDhOBhxUWDe8AeRv1qp2/uWJ2Y8z5yLWMzmAfkTOiOCZg==",
+          "dev": true,
+          "requires": {
+            "has": "^1.0.3",
+            "object-is": "^1.1.5"
+          }
+        }
       }
     },
     "enzyme-adapter-utils": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/enzyme-adapter-utils/-/enzyme-adapter-utils-1.14.0.tgz",
-      "integrity": "sha512-F/z/7SeLt+reKFcb7597IThpDp0bmzcH1E9Oabqv+o01cID2/YInlqHbFl7HzWBl4h3OdZYedtwNDOmSKkk0bg==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/enzyme-adapter-utils/-/enzyme-adapter-utils-1.14.1.tgz",
+      "integrity": "sha512-JZgMPF1QOI7IzBj24EZoDpaeG/p8Os7WeBZWTJydpsH7JRStc7jYbHE4CmNQaLqazaGFyLM8ALWA3IIZvxW3PQ==",
       "dev": true,
       "requires": {
         "airbnb-prop-types": "^2.16.0",
-        "function.prototype.name": "^1.1.3",
+        "function.prototype.name": "^1.1.5",
         "has": "^1.0.3",
-        "object.assign": "^4.1.2",
-        "object.fromentries": "^2.0.3",
-        "prop-types": "^15.7.2",
+        "object.assign": "^4.1.4",
+        "object.fromentries": "^2.0.5",
+        "prop-types": "^15.8.1",
         "semver": "^5.7.1"
       }
     },
@@ -7035,9 +7047,9 @@
           }
         },
         "minimist": {
-          "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.3.tgz",
-          "integrity": "sha512-cdOrRjzm/cI4sG1c1Kzgo5kpFQm61wrgADF89L2ONgCqlwWNCJ3L4DoOLamFIagKhdnRuC+4eWgdRB4OoibyuQ==",
+          "version": "0.2.4",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.4.tgz",
+          "integrity": "sha512-Pkrrm8NjyQ8yVt8Am9M+yUt74zE3iokhzbG1bFVNjLB92vwM71hf40RkEsryg98BujhVOncKm/C1xROxZ030LQ==",
           "dev": true
         },
         "readable-stream": {
@@ -7399,9 +7411,9 @@
       },
       "dependencies": {
         "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "version": "3.6.2",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+          "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
           "dev": true,
           "requires": {
             "inherits": "^2.0.3",
@@ -8324,14 +8336,27 @@
       }
     },
     "is-array-buffer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.1.tgz",
-      "integrity": "sha512-ASfLknmY8Xa2XtB4wmbz13Wu202baeA18cJBCeCy0wXUHZF0IPyVEXqKEcd+t2fNSLLL1vC6k7lxZEojNbISXQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.2.tgz",
+      "integrity": "sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.1.3",
+        "get-intrinsic": "^1.2.0",
         "is-typed-array": "^1.1.10"
+      },
+      "dependencies": {
+        "get-intrinsic": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.0.tgz",
+          "integrity": "sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==",
+          "dev": true,
+          "requires": {
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.3"
+          }
+        }
       }
     },
     "is-arrayish": {
@@ -8831,12 +8856,12 @@
       "dev": true
     },
     "jasmine-reporters": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/jasmine-reporters/-/jasmine-reporters-2.5.0.tgz",
-      "integrity": "sha512-J69peyTR8j6SzvIPP6aO1Y00wwCqXuIvhwTYvE/di14roCf6X3wDZ4/cKGZ2fGgufjhP2FKjpgrUIKjwau4e/Q==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jasmine-reporters/-/jasmine-reporters-2.5.2.tgz",
+      "integrity": "sha512-qdewRUuFOSiWhiyWZX8Yx3YNQ9JG51ntBEO4ekLQRpktxFTwUHy24a86zD/Oi2BRTKksEdfWQZcQFqzjqIkPig==",
       "dev": true,
       "requires": {
-        "@xmldom/xmldom": "^0.7.3",
+        "@xmldom/xmldom": "^0.8.5",
         "mkdirp": "^1.0.4"
       },
       "dependencies": {
@@ -10390,9 +10415,9 @@
       "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
     },
     "moment-timezone": {
-      "version": "0.5.41",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.41.tgz",
-      "integrity": "sha512-e0jGNZDOHfBXJGz8vR/sIMXvBIGJJcqFjmlg9lmE+5KX1U7/RZNMswfD8nKnNCnQdKTIj50IaRKwl1fvMLyyRg==",
+      "version": "0.5.42",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.42.tgz",
+      "integrity": "sha512-tjI9goqwzkflKSTxJo+jC/W8riTFwEjjunssmFvAWlvNVApjbkJM7UHggyKO0q1Fd/kZVKY77H7C9A0XKhhAFw==",
       "requires": {
         "moment": "^2.29.4"
       }
@@ -13316,7 +13341,7 @@
     "reflect.ownkeys": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/reflect.ownkeys/-/reflect.ownkeys-0.2.0.tgz",
-      "integrity": "sha1-dJrO7H8/34tj+SegSAnpDFwLNGA=",
+      "integrity": "sha512-qOLsBKHCpSOFKK1NUOCGC5VyeufB6lEsFe92AL2bhIJsacZS1qdoOZSbPk3MYKuT2cFlRDnulKXuuElIrMjGUg==",
       "dev": true
     },
     "regenerator-runtime": {
@@ -14670,9 +14695,9 @@
       "dev": true
     },
     "spdx-correct": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
-      "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
+      "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
       "dev": true,
       "requires": {
         "spdx-expression-parse": "^3.0.0",
@@ -14696,9 +14721,9 @@
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.12",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.12.tgz",
-      "integrity": "sha512-rr+VVSXtRhO4OHbXUiAF7xW3Bo9DuuF6C5jH+q/x15j2jniycgKbxU09Hr0WqlSLUs4i4ltHGXqTe7VHclYWyA==",
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.13.tgz",
+      "integrity": "sha512-XkD+zwiqXHikFZm4AX/7JSCXA98U5Db4AFd5XUg/+9UNtnH75+Z9KxtpYiJZx36mUDVOwH83pl7yvCer6ewM3w==",
       "dev": true
     },
     "spdy": {
@@ -15477,7 +15502,7 @@
       }
     },
     "superdesk-core": {
-      "version": "github:superdesk/superdesk-client-core#2e037583bccc89e1b78dfbc2108e6728ddfc3ba4",
+      "version": "github:superdesk/superdesk-client-core#3d895bd01716167c0d929637b616bea0a43f2dd1",
       "from": "github:superdesk/superdesk-client-core#hotfix/2.6.1",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "dompurify": "^1.0.11",
     "moment": "^2.29.4",
-    "moment-timezone": "^0.5.41",
+    "moment-timezone": "^0.5.42",
     "nominatim-browser": "~2.0.2",
     "react-bootstrap": "0.32.1",
     "react-debounce-input": "3.2.0",
@@ -40,7 +40,7 @@
     "whatwg-fetch": "~2.0.4"
   },
   "devDependencies": {
-    "@types/jasmine": "^3.5.11",
+    "@types/jasmine": "^3.10.7",
     "@types/lodash": "4.14.117",
     "@types/react": "16.8.23",
     "@types/react-dom": "16.8.0",
@@ -50,11 +50,11 @@
     "btoa": "^1.1.2",
     "cheerio": "1.0.0-rc.10",
     "enzyme": "~3.11.0",
-    "enzyme-adapter-react-16": "^1.15.5",
+    "enzyme-adapter-react-16": "^1.15.7",
     "eslint": "6.6.0",
     "eslint-plugin-react": "7.16.0",
     "jasmine": "^2.99.0",
-    "jasmine-reporters": "^2.3.0",
+    "jasmine-reporters": "^2.5.2",
     "karma": "^2.0.0",
     "karma-chrome-launcher": "2.2.0",
     "karma-cli": "^1.0.1",

--- a/server/planning/search/eventsplanning_filters.py
+++ b/server/planning/search/eventsplanning_filters.py
@@ -137,6 +137,7 @@ filters_schema = {
             "item_ids": list_strings(),
             "name": string(),
             "tz_offset": string(),
+            "time_zone": string(),
             "full_text": string(),
             "anpa_category": list_cvs(),
             "subject": list_cvs(),

--- a/server/planning/search/queries/common.py
+++ b/server/planning/search/queries/common.py
@@ -12,11 +12,9 @@ from typing import Dict, Any, Optional, List, Callable, Union
 
 import logging
 from datetime import datetime
-from flask import current_app as app
 from eve.utils import str_to_date as _str_to_date, date_to_str
 
 from superdesk import get_resource_service
-from superdesk.utc import get_timezone_offset, utcnow
 from superdesk.errors import SuperdeskApiError
 from superdesk.default_settings import strtobool as _strtobool
 from superdesk.users.services import current_user_has_privilege
@@ -29,13 +27,9 @@ from planning.common import POST_STATE, WORKFLOW_STATE
 logger = logging.getLogger(__name__)
 
 
-def get_time_zone(params: Dict[str, Any]):
-    return params.get("tz_offset") or get_timezone_offset(app.config["DEFAULT_TIMEZONE"], utcnow())
-
-
 def get_date_params(params: Dict[str, Any]):
     date_filter = (params.get("date_filter") or "").strip().lower()
-    tz_offset = get_time_zone(params)
+    time_zone = params.get("time_zone")
 
     try:
         start_date = params.get("start_date")
@@ -66,7 +60,7 @@ def get_date_params(params: Dict[str, Any]):
         logger.exception(e)
         raise SuperdeskApiError.badRequestError("Invalid value for end date")
 
-    return date_filter, start_date, end_date, tz_offset
+    return date_filter, start_date, end_date, time_zone
 
 
 def str_to_array(arg: Optional[Union[List[str], str]] = None) -> List[str]:
@@ -268,16 +262,16 @@ def search_date_non_schedule(params: Dict[str, Any], query: elastic.ElasticQuery
     if not field_name or field_name == "schedule":
         return
 
-    date_filter, start_date, end_date, tz_offset = get_date_params(params)
+    date_filter, start_date, end_date, time_zone = get_date_params(params)
 
     if not date_filter and not start_date and not end_date:
         query.filter.append(
-            elastic.date_range(elastic.ElasticRangeParams(field=field_name, lte="now/d", time_zone=tz_offset))
+            elastic.date_range(elastic.ElasticRangeParams(field=field_name, lte="now/d", time_zone=time_zone))
         )
     else:
         base_query = elastic.ElasticRangeParams(
             field=field_name,
-            time_zone=tz_offset,
+            time_zone=time_zone,
             start_of_week=int(params.get("start_of_week") or 0),
         )
 
@@ -416,6 +410,7 @@ COMMON_PARAMS: List[str] = [
     "item_ids",
     "name",
     "tz_offset",
+    "time_zone",
     "full_text",
     "anpa_category",
     "subject",

--- a/server/planning/search/queries/elastic.py
+++ b/server/planning/search/queries/elastic.py
@@ -8,13 +8,16 @@
 # AUTHORS and LICENSE files distributed with this source code, or
 # at https://www.sourcefabric.org/superdesk/license
 
+import pytz
+
+from datetime import datetime
+
 from typing import Any, List, NamedTuple, Dict, Optional
 
 from datetime import timedelta
 from flask import current_app as app
 from eve.utils import str_to_date
 
-from superdesk.utc import get_timezone_offset, utcnow
 from planning.common import get_start_of_next_week, sanitize_query_text
 
 
@@ -112,7 +115,7 @@ class ElasticRangeParams:
         self.lt = lt
         self.lte = lte
         self.value_format = value_format
-        self.time_zone = time_zone if time_zone else get_timezone_offset(app.config["DEFAULT_TIMEZONE"], utcnow())
+        self.time_zone = time_zone or app.config.get("DEFAULT_TIMEZONE")
         self.start_of_week = int(start_of_week or 0)
         self.date_range = date_range
         self.date = str_to_date(date) if date else None
@@ -197,8 +200,34 @@ def field_range(query: ElasticRangeParams):
     if query.value_format:
         params["format"] = query.value_format
 
-    if query.time_zone:
-        params["time_zone"] = query.time_zone
+    if query.field in ("dates.start", "dates.end"):
+        # handle also all day events
+        # there we get value which is in utc,
+        # so we first convert it to local timezone
+        # and then we take only date part of it
+        local_params = params.copy()
+        local_params.pop("time_zone", None)
+        for key in ("gt", "gte", "lt", "lte"):
+            if local_params.get(key) and "T" in local_params[key] and query.time_zone:
+                tz = pytz.timezone(query.time_zone)
+                utc_value = datetime.fromisoformat(local_params[key].replace("+0000", "+00:00"))
+                local_value = utc_value.astimezone(tz)
+                local_params[key] = local_value.strftime("%Y-%m-%d")
+        return {
+            "bool": {
+                "should": [
+                    {"range": {query.field: params}},
+                    {
+                        "bool": {
+                            "must": [
+                                {"term": {"dates.all_day": True}},
+                                {"range": {query.field: local_params}},
+                            ],
+                        }
+                    },
+                ],
+            },
+        }
 
     return {"range": {query.field: params}}
 
@@ -243,7 +272,7 @@ def range_this_week(query: ElasticRangeParams):
     return field_range(
         ElasticRangeParams(
             field=query.field,
-            time_zone=query.time_zone or app.config["DEFAULT_TIMEZONE"],
+            time_zone=query.time_zone,
             value_format=query.value_format,
             gte=start_of_this_week(query.start_of_week),
             lt=start_of_next_week(query.start_of_week),
@@ -255,7 +284,7 @@ def range_next_week(query: ElasticRangeParams):
     return field_range(
         ElasticRangeParams(
             field=query.field,
-            time_zone=query.time_zone or app.config["DEFAULT_TIMEZONE"],
+            time_zone=query.time_zone,
             value_format=query.value_format,
             gte=start_of_next_week(query.start_of_week),
             lt=end_of_next_week(query.start_of_week),

--- a/server/planning/search/queries/events.py
+++ b/server/planning/search/queries/events.py
@@ -12,7 +12,6 @@ from typing import Any, Dict, List, Callable
 
 from planning.search.queries import elastic
 from .common import (
-    get_time_zone,
     get_date_params,
     COMMON_SEARCH_FILTERS,
     COMMON_PARAMS,
@@ -72,7 +71,7 @@ def search_no_calendar_assigned(params: Dict[str, Any], query: elastic.ElasticQu
 
 def search_date_today(params: Dict[str, Any], query: elastic.ElasticQuery):
     if params.get("date_filter") == elastic.DATE_RANGE.TODAY:
-        time_zone = get_time_zone(params)
+        time_zone = params.get("time_zone")
 
         query.filter.append(
             elastic.bool_or(
@@ -104,7 +103,7 @@ def search_date_today(params: Dict[str, Any], query: elastic.ElasticQuery):
 
 def search_date_tomorrow(params: Dict[str, Any], query: elastic.ElasticQuery):
     if params.get("date_filter") == elastic.DATE_RANGE.TOMORROW:
-        time_zone = get_time_zone(params)
+        time_zone = params.get("time_zone")
 
         query.filter.append(
             elastic.bool_or(
@@ -136,7 +135,7 @@ def search_date_tomorrow(params: Dict[str, Any], query: elastic.ElasticQuery):
 
 def search_date_last_24_hours(params: Dict[str, Any], query: elastic.ElasticQuery):
     if params.get("date_filter") == elastic.DATE_RANGE.LAST_24:
-        time_zone = get_time_zone(params)
+        time_zone = params.get("time_zone")
 
         query.filter.append(
             elastic.bool_or(
@@ -164,7 +163,7 @@ def search_date_last_24_hours(params: Dict[str, Any], query: elastic.ElasticQuer
 
 def search_date_this_week(params: Dict[str, Any], query: elastic.ElasticQuery):
     if params.get("date_filter") == elastic.DATE_RANGE.THIS_WEEK:
-        time_zone = get_time_zone(params)
+        time_zone = params.get("time_zone")
         start_of_week = int(params.get("start_of_week") or 0)
 
         query.filter.append(
@@ -209,7 +208,7 @@ def search_date_this_week(params: Dict[str, Any], query: elastic.ElasticQuery):
 
 def search_date_next_week(params: Dict[str, Any], query: elastic.ElasticQuery):
     if params.get("date_filter") == elastic.DATE_RANGE.NEXT_WEEK:
-        time_zone = get_time_zone(params)
+        time_zone = params.get("time_zone")
         start_of_week = int(params.get("start_of_week") or 0)
 
         query.filter.append(
@@ -253,17 +252,17 @@ def search_date_next_week(params: Dict[str, Any], query: elastic.ElasticQuery):
 
 
 def search_date_start(params: Dict[str, Any], query: elastic.ElasticQuery):
-    date_filter, start_date, end_date, tz_offset = get_date_params(params)
+    date_filter, start_date, end_date, time_zone = get_date_params(params)
 
     if not date_filter and start_date and not end_date:
         query.filter.append(
             elastic.bool_or(
                 [
                     elastic.date_range(
-                        elastic.ElasticRangeParams(field="dates.start", gte=start_date, time_zone=tz_offset)
+                        elastic.ElasticRangeParams(field="dates.start", gte=start_date, time_zone=time_zone)
                     ),
                     elastic.date_range(
-                        elastic.ElasticRangeParams(field="dates.end", gte=start_date, time_zone=tz_offset)
+                        elastic.ElasticRangeParams(field="dates.end", gte=start_date, time_zone=time_zone)
                     ),
                 ]
             )
@@ -271,17 +270,17 @@ def search_date_start(params: Dict[str, Any], query: elastic.ElasticQuery):
 
 
 def search_date_end(params: Dict[str, Any], query: elastic.ElasticQuery):
-    date_filter, start_date, end_date, tz_offset = get_date_params(params)
+    date_filter, start_date, end_date, time_zone = get_date_params(params)
 
     if not date_filter and not start_date and end_date:
         query.filter.append(
             elastic.bool_or(
                 [
                     elastic.date_range(
-                        elastic.ElasticRangeParams(field="dates.start", lte=end_date, time_zone=tz_offset)
+                        elastic.ElasticRangeParams(field="dates.start", lte=end_date, time_zone=time_zone)
                     ),
                     elastic.date_range(
-                        elastic.ElasticRangeParams(field="dates.end", lte=end_date, time_zone=tz_offset)
+                        elastic.ElasticRangeParams(field="dates.end", lte=end_date, time_zone=time_zone)
                     ),
                 ]
             )
@@ -289,7 +288,7 @@ def search_date_end(params: Dict[str, Any], query: elastic.ElasticQuery):
 
 
 def search_date_range(params: Dict[str, Any], query: elastic.ElasticQuery):
-    date_filter, start_date, end_date, tz_offset = get_date_params(params)
+    date_filter, start_date, end_date, time_zone = get_date_params(params)
 
     if not date_filter and start_date and end_date:
         query.filter.append(
@@ -301,11 +300,11 @@ def search_date_range(params: Dict[str, Any], query: elastic.ElasticQuery):
                                 elastic.ElasticRangeParams(
                                     field="dates.start",
                                     gte=start_date,
-                                    time_zone=tz_offset,
+                                    time_zone=time_zone,
                                 )
                             ),
                             elastic.date_range(
-                                elastic.ElasticRangeParams(field="dates.end", lte=end_date, time_zone=tz_offset)
+                                elastic.ElasticRangeParams(field="dates.end", lte=end_date, time_zone=time_zone)
                             ),
                         ]
                     ),
@@ -315,11 +314,11 @@ def search_date_range(params: Dict[str, Any], query: elastic.ElasticQuery):
                                 elastic.ElasticRangeParams(
                                     field="dates.start",
                                     lt=start_date,
-                                    time_zone=tz_offset,
+                                    time_zone=time_zone,
                                 )
                             ),
                             elastic.date_range(
-                                elastic.ElasticRangeParams(field="dates.end", gt=end_date, time_zone=tz_offset)
+                                elastic.ElasticRangeParams(field="dates.end", gt=end_date, time_zone=time_zone)
                             ),
                         ]
                     ),
@@ -330,7 +329,7 @@ def search_date_range(params: Dict[str, Any], query: elastic.ElasticQuery):
                                     field="dates.start",
                                     gte=start_date,
                                     lte=end_date,
-                                    time_zone=tz_offset,
+                                    time_zone=time_zone,
                                 )
                             ),
                             elastic.date_range(
@@ -338,7 +337,7 @@ def search_date_range(params: Dict[str, Any], query: elastic.ElasticQuery):
                                     field="dates.end",
                                     gte=start_date,
                                     lte=end_date,
-                                    time_zone=tz_offset,
+                                    time_zone=time_zone,
                                 )
                             ),
                         ]
@@ -349,12 +348,12 @@ def search_date_range(params: Dict[str, Any], query: elastic.ElasticQuery):
 
 
 def search_date_default(params: Dict[str, Any], query: elastic.ElasticQuery):
-    date_filter, start_date, end_date, tz_offset = get_date_params(params)
+    date_filter, start_date, end_date, time_zone = get_date_params(params)
     only_future = strtobool(params.get("only_future", True))
 
     if not date_filter and not start_date and not end_date and only_future:
         query.filter.append(
-            elastic.date_range(elastic.ElasticRangeParams(field="dates.end", gte="now/d", time_zone=tz_offset))
+            elastic.date_range(elastic.ElasticRangeParams(field="dates.end", gte="now/d", time_zone=time_zone))
         )
 
 

--- a/server/planning/search/queries/planning.py
+++ b/server/planning/search/queries/planning.py
@@ -132,13 +132,13 @@ def search_by_events(params: Dict[str, Any], query: elastic.ElasticQuery):
 
 
 def search_date(params: Dict[str, Any], query: elastic.ElasticQuery):
-    date_filter, start_date, end_date, tz_offset = get_date_params(params)
+    date_filter, start_date, end_date, time_zone = get_date_params(params)
 
     if date_filter or start_date or end_date:
         field_name = "_planning_schedule.scheduled"
         base_query = elastic.ElasticRangeParams(
             field=field_name,
-            time_zone=tz_offset,
+            time_zone=time_zone,
             start_of_week=int(params.get("start_of_week") or 0),
         )
 
@@ -181,7 +181,7 @@ def search_date(params: Dict[str, Any], query: elastic.ElasticQuery):
             )
 
             query.extra["sort_filter"] = elastic.date_range(
-                elastic.ElasticRangeParams(field=field_name, gte="now/d", time_zone=tz_offset)
+                elastic.ElasticRangeParams(field=field_name, gte="now/d", time_zone=time_zone)
             )
         else:
             query.filter.append(planning_schedule)
@@ -189,7 +189,7 @@ def search_date(params: Dict[str, Any], query: elastic.ElasticQuery):
 
 
 def search_date_default(params: Dict[str, Any], query: elastic.ElasticQuery):
-    date_filter, start_date, end_date, tz_offset = get_date_params(params)
+    date_filter, start_date, end_date, time_zone = get_date_params(params)
     only_future = strtobool(params.get("only_future", True))
 
     if not date_filter and not start_date and not end_date and only_future:
@@ -198,7 +198,7 @@ def search_date_default(params: Dict[str, Any], query: elastic.ElasticQuery):
             elastic.ElasticRangeParams(
                 field=field_name,
                 gte="now/d",
-                time_zone=tz_offset,
+                time_zone=time_zone,
             )
         )
 


### PR DESCRIPTION
when making a query also do a query for all_day events using only date part of the given date, but it must be first converted to local time using client timezone so it will the date user sees in the UI.

also tweak the way the all_day events are assigned to dates in the UI based on newsroom code.

SDCP-682