### PR TITLE
optimize validation of related planning items when posted alongside events [SDESK-7202]

### DIFF
--- a/client/actions/events/api.ts
+++ b/client/actions/events/api.ts
@@ -394,7 +394,10 @@ const post = (original, updates) => (
             pubstatus: get(updates, 'pubstatus', POST_STATE.USABLE),
             update_method: get(updates, 'update_method.value', EVENTS.UPDATE_METHODS[0].value),
         }).then(
-            () => dispatch(self.fetchById(original._id, {force: true})),
+            (data) => Promise.all([
+                dispatch(self.fetchById(original._id, {force: true})),
+                {itemId: data?._id?.item_id, failedPlanningIds: data?._id?.failed_planning_ids}
+            ]),
             (error) => Promise.reject(error)
         )
     )

--- a/client/actions/events/api.ts
+++ b/client/actions/events/api.ts
@@ -393,10 +393,11 @@ const post = (original, updates) => (
             etag: original._etag,
             pubstatus: get(updates, 'pubstatus', POST_STATE.USABLE),
             update_method: get(updates, 'update_method.value', EVENTS.UPDATE_METHODS[0].value),
+            failed_planning_ids: get(updates, 'failed_planning_ids', []),
         }).then(
             (data) => Promise.all([
                 dispatch(self.fetchById(original._id, {force: true})),
-                {failedPlanningIds: data?._id?.failed_planning_ids}
+                {failedPlanningIds: data?.failed_planning_ids}
             ]),
             (error) => Promise.reject(error)
         )

--- a/client/actions/events/api.ts
+++ b/client/actions/events/api.ts
@@ -396,7 +396,7 @@ const post = (original, updates) => (
         }).then(
             (data) => Promise.all([
                 dispatch(self.fetchById(original._id, {force: true})),
-                {itemId: data?._id?.item_id, failedPlanningIds: data?._id?.failed_planning_ids}
+                {failedPlanningIds: data?._id?.failed_planning_ids}
             ]),
             (error) => Promise.reject(error)
         )

--- a/client/actions/events/tests/api_test.ts
+++ b/client/actions/events/tests/api_test.ts
@@ -579,6 +579,7 @@ describe('actions.events.api', () => {
                         etag: data.events[0]._etag,
                         pubstatus: 'usable',
                         update_method: 'single',
+                        failed_planning_ids: [],
                     },
                 ]);
                 done();

--- a/client/actions/main.ts
+++ b/client/actions/main.ts
@@ -472,9 +472,7 @@ const post = (original, updates = {}, withConfirmation = true) => (
                     failedPlanningIds?.map((failedItem) => notifyError(
                         notify,
                         failedItem,
-                        gettext(
-                            'Related item {{ itemId }} Post Validation Failed',
-                            {itemId: failedItem?._id})));
+                        gettext('Some related planning item post validation failed')));
 
                     return Promise.resolve(item);
                 },

