### PR TITLE
fix duplicate event IDs

### DIFF
--- a/client/reducers/events.ts
+++ b/client/reducers/events.ts
@@ -166,7 +166,10 @@ const eventsReducer = createReducer<IEventState>(initialState, {
 
         const planningIds = get(event, 'planning_ids', []);
 
-        planningIds.push(payload.planning_item);
+        if (planningIds.includes(payload.planning_item) !== true) {
+            planningIds.push(payload.planning_item);
+        }
+
         event.planning_ids = planningIds;
 
         return {


### PR DESCRIPTION
STT-70

## Front-end checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [x] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [x] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [x] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [x] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [x] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [x] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [x] This pull request is not adding redux based modals
- [x] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [x] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)


Fixes a bug when after adding a related planning item - 2 related items would be shown when in reality it's only one displayed twice.

https://github.com/user-attachments/assets/3d1fae84-1329-4f0f-9d18-095823691d27

