### PR TITLE
allow ingestion of cancelled events

### DIFF
--- a/server/planning/commands/export_to_newsroom.py
+++ b/server/planning/commands/export_to_newsroom.py
@@ -73,7 +73,6 @@ class ExportToNewsroom(Command):
         logger.info("Completed export events and planning.")
 
     def _fetch_items(self, fetch_callback):
-        """"""
         query = {
             "query": {
                 "bool": {

--- a/server/planning/events/events.py
+++ b/server/planning/events/events.py
@@ -121,7 +121,6 @@ class EventsService(superdesk.Service):
 
         for doc in docs:
             self._resolve_defaults(doc)
-            doc.pop("pubstatus", None)
             set_ingest_version_datetime(doc)
 
         self.on_create(docs)

--- a/server/planning/events/events_tests.py
+++ b/server/planning/events/events_tests.py
@@ -134,6 +134,27 @@ class EventTestCase(TestCase):
                 self.assertEquals(e["dates"]["start"], expected_time)
                 expected_time += timedelta(days=1)
 
+    def test_create_cancelled_event(self):
+        with self.app.app_context():
+            service = get_resource_service("events")
+            service.post_in_mongo(
+                [
+                    {
+                        "guid": "test",
+                        "name": "Test Event",
+                        "pubstatus": "cancelled",
+                        "dates": {
+                            "start": datetime.now(),
+                            "end": datetime.now() + timedelta(days=1),
+                        },
+                    }
+                ]
+            )
+
+            event = service.find_one(req=None, guid="test")
+            assert event is not None
+            assert event["pubstatus"] == "cancelled"
+
 
 class EventLocationFormatAddress(TestCase):
     def test_format_address(self):


### PR DESCRIPTION
we have some events which already expired but then they get cancelled but those get ingested with usable pubstatus

SDCP-792