### PR TITLE
Fix tree select item rendering

### DIFF
--- a/client/components/fields/editor/CustomVocabularies.tsx
+++ b/client/components/fields/editor/CustomVocabularies.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import {connect} from 'react-redux';
 
-import {IVocabulary} from 'superdesk-api';
+import {ISubject, IVocabulary} from 'superdesk-api';
 import {superdeskApi} from '../../../superdeskApi';
 import {IEditorFieldProps, IProfileSchemaTypeList} from '../../../interfaces';
 import {Row} from '../../UI/Form';
@@ -56,11 +56,14 @@ class CustomVocabulariesComponent extends React.PureComponent<IProps> {
                         sortable={true}
                         kind="synchronous"
                         allowMultiple={true}
-                        value={item[itemFieldName] ?? []}
+                        value={item.subject.filter((x) => x.scheme === cv._id)}
                         label={gettext(cv.display_name)}
                         required={required ?? schema?.required}
                         getOptions={() => arrayToTree(
-                            cv.items,
+                            cv.items.map((cvItem) => ({
+                                ...cvItem,
+                                scheme: cv._id,
+                            })) as Array<ISubject>,
                             ({qcode}) => qcode.toString(),
                             ({parent}) => parent?.toString(),
                         ).result}
@@ -69,15 +72,18 @@ class CustomVocabulariesComponent extends React.PureComponent<IProps> {
                             'name',
                             language,
                         )}
-                        getId={(item) => item.id}
+                        getId={(item) => item.qcode}
                         invalid={errors?.length > 0 || invalid}
                         error={showErrors ? errors[itemFieldName] : undefined}
                         readOnly={disabled}
                         disabled={disabled}
                         onChange={(vals) => {
-                            const filteredValues = vals.filter((value) => cv._id == null || value?.scheme === cv._id);
+                            const restOfItems = (item.subject ?? []).filter((x) => x.scheme !== cv._id);
 
-                            onChange(itemFieldName, filteredValues);
+                            onChange(
+                                'subject',
+                                [...restOfItems, ...vals],
+                            );
                         }}
                         tabindex={0}
                         zIndex={1051}


### PR DESCRIPTION
SDCP-844

## Front-end checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [x] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [x] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [x] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [x] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [x] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [x] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [x] This pull request is not adding redux based modals
- [x] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [x] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)
