### PR TITLE
[SDESK-7163] fix: Purge assignment lock fails

### DIFF
--- a/server/planning/assignments/assignments.py
+++ b/server/planning/assignments/assignments.py
@@ -278,8 +278,8 @@ class AssignmentsService(superdesk.Service):
         self.notify("assignments:updated", updates, original)
         self.send_assignment_notification(updates, original)
 
-    def system_update(self, id, updates, original):
-        super().system_update(id, updates, original)
+    def system_update(self, id, updates, original, **kwargs):
+        super().system_update(id, updates, original, **kwargs)
         if self.is_assignment_being_activated(updates, original):
             doc = deepcopy(original)
             doc.update(updates)


### PR DESCRIPTION
Due to incomplete `system_update` signature in Assignments service (missing `kwargs`)