--- a/client/actions/main.ts
+++ b/client/actions/main.ts
@@ -452,7 +452,17 @@ const post = (original, updates = {}, withConfirmation = true) => (
         return promise
             .then(
                 (rtn) => {
-                    if (!confirmation && rtn) {
+                    let itemId, failedPlanningIds, item;
+
+                    if (Array.isArray(rtn) && rtn.length === 2) {
+                        [item, {itemId, failedPlanningIds}] = rtn;
+                    } else {
+                        itemId = rtn._id;
+                        item = rtn;
+                        failedPlanningIds = [];
+                    }
+
+                    if (!confirmation && item) {
                         notify.success(
                             gettext(
                                 'The {{ itemType }} has been posted',
@@ -460,8 +470,14 @@ const post = (original, updates = {}, withConfirmation = true) => (
                             )
                         );
                     }
+                    failedPlanningIds?.map((item) => notifyError(
+                        notify,
+                        item,
+                        gettext(
+                            'Related item {{ itemId }} Post Validation Failed',
+                            {itemId: item?._id})));
 
-                    return Promise.resolve(rtn);
+                    return Promise.resolve(item);
                 },
                 (error) => {
                     notifyError(

--- a/client/actions/main.ts
+++ b/client/actions/main.ts
@@ -452,12 +452,11 @@ const post = (original, updates = {}, withConfirmation = true) => (
         return promise
             .then(
                 (rtn) => {
-                    let itemId, failedPlanningIds, item;
+                    let failedPlanningIds, item;
 
                     if (Array.isArray(rtn) && rtn.length === 2) {
-                        [item, {itemId, failedPlanningIds}] = rtn;
+                        [item, {failedPlanningIds}] = rtn;
                     } else {
-                        itemId = rtn._id;
                         item = rtn;
                         failedPlanningIds = [];
                     }
@@ -470,12 +469,12 @@ const post = (original, updates = {}, withConfirmation = true) => (
                             )
                         );
                     }
-                    failedPlanningIds?.map((item) => notifyError(
+                    failedPlanningIds?.map((failedItem) => notifyError(
                         notify,
-                        item,
+                        failedItem,
                         gettext(
                             'Related item {{ itemId }} Post Validation Failed',
-                            {itemId: item?._id})));
+                            {itemId: failedItem?._id})));
 
                     return Promise.resolve(item);
                 },

--- a/client/interfaces.ts
+++ b/client/interfaces.ts
@@ -593,6 +593,10 @@ export interface IEventItem extends IBaseRestApiResponse {
     _post?: boolean;
     _events: Array<IEventItem>;
     _relatedPlannings: Array<IPlanningItem>;
+    failed_planning_ids?: Array<{
+        id: string,
+        error: Array<string>
+    }>
 }
 
 export interface IEventTemplate extends IBaseRestApiResponse {

--- a/client/utils/index.ts
+++ b/client/utils/index.ts
@@ -258,6 +258,8 @@ export const getErrorMessage = (error, defaultMessage) => {
         return get(error, '_issues.validator exception');
     } else if (typeof error === 'string') {
         return error;
+    } else if (get(error, 'error')) {
+        return get(error, 'error');
     }
 
     return defaultMessage;

--- a/server/features/events_post.feature
+++ b/server/features/events_post.feature
@@ -1242,18 +1242,12 @@ Feature: Events Post
         "event": "#EVENT1._id#",
         "etag": "#EVENT1._etag#",
         "pubstatus": "usable",
-        "update_method": "single"
+        "update_method": "single",
+        "failed_planning_ids": []
     }
     """
     Then we get OK response
     Then we get updated response
     """
-    {
-     "_id": {
-        "failed_planning_ids": [{
-            "_id": "123", "error": ["Related planning : SLUGLINE is a required field"]
-            }],
-            "item_id": "#EVENT1._id#"
-        }   
-    }
+    {"failed_planning_ids": [{"_id": "123", "error": ["Related planning : SLUGLINE is a required field"]}]}
     """

--- a/server/features/events_post.feature
+++ b/server/features/events_post.feature
@@ -1185,3 +1185,75 @@ Feature: Events Post
             }]
         }
         """
+    @auth
+    @notification
+    Scenario: Post single event with planning item
+    Given "planning_types"
+    """
+    [{
+        "_id": "event",
+        "name": "event",
+        "editor": {
+            "related_plannings": {"enabled": true}
+        },
+        "schema": {
+            "related_plannings": {"planning_auto_publish": true}
+        }
+    },
+    {
+        "_id": "planning",
+        "name": "planning",
+        "editor": {
+            "slugline": {"enabled": true}
+        },
+        "schema": {
+            "slugline": {"required": true}
+        } 
+    }
+    ]
+    """
+    When we post to "events"
+    """
+    [{
+        "name": "Friday Club",
+        "dates": {
+            "start": "2029-11-21T23:00:00.000Z",
+            "end": "2029-11-22T02:00:00.000Z",
+            "tz": "Australia/Sydney"
+        },
+        "state": "draft"
+    }]
+    """
+    Then we get OK response
+    Then we store response in "EVENT1"
+    When we post to "/planning"
+    """
+    [{
+        "headline": "test headline",
+        "guid": "123",
+        "planning_date": "2029-11-22",
+        "event_item": "#EVENT1._id#"
+    }]
+    """
+    Then we get OK response
+    When we post to "/events/post"
+    """
+    {
+        "event": "#EVENT1._id#",
+        "etag": "#EVENT1._etag#",
+        "pubstatus": "usable",
+        "update_method": "single"
+    }
+    """
+    Then we get OK response
+    Then we get updated response
+    """
+    {
+     "_id": {
+        "failed_planning_ids": [{
+            "_id": "123", "error": ["Related planning : SLUGLINE is a required field"]
+            }],
+            "item_id": "#EVENT1._id#"
+        }   
+    }
+    """

--- a/server/planning/events/events_post.py
+++ b/server/planning/events/events_post.py
@@ -36,6 +36,11 @@ class EventsPostResource(EventsResource):
         },
         # used to only repost an item when data changes from backend (update_repetitions)
         "repost_on_update": {"type": "boolean", "required": False, "default": False},
+        "failed_planning_ids": {
+            "type": "list",
+            "required": False,
+            "schema": {"type": "dict", "schema": {}},
+        },
     }
 
     url = "events/post"
@@ -48,7 +53,6 @@ class EventsPostResource(EventsResource):
 class EventsPostService(EventsBaseService):
     def create(self, docs):
         ids = []
-        failed_planning_ids = []
         events_service = get_resource_service("events")
         for doc in docs:
             event = events_service.find_one(req=None, _id=doc["event"])
@@ -65,9 +69,9 @@ class EventsPostService(EventsBaseService):
 
             ids.append(event_id)
             if planning_ids:
-                failed_planning_ids.extend(planning_ids)
+                doc["failed_planning_ids"].extend(planning_ids)
 
-        return [{"item_id": event_id, "failed_planning_ids": failed_planning_ids}] if failed_planning_ids else ids
+        return ids
 
     @staticmethod
     def validate_post_state(new_post_state):

--- a/server/planning/events/events_post.py
+++ b/server/planning/events/events_post.py
@@ -56,6 +56,7 @@ class EventsPostService(EventsBaseService):
         events_service = get_resource_service("events")
         for doc in docs:
             event = events_service.find_one(req=None, _id=doc["event"])
+            doc["failed_planning_ids"] = []
 
             if not event:
                 abort(412)
@@ -68,7 +69,7 @@ class EventsPostService(EventsBaseService):
                 event_id, planning_ids = self._post_recurring_events(doc, event, update_method)
 
             ids.append(event_id)
-            if planning_ids and doc.get("failed_planning_ids"):
+            if planning_ids:
                 doc["failed_planning_ids"].extend(planning_ids)
 
         return ids

--- a/server/planning/events/events_post.py
+++ b/server/planning/events/events_post.py
@@ -128,6 +128,7 @@ class EventsPostService(EventsBaseService):
         updated_event = None
         ids = []
         items = []
+        failed_planning_ids = []
         for event in posted_events:
             updated_event, failed_planning_ids = self.post_event(event, post_to_state, doc.get("repost_on_update"))
             ids.append(event[config.ID_FIELD])

--- a/server/planning/events/events_post.py
+++ b/server/planning/events/events_post.py
@@ -64,7 +64,8 @@ class EventsPostService(EventsBaseService):
                 event_id, planning_ids = self._post_recurring_events(doc, event, update_method)
 
             ids.append(event_id)
-            failed_planning_ids.extend(planning_ids)
+            if planning_ids:
+                failed_planning_ids.extend(planning_ids)
 
         return [{"item_id": event_id, "failed_planning_ids": failed_planning_ids}] if failed_planning_ids else ids
 

--- a/server/planning/events/events_post.py
+++ b/server/planning/events/events_post.py
@@ -156,6 +156,8 @@ class EventsPostService(EventsBaseService):
             # same pubstatus or scheduled (for draft events)
             new_post_state = event.get("pubstatus", POST_STATE.USABLE)
 
+        failed_planning_ids = []
+
         new_item_state = get_item_post_state(event, new_post_state, repost)
         updates = {"state": new_item_state, "pubstatus": new_post_state}
 

--- a/server/planning/events/events_schema.py
+++ b/server/planning/events/events_schema.py
@@ -411,4 +411,9 @@ events_schema = {
             },
         },
     },
+    "failed_planning_ids": {
+        "type": "list",
+        "required": False,
+        "schema": {"type": "dict", "schema": {}},
+    },
 }  # end events_schema:

