### PR TITLE
Fix: display of accurate Items using manual filters search [SDESK-7264]

### DIFF
--- a/client/api/ui/list.ts
+++ b/client/api/ui/list.ts
@@ -34,7 +34,7 @@ function reloadList(params: ICombinedEventOrPlanningSearchParams = {}) {
 
     if (currentView === MAIN.FILTERS.PLANNING) {
         dispatch(actions.eventsPlanning.ui.clearList());
-        dispatch(actions.planning.ui.clearList());
+        dispatch(actions.events.ui.clearList());
         promise = dispatch<any>(actions.planning.ui.fetchToList({
             ...getPlanningFilterParams(getState()),
             ...params,
@@ -42,7 +42,7 @@ function reloadList(params: ICombinedEventOrPlanningSearchParams = {}) {
         }));
     } else if (currentView === MAIN.FILTERS.EVENTS) {
         dispatch(actions.eventsPlanning.ui.clearList());
-        dispatch(actions.events.ui.clearList());
+        dispatch(actions.planning.ui.clearList());
         promise = dispatch<any>(actions.events.ui.fetchEvents({
             ...getEventFilterParams(getState()),
             ...params,

--- a/client/api/ui/list.ts
+++ b/client/api/ui/list.ts
@@ -34,7 +34,7 @@ function reloadList(params: ICombinedEventOrPlanningSearchParams = {}) {
 
     if (currentView === MAIN.FILTERS.PLANNING) {
         dispatch(actions.eventsPlanning.ui.clearList());
-        dispatch(actions.events.ui.clearList());
+        dispatch(actions.planning.ui.clearList());
         promise = dispatch<any>(actions.planning.ui.fetchToList({
             ...getPlanningFilterParams(getState()),
             ...params,
@@ -42,7 +42,7 @@ function reloadList(params: ICombinedEventOrPlanningSearchParams = {}) {
         }));
     } else if (currentView === MAIN.FILTERS.EVENTS) {
         dispatch(actions.eventsPlanning.ui.clearList());
-        dispatch(actions.planning.ui.clearList());
+        dispatch(actions.events.ui.clearList());
         promise = dispatch<any>(actions.events.ui.fetchEvents({
             ...getEventFilterParams(getState()),
             ...params,

--- a/client/components/Main/FilterSubnavDropdown.tsx
+++ b/client/components/Main/FilterSubnavDropdown.tsx
@@ -79,7 +79,10 @@ class FilterSubnavDropdownComponent extends React.PureComponent<IProps> {
         return filters.map((filter) => ({
             id: filter._id,
             label: filter.name,
-            action: () => planningApi.ui.list.changeFilterId(filter._id),
+            action: () => planningApi.ui.list.changeFilterId(
+                filter._id,
+                {advancedSearch: {dates: {range: filter?.params?.date_filter}}}
+            ),
             group: gettext('Search Filters'),
         }));
     }
@@ -93,7 +96,10 @@ class FilterSubnavDropdownComponent extends React.PureComponent<IProps> {
                 label: this.hasGlobalFiltersPrivilege() ?
                     gettext('All Events & Planning') :
                     gettext('My Events & Planning'),
-                action: () => planningApi.ui.list.changeFilterId(EVENTS_PLANNING.FILTER.ALL_EVENTS_PLANNING),
+                action: () => planningApi.ui.list.changeFilterId(
+                    EVENTS_PLANNING.FILTER.ALL_EVENTS_PLANNING,
+                    {advancedSearch: {}}
+                ),
                 group: '',
             }
         ];
@@ -107,7 +113,10 @@ class FilterSubnavDropdownComponent extends React.PureComponent<IProps> {
             label: this.hasGlobalFiltersPrivilege() ?
                 gettext('All Events') :
                 gettext('My Events'),
-            action: () => planningApi.ui.list.changeCalendarId(EVENTS.FILTER.ALL_CALENDARS),
+            action: () => planningApi.ui.list.changeCalendarId(
+                EVENTS.FILTER.ALL_CALENDARS,
+                {advancedSearch: {}}
+            ),
             group: '',
         }, {
             id: 'no_calendar',
@@ -163,7 +172,10 @@ class FilterSubnavDropdownComponent extends React.PureComponent<IProps> {
             label: this.hasGlobalFiltersPrivilege() ?
                 gettext('All Planning Items') :
                 gettext('My Planning'),
-            action: () => planningApi.ui.list.changeAgendaId(AGENDA.FILTER.ALL_PLANNING),
+            action: () => planningApi.ui.list.changeAgendaId(
+                AGENDA.FILTER.ALL_PLANNING,
+                {advancedSearch: {}}
+            ),
             group: '',
         }, {
             id: 'no_agenda',


### PR DESCRIPTION
When using the next_filter from the sidenav bar (Advanced Search), the list is filtered and displays the accurate items. However, when applying filters manually, the data is not filtered correctly. The root cause was identified as the absence of the `advancedSearch.dates.range` parameter in the manual filter process. so when this param is missing, the datetime is not updated from here : https://github.com/superdesk/superdesk-planning/blob/develop/client/utils/index.ts#L690-L728