### PR TITLE
Missing 'assignment available' circle on SD left panel

### DIFF
--- a/client/planning-extension/src/assignments-overview/hiddenAssignmentsList.tsx
+++ b/client/planning-extension/src/assignments-overview/hiddenAssignmentsList.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
-import {ISuperdeskQuery, IUser} from 'superdesk-api';
-import {IAssignmentItem} from '../../../interfaces';
+import {IUser} from 'superdesk-api';
+import {getAssignmentsQuery} from '.';
+import {ASSIGNMENT_STATE, IAssignmentItem} from '../../../interfaces';
 import {superdesk} from '../superdesk';
 const {getLiveQueryHOC} = superdesk.components;
 const LiveAssignmentsHOC = getLiveQueryHOC<IAssignmentItem>();
@@ -8,22 +9,6 @@ const LiveAssignmentsHOC = getLiveQueryHOC<IAssignmentItem>();
 interface IState {
     loading: false;
     currentUser: IUser;
-}
-
-function getAssignmentsQuery(userId: IUser['_id']): ISuperdeskQuery {
-    const query: ISuperdeskQuery = {
-        filter: {
-            $and: [
-                {'assigned_to.user': {$eq: userId}},
-                {'assigned_to.state': {$in: ['assigned']}},
-            ],
-        },
-        sort: [{'planning.scheduled': 'asc'}],
-        page: 1,
-        max_results: 100,
-    };
-
-    return query;
 }
 
 export class HiddenAssignmentsList extends React.PureComponent<{}, {loading: true} | IState> {
@@ -51,20 +36,23 @@ export class HiddenAssignmentsList extends React.PureComponent<{}, {loading: tru
         const {currentUser} = this.state;
 
         return (
-                <LiveAssignmentsHOC resource="assignments" query={getAssignmentsQuery(currentUser._id)}>
-                    {
-                        (data) => {
-                            const itemsCount = data._meta.total;
+            <LiveAssignmentsHOC
+                resource="assignments"
+                query={getAssignmentsQuery(currentUser._id, [ASSIGNMENT_STATE.ASSIGNED])}
+            >
+                {
+                    (data) => {
+                        const itemsCount = data._meta.total;
 
-                            superdesk.dispatchEvent(
-                                'menuItemBadgeValueChange',
-                                {menuId: 'MENU_ITEM_PLANNING_ASSIGNMENTS', badgeValue: itemsCount.toString()},
-                            );
+                        superdesk.dispatchEvent(
+                            'menuItemBadgeValueChange',
+                            {menuId: 'MENU_ITEM_PLANNING_ASSIGNMENTS', badgeValue: itemsCount.toString()},
+                        );
 
-                            return null;
-                        }
+                        return null;
                     }
-                </LiveAssignmentsHOC>
+                }
+            </LiveAssignmentsHOC>
         );
     }
 }

--- a/client/planning-extension/src/assignments-overview/hiddenAssignmentsList.tsx
+++ b/client/planning-extension/src/assignments-overview/hiddenAssignmentsList.tsx
@@ -11,7 +11,7 @@ interface IState {
     currentUser: IUser;
 }
 
-export class HiddenAssignmentsList extends React.PureComponent<{}, {loading: true} | IState> {
+export class AssignmentsCountTracker extends React.PureComponent<{}, {loading: true} | IState> {
     constructor(props: {}) {
         super(props);
 

--- a/client/planning-extension/src/assignments-overview/hiddenAssignmentsList.tsx
+++ b/client/planning-extension/src/assignments-overview/hiddenAssignmentsList.tsx
@@ -1,26 +1,29 @@
-import {groupBy, keyBy} from 'lodash';
 import * as React from 'react';
-import {
-    IDesk,
-    ILiveResourcesProps,
-    IRestApiResponse,
-    IUser,
-    IVocabulary,
-} from 'superdesk-api';
+import {ISuperdeskQuery, IUser} from 'superdesk-api';
 import {IAssignmentItem} from '../../../interfaces';
 import {superdesk} from '../superdesk';
-import {Badge} from 'superdesk-ui-framework';
-import {AssignmentsOverviewListItem} from './assignments-overview-list-item';
-import {getAssignmentsQuery} from '.';
-
-const DropdownTree = superdesk.components.getDropdownTree<IAssignmentItem>();
-const {GroupLabel, IconBig, TopMenuDropdownButton, getLiveQueryHOC, WithLiveResources} = superdesk.components;
+const {getLiveQueryHOC} = superdesk.components;
 const LiveAssignmentsHOC = getLiveQueryHOC<IAssignmentItem>();
-const {gettext} = superdesk.localization;
 
 interface IState {
     loading: false;
     currentUser: IUser;
+}
+
+function getAssignmentsQuery(userId: IUser['_id']): ISuperdeskQuery {
+    const query: ISuperdeskQuery = {
+        filter: {
+            $and: [
+                {'assigned_to.user': {$eq: userId}},
+                {'assigned_to.state': {$in: ['assigned']}},
+            ],
+        },
+        sort: [{'planning.scheduled': 'asc'}],
+        page: 1,
+        max_results: 100,
+    };
+
+    return query;
 }
 
 export class HiddenAssignmentsList extends React.PureComponent<{}, {loading: true} | IState> {
@@ -48,94 +51,20 @@ export class HiddenAssignmentsList extends React.PureComponent<{}, {loading: tru
         const {currentUser} = this.state;
 
         return (
-            <div style={{display: 'none'}}>
                 <LiveAssignmentsHOC resource="assignments" query={getAssignmentsQuery(currentUser._id)}>
                     {
                         (data) => {
-                            const assignments = data._items;
                             const itemsCount = data._meta.total;
-                            const grouped = groupBy(assignments, (item) => item.assigned_to.desk);
-
 
                             superdesk.dispatchEvent(
                                 'menuItemBadgeValueChange',
                                 {menuId: 'MENU_ITEM_PLANNING_ASSIGNMENTS', badgeValue: itemsCount.toString()},
                             );
 
-                            const resources: ILiveResourcesProps['resources'] = [
-                                {resource: 'desks', ids: Object.keys(grouped)},
-                                {resource: 'vocabularies', ids: ['g2_content_type']},
-                            ];
-
-                            return (
-                                <WithLiveResources resources={resources}>
-                                    {(resourcesResponse) => {
-                                        const desksResponse = resourcesResponse[0] as IRestApiResponse<IDesk>;
-                                        const desks = keyBy(desksResponse._items, ({_id}) => _id);
-                                        const vocabulariesResponse
-                                            = resourcesResponse[1] as IRestApiResponse<IVocabulary>;
-                                        const contentTypes = vocabulariesResponse._items[0].items;
-
-                                        return (
-                                            <DropdownTree
-                                                groups={Object.keys(grouped).map((deskId) => ({
-                                                    render: () => (
-                                                        <GroupLabel>
-                                                            <Badge
-                                                                type="highlight"
-                                                                text={grouped[deskId].length.toString()}
-                                                            />
-                                                            <span className="sd-margin-l--1">{desks[deskId].name}</span>
-                                                        </GroupLabel>
-                                                    ),
-                                                    items: grouped[deskId],
-                                                }))}
-                                                getToggleElement={
-                                                    (isOpen, onClick) => (
-                                                        <TopMenuDropdownButton
-                                                            onClick={() => {
-                                                                if (itemsCount > 0) {
-                                                                    onClick();
-                                                                }
-                                                            }}
-                                                            active={isOpen}
-                                                            disabled={itemsCount < 1}
-                                                            pulsate={false}
-                                                            data-test-id="toggle-button"
-                                                            tooltip={gettext('Assignments')}
-                                                        >
-                                                            <Badge type="highlight" text={itemsCount.toString()}>
-                                                                <span
-                                                                    style={{
-                                                                        color: isOpen
-                                                                            ? 'var(--sd-slugline-color)'
-                                                                            : 'var(--color-bg-00)'
-                                                                    }}
-                                                                >
-                                                                    <IconBig name="tasks" />
-                                                                </span>
-                                                            </Badge>
-                                                        </TopMenuDropdownButton>
-                                                    )
-                                                }
-                                                renderItem={(key, assignment, closeDropdown) => (
-                                                    <AssignmentsOverviewListItem
-                                                        key={key}
-                                                        assignment={assignment}
-                                                        contentTypes={contentTypes}
-                                                        onClick={closeDropdown}
-                                                    />
-                                                )}
-                                                wrapperStyles={{whiteSpace: 'nowrap', padding: '0 16 16'}}
-                                            />
-                                        );
-                                    }}
-                                </WithLiveResources>
-                            );
+                            return null;
                         }
                     }
                 </LiveAssignmentsHOC>
-            </div>
         );
     }
 }

--- a/client/planning-extension/src/assignments-overview/hiddenAssignmentsList.tsx
+++ b/client/planning-extension/src/assignments-overview/hiddenAssignmentsList.tsx
@@ -1,0 +1,141 @@
+import {groupBy, keyBy} from 'lodash';
+import * as React from 'react';
+import {
+    IDesk,
+    ILiveResourcesProps,
+    IRestApiResponse,
+    IUser,
+    IVocabulary,
+} from 'superdesk-api';
+import {IAssignmentItem} from '../../../interfaces';
+import {superdesk} from '../superdesk';
+import {Badge} from 'superdesk-ui-framework';
+import {AssignmentsOverviewListItem} from './assignments-overview-list-item';
+import {getAssignmentsQuery} from '.';
+
+const DropdownTree = superdesk.components.getDropdownTree<IAssignmentItem>();
+const {GroupLabel, IconBig, TopMenuDropdownButton, getLiveQueryHOC, WithLiveResources} = superdesk.components;
+const LiveAssignmentsHOC = getLiveQueryHOC<IAssignmentItem>();
+const {gettext} = superdesk.localization;
+
+interface IState {
+    loading: false;
+    currentUser: IUser;
+}
+
+export class HiddenAssignmentsList extends React.PureComponent<{}, {loading: true} | IState> {
+    constructor(props: {}) {
+        super(props);
+
+        this.state = {loading: true};
+    }
+
+    componentDidMount() {
+        superdesk.session.getCurrentUser()
+            .then((currentUser) => {
+                this.setState({
+                    loading: false,
+                    currentUser: currentUser,
+                });
+            });
+    }
+
+    render() {
+        if (this.state.loading === true) {
+            return null;
+        }
+
+        const {currentUser} = this.state;
+
+        return (
+            <div style={{display: 'none'}}>
+                <LiveAssignmentsHOC resource="assignments" query={getAssignmentsQuery(currentUser._id)}>
+                    {
+                        (data) => {
+                            const assignments = data._items;
+                            const itemsCount = data._meta.total;
+                            const grouped = groupBy(assignments, (item) => item.assigned_to.desk);
+
+
+                            superdesk.dispatchEvent(
+                                'menuItemBadgeValueChange',
+                                {menuId: 'MENU_ITEM_PLANNING_ASSIGNMENTS', badgeValue: itemsCount.toString()},
+                            );
+
+                            const resources: ILiveResourcesProps['resources'] = [
+                                {resource: 'desks', ids: Object.keys(grouped)},
+                                {resource: 'vocabularies', ids: ['g2_content_type']},
+                            ];
+
+                            return (
+                                <WithLiveResources resources={resources}>
+                                    {(resourcesResponse) => {
+                                        const desksResponse = resourcesResponse[0] as IRestApiResponse<IDesk>;
+                                        const desks = keyBy(desksResponse._items, ({_id}) => _id);
+                                        const vocabulariesResponse
+                                            = resourcesResponse[1] as IRestApiResponse<IVocabulary>;
+                                        const contentTypes = vocabulariesResponse._items[0].items;
+
+                                        return (
+                                            <DropdownTree
+                                                groups={Object.keys(grouped).map((deskId) => ({
+                                                    render: () => (
+                                                        <GroupLabel>
+                                                            <Badge
+                                                                type="highlight"
+                                                                text={grouped[deskId].length.toString()}
+                                                            />
+                                                            <span className="sd-margin-l--1">{desks[deskId].name}</span>
+                                                        </GroupLabel>
+                                                    ),
+                                                    items: grouped[deskId],
+                                                }))}
+                                                getToggleElement={
+                                                    (isOpen, onClick) => (
+                                                        <TopMenuDropdownButton
+                                                            onClick={() => {
+                                                                if (itemsCount > 0) {
+                                                                    onClick();
+                                                                }
+                                                            }}
+                                                            active={isOpen}
+                                                            disabled={itemsCount < 1}
+                                                            pulsate={false}
+                                                            data-test-id="toggle-button"
+                                                            tooltip={gettext('Assignments')}
+                                                        >
+                                                            <Badge type="highlight" text={itemsCount.toString()}>
+                                                                <span
+                                                                    style={{
+                                                                        color: isOpen
+                                                                            ? 'var(--sd-slugline-color)'
+                                                                            : 'var(--color-bg-00)'
+                                                                    }}
+                                                                >
+                                                                    <IconBig name="tasks" />
+                                                                </span>
+                                                            </Badge>
+                                                        </TopMenuDropdownButton>
+                                                    )
+                                                }
+                                                renderItem={(key, assignment, closeDropdown) => (
+                                                    <AssignmentsOverviewListItem
+                                                        key={key}
+                                                        assignment={assignment}
+                                                        contentTypes={contentTypes}
+                                                        onClick={closeDropdown}
+                                                    />
+                                                )}
+                                                wrapperStyles={{whiteSpace: 'nowrap', padding: '0 16 16'}}
+                                            />
+                                        );
+                                    }}
+                                </WithLiveResources>
+                            );
+                        }
+                    }
+                </LiveAssignmentsHOC>
+            </div>
+        );
+    }
+}

--- a/client/planning-extension/src/assignments-overview/index.tsx
+++ b/client/planning-extension/src/assignments-overview/index.tsx
@@ -27,16 +27,16 @@ interface IState {
     currentUser: IUser;
 }
 
-function getAssignmentsQuery(userId: IUser['_id']): ISuperdeskQuery {
+export function getAssignmentsQuery(userId: IUser['_id']): ISuperdeskQuery {
     const query: ISuperdeskQuery = {
         filter: {
             $and: [
                 {'assigned_to.user': {$eq: userId}},
-                {'assigned_to.state': {$in: ['assigned', 'submitted', 'in_progress']}},
+                {'assigned_to.state': {$in: ['assigned']}},
             ],
         },
         sort: [{'planning.scheduled': 'asc'}],
-        page: 0,
+        page: 1,
         max_results: 100,
     };
 

--- a/client/planning-extension/src/assignments-overview/index.tsx
+++ b/client/planning-extension/src/assignments-overview/index.tsx
@@ -27,12 +27,12 @@ interface IState {
     currentUser: IUser;
 }
 
-export function getAssignmentsQuery(userId: IUser['_id']): ISuperdeskQuery {
+function getAssignmentsQuery(userId: IUser['_id']): ISuperdeskQuery {
     const query: ISuperdeskQuery = {
         filter: {
             $and: [
                 {'assigned_to.user': {$eq: userId}},
-                {'assigned_to.state': {$in: ['assigned']}},
+                {'assigned_to.state': {$in: ['assigned', 'submitted', 'in_progress']}},
             ],
         },
         sort: [{'planning.scheduled': 'asc'}],

--- a/client/planning-extension/src/assignments-overview/index.tsx
+++ b/client/planning-extension/src/assignments-overview/index.tsx
@@ -8,7 +8,7 @@ import {
     IUser,
     IVocabulary,
 } from 'superdesk-api';
-import {IAssignmentItem} from '../../../interfaces';
+import {ASSIGNMENT_STATE, IAssignmentItem} from '../../../interfaces';
 import {superdesk} from '../superdesk';
 import {Badge} from 'superdesk-ui-framework';
 import {AssignmentsOverviewListItem} from './assignments-overview-list-item';
@@ -27,12 +27,12 @@ interface IState {
     currentUser: IUser;
 }
 
-function getAssignmentsQuery(userId: IUser['_id']): ISuperdeskQuery {
+export function getAssignmentsQuery(userId: IUser['_id'], assignmentToState: Array<ASSIGNMENT_STATE>): ISuperdeskQuery {
     const query: ISuperdeskQuery = {
         filter: {
             $and: [
                 {'assigned_to.user': {$eq: userId}},
-                {'assigned_to.state': {$in: ['assigned', 'submitted', 'in_progress']}},
+                {'assigned_to.state': {$in: assignmentToState}},
             ],
         },
         sort: [{'planning.scheduled': 'asc'}],
@@ -68,7 +68,13 @@ export class AssignmentsList extends React.PureComponent<IProps, {loading: true}
         const {currentUser} = this.state;
 
         return (
-            <LiveAssignmentsHOC resource="assignments" query={getAssignmentsQuery(currentUser._id)}>
+            <LiveAssignmentsHOC
+                resource="assignments"
+                query={getAssignmentsQuery(
+                    currentUser._id,
+                    [ASSIGNMENT_STATE.ASSIGNED, ASSIGNMENT_STATE.SUBMITTED, ASSIGNMENT_STATE.IN_PROGRESS],
+                )}
+            >
                 {
                     (data) => {
                         const assignments = data._items;

--- a/client/planning-extension/src/extension.ts
+++ b/client/planning-extension/src/extension.ts
@@ -252,7 +252,7 @@ const extension: IExtension = {
                         },
                     },
                 ],
-                globalMenuHorizontal: displayTopbarWidget ? [AssignmentsList] : [HiddenAssignmentsList],
+                globalMenuHorizontal: [HiddenAssignmentsList, ...(displayTopbarWidget ? [AssignmentsList] : [])],
             },
         };
 

--- a/client/planning-extension/src/extension.ts
+++ b/client/planning-extension/src/extension.ts
@@ -20,7 +20,7 @@ import {
     PLANNING_DETAILS_WIDGET_ID,
     PLANNING_DETAILS_WIDGET_LABEL,
 } from './planning-details-widget';
-import {HiddenAssignmentsList} from './assignments-overview/hiddenAssignmentsList';
+import {AssignmentsCountTracker} from './assignments-overview/hiddenAssignmentsList';
 
 function onSpike(superdesk: ISuperdesk, item: IArticle) {
     const {gettext} = superdesk.localization;
@@ -252,7 +252,7 @@ const extension: IExtension = {
                         },
                     },
                 ],
-                globalMenuHorizontal: [HiddenAssignmentsList, ...(displayTopbarWidget ? [AssignmentsList] : [])],
+                globalMenuHorizontal: [AssignmentsCountTracker, ...(displayTopbarWidget ? [AssignmentsList] : [])],
             },
         };
 

--- a/client/planning-extension/src/extension.ts
+++ b/client/planning-extension/src/extension.ts
@@ -20,6 +20,7 @@ import {
     PLANNING_DETAILS_WIDGET_ID,
     PLANNING_DETAILS_WIDGET_LABEL,
 } from './planning-details-widget';
+import {HiddenAssignmentsList} from './assignments-overview/hiddenAssignmentsList';
 
 function onSpike(superdesk: ISuperdesk, item: IArticle) {
     const {gettext} = superdesk.localization;
@@ -251,7 +252,7 @@ const extension: IExtension = {
                         },
                     },
                 ],
-                globalMenuHorizontal: displayTopbarWidget ? [AssignmentsList] : [],
+                globalMenuHorizontal: displayTopbarWidget ? [AssignmentsList] : [HiddenAssignmentsList],
             },
         };
 


### PR DESCRIPTION
SDCP-826

## Front-end checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [x] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [x] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [x] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [x] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [x] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [x] This pull request is not adding redux based modals
- [x] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [x] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)
