### PR TITLE
improve naming of definition_short

### DIFF
--- a/client/components/fields/resources/events.ts
+++ b/client/components/fields/resources/events.ts
@@ -21,7 +21,7 @@ registerEditorField(
     'definition_short',
     EditorFieldMultilingualText,
     () => ({
-        label: superdeskApi.localization.gettext('Description'),
+        label: superdeskApi.localization.gettext('Short Description'),
         field: 'definition_short',
     }),
     null,


### PR DESCRIPTION
When label was "Description" it matches planning item's "Description" label and creates confusion why translations in multi-lingual mode were not copied over.

SDESK-7001