### PR TITLE
[SDESK-7117]

### DIFF
--- a/client/components/fields/style.scss
+++ b/client/components/fields/style.scss
@@ -32,11 +32,6 @@
 	}
 }
 
-[data-sd-tooltip] {
-	z-index: 1000 !important;
-	opacity: 1 !important;
-}
-
 .Planning {
     .sd-list-item__column {
       overflow: visible !important;


### PR DESCRIPTION
The z-index for tooltips defined in planning is at the wrong place and causes issues in Superdesk core. Removed code: 
`[data-sd-tooltip] {
	z-index: 1000 !important;
	opacity: 1 !important;
}`