### PR TITLE
add links to all events in the planning output

### DIFF
--- a/server/planning/events/events_tests.py
+++ b/server/planning/events/events_tests.py
@@ -657,7 +657,6 @@ class EventsRelatedPlanningAutoPublish(TestCase):
                 "slugline": "slug",
                 "agendas": [],
                 "languages": ["en"],
-                "event_item": event_id[0],
                 "coverages": [
                     {
                         "coverage_id": "urn:newsmle264a179-5b1a-4b52-b73b-332660848cae",
@@ -676,6 +675,9 @@ class EventsRelatedPlanningAutoPublish(TestCase):
                         "assigned_to": {},
                         "firstcreated": datetime(2099, 11, 21, 12, 00, 00, tzinfo=pytz.UTC),
                     }
+                ],
+                "related_events": [
+                    PlanningRelatedEventLink(_id=event_id[0], link_type="primary"),
                 ],
             }
             planning_id = planning_service.post([planning])

--- a/server/planning/output_formatters/json_planning.py
+++ b/server/planning/output_formatters/json_planning.py
@@ -21,7 +21,7 @@ from superdesk.metadata.item import CONTENT_STATE
 from apps.archive.common import ARCHIVE
 
 from planning.common import ASSIGNMENT_WORKFLOW_STATE, WORKFLOW_STATE
-from planning.utils import get_first_related_event_id_for_planning
+from planning.utils import get_first_related_event_id_for_planning, get_related_event_links_for_planning
 from .utils import expand_contact_info, get_matching_products
 from .json_utils import translate_names
 
@@ -109,6 +109,19 @@ class JsonPlanningFormatter(Formatter):
         first_primary_event_id = get_first_related_event_id_for_planning(item, "primary")
         if first_primary_event_id:
             output_item["event_item"] = first_primary_event_id
+
+        events = []
+        for event_ref in get_related_event_links_for_planning(item):
+            event = get_resource_service("events").find_one(req=None, _id=event_ref["_id"])
+            events.append(
+                {
+                    "rel": event_ref["link_type"],
+                    "uri": f"urn:event:{event_ref['_id']}",
+                    "literal": event_ref["_id"],
+                    "name": event.get("name") if event else "",
+                }
+            )
+        output_item["events"] = events
 
         return output_item
 

--- a/server/planning/tests/output_formatters/json_planning_test.py
+++ b/server/planning/tests/output_formatters/json_planning_test.py
@@ -78,7 +78,7 @@ class JsonPlanningTestCase(TestCase):
             PlanningRelatedEventLink(
                 _id="event_prim_1",
                 link_type="primary",
-            )
+            ),
         ],
         "place": [
             {
@@ -410,6 +410,8 @@ class JsonPlanningTestCase(TestCase):
         item = deepcopy(self.item)
         self.assertEqual(self.format(item)["event_item"], "event_prim_1")
 
+        self.app.data.insert("events", [{"_id": "event_prim_1", "name": "Event 1"}])
+
         item["related_events"] = [
             PlanningRelatedEventLink(
                 _id="event_sec_1",
@@ -421,6 +423,16 @@ class JsonPlanningTestCase(TestCase):
             ),
         ]
         self.assertEqual(self.format(item)["event_item"], "event_prim_1")
+        events = self.format(item)["events"]
+        self.assertEqual(2, len(events))
+        self.assertIn(
+            {"literal": "event_prim_1", "rel": "primary", "uri": "urn:event:event_prim_1", "name": "Event 1"},
+            events,
+        )
+        self.assertIn(
+            {"literal": "event_sec_1", "rel": "secondary", "uri": "urn:event:event_sec_1", "name": ""},
+            events,
+        )
 
         item["related_events"] = [
             PlanningRelatedEventLink(


### PR DESCRIPTION
based on ninjs2 schema

STT-50

## Front-end checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)
