### PR TITLE
fix onclusive ingest

### DIFF
--- a/server/planning/events/events.py
+++ b/server/planning/events/events.py
@@ -17,6 +17,7 @@ import itertools
 import copy
 import pytz
 import re
+from datetime import timedelta
 from eve.methods.common import resolve_document_etag
 from eve.utils import config, date_to_str
 from flask import current_app as app
@@ -862,7 +863,8 @@ def setRecurringMode(event):
 
 def overwrite_event_expiry_date(event):
     if "expiry" in event:
-        event["expiry"] = event["dates"]["end"]
+        expiry_minutes = app.settings.get("PLANNING_EXPIRY_MINUTES", None)
+        event["expiry"] = event["dates"]["end"] + timedelta(minutes=expiry_minutes or 0)
 
 
 def generate_recurring_events(event):

--- a/server/planning/feed_parsers/onclusive_tests.py
+++ b/server/planning/feed_parsers/onclusive_tests.py
@@ -67,7 +67,7 @@ class OnclusiveFeedParserTestCase(TestCase):
         self.assertIn("https://www.canadianinstitute.com/anti-money-laundering-financial-crime/", item["links"])
 
         self.assertEqual(item["dates"]["start"], datetime.datetime(2022, 6, 15, 10, 30, tzinfo=datetime.timezone.utc))
-        self.assertEqual(item["dates"]["end"], datetime.datetime(2022, 6, 16, 3, 59, 59, tzinfo=datetime.timezone.utc))
+        self.assertEqual(item["dates"]["end"], datetime.datetime(2022, 6, 15, 10, 30, tzinfo=datetime.timezone.utc))
         self.assertEqual(item["dates"]["tz"], "US/Eastern")
         self.assertEqual(item["dates"]["no_end_time"], True)
 
@@ -111,6 +111,32 @@ class OnclusiveFeedParserTestCase(TestCase):
                 with self.assertLogs("planning", level=logging.ERROR) as logger:
                     OnclusiveFeedParser().parse([self.data])
                     self.assertIn("ERROR:planning.feed_parsers.onclusive:Unknown Timezone FOO", logger.output)
+
+    def test_cst_timezone(self):
+        data = self.data.copy()
+        data.update(
+            {
+                "startDate": "2023-04-18T00:00:00.0000000",
+                "endDate": "2023-04-18T00:00:00.0000000",
+                "time": "10:00",
+                "timezone": {
+                    "timezoneID": 24,
+                    "timezoneAbbreviation": "CST",
+                    "timezoneName": "(CST) China Standard Time : Beijing, Taipei",
+                    "timezoneOffset": 8.00,
+                },
+            }
+        )
+        item = OnclusiveFeedParser().parse([data])[0]
+        self.assertEqual(
+            {
+                "start": datetime.datetime(2023, 4, 18, 2, tzinfo=datetime.timezone.utc),
+                "end": datetime.datetime(2023, 4, 18, 2, tzinfo=datetime.timezone.utc),
+                "no_end_time": True,
+                "tz": "Asia/Macau",
+            },
+            item["dates"],
+        )
 
     def test_embargoed(self):
         data = self.data.copy()

--- a/server/planning/feeding_services/onclusive_api_service_tests.py
+++ b/server/planning/feeding_services/onclusive_api_service_tests.py
@@ -49,7 +49,8 @@ class OnclusiveApiServiceTestCase(unittest.TestCase):
                 list(service._update(provider, updates))
             self.assertIn("tokens", updates)
             self.assertEqual("refresh", updates["tokens"]["refreshToken"])
-            self.assertEqual(event["versioncreated"], updates["tokens"]["import_finished"])
+            self.assertIn("import_finished", updates["tokens"])
+            self.assertEqual(updates["last_updated"], updates["tokens"]["next_start"])
 
             provider.update(updates)
             updates = {}


### PR DESCRIPTION
- keep timestamp for next run based on current start
- look for timezone not only using name but also offset
- increase buffer when getting updates (not clear if the timestamps should be utc or local, so add some extra time
- for events with no end time set it to start time and not some fake end time which might make it go visible on a next day

SDCP-688 SDCP-690