### PR TITLE
fix related plannings not visible in the editor

### DIFF
--- a/client/actions/eventsPlanning/ui.ts
+++ b/client/actions/eventsPlanning/ui.ts
@@ -90,7 +90,7 @@ const refetchPlanning = (planningId) => (
     (dispatch, getState) => {
         const storedPlannings = selectors.planning.storedPlannings(getState());
         const plan = get(storedPlannings, planningId);
-        const relatedEventIds = getRelatedEventIdsForPlanning(plan, 'primary');
+        const relatedEventIds = getRelatedEventIdsForPlanning(plan);
         const eventId = relatedEventIds.length > 0 ? relatedEventIds[0] : undefined;
         const events = selectors.eventsPlanning.getRelatedPlanningsList(getState()) || {};
 

--- a/client/actions/planning/ui.ts
+++ b/client/actions/planning/ui.ts
@@ -209,7 +209,7 @@ const duplicate = (plan) => (
             .then((newPlan) => {
                 notify.success(gettext('Planning duplicated'));
                 const openInModal = selectors.forms.currentItemIdModal(getState());
-                const relatedEventIds = getRelatedEventIdsForPlanning(plan, 'primary');
+                const relatedEventIds = getRelatedEventIdsForPlanning(plan);
 
                 if (relatedEventIds.length > 0) {
                     dispatch(main.unlockAndCancel(plan)).then(() => {

--- a/client/api/editor/item.ts
+++ b/client/api/editor/item.ts
@@ -27,7 +27,7 @@ export function getItemInstance(type: EDITOR_TYPE): IEditorAPI['item'] {
         return Object.keys(plans)
             .filter((planId) => (
                 plans[planId] != null &&
-                getRelatedEventIdsForPlanning(plans[planId], 'primary').includes(eventId))
+                getRelatedEventIdsForPlanning(plans[planId]).includes(eventId))
             )
             .map((planId) => cloneDeep(plans[planId]));
     }

--- a/client/api/editor/item_planning.ts
+++ b/client/api/editor/item_planning.ts
@@ -47,7 +47,7 @@ export function getPlanningInstance(type: EDITOR_TYPE): IEditorAPI['item']['plan
         const profile = planningApi.contentProfiles.get('planning');
         const groups = getEditorFormGroupsFromProfile(profile);
 
-        if (getRelatedEventLinksForPlanning(item, 'primary').length === 0) {
+        if (getRelatedEventLinksForPlanning(item).length === 0) {
             delete groups['associated_event'];
         }
         const bookmarks = getBookmarksFromFormGroups(groups);

--- a/client/components/Planning/PlanningDateTime.tsx
+++ b/client/components/Planning/PlanningDateTime.tsx
@@ -34,7 +34,7 @@ export const PlanningDateTime = ({
 }: IProps) => {
     const coverages = get(item, 'coverages', []);
     const coverageTypes = planningUtils.mapCoverageByDate(coverages);
-    const hasAssociatedEvent = getRelatedEventIdsForPlanning(item, 'primary').length > 0;
+    const hasAssociatedEvent = getRelatedEventIdsForPlanning(item).length > 0;
     const isSameDay = (scheduled) => scheduled && (date == null || moment(scheduled).format('YYYY-MM-DD') === date);
     const coverageToDisplay = coverageTypes.filter((coverage) => {
         const scheduled = get(coverage, 'planning.scheduled');

--- a/client/utils/planning.ts
+++ b/client/utils/planning.ts
@@ -384,7 +384,7 @@ export function mapCoverageByDate(coverages: Array<IPlanningCoverageItem> = []):
 
 // ad hoc plan created directly from planning list and not from an event
 function isPlanAdHoc(plan: IPlanningItem): boolean {
-    return getRelatedEventLinksForPlanning(plan, 'primary').length === 0;
+    return getRelatedEventLinksForPlanning(plan).length === 0;
 }
 
 function isPlanMultiDay(plan: IPlanningItem): boolean {

--- a/server/planning/search/queries/planning.py
+++ b/server/planning/search/queries/planning.py
@@ -150,13 +150,10 @@ def search_by_events(params: Dict[str, Any], query: elastic.ElasticQuery):
 
     if len(event_ids):
         query.must.append(
-            elastic.bool_and(
-                [
-                    elastic.terms(field="related_events._id", values=event_ids),
-                    # elastic.term(field="related_events.link_type", value="primary"),
-                ],
+            elastic.nested(
                 "related_events",
-            )
+                query=elastic.terms(field="related_events._id", values=event_ids),
+            ),
         )
 
 

--- a/server/planning/search/queries/planning.py
+++ b/server/planning/search/queries/planning.py
@@ -153,7 +153,7 @@ def search_by_events(params: Dict[str, Any], query: elastic.ElasticQuery):
             elastic.bool_and(
                 [
                     elastic.terms(field="related_events._id", values=event_ids),
-                    elastic.term(field="related_events.link_type", value="primary"),
+                    # elastic.term(field="related_events.link_type", value="primary"),
                 ],
                 "related_events",
             )


### PR DESCRIPTION
it was only working with primary events, not secondary

STT-72

## Front-end checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)
