### PR TITLE
Respect date filter for today

### DIFF
--- a/client/apps/Planning/PlanningList.tsx
+++ b/client/apps/Planning/PlanningList.tsx
@@ -187,15 +187,12 @@ export class PlanningListComponent extends React.PureComponent<IProps> {
                 <PlanningListSubNav />
                 <ListPanel
                     groups={(() => {
-                        const dateFilter = currentSearch.advancedSearch?.dates?.start;
+                        // Date filter by default has today's value
+                        const dateFilter = currentSearch.advancedSearch?.dates?.start ?? moment().date();
 
-                        if (dateFilter != null) {
-                            return groups.filter((group) =>
-                                moment(group.date).isSameOrAfter(dateFilter),
-                            );
-                        }
-
-                        return groups;
+                        return groups.filter((group) =>
+                            moment(group.date).isSameOrAfter(dateFilter),
+                        );
                     })()}
                     onItemClick={openPreview}
                     onDoubleClick={edit}

--- a/client/apps/Planning/PlanningList.tsx
+++ b/client/apps/Planning/PlanningList.tsx
@@ -187,7 +187,6 @@ export class PlanningListComponent extends React.PureComponent<IProps> {
                 <PlanningListSubNav />
                 <ListPanel
                     groups={(() => {
-                        // Date filter by default has today's value
                         const dateFilter = currentSearch.advancedSearch?.dates?.start ?? moment().date();
 
                         return groups.filter((group) =>


### PR DESCRIPTION
SDESK-7310

Date filter can never be "null". It either has today's value (by default) or it has a user set value