### PR TITLE
Fix: Planning items created via an event are not always scheduled, but are being kept in draft mode [SDBELGA-879]

### DIFF
--- a/client/components/ContentProfiles/ContentProfileModal.tsx
+++ b/client/components/ContentProfiles/ContentProfileModal.tsx
@@ -392,6 +392,11 @@ class ContentProfileModalComponent extends React.Component<IProps, IState> {
             fields.forEach((item, index) => {
                 profile.editor[item.name] = {...item.field};
                 profile.editor[item.name].index = index;
+
+                // If the field is disabled in the editor, mark it as not required to avoid backend validation issues.
+                if (item.field?.enabled == false) {
+                    profile.schema[item.name].required = false;
+                }
             });
 
             return key === 'profile' ?

--- a/client/components/ContentProfiles/ContentProfileModal.tsx
+++ b/client/components/ContentProfiles/ContentProfileModal.tsx
@@ -392,11 +392,6 @@ class ContentProfileModalComponent extends React.Component<IProps, IState> {
             fields.forEach((item, index) => {
                 profile.editor[item.name] = {...item.field};
                 profile.editor[item.name].index = index;
-
-                // If the field is disabled in the editor, mark it as not required to avoid backend validation issues.
-                if (item.field?.enabled == false) {
-                    profile.schema[item.name].required = false;
-                }
             });
 
             return key === 'profile' ?

--- a/server/features/planning_validate.feature
+++ b/server/features/planning_validate.feature
@@ -30,6 +30,11 @@ Feature: Planning Validate
             }
         }, {
             "_id": "planning", "name": "planning",
+            "editor":{
+                "place": {
+                    "enabled":true
+                }
+            },
             "schema": {
                 "slugline": {
                     "type": "string",

--- a/server/planning/validate/planning_validate.py
+++ b/server/planning/validate/planning_validate.py
@@ -17,6 +17,7 @@ from superdesk.logging import logger
 from apps.validate.validate import SchemaValidator as Validator
 
 from copy import deepcopy
+from planning.content_profiles.utils import get_enabled_fields
 
 REQUIRED_ERROR = "{} is a required field"
 
@@ -128,14 +129,16 @@ class PlanningValidateService(Service):
         return get_resource_service("planning_types").find_one(req=None, name=doc[ITEM_TYPE])
 
     def _get_validator_schema(self, validator, validate_on_post):
-        """Get schema for given validator.
+        """Get schema for a given validator, excluding fields with None values,
+        and only include fields that are in enabled_fields."""
 
-        And make sure there is no `None` value which would raise an exception.
-        """
+        enabled_fields = get_enabled_fields(validator)
         return {
-            field: get_validator_schema(schema)
-            for field, schema in validator["schema"].items()
-            if schema and schema.get("validate_on_post", False) == validate_on_post
+            field: get_validator_schema(field_schema)
+            for field, field_schema in validator["schema"].items()
+            if field in enabled_fields
+            and field_schema
+            and field_schema.get("validate_on_post", False) == validate_on_post
         }
 
     def _validate(self, doc):


### PR DESCRIPTION
when we remove the required field from the editor, in the schema its still marked as required, so when we validate the related_item, it gives us validation error as it is required

## Front-end checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)
