### PR TITLE
display related planning items also for secondary links

### DIFF
--- a/server/features/events.feature
+++ b/server/features/events.feature
@@ -1713,6 +1713,15 @@ Feature: Events
         """
         {"related_events": [{"_id": "#events._id#", "link_type": "secondary"}]}
         """
+        When we get "/events/event_1"
+        Then we get existing resource
+        """
+        {
+            "planning_ids": [
+                "plan1"
+            ]
+        }
+        """
      
     @auth
     Scenario: Link new Event with one_primary link method

--- a/server/planning/events/events.py
+++ b/server/planning/events/events.py
@@ -174,7 +174,7 @@ class EventsService(superdesk.Service):
         self._enhance_event_item(doc)
 
     def _enhance_event_item(self, doc):
-        plannings = get_related_planning_for_events([doc[config.ID_FIELD]], "primary")
+        plannings = get_related_planning_for_events([doc[config.ID_FIELD]])
 
         if len(plannings):
             doc["planning_ids"] = [planning.get("_id") for planning in plannings]


### PR DESCRIPTION
STT-70

## Front-end checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)
