### PR TITLE
Nested event displays redundant planning icon

### DIFF
--- a/client/components/Events/EventItem.tsx
+++ b/client/components/Events/EventItem.tsx
@@ -46,6 +46,7 @@ class EventItemComponent extends React.Component<IProps, IState> {
             this.state.hover !== nextState.hover ||
             this.props.minTimeWidth !== nextProps.minTimeWidth ||
             this.props.lockedItems != nextProps.lockedItems ||
+            (this.props.relatedEventsUI && this.props.relatedEventsUI.visible != nextProps.relatedEventsUI.visible) ||
             this.props.filterLanguage !== nextProps.filterLanguage;
     }
 
@@ -143,7 +144,7 @@ class EventItemComponent extends React.Component<IProps, IState> {
     }
 
     render() {
-        const {gettext} = superdeskApi.localization;
+        const {gettext, gettextPlural} = superdeskApi.localization;
         const {querySelectorParent} = superdeskApi.utilities;
 
         const {
@@ -151,7 +152,6 @@ class EventItemComponent extends React.Component<IProps, IState> {
             onItemClick,
             lockedItems,
             activeFilter,
-            toggleRelatedPlanning,
             onMultiSelectClick,
             calendars,
             listFields,
@@ -260,22 +260,44 @@ class EventItemComponent extends React.Component<IProps, IState> {
 
                         {secondaryFields.includes('files') && renderFields('files', item)}
 
+                        {(() => {
+                            const {relatedEventsUI} = this.props;
 
-                        {(hasPlanning) && (
-                            <span
-                                className="sd-overflow-ellipsis sd-list-item__element-lm-10"
-                            >
-                                <a
-                                    className="sd-line-input__input--related-item-link"
-                                    onClick={toggleRelatedPlanning}
+                            if (!hasPlanning || relatedEventsUI == null) {
+                                return null;
+                            }
+
+                            const relatedPlanningText = relatedEventsUI.visible
+                                ? gettextPlural(
+                                    this.props.planningItemsLength,
+                                    'Hide 1 planning item', 'Hide {{n}} planning items',
+                                    {n: this.props.planningItemsLength},
+                                )
+                                : gettextPlural(
+                                    this.props.planningItemsLength,
+                                    'Show 1 planning item', 'Show {{n}} planning items',
+                                    {n: this.props.planningItemsLength},
+                                );
+
+                            return (
+                                <span
+                                    className="sd-overflow-ellipsis sd-list-item__element-lm-10"
                                 >
-                                    <i className="icon-calendar" />
-                                    <span className="sd-margin-l--0-5">
-                                        {this.props.relatedPlanningText}
-                                    </span>
-                                </a>
-                            </span>
-                        )}
+                                    <a
+                                        className="sd-line-input__input--related-item-link"
+                                        onClick={(event) => {
+                                            event.stopPropagation();
+                                            relatedEventsUI.setVisibility(!relatedEventsUI.visible);
+                                        }}
+                                    >
+                                        <i className="icon-calendar" />
+                                        <span className="sd-margin-l--0-5">
+                                            {relatedPlanningText}
+                                        </span>
+                                    </a>
+                                </span>
+                            );
+                        })()}
 
                         {secondaryFields.includes('location') && renderFields('location', item)}
                     </Row>

--- a/client/components/Events/EventItem.tsx
+++ b/client/components/Events/EventItem.tsx
@@ -269,14 +269,14 @@ class EventItemComponent extends React.Component<IProps, IState> {
 
                             const relatedPlanningText = relatedEventsUI.visible
                                 ? gettextPlural(
-                                    this.props.planningItemsLength,
+                                    this.props.relatedPlanningsCount,
                                     'Hide 1 planning item', 'Hide {{n}} planning items',
-                                    {n: this.props.planningItemsLength},
+                                    {n: this.props.relatedPlanningsCount},
                                 )
                                 : gettextPlural(
-                                    this.props.planningItemsLength,
+                                    this.props.relatedPlanningsCount,
                                     'Show 1 planning item', 'Show {{n}} planning items',
-                                    {n: this.props.planningItemsLength},
+                                    {n: this.props.relatedPlanningsCount},
                                 );
 
                             return (

--- a/client/components/Events/EventItemWithPlanning.tsx
+++ b/client/components/Events/EventItemWithPlanning.tsx
@@ -220,7 +220,7 @@ export class EventItemWithPlanning extends React.Component<IProps, IState> {
 
         const eventProps = {
             ...this.props.eventProps,
-            planningItemsLength: planningItems,
+            relatedPlanningsCount: planningItems,
         };
 
         // Event is always indexed as 0

--- a/client/components/Events/EventItemWithPlanning.tsx
+++ b/client/components/Events/EventItemWithPlanning.tsx
@@ -48,8 +48,7 @@ export class EventItemWithPlanning extends React.Component<IProps, IState> {
         this.handleKeyDown = this.handleKeyDown.bind(this);
     }
 
-    toggleRelatedPlanning(evt) {
-        evt.stopPropagation();
+    toggleRelatedPlanning(isOpen) {
         if (!this.state.openPlanningItems) {
             this.props.showRelatedPlannings(get(this.props, 'eventProps.item', {}));
         }
@@ -58,7 +57,7 @@ export class EventItemWithPlanning extends React.Component<IProps, IState> {
 
         this.setState({
             activeIndex: activeIndex,
-            openPlanningItems: !this.state.openPlanningItems,
+            openPlanningItems: isOpen,
         });
 
         this.activateItem(activeIndex, false);
@@ -205,12 +204,7 @@ export class EventItemWithPlanning extends React.Component<IProps, IState> {
     }
 
     render() {
-        const {gettextPlural} = superdeskApi.localization;
         const planningItems = get(this.props, 'eventProps.item.planning_ids', []).length;
-
-        const relatedPlanningText = this.state.openPlanningItems
-            ? gettextPlural(planningItems, 'Hide 1 planning item', 'Hide {{n}} planning items', {n: planningItems})
-            : gettextPlural(planningItems, 'Show 1 planning item', 'Show {{n}} planning items', {n: planningItems});
 
         const getPlannings = (item) => (
             get(this.props.relatedPlanningsInList, item._id, []).map((plan, index) => {
@@ -226,12 +220,20 @@ export class EventItemWithPlanning extends React.Component<IProps, IState> {
 
         const eventProps = {
             ...this.props.eventProps,
-            toggleRelatedPlanning: this.toggleRelatedPlanning,
-            relatedPlanningText: relatedPlanningText,
+            planningItemsLength: planningItems,
         };
 
         // Event is always indexed as 0
-        const eventItem = <EventItem {...eventProps} active={this.state.activeIndex === 0} />;
+        const eventItem = (
+            <EventItem
+                {...eventProps}
+                active={this.state.activeIndex === 0}
+                relatedEventsUI={{
+                    visible: this.state.openPlanningItems,
+                    setVisibility: this.toggleRelatedPlanning,
+                }}
+            />
+        );
 
         return (
             <NestedItem

--- a/client/interfaces.ts
+++ b/client/interfaces.ts
@@ -926,7 +926,7 @@ export interface IBaseListItemProps<T> {
 export interface IEventListItemProps extends IBaseListItemProps<IEventItem> {
     calendars: Array<ICalendar>;
     filterLanguage?: string;
-    planningItemsLength?: number;
+    relatedPlanningsCount: number;
     relatedEventsUI?: {
         visible: boolean;
         setVisibility(value: boolean): void;

--- a/client/interfaces.ts
+++ b/client/interfaces.ts
@@ -924,10 +924,13 @@ export interface IBaseListItemProps<T> {
 }
 
 export interface IEventListItemProps extends IBaseListItemProps<IEventItem> {
-    relatedPlanningText?: string;
     calendars: Array<ICalendar>;
     filterLanguage?: string;
-    toggleRelatedPlanning?(event: React.MouseEvent): void;
+    planningItemsLength?: number;
+    relatedEventsUI?: {
+        visible: boolean;
+        setVisibility(value: boolean): void;
+    };
 }
 
 export interface IPlanningListItemProps extends IBaseListItemProps<IPlanningItem> {


### PR DESCRIPTION
STT-87

## Front-end checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [x] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [x] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [x] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [x] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [x] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [x] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [x] This pull request is not adding redux based modals
- [x] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [x] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)
