### PR TITLE
Fix ingest config

### DIFF
--- a/client/planning-extension/src/ingest_rule_autopost/AutopostIngestRuleEditor.tsx
+++ b/client/planning-extension/src/ingest_rule_autopost/AutopostIngestRuleEditor.tsx
@@ -1,9 +1,7 @@
 import * as React from 'react';
 import {
     IIngestRuleHandlerEditorProps,
-    ILiveResourcesProps,
     IRestApiResponse,
-    IVocabulary,
     IVocabularyItem
 } from 'superdesk-api';
 import {IAgenda} from '../../../interfaces';
@@ -12,7 +10,6 @@ import {superdesk} from '../superdesk';
 import {extensionBridge} from '../extension_bridge';
 
 const {EditorFieldVocabulary} = extensionBridge.ui.components;
-const {WithLiveResources} = superdesk.components;
 
 interface IExtraAttributes {
     autopost: boolean,
@@ -22,12 +19,27 @@ interface IExtraAttributes {
 
 type IProps = IIngestRuleHandlerEditorProps<IExtraAttributes>;
 
-export class AutopostIngestRuleEditor extends React.PureComponent<IProps> {
+interface IStateLoading {
+    loading: true;
+}
+
+interface IStateLoaded {
+    loading: false;
+    agendas: Array<IAgenda>;
+}
+
+type IState = IStateLoading | IStateLoaded;
+
+export class AutopostIngestRuleEditor extends React.PureComponent<IProps, IState> {
     constructor(props: IProps) {
         super(props);
 
         this.updateAttributes = this.updateAttributes.bind(this);
         this.updateAutopostValue = this.updateAutopostValue.bind(this);
+
+        this.state = {
+            loading: true,
+        };
     }
 
     updateAttributes<T extends keyof IExtraAttributes>(field: T, value: IExtraAttributes[T]) {
@@ -47,12 +59,26 @@ export class AutopostIngestRuleEditor extends React.PureComponent<IProps> {
         this.updateAttributes('autopost', value);
     }
 
+    componentDidMount(): void {
+        superdesk.httpRequestJsonLocal<IRestApiResponse<IAgenda>>({
+            method: 'GET',
+            path: '/agenda',
+        }).then((res) => {
+            this.setState({
+                loading: false,
+                agendas: res._items,
+            });
+        })
+    }
+
     render() {
+        if (this.state.loading) {
+            return null;
+        }
+
+        const {agendas} = this.state;
+        const calendars = superdesk.entities.vocabulary.getAll().get('event_calendars').items;
         const {gettext} = superdesk.localization;
-        const resources: ILiveResourcesProps['resources'] = [
-            {resource: 'vocabularies', ids: ['event_calendars']},
-            {resource: 'agenda'},
-        ];
 
         return (
             <div>
@@ -61,38 +87,31 @@ export class AutopostIngestRuleEditor extends React.PureComponent<IProps> {
                     value={this.props.rule.actions.extra?.autopost === true}
                     onChange={this.updateAutopostValue}
                 />
-                <WithLiveResources resources={resources}>{(resourcesResponse) => {
-                    const calendars = resourcesResponse[0] as IRestApiResponse<IVocabulary>;
-                    const agendas = resourcesResponse[1] as IRestApiResponse<IAgenda>;
 
-                    return (
-                        <React.Fragment>
-                            <EditorFieldVocabulary
-                                item={this.props.rule.actions.extra ?? {}}
-                                field="calendars"
-                                label={gettext('Calendars')}
-                                defaultValue={[]}
-                                onChange={this.updateAttributes}
-                                options={calendars._items[0].items.filter((item) => (
-                                    item.is_active !== false
-                                ))}
-                                valueAsString={true}
-                            />
-                            <EditorFieldVocabulary
-                                item={this.props.rule.actions.extra ?? {}}
-                                field="agendas"
-                                label={gettext('Agendas')}
-                                defaultValue={[]}
-                                onChange={this.updateAttributes}
-                                options={agendas._items.filter((item) => (
-                                    item.is_enabled !== false
-                                ))}
-                                valueAsString={true}
-                                valueKey="_id"
-                            />
-                        </React.Fragment>
-                    );
-                }}</WithLiveResources>
+                <EditorFieldVocabulary
+                    item={this.props.rule.actions.extra ?? {}}
+                    field="calendars"
+                    label={gettext('Calendars')}
+                    defaultValue={[]}
+                    onChange={this.updateAttributes}
+                    options={calendars.filter((item) => (
+                        item.is_active !== false
+                    ))}
+                    valueAsString={true}
+                />
+
+                <EditorFieldVocabulary
+                    item={this.props.rule.actions.extra ?? {}}
+                    field="agendas"
+                    label={gettext('Agendas')}
+                    defaultValue={[]}
+                    onChange={this.updateAttributes}
+                    options={agendas.filter((item) => (
+                        item.is_enabled !== false
+                    ))}
+                    valueAsString={true}
+                    valueKey="_id"
+                />
             </div>
         );
     }

--- a/client/planning-extension/src/ingest_rule_autopost/AutopostIngestRuleEditor.tsx
+++ b/client/planning-extension/src/ingest_rule_autopost/AutopostIngestRuleEditor.tsx
@@ -68,7 +68,7 @@ export class AutopostIngestRuleEditor extends React.PureComponent<IProps, IState
                 loading: false,
                 agendas: res._items,
             });
-        })
+        });
     }
 
     render() {

--- a/client/planning-extension/src/ingest_rule_autopost/AutopostIngestRulePreview.tsx
+++ b/client/planning-extension/src/ingest_rule_autopost/AutopostIngestRulePreview.tsx
@@ -1,10 +1,9 @@
 import * as React from 'react';
-import {IIngestRuleHandlerPreviewProps, ILiveResourcesProps, IRestApiResponse, IVocabulary} from 'superdesk-api';
+import {IIngestRuleHandlerPreviewProps, IRestApiResponse} from 'superdesk-api';
 import {superdesk} from '../superdesk';
 import {IAgenda} from '../../../interfaces';
 import {extensionBridge} from '../extension_bridge';
 
-const {WithLiveResources} = superdesk.components;
 const {getUserInterfaceLanguageFromCV, getVocabularyItemFieldTranslated} = extensionBridge.ui.utils;
 
 type IProps = IIngestRuleHandlerPreviewProps<{
@@ -13,70 +12,95 @@ type IProps = IIngestRuleHandlerPreviewProps<{
     calendars?: Array<string>;
 }>;
 
-export class AutopostIngestRulePreview extends React.PureComponent<IProps> {
+interface IStateLoading {
+    loading: true;
+}
+
+interface IStateLoaded {
+    loading: false;
+    agendas: Array<IAgenda>;
+}
+
+type IState = IStateLoading | IStateLoaded;
+
+export class AutopostIngestRulePreview extends React.PureComponent<IProps, IState> {
+    constructor(props: IProps) {
+        super(props);
+
+        this.state = {
+            loading: true,
+        };
+
+    }
+
+    componentDidMount(): void {
+        superdesk.httpRequestJsonLocal<IRestApiResponse<IAgenda>>({
+            method: 'GET',
+            path: '/agenda',
+        }).then((res) => {
+            this.setState({
+                loading: false,
+                agendas: res._items,
+            });
+        })
+    }
+
     render() {
+        if (this.state.loading) {
+            return null;
+        }
+
+        const {agendas} = this.state;
+        const calendars = superdesk.entities.vocabulary.getAll().get('event_calendars').items;
         const {gettext} = superdesk.localization;
-        const resources: ILiveResourcesProps['resources'] = [
-            {resource: 'vocabularies', ids: ['event_calendars']},
-            {resource: 'agenda'},
-        ];
+
+        const calendarsNames: string = calendars
+            .filter((calendar) => (
+                (this.props.rule.actions.extra?.calendars ?? []).includes(calendar.qcode)
+            ))
+            .map((calendar) => getVocabularyItemFieldTranslated(
+                calendar,
+                'name',
+                getUserInterfaceLanguageFromCV()
+            ))
+            .join(', ');
+        const agendaNames: string = agendas
+            .filter((agenda) => (
+                (this.props.rule.actions.extra?.agendas ?? []).includes(agenda._id)
+            ))
+            .map((agenda) => agenda.name)
+            .join(', ');
 
         return (
-            <WithLiveResources resources={resources}>
-                {(resourcesResponse) => {
-                    const calendars = resourcesResponse[0] as IRestApiResponse<IVocabulary>;
-                    const agendas = resourcesResponse[1] as IRestApiResponse<IAgenda>;
-
-                    const calendarsNames: string = calendars._items[0].items
-                        .filter((calendar) => (
-                            (this.props.rule.actions.extra?.calendars ?? []).includes(calendar.qcode)
-                        ))
-                        .map((calendar) => getVocabularyItemFieldTranslated(
-                            calendar,
-                            'name',
-                            getUserInterfaceLanguageFromCV()
-                        ))
-                        .join(', ');
-                    const agendaNames: string = agendas._items
-                        .filter((agenda) => (
-                            (this.props.rule.actions.extra?.agendas ?? []).includes(agenda._id)
-                        ))
-                        .map((agenda) => agenda.name)
-                        .join(', ');
-
-                    return (
-                        <React.Fragment>
-                            <div className="list-row">
-                                <span className="text-label text-label--auto">
-                                    {gettext('Post Items')}:
-                                </span>
-                                <span className="list-row__item">
-                                    {this.props.rule.actions.extra?.autopost === true ?
-                                        gettext('On') :
-                                        gettext('Off')
-                                    }
-                                </span>
-                            </div>
-                            <div className="list-row">
-                                <span className="text-label text-label--auto">
-                                    {gettext('Agendas')}:
-                                </span>
-                                <span className="list-row__item">
-                                    {agendaNames}
-                                </span>
-                            </div>
-                            <div className="list-row">
-                                <span className="text-label text-label--auto">
-                                    {gettext('Calendars')}:
-                                </span>
-                                <span className="list-row__item">
-                                    {calendarsNames}
-                                </span>
-                            </div>
-                        </React.Fragment>
-                    );
-                }}
-            </WithLiveResources>
+            <React.Fragment>
+                <div className="list-row">
+                    <span className="text-label text-label--auto">
+                        {gettext('Post Items')}:
+                    </span>
+                    <span className="list-row__item">
+                        {this.props.rule.actions.extra?.autopost === true ?
+                            gettext('On') :
+                            gettext('Off')
+                        }
+                    </span>
+                </div>
+                <div className="list-row">
+                    <span className="text-label text-label--auto">
+                        {gettext('Agendas')}:
+                    </span>
+                    <span className="list-row__item">
+                        {agendaNames}
+                    </span>
+                </div>
+                <div className="list-row">
+                    <span className="text-label text-label--auto">
+                        {gettext('Calendars')}:
+                    </span>
+                    <span className="list-row__item">
+                        {calendarsNames}
+                    </span>
+                </div>
+            </React.Fragment>
         );
     }
 }

--- a/client/planning-extension/src/ingest_rule_autopost/AutopostIngestRulePreview.tsx
+++ b/client/planning-extension/src/ingest_rule_autopost/AutopostIngestRulePreview.tsx
@@ -30,7 +30,6 @@ export class AutopostIngestRulePreview extends React.PureComponent<IProps, IStat
         this.state = {
             loading: true,
         };
-
     }
 
     componentDidMount(): void {
@@ -42,7 +41,7 @@ export class AutopostIngestRulePreview extends React.PureComponent<IProps, IStat
                 loading: false,
                 agendas: res._items,
             });
-        })
+        });
     }
 
     render() {


### PR DESCRIPTION
SDESK-7432

The issue was that WithLiveResources component was used without IDs when it only supports usage with IDs. I've updated the code not to use it. I'll update the types on client-core so it wouldn't compile next time if someone tries to use it without IDs.

## Front-end checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [x] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [x] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [x] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [x] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [x] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [x] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [x] This pull request is not adding redux based modals
- [x] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [x] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)
