### PR TITLE
As a planning editor I want to link items (events and planning items) via drag and drop

### DIFF
--- a/client/actions/events/api.ts
+++ b/client/actions/events/api.ts
@@ -394,12 +394,8 @@ const post = (original, updates) => (
             etag: original._etag,
             pubstatus: get(updates, 'pubstatus', POST_STATE.USABLE),
             update_method: get(updates, 'update_method.value', EVENTS.UPDATE_METHODS[0].value),
-            failed_planning_ids: get(updates, 'failed_planning_ids', []),
         }).then(
-            (data) => Promise.all([
-                dispatch(self.fetchById(original._id, {force: true})),
-                {failedPlanningIds: data?.failed_planning_ids}
-            ]),
+            () => dispatch(self.fetchById(original._id, {force: true})),
             (error) => Promise.reject(error)
         )
     )
@@ -679,21 +675,6 @@ const createEventTemplate = (item: IEventItem) => (dispatch, getState, {api, mod
                         template_name: templateName,
                         based_on_event: item._id,
                         data: {
-                            embedded_planning: item.associated_plannings.map((planning) => ({
-                                coverages: planning.coverages.map((coverage) => ({
-                                    coverage_id: coverage.coverage_id,
-                                    g2_content_type: coverage.planning.g2_content_type,
-                                    desk: coverage.assigned_to.desk,
-                                    user: coverage.assigned_to.user,
-                                    language: coverage.planning.language,
-                                    news_coverage_status: coverage.news_coverage_status.qcode,
-                                    scheduled: coverage.planning.scheduled,
-                                    genre: coverage.planning.genre?.qcode,
-                                    slugline: coverage.planning.slugline,
-                                    ednote: coverage.planning.ednote,
-                                    internal_note: coverage.planning.internal_note,
-                                })),
-                            })),
                         },
                     })
                         .then(() => {

--- a/client/api/editor/item_events.ts
+++ b/client/api/editor/item_events.ts
@@ -101,6 +101,27 @@ export function getEventsInstance(type: EDITOR_TYPE): IEditorAPI['item']['events
             });
     }
 
