### PR TITLE
Fix tree select item rendering (#2102)

### DIFF
--- a/client/components/fields/editor/CustomVocabularies.tsx
+++ b/client/components/fields/editor/CustomVocabularies.tsx
@@ -5,8 +5,9 @@ import {ISubject, IVocabulary} from 'superdesk-api';
 import {superdeskApi} from '../../../superdeskApi';
 import {IEditorFieldProps, IProfileSchemaTypeList} from '../../../interfaces';
 import {Row} from '../../UI/Form';
-import {getVocabularyItemNameFromString} from '../../../utils/vocabularies';
-import {EditorFieldTreeSelect} from '../editor/base/treeSelect';
+import {getVocabularyItemFieldTranslated} from '../../../utils/vocabularies';
+import {arrayToTree} from 'superdesk-core/scripts/core/helpers/tree';
+import {TreeSelect} from 'superdesk-ui-framework/react';
 
 interface IProps extends IEditorFieldProps {
     schema?: IProfileSchemaTypeList;
@@ -33,6 +34,8 @@ class CustomVocabulariesComponent extends React.PureComponent<IProps> {
             required,
             testId,
             language,
+            disabled,
+            invalid,
         } = this.props;
 
         const customVocabularies = vocabularies.filter((cv) =>
@@ -41,7 +44,7 @@ class CustomVocabulariesComponent extends React.PureComponent<IProps> {
 
         return customVocabularies.map((cv) => {
             const cvFieldName = `custom_vocabularies.${cv._id}`;
-            const parentField = cv.schema_field || 'subject';
+            const itemFieldName = cv.schema_field ?? 'subject';
 
             return (
                 <Row
@@ -49,35 +52,41 @@ class CustomVocabulariesComponent extends React.PureComponent<IProps> {
                     id={`form-row-${cvFieldName}`}
                     data-test-id={testId?.length ? `${testId}.${cv._id}` : cv._id}
                 >
-                    <EditorFieldTreeSelect
-                        filterScheme={(values) => values.filter((value) => cv._id == null || value?.scheme === cv._id)}
-                        item={item}
-                        field={parentField}
-                        label={gettext(cv.display_name)}
-                        required={required || schema?.required}
-                        allowMultiple={true}
+                    <TreeSelect
                         sortable={true}
-                        getOptions={() => cv.items.map((item: ISubject) => ({value: {...item, scheme: cv._id}}))}
-                        getId={(item: ISubject) => item.qcode}
-                        getLabel={(item: ISubject) => (
-                            getVocabularyItemNameFromString(
-                                item.qcode,
-                                cv.items,
-                                'qcode',
-                                'name',
-                                language
-                            )
+                        kind="synchronous"
+                        allowMultiple={true}
+                        value={item.subject.filter((x) => x.scheme === cv._id)}
+                        label={gettext(cv.display_name)}
+                        required={required ?? schema?.required}
+                        getOptions={() => arrayToTree(
+                            cv.items.map((cvItem) => ({
+                                ...cvItem,
+                                scheme: cv._id,
+                            })) as Array<ISubject>,
+                            ({qcode}) => qcode.toString(),
+                            ({parent}) => parent?.toString(),
+                        ).result}
+                        getLabel={(item) => getVocabularyItemFieldTranslated(
+                            item,
+                            'name',
+                            language,
                         )}
-                        onChange={(field, value) => {
-                            const otherCvValues = item[parentField] ?? [];
+                        getId={(item) => item.qcode}
+                        invalid={errors?.length > 0 || invalid}
+                        error={showErrors ? errors[itemFieldName] : undefined}
+                        readOnly={disabled}
+                        disabled={disabled}
+                        onChange={(vals) => {
+                            const restOfItems = (item.subject ?? []).filter((x) => x.scheme !== cv._id);
 
-                            const newValues = value.concat(
-                                otherCvValues.filter((value) => value?.scheme != cv._id)
+                            onChange(
+                                'subject',
+                                [...restOfItems, ...vals],
                             );
-
-                            onChange(field, newValues);
                         }}
-                        errors={errors}
+                        tabindex={0}
+                        zIndex={1051}
                     />
                 </Row>
             );


### PR DESCRIPTION
## Front-end checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)
