### PR TITLE
Planning workqueue cherrypick

### DIFF
--- a/client/actions/agenda.ts
+++ b/client/actions/agenda.ts
@@ -9,6 +9,7 @@ import {AGENDA, MODALS, EVENTS} from '../constants';
 import {getErrorMessage, gettext, planningUtils} from '../utils';
 import {planning, showModal, main} from './index';
 import {convertStringFields} from '../utils/strings';
+import planningApis from '../actions/planning/api';
 
 const openAgenda = () => (
     (dispatch) => (
@@ -302,7 +303,7 @@ const createPlanningFromEvent = (
     newPlanningItem.agendas = newPlanningItem.agendas.concat(agendas);
 
     return (dispatch) => (
-        dispatch(planning.api.save({}, newPlanningItem))
+        dispatch(planningApis.save({}, newPlanningItem))
     );
 };
 

--- a/client/actions/assignments/notifications.ts
+++ b/client/actions/assignments/notifications.ts
@@ -9,9 +9,9 @@ import {lockUtils, assignmentUtils, gettext, isExistingItem} from '../../utils';
 import * as selectors from '../../selectors';
 import assignments from './index';
 import main from '../main';
-import planning from '../planning';
 import {hideModal, showModal} from '../index';
 import * as actions from '../../actions';
+import planningApis from '../planning/api';
 
 const _notifyAssignmentEdited = (assignmentId) => (
     (dispatch, getState, {notify}) => {
@@ -191,7 +191,7 @@ const _updatePlannigRelatedToAssignment = (data) => (
             return Promise.resolve();
         }
 
-        dispatch(planning.api.loadPlanningByIds([data.planning]));
+        dispatch(planningApis.loadPlanningByIds([data.planning]));
         dispatch(main.fetchItemHistory(planningItem));
     }
 );

--- a/client/actions/main.ts
+++ b/client/actions/main.ts
@@ -1,7 +1,10 @@
 import {get, isEmpty, isEqual, isNil, omit} from 'lodash';
 import moment from 'moment';
 
-import {appConfig} from 'appConfig';
+import {appConfig as config} from 'appConfig';
+
+const appConfig = config as IPlanningConfig;
+
 import {IUser} from 'superdesk-api';
 import {planningApi, superdeskApi} from '../superdeskApi';
 import {
@@ -18,6 +21,7 @@ import {
     ITEM_TYPE,
     IEventTemplate,
     IEventItem,
+    IPlanningConfig,
 } from '../interfaces';
 
 import {
@@ -68,6 +72,7 @@ import eventsPlanningUi from './eventsPlanning/ui';
 import * as selectors from '../selectors';
 import {validateItem} from '../validators';
 import {searchParamsToOld} from '../utils/search';
+import {searchAndStore} from '../api/combined';
 
 function openForEdit(item: IEventOrPlanningItem, updateUrl: boolean = true, modal: boolean = false) {
     return (dispatch, getState) => {
@@ -716,7 +721,7 @@ const openIgnoreCancelSaveModal = ({
         const storedItems = itemType === ITEM_TYPE.EVENT ?
             selectors.events.storedEvents(getState()) :
             selectors.planning.storedPlannings(getState());
-        const item = get(storedItems, itemId) || {};
+        const item = storedItems[itemId] ?? {};
 
         if (!isExistingItem(item)) {
             delete item._id;
@@ -725,19 +730,17 @@ const openIgnoreCancelSaveModal = ({
         let promise = Promise.resolve(item);
 
         if (itemType === ITEM_TYPE.EVENT && eventUtils.isEventRecurring(item)) {
-            const originalEvent = get(storedItems, itemId, {});
-
-            promise = dispatch(eventsApi.query({
-                recurrenceId: originalEvent.recurrence_id,
-                maxResults: appConfig.max_recurrent_events,
-                onlyFuture: false,
-            }))
-                .then((relatedEvents) => ({
-                    ...item,
-                    _recurring: relatedEvents || [item],
-                    _events: [],
-                    _originalEvent: originalEvent,
-                }));
+            promise = searchAndStore({
+                recurrence_id: item.recurrence_id,
+                max_results: appConfig.max_recurrent_events,
+                only_future: false,
+                include_associated_planning: true,
+            }).then((relatedEvents) => ({
+                ...item,
+                _recurring: relatedEvents.filter((item) => item.type === 'event') ?? [item],
+                _events: [],
+                _originalEvent: item,
+            }));
         }
 
         return promise.then((itemWithAssociatedData) => (
@@ -1200,8 +1203,10 @@ const openFromLockActions = () => (
             if (action) {
                 /* get the item we're operating on */
                 dispatch(self.fetchById(sessionLastLock.item_id, sessionLastLock.item_type)).then((item) => {
-                    actionUtils.getActionDispatches({dispatch: dispatch, eventOnly: false,
-                        planningOnly: false})[action[0].actionName](item, false, false);
+                    actionUtils.getActionDispatches({
+                        dispatch: dispatch, eventOnly: false,
+                        planningOnly: false
+                    })[action[0].actionName](item, false, false);
                 });
             }
         }
@@ -1460,7 +1465,7 @@ function onItemUnlocked(
             }));
 
             if (getItemType(item) === ITEM_TYPE.PLANNING && selectors.general.currentWorkspace(state)
-                    === WORKSPACE.AUTHORING) {
+                === WORKSPACE.AUTHORING) {
                 dispatch(self.closePreviewAndEditorForItems([item]));
             }
         }

--- a/client/actions/planning/api.ts
+++ b/client/actions/planning/api.ts
@@ -486,7 +486,7 @@ const unpost = (original, updates) => (
  * Also loads all the associated contacts (if any)
  * @param  {array, object} plannings - An array of planning item objects
  */
-const receivePlannings = (plannings) => (
+const receivePlannings = (plannings): any => (
     (dispatch) => {
         dispatch(actions.contacts.fetchContactsFromPlanning(plannings));
         dispatch({

--- a/client/actions/planning/notifications.ts
+++ b/client/actions/planning/notifications.ts
@@ -14,6 +14,7 @@ import {events, fetchAgendas} from '../index';
 import main from '../main';
 import {showModal, hideModal} from '../index';
 import eventsPlanning from '../eventsPlanning';
+import planningApis from '../planning/api';
 
 /**
  * WS Action when a new Planning item is created
@@ -104,7 +105,7 @@ const onPlanningLocked = (e, data) => (
 
             const sessionId = selectors.general.session(getState()).sessionId;
 
-            return dispatch(planning.api.getPlanning(data.item, false))
+            return dispatch(planningApis.getPlanning(data.item, false))
                 .then((planInStore) => {
                     let plan = {
                         ...planInStore,

--- a/client/actions/planning/tests/api_test.ts
+++ b/client/actions/planning/tests/api_test.ts
@@ -6,10 +6,8 @@ import {
     restoreSinonStub,
     convertEventDatesToMoment,
 } from '../../../utils/testUtils';
-import {createTestStore} from '../../../utils';
-import {PLANNING, SPIKED_STATE, WORKFLOW_STATE} from '../../../constants';
+import {PLANNING, SPIKED_STATE} from '../../../constants';
 import {MAIN} from '../../../constants';
-import * as selectors from '../../../selectors';
 import contactsApi from '../../contacts';
 import {planningApis} from '../../../api';
 

--- a/client/actions/planning/tests/notifications_test.ts
+++ b/client/actions/planning/tests/notifications_test.ts
@@ -1,5 +1,5 @@
 import {planningApi} from '../../../superdeskApi';
-import planningApis from '../api';
+import planningApis from '../../planning/api';
 import planningUi from '../ui';
 import featuredPlanning from '../featuredPlanning';
 import eventsPlanningUi from '../../eventsPlanning/ui';
@@ -197,7 +197,7 @@ describe('actions.planning.notifications', () => {
     describe('onPlanningLocked', () => {
         beforeEach(() => {
             sinon.stub(planningApi.locks, 'setItemAsLocked').returns(undefined);
-            sinon.stub(planningApis, 'getPlanning').returns(Promise.resolve(data.plannings[0]));
+            sinon.stub(planningApis, 'getPlanning').returns(() => Promise.resolve(data.plannings[0]));
         });
 
         afterEach(() => {
@@ -219,7 +219,6 @@ describe('actions.planning.notifications', () => {
             ))
                 .then(() => {
                     expect(planningApi.locks.setItemAsLocked.callCount).toBe(1);
-                    expect(planningApis.getPlanning.callCount).toBe(1);
                     expect(planningApis.getPlanning.args[0]).toEqual([
                         'p1',
                         false,

--- a/client/api/combined.ts
+++ b/client/api/combined.ts
@@ -8,11 +8,11 @@ import {
     IEventOrPlanningItem,
 } from '../interfaces';
 import {IRestApiResponse} from 'superdesk-api';
-import {searchRaw, searchRawGetAll, convertCommonParams, cvsToString, arrayToString} from './search';
+import {searchRaw, searchRawGetAll, convertCommonParams, cvsToString, arrayToString, searchRawAndStore} from './search';
 import {eventUtils, planningUtils} from '../utils';
 import {planningApi} from '../superdeskApi';
 import {combinedSearchProfile} from '../selectors/forms';
-import {searchPlanningGetAll} from './planning';
+import {searchPlanningGetAll, convertPlanningParams} from './planning';
 import {searchEventsGetAll} from './events';
 
 type IResponse = IRestApiResponse<IEventOrPlanningItem>;
@@ -65,6 +65,18 @@ export function searchCombinedGetAll(params: ISearchParams): Promise<Array<IEven
 
             return items;
         });
+}
+
+export function searchAndStore(params: ISearchParams) {
+    return searchRawAndStore<IEventOrPlanningItem>({
+        ...convertCommonParams(params),
+        ...convertPlanningParams(params),
+        repo: FILTER_TYPE.COMBINED,
+    }).then((res) => {
+        res._items.forEach(modifyItemForClient);
+
+        return res._items;
+    });
 }
 
 export function getEventsAndPlanning(params: ISearchParams): Promise<{
@@ -145,5 +157,6 @@ export const combined: IPlanningAPI['combined'] = {
     getRecurringEventsAndPlanningItems: getRecurringEventsAndPlanningItems,
     getEventsAndPlanning: getEventsAndPlanning,
     getSearchProfile: getCombinedSearchProfile,
+    searchAndStore: searchAndStore,
 };
 

--- a/client/api/events.ts
+++ b/client/api/events.ts
@@ -16,7 +16,7 @@ import {EVENTS, TEMP_ID_PREFIX} from '../constants';
 import {arrayToString, convertCommonParams, cvsToString, searchRaw, searchRawGetAll} from './search';
 import {eventUtils} from '../utils';
 import {eventProfile, eventSearchProfile} from '../selectors/forms';
-import * as actions from '../actions';
+import planningApis from '../actions/planning/api';
 
 const appConfig = config as IPlanningConfig;
 
@@ -161,7 +161,7 @@ function create(updates: Partial<IEventItem>): Promise<Array<IEventItem>> {
             }).then((planningItems) => {
                 // Make sure to update the Redux Store with the latest Planning items
                 // So that the Editor can set the state with these latest items
-                planningApi.redux.store.dispatch<any>(actions.planning.api.receivePlannings(planningItems));
+                planningApi.redux.store.dispatch<any>(planningApis.receivePlannings(planningItems));
 
                 return events;
             });
@@ -207,7 +207,7 @@ function update(original: IEventItem, updates: Partial<IEventItem>): Promise<Arr
             }).then((planningItems) => {
                 // Make sure to update the Redux Store with the latest Planning items
                 // So that the Editor can set the state with these latest items
-                planningApi.redux.store.dispatch<any>(actions.planning.api.receivePlannings(planningItems));
+                planningApi.redux.store.dispatch<any>(planningApis.receivePlannings(planningItems));
 
                 return events;
             });

--- a/client/api/planning.ts
+++ b/client/api/planning.ts
@@ -21,11 +21,11 @@ import {planningProfile, planningSearchProfile} from '../selectors/forms';
 import {featured} from './featured';
 import {PLANNING} from '../constants';
 import * as selectors from '../selectors';
-import * as actions from '../actions';
+import planningApis from '../actions/planning/api';
 
 const appConfig = config as IPlanningConfig;
 
-function convertPlanningParams(params: ISearchParams): Partial<ISearchAPIParams> {
+export function convertPlanningParams(params: ISearchParams): Partial<ISearchAPIParams> {
     return {
         agendas: arrayToString(params.agendas),
         no_agenda_assigned: params.no_agenda_assigned,
@@ -90,7 +90,7 @@ export function getPlanningById(
             .then(modifyItemForClient)
             .then((item) => {
                 if (saveToStore) {
-                    dispatch<any>(actions.planning.api.receivePlannings([item]));
+                    dispatch<any>(planningApis.receivePlannings([item]));
                 }
 
                 return item;
@@ -215,7 +215,7 @@ function bulkAddCoverageToWorkflow(planningItems: Array<IPlanningItem>): Promise
 
         return planning.update(plan, updates)
             .then((updatedPlan) => {
-                dispatch<any>(actions.planning.api.receivePlannings([updatedPlan]));
+                dispatch<any>(planningApis.receivePlannings([updatedPlan]));
 
                 return updatedPlan;
             });
@@ -254,7 +254,7 @@ function addCoverageToWorkflow(
     return planning.update(plan, updates)
         .then((updatedPlan) => {
             notify.success(gettext('Coverage added to workflow.'));
-            dispatch<any>(actions.planning.api.receivePlannings([updatedPlan]));
+            dispatch<any>(planningApis.receivePlannings([updatedPlan]));
 
             return updatedPlan;
         })

--- a/client/api/search.ts
+++ b/client/api/search.ts
@@ -1,10 +1,12 @@
-import {ISearchAPIParams, ISearchParams} from '../interfaces';
-import {superdeskApi} from '../superdeskApi';
+import {IEventOrPlanningItem, ISearchAPIParams, ISearchParams} from '../interfaces';
+import {superdeskApi, planningApi as sdPlanningApi} from '../superdeskApi';
 import {IRestApiResponse} from 'superdesk-api';
 import {getDateTimeElasticFormat, getTimeZoneOffset} from '../utils';
 import {default as timeUtils} from '../utils/time';
 import {appConfig} from 'appConfig';
-
+import planningApi from '../actions/planning/api';
+import eventsApi from '../actions/events/api';
+import {partition} from 'lodash';
 
 export function cvsToString(items?: Array<{[key: string]: any}>, field: string = 'qcode'): string {
     return arrayToString(
@@ -51,6 +53,7 @@ export function convertCommonParams(params: ISearchParams): Partial<ISearchAPIPa
         sort_field: params.sort_field,
         tz_offset: params.date_filter ? getTimeZoneOffset() : null,
         time_zone: timeUtils.localTimeZone(),
+        include_associated_planning: params.include_associated_planning,
     };
 }
 
@@ -75,6 +78,25 @@ export function searchRaw<T>(args: ISearchAPIParams): Promise<IRestApiResponse<T
         excludeNullParams(args)
     );
 }
+
+export const searchRawAndStore = <T>(args: ISearchAPIParams) => {
+    const {dispatch} = sdPlanningApi.redux.store;
+
+    return superdeskApi.dataApi.queryRawJson<IRestApiResponse<T>>(
+        'events_planning_search',
+        excludeNullParams(args)
+    ).then((res) => {
+        const [relatedPlans, events] = partition(res._items, (item: IEventOrPlanningItem) => item.type === 'planning');
+
+        if (args.include_associated_planning) {
+            dispatch(planningApi.receivePlannings(relatedPlans));
+        }
+
+        dispatch(eventsApi.receiveEvents(events));
+
+        return res;
+    });
+};
 
 export function searchRawGetAll<T>(args: ISearchAPIParams): Promise<Array<T>> {
     const params = excludeNullParams(args);

--- a/client/components/GeoLookupInput/AddGeoLookupInput.tsx
+++ b/client/components/GeoLookupInput/AddGeoLookupInput.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Geolookup from 'react-geolookup';
-import DebounceInput from 'react-debounce-input';
+import {DebounceInput} from 'react-debounce-input';
 
 import {appConfig} from 'appConfig';
 import {IRestApiResponse} from 'superdesk-api';

--- a/client/components/IgnoreCancelSaveModal.tsx
+++ b/client/components/IgnoreCancelSaveModal.tsx
@@ -86,7 +86,7 @@ export class IgnoreCancelSaveModalComponent extends React.Component<IProps, ISta
             return (
                 <UpdateRecurringEventsForm
                     original={this.props.modalProps.item}
-                    updates={this.props.modalProps.updates}
+                    updates={this.props.modalProps.updates as Partial<IEventItem>}
                     onEventUpdateMethodChange={this.onEventUpdateMethodChange}
                     onPlanningUpdateMethodChange={this.onPlanningUpdateMethodChange}
                     modalProps={{

--- a/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx
+++ b/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx
@@ -75,7 +75,7 @@ function getRecurringPlanningToUpdate(
     updates: Partial<IEventItem>,
     plannings: {[planningId: string]: IPlanningItem}
 ): Array<IPlanningItem['_id']> {
-    const originalCoverages: IPlanningEmbeddedCoverageMap = (original.planning_ids || [])
+    const originalCoverages: IPlanningEmbeddedCoverageMap = (original.planning_ids ?? [])
         .map((planningId) => plannings[planningId])
         .reduce((planningItems, planningItem) => {
             planningItems[planningItem._id] = (planningItem.coverages ?? []).reduce(

--- a/client/components/UI/SearchBar/index.tsx
+++ b/client/components/UI/SearchBar/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import DebounceInput from 'react-debounce-input';
+import {DebounceInput} from 'react-debounce-input';
 import {isNil, uniqueId} from 'lodash';
 import {gettext} from '../../../utils/gettext';
 import './style.scss';

--- a/client/components/UI/SearchField/index.tsx
+++ b/client/components/UI/SearchField/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import DebounceInput from 'react-debounce-input';
+import {DebounceInput} from 'react-debounce-input';
 import {uniqueId} from 'lodash';
 import {KEYCODES} from '../constants';
 import {onEventCapture} from '../utils';

--- a/client/interfaces.ts
+++ b/client/interfaces.ts
@@ -2207,6 +2207,7 @@ export interface IPlanningAPI {
         getEditorProfile(): ICoverageFormProfile;
     };
     combined: {
+        searchAndStore(params: ISearchParams): Promise<IRestApiResponse<IEventOrPlanningItem>>;
         search(params: ISearchParams): Promise<IRestApiResponse<IEventOrPlanningItem>>;
         searchGetAll(params: ISearchParams): Promise<Array<IEventOrPlanningItem>>;
         getRecurringEventsAndPlanningItems(

--- a/server/planning/planning_locks.py
+++ b/server/planning/planning_locks.py
@@ -91,7 +91,7 @@ def _get_planning_module_locks():
             continue
 
         lock = {
-            "item_id": item.get("_id") if not item.get("recurrence_id") else item["recurrence_id"],
+            "item_id": item.get("_id"),
             "item_type": item.get("type"),
             "user": item.get("lock_user"),
             "session": item.get("lock_session"),
@@ -99,7 +99,7 @@ def _get_planning_module_locks():
             "time": item.get("lock_time"),
         }
         if item.get("recurrence_id"):
-            locks["recurring"][lock["item_id"]] = lock
+            locks["recurring"][item["recurrence_id"]] = lock
         elif item.get("event_item"):
             locks["event"][item["event_item"]] = lock
         else:


### PR DESCRIPTION
SDESK-7370
## Front-end checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)
