### PR TITLE
Event and Planning profile editor doesn't display Groups in Fields

### DIFF
--- a/client/components/ContentProfiles/FieldTab/FieldList.tsx
+++ b/client/components/ContentProfiles/FieldTab/FieldList.tsx
@@ -194,6 +194,7 @@ export class FieldList extends React.PureComponent<IProps> {
             this.renderList()
         ) : (
             <ToggleBox
+                variant="simple"
                 key={this.props.group._id}
                 title={getProfileGroupNameTranslated(this.props.group)}
                 className="toggle-box--circle toggle-box--no-line"

--- a/client/components/ContentProfiles/GroupTab/GroupEditor.tsx
+++ b/client/components/ContentProfiles/GroupTab/GroupEditor.tsx
@@ -127,6 +127,7 @@ export class GroupEditor extends React.PureComponent<IProps> {
                             </div>
                             {!this.props.languages?.length ? null : (
                                 <ToggleBox
+                                    variant="simple"
                                     title={gettext('Name Translations')}
                                     className="toggle-box--circle"
                                     initiallyOpen={true}

--- a/client/components/SortItems/style.scss
+++ b/client/components/SortItems/style.scss
@@ -12,3 +12,13 @@
 .sortable-list__item button {
     padding: 0px !important;
 }
+
+.sd-list-item-group {
+    padding: 4px 4px 18px 4px;
+}
+
+.sd-list-item-group--space-between-items .sortable-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap--small);
+}


### PR DESCRIPTION
STT-74

## Front-end checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [x] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [x] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [x] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [x] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [x] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [x] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [x] This pull request is not adding redux based modals
- [x] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [x] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)
