### PR TITLE
automatically show related plannings added to event

### DIFF
--- a/client/actions/agenda.ts
+++ b/client/actions/agenda.ts
@@ -312,12 +312,10 @@ const createPlanningFromEvent = (
 
     return (dispatch) => (
         dispatch(planningApis.save({}, newPlanningItem))
-        .then((planningResponse) => {
-            return dispatch(eventsApis.fetchById(event.guid, {force: true, saveToStore: true, loadPlanning: false}))
-            .then(() => {
-                return planningResponse;
-            });
-        })
+            .then((planningResponse) => dispatch(
+                eventsApis.fetchById(event.guid, {force: true, saveToStore: true, loadPlanning: false})
+            )
+                .then(() => planningResponse))
     );
 };
 

--- a/client/actions/agenda.ts
+++ b/client/actions/agenda.ts
@@ -10,6 +10,7 @@ import {getErrorMessage, gettext, planningUtils} from '../utils';
 import {planning, showModal, main} from './index';
 import {convertStringFields} from '../utils/strings';
 import planningApis from '../actions/planning/api';
+import eventsApis from '../actions/events/api';
 
 const openAgenda = () => (
     (dispatch) => (
@@ -311,6 +312,12 @@ const createPlanningFromEvent = (
 
     return (dispatch) => (
         dispatch(planningApis.save({}, newPlanningItem))
+        .then((planningResponse) => {
+            return dispatch(eventsApis.fetchById(event.guid, {force: true, saveToStore: true, loadPlanning: false}))
+            .then(() => {
+                return planningResponse;
+            });
+        })
     );
 };
 

--- a/client/actions/events/api.ts
+++ b/client/actions/events/api.ts
@@ -317,7 +317,7 @@ const fetchById = (eventId, {force = false, saveToStore = true, loadPlanning = t
         if (has(storedEvents, eventId) && !force) {
             promise = Promise.resolve(storedEvents[eventId]);
         } else {
-            promise = planningApi.events.getById(eventId)
+            promise = planningApi.events.getById(eventId, force ? {cache: false} : undefined)
                 .then((event) => {
                     if (saveToStore) {
                         dispatch(self.receiveEvents([event]));

--- a/client/actions/events/tests/api_test.ts
+++ b/client/actions/events/tests/api_test.ts
@@ -107,7 +107,7 @@ describe('actions.events.api', () => {
             store.test(done, eventsApi.fetchById('e2'))
                 .then(() => {
                     expect(planningApis.events.getById.callCount).toBe(1);
-                    expect(planningApis.events.getById.args[0]).toEqual(['e2']);
+                    expect(planningApis.events.getById.args[0]).toEqual(['e2', undefined]);
 
                     expect(eventsApi.receiveEvents.callCount).toBe(1);
                     expect(eventsApi.receiveEvents.args[0]).toEqual([[data.events[1]]]);
@@ -141,7 +141,7 @@ describe('actions.events.api', () => {
                     expect(event).toEqual(eventUtils.modifyForClient(data.events[1]));
 
                     expect(planningApis.events.getById.callCount).toBe(1);
-                    expect(planningApis.events.getById.args[0]).toEqual(['e2']);
+                    expect(planningApis.events.getById.args[0]).toEqual(['e2', {cache: false}]);
 
                     expect(eventsApi.receiveEvents.callCount).toBe(1);
                     expect(eventsApi.receiveEvents.args[0]).toEqual([[data.events[1]]]);

--- a/client/api/events.ts
+++ b/client/api/events.ts
@@ -71,9 +71,9 @@ export function searchEventsGetAll(params: ISearchParams): Promise<Array<IEventI
     });
 }
 
-export function getEventById(eventId: IEventItem['_id'], params: IGetRequestParams): Promise<IEventItem> {
+export function getEventById(eventId: IEventItem['_id'], params?: IGetRequestParams): Promise<IEventItem> {
     return superdeskApi.dataApi
-        .findOne<IEventItem>('events', eventId + (params?.cache === false ? `?time=${Math.floor(Date.now() / 1000)}` : ''))
+        .findOne<IEventItem>('events', eventId + (params?.cache === false ? `?time=${Math.floor(Date.now() / 1000)}` : ''), params?.cache)
         .then(modifyItemForClient);
 }
 

--- a/client/api/events.ts
+++ b/client/api/events.ts
@@ -73,7 +73,11 @@ export function searchEventsGetAll(params: ISearchParams): Promise<Array<IEventI
 
 export function getEventById(eventId: IEventItem['_id'], params?: IGetRequestParams): Promise<IEventItem> {
     return superdeskApi.dataApi
-        .findOne<IEventItem>('events', eventId + (params?.cache === false ? `?time=${Math.floor(Date.now() / 1000)}` : ''), params?.cache)
+        .findOne<IEventItem>(
+            'events',
+            eventId + (params?.cache === false ? `?time=${Math.floor(Date.now() / 1000)}` : ''),
+            params?.cache,
+        )
         .then(modifyItemForClient);
 }
 

--- a/client/api/events.ts
+++ b/client/api/events.ts
@@ -7,6 +7,7 @@ import {
     ISearchSpikeState,
     IPlanningConfig,
     IEventUpdateMethod,
+    IGetRequestParams,
 } from '../interfaces';
 import {appConfig as config} from 'appConfig';
 import {IRestApiResponse} from 'superdesk-api';
@@ -70,9 +71,9 @@ export function searchEventsGetAll(params: ISearchParams): Promise<Array<IEventI
     });
 }
 
-export function getEventById(eventId: IEventItem['_id']): Promise<IEventItem> {
+export function getEventById(eventId: IEventItem['_id'], params: IGetRequestParams): Promise<IEventItem> {
     return superdeskApi.dataApi
-        .findOne<IEventItem>('events', eventId)
+        .findOne<IEventItem>('events', eventId + (params?.cache === false ? `?time=${Math.floor(Date.now() / 1000)}` : ''))
         .then(modifyItemForClient);
 }
 

--- a/client/interfaces.ts
+++ b/client/interfaces.ts
@@ -2186,6 +2186,10 @@ export interface IEditorAPI {
     };
 }
 
+export interface IGetRequestParams {
+    cache?: boolean;
+}
+
 export interface IPlanningAPI {
     redux: {
         store: Store;
@@ -2193,7 +2197,7 @@ export interface IPlanningAPI {
     events: {
         search(params: ISearchParams): Promise<IRestApiResponse<IEventItem>>;
         searchGetAll(params: ISearchParams): Promise<Array<IEventItem>>;
-        getById(eventId: IEventItem['_id']): Promise<IEventItem>;
+        getById(eventId: IEventItem['_id'], params?: IGetRequestParams): Promise<IEventItem>;
         getByIds(eventIds: Array<IEventItem['_id']>, spikeState?: ISearchSpikeState): Promise<Array<IEventItem>>;
         getEditorProfile(): IEventFormProfile;
         getSearchProfile(): IEventSearchProfile;

--- a/client/reducers/events.ts
+++ b/client/reducers/events.ts
@@ -322,7 +322,7 @@ const eventsReducer = createReducer<IEventState>(initialState, {
     [EVENTS.ACTIONS.EVENT_RECENT_TEMPLATES]: (state, payload) => ({
         ...state,
         recentEventTemplates: payload,
-    })
+    }),
 });
 
 const onEventPostChanged = (state, payload) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1368,6 +1368,16 @@
       "integrity": "sha512-nbE1WxOTTrUWIfsfZ4aHGYu5DOuNkbxGokjV6Z2kxfJK3uaAb8zNK1muzOeipoLHZjInT4Br88BHpzevc681xA==",
       "dev": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "block-stream": {
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
@@ -4455,6 +4465,13 @@
       "resolved": "https://registry.npmjs.org/file-sync-cmp/-/file-sync-cmp-0.1.1.tgz",
       "integrity": "sha512-0k45oWBokCqh2MOexeYKpyqmGKG+8mQ2Wd8iawx+uWd/weWJQAZ6SoPybagdCI4xFisag8iAR77WPm4h3pTfxA==",
       "dev": true
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
     },
     "filename-regex": {
       "version": "2.0.1",
@@ -13402,6 +13419,7 @@
           "dev": true,
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         },
@@ -13900,6 +13918,7 @@
           "dev": true,
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         },


### PR DESCRIPTION
atm it's a workaround, but eventually we will need to get rid of `planning_ids` on event which is computed on load but without updating event itself it gets cached.

STT-86

## Front-end checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)
