### PR TITLE
[SDNTB-804] fix(ui): Load ContentProfiles using its name not _id

### DIFF
--- a/client/api/contentProfiles.ts
+++ b/client/api/contentProfiles.ts
@@ -31,7 +31,7 @@ function enablePriorityInSearchProfile(profiles: Array<IPlanningContentProfile>)
     // Hack to enable/disable priority field in search profiles based on the content profiles
     // TODO: Remove this hack when we implement a solution for all searchable fields
     const profilesById: {[id: string]: IPlanningContentProfile} = profiles.reduce((profileMap, profile) => {
-        profileMap[profile._id ?? profile.name] = profile;
+        profileMap[profile.name] = profile;
 
         return profileMap;
     }, {});


### PR DESCRIPTION
Mapping by `_id` doesn't always work. In ntb-develop test instance the Event profile is created with an ObjectID: https://github.com/superdesk/superdesk-ntb/blob/master/server/data/planning_types.json#L3.

We're already using `name` attribute when storing in Redux: https://github.com/superdesk/superdesk-planning/blob/develop/client/services/PlanningStoreService.ts#L252