### PR TITLE
Nested single day events always shown only with time

### DIFF
--- a/client/components/Events/EventDateTime.tsx
+++ b/client/components/Events/EventDateTime.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import {superdeskApi} from '../../superdeskApi';
-import {IEventItem} from '../../interfaces';
+import {IEventItem, IPlanningListItemProps} from '../../interfaces';
 
 import {eventUtils, timeUtils} from '../../utils';
 
@@ -13,6 +13,7 @@ interface IProps {
   item: IEventItem;
   ignoreAllDay?: boolean;
   displayLocalTimezone?: boolean;
+  planningItem?: IPlanningListItemProps;
 }
 
 export class EventDateTime extends React.PureComponent<IProps> {
@@ -23,6 +24,7 @@ export class EventDateTime extends React.PureComponent<IProps> {
         const end = eventUtils.getEndDate(item);
         const isAllDay = eventUtils.isEventAllDay(start, end);
         const multiDay = !eventUtils.isEventSameDay(start, end);
+        const showEventStartDate = eventUtils.showEventStartDate(start, this.props.planningItem?.date);
         const isRemoteTimeZone = timeUtils.isEventInDifferentTimeZone(item);
         const withYear = multiDay && start.year() !== end.year();
         const localStart = timeUtils.getLocalDate(start, item.dates.tz);
@@ -79,7 +81,7 @@ export class EventDateTime extends React.PureComponent<IProps> {
                     </span>
                 )}
                 <DateTime
-                    withDate={multiDay}
+                    withDate={(showEventStartDate || multiDay)}
                     withYear={withYear}
                     date={start}
                     {...commonProps}

--- a/client/components/Events/EventDateTime.tsx
+++ b/client/components/Events/EventDateTime.tsx
@@ -13,7 +13,7 @@ interface IProps {
   item: IEventItem;
   ignoreAllDay?: boolean;
   displayLocalTimezone?: boolean;
-  planningItem?: IPlanningListItemProps;
+  planningProps?: IPlanningListItemProps;
 }
 
 export class EventDateTime extends React.PureComponent<IProps> {
@@ -24,7 +24,7 @@ export class EventDateTime extends React.PureComponent<IProps> {
         const end = eventUtils.getEndDate(item);
         const isAllDay = eventUtils.isEventAllDay(start, end);
         const multiDay = !eventUtils.isEventSameDay(start, end);
-        const showEventStartDate = eventUtils.showEventStartDate(start, this.props.planningItem?.date);
+        const showEventStartDate = eventUtils.showEventStartDate(start, multiDay, this.props.planningProps?.date);
         const isRemoteTimeZone = timeUtils.isEventInDifferentTimeZone(item);
         const withYear = multiDay && start.year() !== end.year();
         const localStart = timeUtils.getLocalDate(start, item.dates.tz);
@@ -81,7 +81,7 @@ export class EventDateTime extends React.PureComponent<IProps> {
                     </span>
                 )}
                 <DateTime
-                    withDate={(showEventStartDate || multiDay)}
+                    withDate={showEventStartDate}
                     withYear={withYear}
                     date={start}
                     {...commonProps}

--- a/client/components/Events/EventDateTimeColumn.tsx
+++ b/client/components/Events/EventDateTimeColumn.tsx
@@ -13,7 +13,7 @@ import {EventDateTime} from './EventDateTime';
 interface IProps {
     item: IEventItem;
     multiRow?: boolean;
-    planningItem?: IPlanningListItemProps;
+    planningProps?: IPlanningListItemProps;
 }
 
 export class EventDateTimeColumn extends React.PureComponent<IProps> {
@@ -24,7 +24,7 @@ export class EventDateTimeColumn extends React.PureComponent<IProps> {
             return (
                 <Column border={false} className="flex-justify--start sd-padding-t--1">
                     <Row classes="sd-margin--0">
-                        <EventDateTime item={this.props.item} planningItem={this.props.planningItem} />
+                        <EventDateTime item={this.props.item} planningProps={this.props.planningProps} />
                     </Row>
                 </Column>
             );

--- a/client/components/Events/EventDateTimeColumn.tsx
+++ b/client/components/Events/EventDateTimeColumn.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import moment from 'moment-timezone';
 
-import {IEventItem} from '../../interfaces';
+import {IEventItem, IPlanningListItemProps} from '../../interfaces';
 import {superdeskApi} from '../../superdeskApi';
 
 import {eventUtils, timeUtils} from '../../utils';
@@ -13,6 +13,7 @@ import {EventDateTime} from './EventDateTime';
 interface IProps {
     item: IEventItem;
     multiRow?: boolean;
+    planningItem?: IPlanningListItemProps;
 }
 
 export class EventDateTimeColumn extends React.PureComponent<IProps> {
@@ -23,7 +24,7 @@ export class EventDateTimeColumn extends React.PureComponent<IProps> {
             return (
                 <Column border={false} className="flex-justify--start sd-padding-t--1">
                     <Row classes="sd-margin--0">
-                        <EventDateTime item={this.props.item} />
+                        <EventDateTime item={this.props.item} planningItem={this.props.planningItem} />
                     </Row>
                 </Column>
             );

--- a/client/components/Events/EventItem.tsx
+++ b/client/components/Events/EventItem.tsx
@@ -305,7 +305,7 @@ class EventItemComponent extends React.Component<IProps, IState> {
                 <EventDateTimeColumn
                     item={item}
                     multiRow={listViewType === LIST_VIEW_TYPE.LIST}
-                    planningItem={this.props.planningItem}
+                    planningProps={this.props.planningProps}
                 />
                 {listViewType === LIST_VIEW_TYPE.SCHEDULE ? null : (
                     <CreatedUpdatedColumn

--- a/client/components/Events/EventItem.tsx
+++ b/client/components/Events/EventItem.tsx
@@ -305,6 +305,7 @@ class EventItemComponent extends React.Component<IProps, IState> {
                 <EventDateTimeColumn
                     item={item}
                     multiRow={listViewType === LIST_VIEW_TYPE.LIST}
+                    planningItem={this.props.planningItem}
                 />
                 {listViewType === LIST_VIEW_TYPE.SCHEDULE ? null : (
                     <CreatedUpdatedColumn

--- a/client/components/Planning/PlanningItemWithEvents.tsx
+++ b/client/components/Planning/PlanningItemWithEvents.tsx
@@ -69,7 +69,7 @@ export class PlanningItemWithEvents extends React.Component<IProps, IState> {
                                                     {...this.props.getEventProps(event)}
                                                     multiSelectDisabled
                                                     key={event._id}
-                                                    planningItem={planningProps}
+                                                    planningProps={planningProps}
                                                 />
                                             );
                                         })

--- a/client/components/Planning/PlanningItemWithEvents.tsx
+++ b/client/components/Planning/PlanningItemWithEvents.tsx
@@ -69,6 +69,7 @@ export class PlanningItemWithEvents extends React.Component<IProps, IState> {
                                                     {...this.props.getEventProps(event)}
                                                     multiSelectDisabled
                                                     key={event._id}
+                                                    planningItem={planningProps}
                                                 />
                                             );
                                         })

--- a/client/interfaces.ts
+++ b/client/interfaces.ts
@@ -906,6 +906,7 @@ export interface IAssignmentItem extends IBaseRestApiResponse {
 
 export interface IBaseListItemProps<T> {
     item: T;
+    planningItem?: IPlanningListItemProps;
     lockedItems: ILockedItems;
     session: ISession;
     privileges: {[key: string]: number};

--- a/client/interfaces.ts
+++ b/client/interfaces.ts
@@ -906,7 +906,7 @@ export interface IAssignmentItem extends IBaseRestApiResponse {
 
 export interface IBaseListItemProps<T> {
     item: T;
-    planningItem?: IPlanningListItemProps;
+    planningProps?: IPlanningListItemProps;
     lockedItems: ILockedItems;
     session: ISession;
     privileges: {[key: string]: number};

--- a/client/utils/events.ts
+++ b/client/utils/events.ts
@@ -80,7 +80,10 @@ function isEventSameDay(startingDate: IDateTime, endingDate: IDateTime): boolean
     return moment(startingDate).format('DD/MM/YYYY') === moment(endingDate).format('DD/MM/YYYY');
 }
 
-function showEventStartDate(eventDate: IDateTime, planningDate: IDateTime): boolean {
+function showEventStartDate(eventDate: IDateTime, planningDate?: IDateTime): boolean {
+    if (planningDate == null) {
+        return true;
+    }
     return moment(eventDate).format('DD/MM/YYYY') != moment(planningDate).format('DD/MM/YYYY');
 }
 

--- a/client/utils/events.ts
+++ b/client/utils/events.ts
@@ -80,11 +80,11 @@ function isEventSameDay(startingDate: IDateTime, endingDate: IDateTime): boolean
     return moment(startingDate).format('DD/MM/YYYY') === moment(endingDate).format('DD/MM/YYYY');
 }
 
-function showEventStartDate(eventDate: IDateTime, planningDate?: IDateTime): boolean {
+function showEventStartDate(eventDate: IDateTime, multiDay: boolean, planningDate?: IDateTime): boolean {
     if (planningDate == null) {
         return true;
     }
-    return moment(eventDate).format('DD/MM/YYYY') != moment(planningDate).format('DD/MM/YYYY');
+    return (!moment(eventDate).isSame(planningDate, 'day') || multiDay);
 }
 
 function eventHasPlanning(event: IEventItem): boolean {

--- a/client/utils/events.ts
+++ b/client/utils/events.ts
@@ -80,6 +80,10 @@ function isEventSameDay(startingDate: IDateTime, endingDate: IDateTime): boolean
     return moment(startingDate).format('DD/MM/YYYY') === moment(endingDate).format('DD/MM/YYYY');
 }
 
+function showEventStartDate(eventDate: IDateTime, planningDate: IDateTime): boolean {
+    return moment(eventDate).format('DD/MM/YYYY') != moment(planningDate).format('DD/MM/YYYY');
+}
+
 function eventHasPlanning(event: IEventItem): boolean {
     return get(event, 'planning_ids', []).length > 0;
 }
@@ -1355,6 +1359,7 @@ const self = {
     canConvertToRecurringEvent,
     canUpdateEventRepetitions,
     isEventSameDay,
+    showEventStartDate,
     isEventRecurring,
     getDateStringForEvent,
     getEventActions,


### PR DESCRIPTION
STT-93

## Front-end checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [x] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [x] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [x] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [x] This pull request is not adding redux based modals
- [x] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [x] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)
