### PR TITLE
Revert "Fix: Empty modal showing up when we add a coverage to an event [SDBELGA-769]"

### DIFF
--- a/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx
+++ b/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx
@@ -90,7 +90,7 @@ function getRecurringPlanningToUpdate(
             if (planningItem._id.startsWith(TEMP_ID_PREFIX)) {
                 // This is a temporary Planning, therefor is not part of a recurring series of items
                 return false;
-            } else if (planningItem.recurrence_id == null) {
+            } else if (planningItem.planning_recurrence_id == null) {
                 // This Planning item part of a recurring series of items
                 return false;
             }
@@ -98,6 +98,7 @@ function getRecurringPlanningToUpdate(
             const embeddedCoverages = (planningItem.coverages ?? []).reduce(
                 (embeddedCoverages, coverage) => {
                     embeddedCoverages[coverage.coverage_id] = eventUtils.convertCoverageToEventEmbedded(coverage);
+
                     return embeddedCoverages;
                 },
                 {}


### PR DESCRIPTION
Reverts superdesk/superdesk-planning#1921