### PR TITLE
fix error when ingesting cancelled planning item with assignments

### DIFF
--- a/server/planning/assignments/assignments.py
+++ b/server/planning/assignments/assignments.py
@@ -1195,7 +1195,7 @@ class AssignmentsService(superdesk.Service):
         """
         Validate that we have a lock on the Assignment and it's associated Planning item
         """
-        if doc.get("_to_delete") is True:
+        if doc.get("_to_delete") is True or not request:
             # Already marked for delete - no validation needed (could be the background job)
             return
 

--- a/server/planning/commands/populate_planning_types_test.py
+++ b/server/planning/commands/populate_planning_types_test.py
@@ -11,7 +11,7 @@
 import os
 import json
 
-from superdesk.tests import TestCase
+from planning.tests import TestCase
 from superdesk import get_resource_service
 from apps.prepopulate.app_populate import AppPopulateCommand
 

--- a/server/planning/planning/planning.py
+++ b/server/planning/planning/planning.py
@@ -15,7 +15,7 @@ from copy import deepcopy
 import logging
 from datetime import datetime
 
-from flask import json, current_app as app
+from flask import json, current_app as app, request
 from eve.methods.common import resolve_document_etag
 
 import superdesk
@@ -1274,23 +1274,24 @@ class PlanningService(superdesk.Service):
                 if original_assigment:
                     assignment_service.system_update(ObjectId(assign_id), {"_to_delete": True}, original_assigment)
 
-        session_id = get_auth().get("_id")
-        user_id = get_user().get(config.ID_FIELD)
-        if len(deleted_assignments) > 0:
-            push_notification(
-                "assignments:delete",
-                items=deleted_assignments,
-                session=session_id,
-                user=user_id,
-            )
+        if request:
+            session_id = get_auth().get("_id")
+            user_id = get_user().get(config.ID_FIELD)
+            if len(deleted_assignments) > 0:
+                push_notification(
+                    "assignments:delete",
+                    items=deleted_assignments,
+                    session=session_id,
+                    user=user_id,
+                )
 
-        if len(failed_assignments) > 0 and notify:
-            push_notification(
-                "assignments:delete:fail",
-                items=failed_assignments,
-                session=session_id,
-                user=user_id,
-            )
+            if len(failed_assignments) > 0 and notify:
+                push_notification(
+                    "assignments:delete:fail",
+                    items=failed_assignments,
+                    session=session_id,
+                    user=user_id,
+                )
 
     def get_expired_items(self, expiry_datetime, spiked_planning_only=False):
         """Get the expired items

--- a/server/planning/tests/__init__.py
+++ b/server/planning/tests/__init__.py
@@ -3,6 +3,8 @@ from superdesk.factory.app import get_app
 
 
 class TestCase(_TestCase):
+    test_context = None  # avoid using test_request_context
+
     def setUp(self):
         config = {"INSTALLED_APPS": ["planning"]}
         update_config(config)

--- a/server/planning/tests/ingest_cancelled_test.py
+++ b/server/planning/tests/ingest_cancelled_test.py
@@ -1,0 +1,36 @@
+from flask import request
+from planning.tests import TestCase
+from planning.common import update_post_item
+
+
+class IngestCancelledTestCase(TestCase):
+    def test_ingest_cancelled_event(self):
+        assert not request, request
+
+        assignments = [
+            {"planning_item": "p1", "coverage_item": "c1"},
+        ]
+
+        self.app.data.insert("assignments", assignments)
+        planning = {
+            "_id": "p1",
+            "name": "planning item",
+            "type": "planning",
+            "coverages": [
+                {
+                    "coverage_id": "c1",
+                    "planning": {},
+                    "assigned_to": {
+                        "assignment_id": assignments[0]["_id"],
+                    },
+                },
+            ],
+        }
+
+        self.app.data.insert("planning", [planning])
+
+        with self.app.app_context():
+            update_post_item({"pubstatus": "cancelled"}, planning)
+
+        cursor, count = self.app.data.find("assignments", req=None, lookup={})
+        assert count == 0

--- a/server/planning/tests/output_formatters/file_providers_test.py
+++ b/server/planning/tests/output_formatters/file_providers_test.py
@@ -12,7 +12,7 @@ from io import BytesIO
 from unittest import mock
 import hmac
 
-from superdesk.tests import TestCase
+from planning.tests import TestCase
 from superdesk.publish import TransmitterFileEntry
 from superdesk.publish.transmitters.ftp import FTPPublishService
 from superdesk.publish.transmitters.http_push import HTTPPushService

--- a/server/planning/tests/output_formatters/json_event_test.py
+++ b/server/planning/tests/output_formatters/json_event_test.py
@@ -2,7 +2,7 @@ import json
 import tempfile
 
 from unittest import mock
-from superdesk.tests import TestCase
+from planning.tests import TestCase
 from planning.output_formatters.json_event import JsonEventFormatter
 from planning.events import init_app
 from eve.methods.common import store_media_files

--- a/server/planning/utils.py
+++ b/server/planning/utils.py
@@ -4,6 +4,7 @@ from bson.errors import InvalidId
 from datetime import datetime
 from flask_babel import lazy_gettext
 from eve.utils import str_to_date
+from superdesk.utc import utc_to_local
 import arrow
 from flask import current_app as app
 import pytz
@@ -67,14 +68,18 @@ def parse_date(datetime: Union[str, datetime]) -> datetime:
     return datetime
 
 
+def local_date(datetime: datetime, tz: pytz.BaseTzInfo) -> datetime:
+    return tz.normalize(parse_date(datetime).replace(tzinfo=pytz.utc).astimezone(tz))
+
+
 def time_short(datetime: datetime, tz: pytz.BaseTzInfo):
     if datetime:
-        return parse_date(datetime).astimezone(tz).strftime(app.config.get("TIME_FORMAT_SHORT", "%H:%M"))
+        return local_date(datetime, tz).strftime(app.config.get("TIME_FORMAT_SHORT", "%H:%M"))
 
 
 def date_short(datetime: datetime, tz: pytz.BaseTzInfo):
     if datetime:
-        return parse_date(datetime).astimezone(tz).strftime(app.config.get("DATE_FORMAT_SHORT", "%d/%m/%Y"))
+        return local_date(datetime, tz).strftime(app.config.get("DATE_FORMAT_SHORT", "%d/%m/%Y"))
 
 
 def get_event_formatted_dates(event: Dict[str, Any]) -> str:


### PR DESCRIPTION
it was checking session data which failed during ingest

had to avoid test request context in tests otherwise it
wouldn't be testing it properly, that's affecting some
of the other tests

STTNHUB-361

## Front-end checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)
