### PR TITLE
Planning: provide a visual solution for smaller screens to show the additional link action in the header of the list views

### DIFF
--- a/client/components/MultiSelectActions.tsx
+++ b/client/components/MultiSelectActions.tsx
@@ -6,8 +6,8 @@ import {every} from 'lodash';
 import {eventUtils, planningUtils, gettext} from '../utils';
 import {MAIN} from '../constants';
 import {SlidingToolBar} from './UI/SubNav';
-import {Button} from './UI';
 import {IEventItem, ILockedItems, IPlanningItem, IPrivileges, ISession} from 'interfaces';
+import {IconButton} from 'superdesk-ui-framework';
 
 interface IReduxState {
     selectedEvents: Array<any>;
@@ -119,48 +119,46 @@ export class MultiSelectActionsComponent extends React.PureComponent<IProps> {
 
         if (selectedPlannings.every((planning) => planning.lock_action == null)) {
             tools.push(
-                <Button
+                <IconButton
                     key={0}
-                    hollow={true}
+                    icon="assign"
+                    ariaValue={gettext('Add to workflow')}
                     onClick={() => {
                         this.props.addToWorkflow(this.getItemList());
                     }}
-                    text={gettext('Add to workflow')}
                 />
             );
         }
+
         if (showExport) {
             tools.push(
-                <Button
+                <IconButton
                     key={1}
-                    hollow={true}
+                    icon="upload"
+                    ariaValue={gettext('Export')}
                     onClick={this.exportArticle}
-                    text={gettext('Export')}
                 />
             );
         }
 
         if (showSpike) {
             tools.push(
-                <Button
+                <IconButton
                     key={2}
+                    icon="trash"
+                    ariaValue={gettext('Spike')}
                     onClick={this.itemSpike}
-                    color="alert"
-                    hollow={true}
-                    text={gettext('Spike')}
-                    icon="icon-trash"
                 />
             );
         }
 
         if (showUnspike) {
             tools.push(
-                <Button
+                <IconButton
                     key={3}
+                    icon="unspike"
+                    ariaValue={gettext('Unspike')}
                     onClick={this.itemUnSpike}
-                    color="warning"
-                    icon="icon-unspike"
-                    text={gettext('Unspike')}
                 />
             );
         }
@@ -192,53 +190,50 @@ export class MultiSelectActionsComponent extends React.PureComponent<IProps> {
         );
 
         let tools = [(
-            <Button
+            <IconButton
                 key={0}
+                icon="upload"
+                ariaValue={gettext('Export')}
                 onClick={this.exportArticle}
-                hollow
-                text={gettext('Export')}
             />
         ), (
-            <Button
+            <IconButton
                 key={1}
+                icon="download"
+                ariaValue={gettext('Download')}
                 onClick={this.exportArticle.bind(null, true)}
-                color="primary"
-                text={gettext('Download')}
             />
         )];
 
         if (showCreatePlan) {
             tools.push(
-                <Button
+                <IconButton
                     key={2}
+                    icon="calendar"
+                    ariaValue={gettext('Create planning')}
                     onClick={this.createPlanning}
-                    color="primary"
-                    text={gettext('Create planning')}
                 />
             );
         }
 
         if (showSpike) {
             tools.push(
-                <Button
+                <IconButton
                     key={3}
+                    icon="trash"
+                    ariaValue={gettext('Spike')}
                     onClick={this.itemSpike}
-                    color="alert"
-                    hollow={true}
-                    text={gettext('Spike')}
-                    icon="icon-trash"
                 />
             );
         }
 
         if (showUnspike) {
             tools.push(
-                <Button
+                <IconButton
                     key={4}
+                    icon="unspike"
+                    ariaValue={gettext('Unspike')}
                     onClick={this.itemUnSpike}
-                    color="warning"
-                    text={gettext('Unspike')}
-                    icon="icon-unspike"
                 />
             );
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -267,9 +267,9 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "2.6.3",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-          "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
           "dev": true
         }
       }
@@ -330,15 +330,6 @@
       "requires": {
         "@types/cheerio": "*",
         "@types/react": "*"
-      }
-    },
-    "@types/enzyme-adapter-react-16": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@types/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.0.9.tgz",
-      "integrity": "sha512-z24MMxGtUL8HhXdye3tWzjp+19QTsABqLaX2oOZpxMPHRJgLfahQmOeTTrEBQd9ogW20+UmPBXD9j+XOasFHvw==",
-      "dev": true,
-      "requires": {
-        "@types/enzyme": "*"
       }
     },
     "@types/hoist-non-react-statics": {
@@ -12250,7 +12241,7 @@
         "sass-loader": "6.0.6",
         "shortid": "2.2.8",
         "style-loader": "0.20.2",
-        "superdesk-ui-framework": "^3.1.21",
+        "superdesk-ui-framework": "^3.1.28",
         "ts-loader": "3.5.0",
         "typescript": "4.9.5",
         "uuid": "8.3.1",
@@ -12263,12 +12254,6 @@
           "version": "4.14.117",
           "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.117.tgz",
           "integrity": "sha512-xyf2m6tRbz8qQKcxYZa7PA4SllYcay+eh25DN3jmNYY6gSTL7Htc/bttVdkqj2wfJGbeWlQiX8pIyJpKU+tubw==",
-          "dev": true
-        },
-        "@types/node": {
-          "version": "14.18.63",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
-          "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
           "dev": true
         },
         "classnames": {
@@ -12340,22 +12325,17 @@
           }
         },
         "superdesk-ui-framework": {
-          "version": "3.1.21",
-          "resolved": "https://registry.npmjs.org/superdesk-ui-framework/-/superdesk-ui-framework-3.1.21.tgz",
-          "integrity": "sha512-+o9MwlATifWK+f+8Lq61GOjgQ5sFsIqj//6lk3DEN2QvDsnm7B7ZQGJGK+74lNe/X/HMUQzaxLc1vPbw7GjUfg==",
+          "version": "3.1.29",
+          "resolved": "https://registry.npmjs.org/superdesk-ui-framework/-/superdesk-ui-framework-3.1.29.tgz",
+          "integrity": "sha512-Dowv3C7+0i3uzqTKwZONSdbvhrRkzesNw6laaJQ80IcuJT7/15VPNspcWK9+eYZQTn3nGJwJZpwdj1i37nLUtA==",
           "dev": true,
           "requires": {
             "@popperjs/core": "^2.4.0",
             "@superdesk/common": "0.0.28",
             "@superdesk/primereact": "^5.0.2-12",
             "@superdesk/react-resizable-panels": "0.0.39",
-            "@types/enzyme-adapter-react-16": "^1.0.6",
-            "@types/node": "^14.10.2",
             "chart.js": "^2.9.3",
             "date-fns": "2.7.0",
-            "enzyme": "^3.11.0",
-            "enzyme-adapter-react-16": "^1.15.7",
-            "moment": "^2.29.3",
             "popper-max-size-modifier": "^0.2.0",
             "popper.js": "1.14.4",
             "primeicons": "2.0.0",
@@ -12389,22 +12369,17 @@
       }
     },
     "superdesk-ui-framework": {
-      "version": "3.1.15",
-      "resolved": "https://registry.npmjs.org/superdesk-ui-framework/-/superdesk-ui-framework-3.1.15.tgz",
-      "integrity": "sha512-izv4Psj1NcGnOzQDAD1dSkR38oA1eTGVV5/zgnig8hI2Z9v9eKKKWkpFLCeqiRNLm2lopoibp4VI7VYyhmewmg==",
+      "version": "3.1.29",
+      "resolved": "https://registry.npmjs.org/superdesk-ui-framework/-/superdesk-ui-framework-3.1.29.tgz",
+      "integrity": "sha512-Dowv3C7+0i3uzqTKwZONSdbvhrRkzesNw6laaJQ80IcuJT7/15VPNspcWK9+eYZQTn3nGJwJZpwdj1i37nLUtA==",
       "dev": true,
       "requires": {
         "@popperjs/core": "^2.4.0",
         "@superdesk/common": "0.0.28",
         "@superdesk/primereact": "^5.0.2-12",
         "@superdesk/react-resizable-panels": "0.0.39",
-        "@types/enzyme-adapter-react-16": "^1.0.6",
-        "@types/node": "^14.10.2",
         "chart.js": "^2.9.3",
         "date-fns": "2.7.0",
-        "enzyme": "^3.11.0",
-        "enzyme-adapter-react-16": "^1.15.7",
-        "moment": "^2.29.3",
         "popper-max-size-modifier": "^0.2.0",
         "popper.js": "1.14.4",
         "primeicons": "2.0.0",
@@ -12426,12 +12401,6 @@
             "react-dom": "16.9.0",
             "react-sortable-hoc": "^1.11.0"
           }
-        },
-        "@types/node": {
-          "version": "14.18.63",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
-          "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
-          "dev": true
         },
         "date-fns": {
           "version": "2.7.0",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "sinon": "^4.5.0",
     "superdesk-code-style": "1.5.0",
     "superdesk-core": "github:superdesk/superdesk-client-core#develop",
-    "superdesk-ui-framework": "^3.1.15",
+    "superdesk-ui-framework": "^3.1.29",
     "ts-node": "~7.0.1",
     "tslint": "5.11.0",
     "typescript-eslint-parser": "^18.0.0"


### PR DESCRIPTION
STT-99

## Front-end checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [x] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [x] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [x] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [x] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [x] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [x] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [x] This pull request is not adding redux based modals
- [x] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [x] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)
