### PR TITLE
Show reassign on auto add to workflow, types cleanup

### DIFF
--- a/client/components/Coverages/CoverageArrayInput.tsx
+++ b/client/components/Coverages/CoverageArrayInput.tsx
@@ -105,7 +105,7 @@ const mapStateToProps = (state) => ({
 
 const mapDispatchToProps = (dispatch) => ({
     onRemoveAssignment: (assignment) => dispatch(actions.assignments.ui.showRemoveAssignmentModal(assignment)),
-})
+});
 
 class CoverageArrayInputComponent extends React.Component<IProps, IState> {
     constructor(props) {

--- a/client/components/Coverages/CoverageArrayInput.tsx
+++ b/client/components/Coverages/CoverageArrayInput.tsx
@@ -4,6 +4,7 @@ import {isEmpty} from 'lodash';
 
 import {
     EDITOR_TYPE,
+    IAssignmentItem,
     IAssignmentPriority,
     ICoverageFormProfile,
     ICoverageProvider, ICoverageScheduledUpdate, IEventItem, IFile,
@@ -22,6 +23,7 @@ import * as selectors from '../../selectors';
 import {InputArray} from '../UI/Form';
 import {CoverageEditor} from './CoverageEditor';
 import {CoverageAddButton} from './CoverageAddButton';
+import * as actions from '../../actions';
 
 
 interface IProps {
@@ -78,12 +80,7 @@ interface IProps {
         scheduledUpdate?: ICoverageScheduledUpdate,
         scheduledUpdateIndex?: number
     ): void;
-    onRemoveAssignment(
-        coverage: IPlanningCoverageItem,
-        index: number,
-        scheduledUpdate?: ICoverageScheduledUpdate,
-        scheduledUpdateIndex?: number
-    ): void;
+    onRemoveAssignment(assignemnt: IAssignmentItem): Promise<void>;
     uploadFiles(files: Array<Array<File>>): Promise<Array<IFile>>;
     notifyValidationErrors(errors: Array<string>): void;
 }
@@ -105,6 +102,10 @@ const mapStateToProps = (state) => ({
     coverageAddAdvancedMode: selectors.general.coverageAddAdvancedMode(state),
     defaultDesk: selectors.general.defaultDesk(state),
 });
+
+const mapDispatchToProps = (dispatch) => ({
+    onRemoveAssignment: (assignment) => dispatch(actions.assignments.ui.showRemoveAssignmentModal(assignment)),
+})
 
 class CoverageArrayInputComponent extends React.Component<IProps, IState> {
     constructor(props) {
@@ -214,6 +215,7 @@ class CoverageArrayInputComponent extends React.Component<IProps, IState> {
                 onChange={onChange}
                 addButtonText={addButtonText}
                 addButtonComponent={CoverageAddButton}
+                onRemoveAssignment={this.props.onRemoveAssignment}
                 addButtonProps={{
                     contentTypes,
                     defaultDesk,
@@ -260,4 +262,4 @@ class CoverageArrayInputComponent extends React.Component<IProps, IState> {
     }
 }
 
-export const CoverageArrayInput = connect(mapStateToProps)(CoverageArrayInputComponent);
+export const CoverageArrayInput = connect(mapStateToProps, mapDispatchToProps)(CoverageArrayInputComponent);

--- a/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx
+++ b/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx
@@ -25,7 +25,7 @@ interface IProps {
     addNewsItemToPlanning?: IArticle;
     onChange(field: string, value: any): void;
     onFocus?(): void;
-    onRemoveAssignment?(): void;
+    onRemoveAssignment?(): Promise<void>;
     setCoverageDefaultDesk(coverage: IPlanningCoverageItem | ICoverageScheduledUpdate): void;
     showEditCoverageAssignmentModal(props: {
         field: string;
@@ -76,14 +76,14 @@ export class CoverageFormHeaderComponent extends React.PureComponent<IProps> {
         } = this.props;
 
         const userAssigned = getCreator(value, 'assigned_to.user', users);
-        const deskAssigned = getItemInArrayById(desks, value.assigned_to.desk);
-        const coverageProvider = value.assigned_to.coverage_provider;
-        const assignmentState = value.assigned_to.state;
+        const deskAssigned = getItemInArrayById(desks, value.assigned_to?.desk);
+        const coverageProvider = value.assigned_to?.coverage_provider;
+        const assignmentState = value.assigned_to?.state;
         const cancelled = value.workflow_status === ASSIGNMENTS.WORKFLOW_STATE.CANCELLED;
         const canEditAssignment = planningUtils.isCoverageDraft(value) ||
             (!!addNewsItemToPlanning && !value.coverage_id && !get(value, 'scheduled_update_id'));
-        const shouldShowRemove = (onRemoveAssignment != null
-            && planningConfig.planning_auto_assign_to_workflow === false);
+
+        const autoAddToWf = true;
 
         if (!deskAssigned && (!userAssigned || !coverageProvider)) {
             return (
@@ -174,7 +174,7 @@ export class CoverageFormHeaderComponent extends React.PureComponent<IProps> {
                         </ListRow>
                     )}
                 </Column>
-                {(canEditAssignment || planningConfig.planning_auto_assign_to_workflow) && !readOnly && (
+                {(canEditAssignment || autoAddToWf) && !readOnly && (
                     <Column>
                         <ListRow>
                             <Button
@@ -187,12 +187,14 @@ export class CoverageFormHeaderComponent extends React.PureComponent<IProps> {
                                 autoFocus
                             />
                         </ListRow>
-                        {shouldShowRemove && (
+                        {onRemoveAssignment != null && (
                             <ListRow>
                                 <Button
                                     text={gettext('Remove')}
                                     className="btn btn--hollow btn--small"
-                                    onClick={onRemoveAssignment}
+                                    onClick={() => {
+                                        onRemoveAssignment();
+                                    }}
                                     tabIndex={0}
                                     enterKeyIsClick
                                     disabled={!!addNewsItemToPlanning}

--- a/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx
+++ b/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx
@@ -93,7 +93,7 @@ export class CoverageFormHeaderComponent extends React.PureComponent<IProps> {
         */
         const canEditAssignment = addNewsItemToPlanning == null
             && !((value as ICoverageScheduledUpdate).scheduled_update_id);
-        const isAssignmentLocked = lockedItems?.assignment && value.assigned_to.assignment_id in lockedItems.assignment;
+        const isAssignmentLocked = lockedItems?.assignment && value.assigned_to?.assignment_id in lockedItems.assignment;
 
         if (!deskAssigned && (!userAssigned || !coverageProvider)) {
             return (

--- a/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx
+++ b/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx
@@ -81,7 +81,7 @@ export class CoverageFormHeaderComponent extends React.PureComponent<IProps> {
         const assignmentState = value.assigned_to?.state;
         const cancelled = value.workflow_status === ASSIGNMENTS.WORKFLOW_STATE.CANCELLED;
         const canEditAssignment = planningUtils.isCoverageDraft(value) ||
-            (!!addNewsItemToPlanning && !value.coverage_id && !get(value, 'scheduled_update_id'));
+            (!!addNewsItemToPlanning && !value.coverage_id && !((value as ICoverageScheduledUpdate).scheduled_update_id));
 
         if (!deskAssigned && (!userAssigned || !coverageProvider)) {
             return (
@@ -185,7 +185,7 @@ export class CoverageFormHeaderComponent extends React.PureComponent<IProps> {
                                 autoFocus
                             />
                         </ListRow>
-                        {onRemoveAssignment != null && (
+                        {onRemoveAssignment != null && value.assigned_to.assignment_id != null && (
                             <ListRow>
                                 <Button
                                     text={gettext('Remove')}

--- a/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx
+++ b/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx
@@ -91,7 +91,8 @@ export class CoverageFormHeaderComponent extends React.PureComponent<IProps> {
             1. This view is rendered from AddToPlanning action
             2. There's an already scheduled update for the coverage
         */
-        const isAssignmentLocked = lockedItems?.assignment && value.assigned_to?.assignment_id in lockedItems.assignment;
+        const isAssignmentLocked = lockedItems?.assignment
+            && value.assigned_to?.assignment_id in lockedItems.assignment;
         const canEditAssignment = addNewsItemToPlanning == null && !isAssignmentLocked
             && !((value as ICoverageScheduledUpdate).scheduled_update_id);
 
@@ -194,18 +195,18 @@ export class CoverageFormHeaderComponent extends React.PureComponent<IProps> {
                             />
                         </ListRow>
                         {onRemoveAssignment != null && (
-                                <ListRow>
-                                    <Button
-                                        text={gettext('Remove')}
-                                        onClick={() => {
-                                            onRemoveAssignment();
-                                        }}
-                                        style="hollow"
-                                        size="small"
-                                        expand
-                                    />
-                                </ListRow>
-                            )}
+                            <ListRow>
+                                <Button
+                                    text={gettext('Remove')}
+                                    onClick={() => {
+                                        onRemoveAssignment();
+                                    }}
+                                    style="hollow"
+                                    size="small"
+                                    expand
+                                />
+                            </ListRow>
+                        )}
                     </Column>
                 )}
             </Item>

--- a/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx
+++ b/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx
@@ -82,7 +82,8 @@ export class CoverageFormHeaderComponent extends React.PureComponent<IProps> {
         const cancelled = value.workflow_status === ASSIGNMENTS.WORKFLOW_STATE.CANCELLED;
         const canEditAssignment = planningUtils.isCoverageDraft(value) ||
             (!!addNewsItemToPlanning && !value.coverage_id && !get(value, 'scheduled_update_id'));
-        const shouldShowRemove = (onRemoveAssignment != null && planningConfig.planning_auto_assign_to_workflow === false);
+        const shouldShowRemove = (onRemoveAssignment != null
+            && planningConfig.planning_auto_assign_to_workflow === false);
 
         if (!deskAssigned && (!userAssigned || !coverageProvider)) {
             return (

--- a/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx
+++ b/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {connect} from 'react-redux';
 import {get} from 'lodash';
 
-import {IPlanningCoverageItem, ICoverageScheduledUpdate} from '../../../interfaces';
+import {IPlanningCoverageItem, ICoverageScheduledUpdate, IPlanningConfig} from '../../../interfaces';
 import {IArticle, IDesk, IUser} from 'superdesk-api';
 
 import {getCreator, getItemInArrayById, gettext, planningUtils, onEventCapture} from '../../../utils';
@@ -11,6 +11,10 @@ import {Button} from '../../UI';
 import {UserAvatar} from '../../../components/UserAvatar';
 import {StateLabel} from '../../StateLabel';
 import * as actions from '../../../actions';
+import {appConfig} from 'superdesk-core/scripts/appConfig';
+import {ASSIGNMENTS} from '../../../constants/assignments';
+
+const planningConfig: IPlanningConfig = appConfig as IPlanningConfig;
 
 interface IProps {
     field: string;
@@ -72,12 +76,13 @@ export class CoverageFormHeaderComponent extends React.PureComponent<IProps> {
         } = this.props;
 
         const userAssigned = getCreator(value, 'assigned_to.user', users);
-        const deskAssigned = getItemInArrayById(desks, get(value, 'assigned_to.desk'));
-        const coverageProvider = get(value, 'assigned_to.coverage_provider');
-        const assignmentState = get(value, 'assigned_to.state');
-        const cancelled = get(value, 'workflow_status') === 'cancelled';
+        const deskAssigned = getItemInArrayById(desks, value.assigned_to.desk);
+        const coverageProvider = value.assigned_to.coverage_provider;
+        const assignmentState = value.assigned_to.state;
+        const cancelled = value.workflow_status === ASSIGNMENTS.WORKFLOW_STATE.CANCELLED;
         const canEditAssignment = planningUtils.isCoverageDraft(value) ||
-            (!!addNewsItemToPlanning && !get(value, 'coverage_id') && !get(value, 'scheduled_update_id'));
+            (!!addNewsItemToPlanning && !value.coverage_id && !get(value, 'scheduled_update_id'));
+        const shouldShowRemove = (onRemoveAssignment != null && planningConfig.planning_auto_assign_to_workflow === false);
 
         if (!deskAssigned && (!userAssigned || !coverageProvider)) {
             return (
@@ -130,7 +135,7 @@ export class CoverageFormHeaderComponent extends React.PureComponent<IProps> {
                             <span className="sd-list-item__text-label sd-list-item__text-label--normal">
                                 {gettext('Desk:')}
                             </span>
-                            <span name={`${field}.assigned_to.desk`}>
+                            <span key={`${field}.assigned_to.desk`}>
                                 {get(deskAssigned, 'name', '')}
                             </span>
                         </span>
@@ -141,7 +146,7 @@ export class CoverageFormHeaderComponent extends React.PureComponent<IProps> {
                                 <span className="sd-list-item__text-label sd-list-item__text-label--normal">
                                     {gettext('Assignee:')}
                                 </span>
-                                <span name={`${field}.assigned_to.user`}>
+                                <span key={`${field}.assigned_to.user`}>
                                     {get(userAssigned, 'display_name', '')}
                                 </span>
                             </span>
@@ -168,7 +173,7 @@ export class CoverageFormHeaderComponent extends React.PureComponent<IProps> {
                         </ListRow>
                     )}
                 </Column>
-                {canEditAssignment && !readOnly && (
+                {(canEditAssignment || planningConfig.planning_auto_assign_to_workflow) && !readOnly && (
                     <Column>
                         <ListRow>
                             <Button
@@ -181,7 +186,7 @@ export class CoverageFormHeaderComponent extends React.PureComponent<IProps> {
                                 autoFocus
                             />
                         </ListRow>
-                        {!onRemoveAssignment ? null : (
+                        {shouldShowRemove && (
                             <ListRow>
                                 <Button
                                     text={gettext('Remove')}

--- a/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx
+++ b/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx
@@ -91,9 +91,9 @@ export class CoverageFormHeaderComponent extends React.PureComponent<IProps> {
             1. This view is rendered from AddToPlanning action
             2. There's an already scheduled update for the coverage
         */
-        const canEditAssignment = addNewsItemToPlanning == null
-            && !((value as ICoverageScheduledUpdate).scheduled_update_id);
         const isAssignmentLocked = lockedItems?.assignment && value.assigned_to?.assignment_id in lockedItems.assignment;
+        const canEditAssignment = addNewsItemToPlanning == null && !isAssignmentLocked
+            && !((value as ICoverageScheduledUpdate).scheduled_update_id);
 
         if (!deskAssigned && (!userAssigned || !coverageProvider)) {
             return (
@@ -193,10 +193,7 @@ export class CoverageFormHeaderComponent extends React.PureComponent<IProps> {
                                 expand
                             />
                         </ListRow>
-                        {onRemoveAssignment != null
-                            && !isAssignmentLocked
-                            && !planningUtils.isCoverageDraft(value)
-                            && (
+                        {onRemoveAssignment != null && (
                                 <ListRow>
                                     <Button
                                         text={gettext('Remove')}

--- a/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx
+++ b/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx
@@ -80,8 +80,11 @@ export class CoverageFormHeaderComponent extends React.PureComponent<IProps> {
         const coverageProvider = value.assigned_to?.coverage_provider;
         const assignmentState = value.assigned_to?.state;
         const cancelled = value.workflow_status === ASSIGNMENTS.WORKFLOW_STATE.CANCELLED;
-        const canEditAssignment = planningUtils.isCoverageDraft(value) ||
-            (!!addNewsItemToPlanning && !value.coverage_id && !((value as ICoverageScheduledUpdate).scheduled_update_id));
+        const canEditAssignment = planningUtils.isCoverageDraft(value) || (
+            !!addNewsItemToPlanning
+            && !value.coverage_id
+            && !((value as ICoverageScheduledUpdate).scheduled_update_id)
+        );
 
         if (!deskAssigned && (!userAssigned || !coverageProvider)) {
             return (

--- a/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx
+++ b/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx
@@ -2,19 +2,18 @@ import React from 'react';
 import {connect} from 'react-redux';
 import {get} from 'lodash';
 
-import {IPlanningCoverageItem, ICoverageScheduledUpdate, IPlanningConfig} from '../../../interfaces';
+import {IPlanningCoverageItem, ICoverageScheduledUpdate, ILockedItems} from '../../../interfaces';
 import {IArticle, IDesk, IUser} from 'superdesk-api';
 
-import {getCreator, getItemInArrayById, gettext, planningUtils, onEventCapture} from '../../../utils';
+import {getCreator, getItemInArrayById, gettext, onEventCapture} from '../../../utils';
 import {Item, Border, Column, Row as ListRow} from '../../UI/List';
-import {Button} from '../../UI';
 import {UserAvatar} from '../../../components/UserAvatar';
 import {StateLabel} from '../../StateLabel';
 import * as actions from '../../../actions';
-import {appConfig} from 'superdesk-core/scripts/appConfig';
 import {ASSIGNMENTS} from '../../../constants/assignments';
-
-const planningConfig: IPlanningConfig = appConfig as IPlanningConfig;
+import * as selectors from '../../../selectors';
+import {planningUtils} from '../../../utils';
+import {Button} from 'superdesk-ui-framework/react';
 
 interface IProps {
     field: string;
@@ -36,12 +35,17 @@ interface IProps {
         onChange(field: string, value: any): void;
         setCoverageDefaultDesk(coverage: IPlanningCoverageItem | ICoverageScheduledUpdate): void;
     }): void;
+    lockedItems: ILockedItems;
 }
 
 const mapDispatchToProps = (dispatch) => ({
     showEditCoverageAssignmentModal: (props) => dispatch(
         actions.assignments.ui.showEditCoverageAssignmentModal(props)
     ),
+});
+
+const mapStateToProps = (state) => ({
+    lockedItems: selectors.locks.getLockedItems(state),
 });
 
 export class CoverageFormHeaderComponent extends React.PureComponent<IProps> {
@@ -73,6 +77,7 @@ export class CoverageFormHeaderComponent extends React.PureComponent<IProps> {
             addNewsItemToPlanning,
             onRemoveAssignment,
             readOnly,
+            lockedItems,
         } = this.props;
 
         const userAssigned = getCreator(value, 'assigned_to.user', users);
@@ -80,11 +85,15 @@ export class CoverageFormHeaderComponent extends React.PureComponent<IProps> {
         const coverageProvider = value.assigned_to?.coverage_provider;
         const assignmentState = value.assigned_to?.state;
         const cancelled = value.workflow_status === ASSIGNMENTS.WORKFLOW_STATE.CANCELLED;
-        const canEditAssignment = planningUtils.isCoverageDraft(value) || (
-            !!addNewsItemToPlanning
-            && !value.coverage_id
-            && !((value as ICoverageScheduledUpdate).scheduled_update_id)
-        );
+
+        /*
+            Check if:
+            1. This view is rendered from AddToPlanning action
+            2. There's an already scheduled update for the coverage
+        */
+        const canEditAssignment = addNewsItemToPlanning == null
+            && !((value as ICoverageScheduledUpdate).scheduled_update_id);
+        const isAssignmentLocked = lockedItems?.assignment && value.assigned_to.assignment_id in lockedItems.assignment;
 
         if (!deskAssigned && (!userAssigned || !coverageProvider)) {
             return (
@@ -109,11 +118,9 @@ export class CoverageFormHeaderComponent extends React.PureComponent<IProps> {
                                 <Button
                                     id="editAssignment"
                                     text={gettext('Assign')}
-                                    tabIndex={0}
-                                    enterKeyIsClick
-                                    className="btn btn--primary btn--small"
                                     onClick={this.showAssignmentModal}
-                                    autoFocus
+                                    size="small"
+                                    type="primary"
                                 />
                             </ListRow>
                         )}
@@ -175,34 +182,33 @@ export class CoverageFormHeaderComponent extends React.PureComponent<IProps> {
                         </ListRow>
                     )}
                 </Column>
-                {(canEditAssignment || planningConfig.planning_auto_assign_to_workflow) && !readOnly && (
+                {canEditAssignment && !readOnly && (
                     <Column>
                         <ListRow>
                             <Button
                                 text={gettext('Reassign')}
-                                className="btn btn--hollow btn--small"
                                 onClick={this.showAssignmentModal}
-                                tabIndex={0}
-                                enterKeyIsClick
-                                disabled={!!addNewsItemToPlanning}
-                                autoFocus
+                                style="hollow"
+                                size="small"
+                                expand
                             />
                         </ListRow>
-                        {onRemoveAssignment != null && value.assigned_to.assignment_id != null && (
-                            <ListRow>
-                                <Button
-                                    text={gettext('Remove')}
-                                    className="btn btn--hollow btn--small"
-                                    onClick={() => {
-                                        onRemoveAssignment();
-                                    }}
-                                    tabIndex={0}
-                                    enterKeyIsClick
-                                    disabled={!!addNewsItemToPlanning}
-                                    autoFocus
-                                />
-                            </ListRow>
-                        )}
+                        {onRemoveAssignment != null
+                            && !isAssignmentLocked
+                            && !planningUtils.isCoverageDraft(value)
+                            && (
+                                <ListRow>
+                                    <Button
+                                        text={gettext('Remove')}
+                                        onClick={() => {
+                                            onRemoveAssignment();
+                                        }}
+                                        style="hollow"
+                                        size="small"
+                                        expand
+                                    />
+                                </ListRow>
+                            )}
                     </Column>
                 )}
             </Item>
@@ -211,6 +217,6 @@ export class CoverageFormHeaderComponent extends React.PureComponent<IProps> {
 }
 
 export const CoverageFormHeader = connect(
-    null,
+    mapStateToProps,
     mapDispatchToProps
 )(CoverageFormHeaderComponent);

--- a/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx
+++ b/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx
@@ -83,8 +83,6 @@ export class CoverageFormHeaderComponent extends React.PureComponent<IProps> {
         const canEditAssignment = planningUtils.isCoverageDraft(value) ||
             (!!addNewsItemToPlanning && !value.coverage_id && !get(value, 'scheduled_update_id'));
 
-        const autoAddToWf = true;
-
         if (!deskAssigned && (!userAssigned || !coverageProvider)) {
             return (
                 <Item noBg={true} noHover={true}>
@@ -174,7 +172,7 @@ export class CoverageFormHeaderComponent extends React.PureComponent<IProps> {
                         </ListRow>
                     )}
                 </Column>
-                {(canEditAssignment || autoAddToWf) && !readOnly && (
+                {(canEditAssignment || planningConfig.planning_auto_assign_to_workflow) && !readOnly && (
                     <Column>
                         <ListRow>
                             <Button

--- a/client/components/Coverages/CoverageEditor/index.tsx
+++ b/client/components/Coverages/CoverageEditor/index.tsx
@@ -56,7 +56,7 @@ interface IProps {
     onDuplicateCoverage(coverage: DeepPartial<IPlanningCoverageItem>, duplicateAs?: IG2ContentType['qcode']): void;
     onCancelCoverage?(): void;
     onAddCoverageToWorkflow?(): void;
-    onRemoveAssignment?(): void;
+    onRemoveAssignment?(coverage: IPlanningCoverageItem): void;
     popupContainer(): void;
     setCoverageDefaultDesk(): void;
     onPopupOpen(): void;

--- a/client/components/UI/Button.tsx
+++ b/client/components/UI/Button.tsx
@@ -1,41 +1,60 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import {KEYCODES} from './constants';
 import {onEventCapture} from './utils';
 
 
-/**
- * @ngdoc react
- * @name Button
- * @description Generic Button component
- */
+interface IButtonProps {
+    id?: string;
+    className?: string;
+    onClick: (...args: any) => any;
+    icon?: string;
+    title?: string;
+    text?: string;
+    disabled?: boolean;
+    textOnly?: boolean;
+    hollow?: boolean;
+    iconOnly?: boolean;
+    expanded?: boolean;
+    color?: 'primary' | 'success' | 'warning' | 'alert' | 'highlight' | 'sd-green' | 'ui-dark' | 'default';
+    size?: 'small' | 'large';
+    tabIndex?: number;
+    enterKeyIsClick?: boolean;
+    autoFocus?: boolean;
+    onKeyDown?: (e: React.KeyboardEvent) => any;
+    refNode?: (...args: any) => any;
+    iconOnlyCircle?: boolean;
+    children?: React.ReactNode;
+    pullRight?: boolean;
+    empty?: boolean;
+}
+
 const Button = ({
+    disabled = false,
+    textOnly = false,
+    hollow = false,
+    expanded = false,
+    enterKeyIsClick = false,
+    autoFocus = false,
+    iconOnlyCircle = false,
+    pullRight = false,
+    empty = false,
     className,
     onClick,
     icon,
     id,
     title,
     text,
-    disabled,
-    textOnly,
-    hollow,
-    expanded,
     color,
     size,
     iconOnly,
     tabIndex,
-    enterKeyIsClick,
-    autoFocus,
     refNode,
     onKeyDown,
-    iconOnlyCircle,
     children,
-    pullRight,
-    empty,
     ...props
-}) => {
+}: IButtonProps) => {
     const handeKeyDown = (event) => {
         if (event.keyCode === KEYCODES.ENTER) {
             onEventCapture(event);
@@ -80,44 +99,6 @@ const Button = ({
             {children}
         </button>
     );
-};
-
-Button.propTypes = {
-    id: PropTypes.string,
-    className: PropTypes.string,
-    onClick: PropTypes.func.isRequired,
-    icon: PropTypes.string,
-    title: PropTypes.string,
-    text: PropTypes.string,
-    disabled: PropTypes.bool,
-    textOnly: PropTypes.bool,
-    hollow: PropTypes.bool,
-    iconOnly: PropTypes.bool,
-    expanded: PropTypes.bool,
-    color: PropTypes.oneOf(['primary', 'success', 'warning', 'alert', 'highlight', 'sd-green', 'ui-dark', 'default']),
-    size: PropTypes.oneOf(['small', 'large']),
-    tabIndex: PropTypes.number,
-    enterKeyIsClick: PropTypes.bool,
-    autoFocus: PropTypes.bool,
-    onKeyDown: PropTypes.func,
-    refNode: PropTypes.func,
-    iconOnlyCircle: PropTypes.bool,
-    children: PropTypes.node,
-    pullRight: PropTypes.bool,
-    empty: PropTypes.bool,
-};
-
-Button.defaultProps = {
-    disabled: false,
-    textOnly: false,
-    hollow: false,
-    iconOnly: false,
-    expanded: false,
-    enterKeyIsClick: false,
-    autoFocus: false,
-    iconOnlyCircle: false,
-    pullRight: false,
-    empty: false,
 };
 
 export default Button;

--- a/client/components/UI/Form/InputArray/index.tsx
+++ b/client/components/UI/Form/InputArray/index.tsx
@@ -7,6 +7,9 @@ import {Button} from '../../';
 import {Row, LineInput} from '../';
 import './style.scss';
 import {superdeskApi} from '../../../../superdeskApi';
+import {planningApis} from '../../../../api';
+import {EDITOR_TYPE, IAssignmentItem, IG2ContentType, IPlanningCoverageItem, IPlanningNewsCoverageStatus} from 'interfaces';
+import {IDesk} from 'superdesk-api';
 
 interface IProps {
     field: string;
@@ -18,7 +21,7 @@ interface IProps {
     maxCount: number;
     addOnly: boolean;
     originalCount: number;
-    element: React.ComponentClass;
+    element: React.ComponentClass<any>;
     defaultElement: any;
     readOnly: boolean;
     message: any;
@@ -37,8 +40,19 @@ interface IProps {
     errors: {[key: string]: any};
     showErrors: boolean;
     testId?: string;
-
+    onRemoveAssignment: (assignment: IAssignmentItem) => Promise<void>;
     getRef?(field: string, value: any): React.RefObject<any>;
+    popupContainer(): HTMLElement;
+    onPopupOpen(): void;
+    onPopupClose(): void;
+    setCoverageDefaultDesk(coverage: IPlanningCoverageItem): void;
+    contentTypes: Array<IG2ContentType>;
+    defaultDesk: IDesk;
+    newsCoverageStatus: Array<IPlanningNewsCoverageStatus>;
+    navigation: any;
+    openCoverageIds: Array<string>;
+    preferredCoverageDesks: {[key: string]: string};
+    editorType: EDITOR_TYPE;
 }
 
 export class InputArray extends React.PureComponent<IProps> {
@@ -153,6 +167,11 @@ export class InputArray extends React.PureComponent<IProps> {
                 {(value || []).map((val, index) => (
                     <Component
                         {...props}
+                        onRemoveAssignment={(val) => {
+                            return planningApis.assignments.getById(val.assigned_to.assignment_id).then((assignment) =>
+                                this.props.onRemoveAssignment(assignment)
+                            );
+                        }}
                         key={index}
                         ref={this.props.getRef == null ? null : this.props.getRef(field, val)}
                         testId={`${testId}[${index}]`}

--- a/client/components/UI/Form/InputArray/index.tsx
+++ b/client/components/UI/Form/InputArray/index.tsx
@@ -8,7 +8,13 @@ import {Row, LineInput} from '../';
 import './style.scss';
 import {superdeskApi} from '../../../../superdeskApi';
 import {planningApis} from '../../../../api';
-import {EDITOR_TYPE, IAssignmentItem, IG2ContentType, IPlanningCoverageItem, IPlanningNewsCoverageStatus} from 'interfaces';
+import {
+    EDITOR_TYPE,
+    IAssignmentItem,
+    IG2ContentType,
+    IPlanningCoverageItem,
+    IPlanningNewsCoverageStatus,
+} from 'interfaces';
 import {IDesk} from 'superdesk-api';
 
 interface IProps {
@@ -167,11 +173,10 @@ export class InputArray extends React.PureComponent<IProps> {
                 {(value || []).map((val, index) => (
                     <Component
                         {...props}
-                        onRemoveAssignment={(val) => {
-                            return planningApis.assignments.getById(val.assigned_to.assignment_id).then((assignment) =>
-                                this.props.onRemoveAssignment(assignment)
-                            );
-                        }}
+                        onRemoveAssignment={(val) =>
+                            planningApis.assignments.getById(val.assigned_to.assignment_id)
+                                .then((assignment) => this.props.onRemoveAssignment(assignment))
+                        }
                         key={index}
                         ref={this.props.getRef == null ? null : this.props.getRef(field, val)}
                         testId={`${testId}[${index}]`}

--- a/client/components/UI/List/Row.tsx
+++ b/client/components/UI/List/Row.tsx
@@ -1,5 +1,4 @@
 import React, {CSSProperties} from 'react';
-import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 interface IProps {

--- a/client/utils/index.ts
+++ b/client/utils/index.ts
@@ -11,9 +11,9 @@ import {
     IPlanningCoverageItem,
     IIngestProvider,
     IFeaturedPlanningItem,
-    ISearchParams,
     ICommonSearchParams,
     JUMP_INTERVAL,
+    ICoverageScheduledUpdate,
 } from '../interfaces';
 import {IUser} from 'superdesk-api';
 import {superdeskApi} from '../superdeskApi';
@@ -288,7 +288,7 @@ export const notifyError = (notify, error, defaultMessage) => {
  * @return {object} The user object found or ingest provider id, otherwise nothing is returned
  */
 export function getCreator(
-    item: IEventOrPlanningItem | IPlanningCoverageItem | IFeaturedPlanningItem,
+    item: IEventOrPlanningItem | IPlanningCoverageItem | IFeaturedPlanningItem | ICoverageScheduledUpdate,
     creator: string,
     users: Array<IUser>
 ): IUser | IIngestProvider['id'] | undefined {


### PR DESCRIPTION
SDCP-863

## Front-end checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [x] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [x] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [x] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [x] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [x] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [x] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [x] This pull request is not adding redux based modals
- [x] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [x] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)
