### PR TITLE
display secondary events in planning preview

### DIFF
--- a/client/actions/planning/api.ts
+++ b/client/actions/planning/api.ts
@@ -187,7 +187,7 @@ const fetchPlanningsEvents = (plannings: Array<IPlanningItem>) => (
         const loadedEvents = selectors.events.storedEvents(getState());
 
         const linkedEventIds = plannings
-            .map((plan) => getRelatedEventIdsForPlanning(plan, 'primary'))
+            .map((plan) => getRelatedEventIdsForPlanning(plan))
             .flat()
             .filter((eventId) => loadedEvents[eventId] == null);
 

--- a/client/components/Planning/PlanningPreviewContent.tsx
+++ b/client/components/Planning/PlanningPreviewContent.tsx
@@ -216,23 +216,23 @@ export class PlanningPreviewContentComponent extends React.PureComponent<IProps>
                             <span className="sd-text__info">{gettext('No attached files added.')}</span>}
                     </ToggleBox>
                 )}
-                {!hideRelatedItems && event && (
-                    <h3 className="side-panel__heading--big">
-                        {gettext('Associated Events')}
-                    </h3>
-                )}
                 {!hideRelatedItems && (relatedEvents?.length ?? 0) > 0 && (
-                    relatedEvents.map((relatedEvent) => (
-                        <EventMetadata
-                            key={`related_event--${relatedEvent._id}`}
-                            event={relatedEvent}
-                            dateOnly={true}
-                            onEditEvent={onEditEvent.bind(null, relatedEvent)}
-                            createUploadLink={getFileDownloadURL}
-                            files={files}
-                            hideEditIcon={hideEditIcon}
-                        />
-                    ))
+                    <>
+                        <h3 className="side-panel__heading--big">
+                            {gettext('Associated Events')}
+                        </h3>
+                        {relatedEvents.map((relatedEvent) => (
+                            <EventMetadata
+                                key={`related_event--${relatedEvent._id}`}
+                                event={relatedEvent}
+                                dateOnly={true}
+                                onEditEvent={onEditEvent.bind(null, relatedEvent)}
+                                createUploadLink={getFileDownloadURL}
+                                files={files}
+                                hideEditIcon={hideEditIcon}
+                            />
+                        ))}
+                    </>
                 )}
                 {!hasCoverage ? null : (
                     <React.Fragment>

--- a/client/selectors/events.ts
+++ b/client/selectors/events.ts
@@ -17,7 +17,7 @@ import {currentPlanning, storedPlannings} from './planning';
 import {agendas, userPreferences} from './general';
 import {currentItem, currentItemModal} from './forms';
 import {eventUtils, getSearchDateRange} from '../utils';
-import {getRelatedEventIdsForPlanning, pickRelatedEventsForPlanning} from '../utils/planning';
+import {pickRelatedEventsForPlanning} from '../utils/planning';
 import {EVENTS, MAIN, SPIKED_STATE} from '../constants';
 
 function getCurrentListViewType(state?: IPlanningAppState) {
@@ -150,7 +150,7 @@ export const getRelatedEventsForPlanning = createSelector<
             return null;
         }
 
-        const pickedEvents = pickRelatedEventsForPlanning(item, Object.values(events ?? {}), 'logic');
+        const pickedEvents = pickRelatedEventsForPlanning(item, Object.values(events ?? {}), 'display');
 
         return pickedEvents.length < 1 ? null : pickedEvents;
     }

--- a/client/utils/planning.ts
+++ b/client/utils/planning.ts
@@ -1628,14 +1628,14 @@ function duplicateCoverage(
 
 export function getRelatedEventLinksForPlanning(
     plan: Partial<IPlanningItem>,
-    linkType: IPlanningRelatedEventLinkType
+    linkType?: IPlanningRelatedEventLinkType
 ): Array<IPlanningRelatedEventLink> {
-    return (plan?.related_events || []).filter((link) => link.link_type === linkType);
+    return (plan?.related_events || []).filter((link) => linkType == null || link.link_type === linkType);
 }
 
 export function getRelatedEventIdsForPlanning(
     plan: Partial<IPlanningItem>,
-    linkType: IPlanningRelatedEventLinkType
+    linkType?: IPlanningRelatedEventLinkType
 ): Array<IEventItem['_id']> {
     return getRelatedEventLinksForPlanning(plan, linkType).map((event) => event._id);
 }
@@ -1646,17 +1646,9 @@ export function pickRelatedEventsForPlanning(
     purpose: 'display' | 'logic',
 ): Array<IEventItem> {
     const events = events_ ?? [];
-    const {assertNever} = superdeskApi.helpers;
+    const allowedEventIds = new Set(getRelatedEventIdsForPlanning(planning, purpose === 'logic' ? 'primary' : null));
 
-    if (purpose === 'logic') {
-        const allowedEventIds = new Set(getRelatedEventIdsForPlanning(planning, 'primary'));
-
-        return events.filter((event) => allowedEventIds.has(event._id));
-    } else if (purpose === 'display') {
-        return events;
-    } else {
-        assertNever(purpose);
-    }
+    return events.filter((event) => allowedEventIds.has(event._id));
 }
 
 export function pickRelatedEventIdsForPlanning(


### PR DESCRIPTION
STT-72

## Front-end checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)