--- a/server/planning/events/events_tests.py
+++ b/server/planning/events/events_tests.py
@@ -517,13 +517,7 @@ class EventsRelatedPlanningAutoPublish(TestCase):
             )
             now = utcnow()
             get_resource_service("events_post").post(
-                [
-                    {
-                        "event": event_id[0],
-                        "pubstatus": "usable",
-                        "update_method": "single",
-                    }
-                ]
+                [{"event": event_id[0], "pubstatus": "usable", "update_method": "single", "failed_planning_ids": []}]
             )
 
             event_item = events_service.find_one(req=None, _id=event_id[0])
@@ -571,13 +565,7 @@ class EventsRelatedPlanningAutoPublish(TestCase):
                 ]
             )[0]
             get_resource_service("events_post").post(
-                [
-                    {
-                        "event": event_id,
-                        "pubstatus": "usable",
-                        "update_method": "single",
-                    }
-                ]
+                [{"event": event_id, "pubstatus": "usable", "update_method": "single", "failed_planning_ids": []}]
             )
             planning_id = planning_service.post(
                 [
@@ -597,105 +585,3 @@ class EventsRelatedPlanningAutoPublish(TestCase):
             planning_item = planning_service.find_one(req=None, _id=planning_id)
             self.assertIsNotNone(planning_item)
             self.assertEqual(planning_item["pubstatus"], POST_STATE.USABLE)
-
-    def test_related_planning_item_validation_on_post(self):
-        """
-        check planning item fields validation
-        if validation fails, plannning item is not posted.
-        """
-        events_service = get_resource_service("events")
-        planning_service = get_resource_service("planning")
-
-        with self.app.app_context():
-            self.app.data.insert(
-                "planning_types",
-                [
-                    {
-                        "_id": "event",
-                        "name": "event",
-                        "editor": {"related_plannings": {"enabled": True}},
-                        "schema": {"related_plannings": {"planning_auto_publish": True}},
-                    },
-                    {
-                        "_id": "planning",
-                        "name": "planning",
-                        "editor": {"slugline": {"enabled": True}},
-                        "schema": {"slugline": {"required": True}},
-                    },
-                ],
-            )
-
-        event_id = events_service.post(
-            [
-                {
-                    "type": "event",
-                    "occur_status": {
-                        "qcode": "eocstat:eos5",
-                        "name": "Planned, occurs certainly",
-                        "label": "Planned, occurs certainly",
-                    },
-                    "dates": {
-                        "start": datetime(2099, 11, 21, 11, 00, 00, tzinfo=pytz.UTC),
-                        "end": datetime(2099, 11, 21, 12, 00, 00, tzinfo=pytz.UTC),
-                        "tz": "Australia/Sydney",
-                    },
-                    "state": "draft",
-                    "name": "Foo event one",
-                }
-            ]
-        )[0]
-        planning_id = planning_service.post(
-            [
-                {
-                    "planning_date": datetime(2099, 11, 21, 12, 00, 00, tzinfo=pytz.UTC),
-                    "name": "foo planning 1",
-                    "type": "planning",
-                    "event_item": event_id,
-                }
-            ]
-        )[0]
-        try:
-            get_resource_service("events_post").post(
-                [
-                    {
-                        "event": event_id,
-                        "pubstatus": "usable",
-                        "update_method": "single",
-                    }
-                ]
-            )
-        except BadRequest as e:
-            self.assertEqual(str(e), "400 Bad Request: ['Related planning : SLUGLINE is a required field']")
-
-        planning_item = planning_service.find_one(req=None, _id=planning_id)
-        self.assertEqual(planning_item["state"], "draft")
-
-        # try to re-post an event.
-        try:
-            get_resource_service("events_post").post(
-                [
-                    {
-                        "event": event_id,
-                        "pubstatus": "usable",
-                        "update_method": "single",
-                    }
-                ]
-            )
-        except BadRequest as e:
-            self.assertEqual(str(e), "400 Bad Request: ['Related planning : SLUGLINE is a required field']")
-
-        # udpate slugline
-        planning_service.patch(planning_id, {"slugline": "update slug"})
-
-        get_resource_service("events_post").post(
-            [
-                {
-                    "event": event_id,
-                    "pubstatus": "usable",
-                    "update_method": "single",
-                }
-            ]
-        )
-        planning_item = planning_service.find_one(req=None, _id=planning_id)
-        self.assertIsNotNone(planning_item)
-        self.assertEqual(planning_item["state"], "scheduled")


### PR DESCRIPTION
PR based on [Comment](https://sofab.atlassian.net/browse/SDESK-7202?focusedCommentId=129158)
Previously, when related planning item validation failed, the API returned an error, which prevented the Redux state from updating and consequently not reflect the event status in the UI
so I've implemented a workaround here, as when posting an Event, if validation of Event passes and the Event is posted, we respond back to the client with a success. If associated Planning items fail validation, we catch all planning posting errors, and return those to the user along with the response