+    function dropPlanningItem(newPlanningItem: IPlanningItem) {
+        const editor = planningApi.editor(type);
+        const event = editor.form.getDiff<IEventItem>();
+        const plans = cloneDeep(event.associated_plannings || []);
+        const id = generateTempId();
+
+        plans.push(newPlanningItem);
+
+        editor.form.changeField('associated_plannings', plans)
+            .then(() => {
+                const node = getRelatedPlanningDomRef(id);
+
+                if (node.current != null) {
+                    node.current.scrollIntoView();
+                    editor.form.waitForScroll().then(() => {
+                        node.current.focus();
+                    });
+                }
+            });
+    }
+
     function removePlanningItem(item: DeepPartial<IPlanningItem>) {
         if (!item._id.startsWith(TEMP_ID_PREFIX)) {
             // We don't support removing existing Planning items
@@ -195,6 +216,7 @@ export function getEventsInstance(type: EDITOR_TYPE): IEditorAPI['item']['events
         getGroupsForItem,
         getRelatedPlanningDomRef,
         addPlanningItem,
+        dropPlanningItem,
         removePlanningItem,
         updatePlanningItem,
         onEventDatesChanged,

--- a/client/api/editor/item_events.ts
+++ b/client/api/editor/item_events.ts
@@ -109,7 +109,7 @@ export function getEventsInstance(type: EDITOR_TYPE): IEditorAPI['item']['events
 
         plans.push(newPlanningItem);
 
-        editor.form.changeField('associated_plannings', plans)
+        editor.form.changeField('associated_plannings', plans, true, true)
             .then(() => {
                 const node = getRelatedPlanningDomRef(id);
 

--- a/client/api/editor/item_planning.ts
+++ b/client/api/editor/item_planning.ts
@@ -47,9 +47,6 @@ export function getPlanningInstance(type: EDITOR_TYPE): IEditorAPI['item']['plan
         const profile = planningApi.contentProfiles.get('planning');
         const groups = getEditorFormGroupsFromProfile(profile);
 
-        if (getRelatedEventLinksForPlanning(item).length === 0) {
-            delete groups['associated_event'];
-        }
         const bookmarks = getBookmarksFromFormGroups(groups);
         let index = bookmarks.length;
 

--- a/client/api/events.ts
+++ b/client/api/events.ts
@@ -161,6 +161,9 @@ function update(original: IEventItem, updates: Partial<IEventItem>): Promise<Arr
         update_method: updates.update_method?.value ?? updates.update_method ?? original.update_method
     })
         .then((response) => {
+            // we don't store associated_plannings field on the server but we need to preserve it on the client
+            // TODO: update the planningItem
+
             const events = modifySaveResponseForClient(response);
 
             return planningApi.planning.searchGetAll({

--- a/client/components/Events/EventEditor/index.tsx
+++ b/client/components/Events/EventEditor/index.tsx
@@ -205,6 +205,7 @@ class EventEditorComponent extends React.PureComponent<IProps> {
                             editor.item.events.getRelatedPlanningDomRef(value._id)
                         ),
                         addPlanningItem: editor.item.events.addPlanningItem,
+                        dropPlanningItem: editor.item.events.dropPlanningItem,
                         removePlanningItem: editor.item.events.removePlanningItem,
                         updatePlanningItem: editor.item.events.updatePlanningItem,
                         addCoverageToWorkflow: editor.item.events.addCoverageToWorkflow,

--- a/client/components/Main/ItemEditor/Editor.tsx
+++ b/client/components/Main/ItemEditor/Editor.tsx
@@ -105,6 +105,7 @@ export class EditorComponent extends React.Component<IEditorProps, IEditorState>
         }
     }
 
+    // TODO: beginning of function which remove associated_planning after saving
     onChangeHandler(field, value, updateDirtyFlag = true, saveAutosave = true) {
         // Use a callback to `this.setState` so we get the state value at the exact point when updating.
         // This allows consecutive updates to the state, while allowing React to batch these updates.

--- a/client/components/Main/ListGroup.tsx
+++ b/client/components/Main/ListGroup.tsx
@@ -241,14 +241,14 @@ export class ListGroup extends React.Component<IProps> {
                                     const mimeTypes = ['application/superdesk.planningItem'];
 
                                     if (item.mimetype && item.mimetype.includes('application')) {
-                                      mimeTypes.push(item.mimetype);
+                                        mimeTypes.push(item.mimetype);
                                     }
 
                                     mimeTypes.forEach((mimetype) => {
-                                      dataTransfer.setData(mimetype, JSON.stringify(item));
+                                        dataTransfer.setData(mimetype, JSON.stringify(item));
                                     });
-                                
-                                    dataTransfer.effectAllowed = 'link'; 
+
+                                    dataTransfer.effectAllowed = 'link';
                                 }}
                             >
                                 <ListGroupItem {...itemProps} />

--- a/client/components/Main/ListGroup.tsx
+++ b/client/components/Main/ListGroup.tsx
@@ -4,10 +4,13 @@ import {ListGroupItem} from './';
 import {Group, Header} from '../UI/List';
 import {
     ICommonAdvancedSearchParams,
-    IEventOrPlanningItem, ISearchFilter,
-    LIST_VIEW_TYPE, SORT_FIELD
+    IEventOrPlanningItem,
+    ILockedItems,
+    ISearchFilter,
+    LIST_VIEW_TYPE,
+    SORT_FIELD
 } from '../../interfaces';
-import {timeUtils} from '../../utils';
+import {lockUtils, timeUtils} from '../../utils';
 
 const TIME_COLUMN_MIN_WIDTH = {
     WITH_YEAR: '11rem',
@@ -55,7 +58,7 @@ interface IProps {
     onDoubleClick?(): void;
     editItem?: {};
     previewItem?: string;
-    lockedItems: {};
+    lockedItems: ILockedItems;
     agendas: Array<any>;
     session?: {};
     privileges?: {};
@@ -224,6 +227,7 @@ export class ListGroup extends React.Component<IProps> {
 
                         const id = listBoxGroupProps.getChildId(index);
                         const selectedId = listBoxGroupProps.containerProps['aria-activedescendant'];
+                        const isItemLocked = lockUtils.isItemLocked(item, this.props.lockedItems);
 
                         return (
                             <div
@@ -231,6 +235,21 @@ export class ListGroup extends React.Component<IProps> {
                                 role="option"
                                 aria-selected={id === selectedId ? true : undefined}
                                 key={item._id}
+                                draggable={!isItemLocked}
+                                onDragStart={(event) => {
+                                    const dataTransfer = event.dataTransfer;
+                                    const mimeTypes = ['application/superdesk.planningItem'];
+
+                                    if (item.mimetype && item.mimetype.includes('application')) {
+                                      mimeTypes.push(item.mimetype);
+                                    }
+
+                                    mimeTypes.forEach((mimetype) => {
+                                      dataTransfer.setData(mimetype, JSON.stringify(item));
+                                    });
+                                
+                                    dataTransfer.effectAllowed = 'link'; 
+                                }}
                             >
                                 <ListGroupItem {...itemProps} />
                             </div>

--- a/client/components/Planning/PlanningEditor/index.tsx
+++ b/client/components/Planning/PlanningEditor/index.tsx
@@ -501,7 +501,7 @@ class PlanningEditorComponent extends React.Component<IProps, IState> {
                         files: this.props.files,
                     },
                     associated_event: {
-                        events: (this.props.item.related_events ?? [])
+                        events: (this.props.diff.related_events ?? [])
                             .map((relatedEvent) => this.props.events[relatedEvent._id]),
                     },
                     coverages: {

--- a/client/components/fields/editor/AssociatedEvent.tsx
+++ b/client/components/fields/editor/AssociatedEvent.tsx
@@ -1,18 +1,19 @@
 import * as React from 'react';
 import {connect} from 'react-redux';
-
-import {IEditorFieldProps, IEventItem, IFile, ILockedItems} from '../../../interfaces';
-
-import {getFileDownloadURL} from '../../../utils';
+import {EDITOR_TYPE, IEditorFieldProps, IEventItem, IFile, ILockedItems, IPlanningItem} from '../../../interfaces';
+import {getFileDownloadURL, gettext} from '../../../utils';
 import * as selectors from '../../../selectors';
-
 import {EventMetadata} from '../../Events';
+import {DropZone3} from 'superdesk-core/scripts/core/ui/components/drop-zone-3';
+import {planningApi} from '../../../../client/superdeskApi';
+import {cloneDeep} from 'lodash';
 
 interface IProps extends IEditorFieldProps {
     events?: Array<IEventItem>;
     lockedItems: ILockedItems;
     files: Array<IFile>;
     tabEnabled?: boolean; // defaults to true
+    dispatch: (action) => Promise<IEventItem>;
 }
 
 const mapStateToProps = (state) => ({
@@ -20,26 +21,71 @@ const mapStateToProps = (state) => ({
     files: selectors.general.files(state),
 });
 
+const mapDispatchToProps = (dispatch) => ({
+    dispatch,
+});
+
+function dropEventItem(newPlanningItem: IEventItem) {
+    const editor = planningApi.editor(EDITOR_TYPE.INLINE);
+    const event = editor.form.getDiff<IPlanningItem>();
+
+    const plans = cloneDeep(event.related_events || []);
+
+    plans.push({_id: newPlanningItem._id});
+
+    editor.form.changeField('related_events', plans, true, true);
+}
+
+function canDrop(eventItem: IEventItem) {
+    if (eventItem.type !== 'event' || this.props.item.events.includes(eventItem)) {
+        return false;
+    }
+    return true;
+}
+
 class EditorFieldAssociatedEventComponent extends React.PureComponent<IProps> {
     render() {
-        return (this.props.events?.length ?? 0) < 1 ? null : this.props.events.map((event) => (
-            <EventMetadata
-                key={event._id}
-                ref={this.props.refNode}
-                testId={`${this.props.testId}--${event._id}`}
-                event={event}
-                navigation={{}}
-                createUploadLink={getFileDownloadURL}
-                files={this.props.files}
-                tabEnabled={this.props.tabEnabled ?? true}
-            />
-        ));
+        return (
+            <div>
+                <label className="InputArray__label side-panel__heading side-panel__heading--big">
+                    {gettext('Related Events')}
+                </label>
+                {(this.props.events?.length ?? 0) < 1 ? null : this.props.events.map((event) => (
+                    <EventMetadata
+                        key={event._id}
+                        ref={this.props.refNode}
+                        testId={`${this.props.testId}--${event._id}`}
+                        event={event}
+                        navigation={{}}
+                        createUploadLink={getFileDownloadURL}
+                        files={this.props.files}
+                        tabEnabled={this.props.tabEnabled ?? true}
+                    />
+                ))}
+
+                <DropZone3
+                    className="basic-drag-block"
+                    canDrop={(event) => canDrop(
+                        JSON.parse(event.dataTransfer.getData('application/superdesk.planningItem'))
+                    )}
+                    onDrop={(event) => {
+                        event.preventDefault();
+                        const eventItem = JSON.parse(
+                            event.dataTransfer.getData('application/superdesk.planningItem')
+                        );
+
+                        dropEventItem(eventItem);
+                    }}
+                    multiple={true}
+                />
+            </div>
+        );
     }
 }
 
 export const EditorFieldAssociatedEvents = connect(
     mapStateToProps,
-    null,
+    mapDispatchToProps,
     null,
     {forwardRef: true}
 )(EditorFieldAssociatedEventComponent);

--- a/client/components/fields/editor/EventRelatedPlannings/EventRelatedPlannings.tsx
+++ b/client/components/fields/editor/EventRelatedPlannings/EventRelatedPlannings.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import planningApis from '../../../../actions/planning/api'
 import {connect} from 'react-redux';
 
 import {
@@ -45,7 +44,7 @@ export class EditorFieldEventRelatedPlanningsComponent extends React.PureCompone
                 return false;
             }
             return true;
-        }
+        };
 
         return (
             <div className="related-plannings">
@@ -109,15 +108,21 @@ export class EditorFieldEventRelatedPlanningsComponent extends React.PureCompone
                 )}
 
                 <DropZone3
-                    className='basic-drag-block'
-                    canDrop={(event) => canDrop(JSON.parse(event.dataTransfer.getData('application/superdesk.planningItem')))}
+                    className="basic-drag-block"
+                    canDrop={(event) => canDrop(
+                        JSON.parse(event.dataTransfer.getData('application/superdesk.planningItem')),
+                    )}
                     onDrop={(event) => {
                         event.preventDefault();
-                        const planningItem = JSON.parse(event.dataTransfer.getData('application/superdesk.planningItem'));
+                        const planningItem = JSON.parse(
+                            event.dataTransfer.getData('application/superdesk.planningItem'),
+                        );
 
-                        this.props.dispatch(planningApis.save(planningItem, {related_events: [{_id: this.props.item._id}]}))
-                        .then((updatedPlan) => {
-                            this.props.dropPlanningItem(updatedPlan);
+                        const planningItemsArray = planningItem.related_events ?? [];
+
+                        this.props.dropPlanningItem({
+                            ...planningItem,
+                            related_events: [...planningItemsArray, {_id: this.props.item._id}],
                         });
                     }}
                     multiple={true}

--- a/client/components/fields/editor/EventRelatedPlannings/EventRelatedPlannings.tsx
+++ b/client/components/fields/editor/EventRelatedPlannings/EventRelatedPlannings.tsx
@@ -1,4 +1,6 @@
 import * as React from 'react';
+import planningApis from '../../../../actions/planning/api'
+import {connect} from 'react-redux';
 
 import {
     IEditorFieldProps,
@@ -16,6 +18,7 @@ import {RelatedPlanningItem} from './RelatedPlanningItem';
 import {PlanningMetaData} from '../../../RelatedPlannings/PlanningMetaData';
 
 import './style.scss';
+import {DropZone3} from 'core/ui/components/drop-zone-3';
 
 interface IProps extends IEditorFieldProps {
     item: IEventItem;
@@ -24,16 +27,25 @@ interface IProps extends IEditorFieldProps {
 
     getRef(value: DeepPartial<IPlanningItem>): React.RefObject<PlanningMetaData | RelatedPlanningItem>;
     addPlanningItem(): void;
+    dropPlanningItem(planningItem: IPlanningItem): void;
     removePlanningItem(item: DeepPartial<IPlanningItem>): void;
     updatePlanningItem(original: DeepPartial<IPlanningItem>, updates: DeepPartial<IPlanningItem>): void;
     addCoverageToWorkflow(original: IPlanningItem, coverage: IPlanningCoverageItem, index: number): void;
+    dispatch: (action) => Promise<IPlanningItem>;
 }
 
-export class EditorFieldEventRelatedPlannings extends React.PureComponent<IProps> {
+export class EditorFieldEventRelatedPlanningsComponent extends React.PureComponent<IProps> {
     render() {
         const {gettext} = superdeskApi.localization;
         const isAgendaEnabled = planningApi.planning.getEditorProfile().editor.agendas.enabled;
         const disabled = this.props.disabled || this.props.schema?.read_only;
+
+        const canDrop = (planningItem: IPlanningItem) => {
+            if (planningItem.type !== 'planning' || this.props.item.associated_plannings.includes(planningItem)) {
+                return false;
+            }
+            return true;
+        }
 
         return (
             <div className="related-plannings">
@@ -95,7 +107,32 @@ export class EditorFieldEventRelatedPlannings extends React.PureComponent<IProps
                         )}
                     </React.Fragment>
                 )}
+
+                <DropZone3
+                    className='basic-drag-block'
+                    canDrop={(event) => canDrop(JSON.parse(event.dataTransfer.getData('application/superdesk.planningItem')))}
+                    onDrop={(event) => {
+                        event.preventDefault();
+                        const planningItem = JSON.parse(event.dataTransfer.getData('application/superdesk.planningItem'));
+
+                        this.props.dispatch(planningApis.save(planningItem, {related_events: [{_id: this.props.item._id}]}))
+                        .then((updatedPlan) => {
+                            this.props.dropPlanningItem(updatedPlan);
+                        });
+                    }}
+                    multiple={true}
+                />
             </div>
         );
     }
 }
+
+const mapDispatchToProps = (dispatch) => ({
+    dispatch,
+});
+
+export const EditorFieldEventRelatedPlannings = connect(
+    null,
+    mapDispatchToProps
+)(EditorFieldEventRelatedPlanningsComponent);
+

--- a/client/components/fields/style.scss
+++ b/client/components/fields/style.scss
@@ -48,6 +48,8 @@
 
 .basic-drag-block {
 	transition: all 0.3s cubic-bezier(0.55, 0, 0.55, 0.2);
+	display: flex;
+	justify-content: center;
 
 	&:focus {
 		background-color: var(--color-input-bg--focus);

--- a/client/interfaces.ts
+++ b/client/interfaces.ts
@@ -2165,6 +2165,7 @@ export interface IEditorAPI {
             };
             getRelatedPlanningDomRef(planId: IPlanningItem['_id']): React.RefObject<any>;
             addPlanningItem(): void;
+            dropPlanningItem(planningItem: IPlanningItem): void;
             removePlanningItem(item: DeepPartial<IPlanningItem>): void;
             updatePlanningItem(
                 original: DeepPartial<IPlanningItem>,

--- a/client/utils/index.ts
+++ b/client/utils/index.ts
@@ -229,6 +229,8 @@ export const createStore = (params = {}, app = planningApp) => {
             middlewares.push(createLogger());
         }
 
+        // TODO: log middlewares
+
         // activate redux devtools for non production instances,
         // if it's available in the browser
         // https://github.com/zalmoxisus/redux-devtools-extension


### PR DESCRIPTION
STT-67

## Front-end checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [x] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [x] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [x] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [x] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [x] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [x] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [x] This pull request is not adding redux based modals
- [x] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [x] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)
