### PR TITLE
change limit when calling onclusive api

### DIFF
--- a/server/planning/feeding_services/onclusive_api_service.py
+++ b/server/planning/feeding_services/onclusive_api_service.py
@@ -74,7 +74,7 @@ class OnclusiveApiService(HTTPFeedingServiceBase):
         :return: a list of events which can be saved.
         """
         URL = provider["config"]["url"]
-        LIMIT = 100
+        LIMIT = 1000
         MAX_OFFSET = int(app.config.get("ONCLUSIVE_MAX_OFFSET", 100000))
         self.session = requests.Session()
         parser = self.get_feed_parser(provider)
@@ -113,7 +113,7 @@ class OnclusiveApiService(HTTPFeedingServiceBase):
                 params = dict(
                     startDate=start.strftime("%Y%m%d"),
                     endDate=end.strftime("%Y%m%d"),
-                    limit=LIMIT,
+                    limit=LIMIT + 100,  # add some overlap to hopefully avoid missing events
                 )
             logger.info("ingest from onclusive %s with params %s", url, params)
             try:

--- a/server/planning/feeding_services/onclusive_api_service_tests.py
+++ b/server/planning/feeding_services/onclusive_api_service_tests.py
@@ -41,8 +41,11 @@ class OnclusiveApiServiceTestCase(unittest.TestCase):
                         "refreshToken": "refresh",
                     },
                 )
-                m.get("https://api.abc.com/api/v2/events/between?offset=0", json=[{}])  # first returns an item
-                m.get("https://api.abc.com/api/v2/events/between?offset=100", json=[])  # second will make it stop
+                m.get(
+                    "https://api.abc.com/api/v2/events/between?offset=0",
+                    json=[{"versioncreated": event["versioncreated"].isoformat()}],
+                )  # first returns an item
+                m.get("https://api.abc.com/api/v2/events/between?offset=1000", json=[])  # second will make it stop
                 list(service._update(provider, updates))
             self.assertIn("tokens", updates)
             self.assertEqual("refresh", updates["tokens"]["refreshToken"])


### PR DESCRIPTION
use 1000 instead of 100 to do less pagination,
also fetch some extra items to avoid possible gaps.

SDCP-684