### PR TITLE
[STTNHUB-376] Add config to not cancel Planning when Event is cancelled

### DIFF
--- a/client/components/ContentProfiles/FieldTab/FieldEditor.tsx
+++ b/client/components/ContentProfiles/FieldTab/FieldEditor.tsx
@@ -88,6 +88,7 @@ export class FieldEditor extends React.Component<IProps, IState> {
             'schema.required': {enabled: !(this.props.disableRequired || this.props.systemRequired)},
             'schema.read_only': {enabled: this.props.item.name === 'related_plannings'},
             'schema.planning_auto_publish': {enabled: this.props.item.name === 'related_plannings'},
+            'schema.cancel_plan_with_event': {enabled: this.props.item.name === 'related_plannings'},
             'schema.field_type': {enabled: fieldType != null},
             'schema.minlength': {enabled: !disableMinMax},
             'schema.maxlength': {enabled: !disableMinMax},
@@ -190,6 +191,7 @@ export class FieldEditor extends React.Component<IProps, IState> {
                                             'schema.languages': {enabled: true, index: 12},
                                             'schema.default_language': {enabled: true, index: 13},
                                             'schema.planning_auto_publish': {enabled: true, index: 14},
+                                            'schema.cancel_plan_with_event': {enabled: true, index: 14},
                                             'schema.default_value': {enabled: true, index: 11},
                                         },
                                         {

--- a/client/components/fields/resources/profiles.ts
+++ b/client/components/fields/resources/profiles.ts
@@ -36,6 +36,17 @@ registerEditorField(
 );
 
 registerEditorField(
+    'schema.cancel_plan_with_event',
+    EditorFieldCheckbox,
+    () => ({
+        label: superdeskApi.localization.gettext('Cancel planning items with Event'),
+        field: 'schema.cancel_plan_with_event',
+    }),
+    null,
+    true
+);
+
+registerEditorField(
     'schema.planning_auto_publish',
     EditorFieldCheckbox,
     () => ({

--- a/client/interfaces.ts
+++ b/client/interfaces.ts
@@ -1047,6 +1047,7 @@ export interface IProfileSchemaTypeList extends IBaseProfileSchemaType<'list'> {
     mandatory_in_list?: {[key: string]: any};
     vocabularies?: Array<IVocabulary['_id']>;
     planning_auto_publish?: boolean;
+    cancel_plan_with_event?: boolean;
 }
 
 export interface IProfileSchemaTypeInteger extends IBaseProfileSchemaType<'integer'> {}
@@ -1149,6 +1150,7 @@ export interface IEventFormProfile {
         reference: IProfileEditorField;
         slugline: IProfileEditorField;
         subject: IProfileEditorField;
+        related_plannings: IProfileEditorField;
     };
     name: 'event';
     schema: {
@@ -1172,6 +1174,7 @@ export interface IEventFormProfile {
         reference: IProfileSchemaTypeString;
         slugline: IProfileSchemaTypeString;
         subject: IProfileSchemaTypeList;
+        related_plannings: IProfileSchemaTypeList;
     };
 }
 

--- a/server/planning/content_profiles/profiles/event.py
+++ b/server/planning/content_profiles/profiles/event.py
@@ -47,6 +47,7 @@ class EventSchema(BaseSchema):
     related_plannings = schema.ListField()
     related_plannings.schema["read_only"] = False
     related_plannings.schema["planning_auto_publish"] = False
+    related_plannings.schema["cancel_plan_with_event"] = True
     registration_details = TextField(field_type="multi_line")
     invitation_details = TextField(field_type="multi_line")
     accreditation_info = TextField(field_type="single_line")

--- a/server/planning/content_profiles/utils.py
+++ b/server/planning/content_profiles/utils.py
@@ -96,3 +96,10 @@ def is_post_planning_with_event_enabled() -> bool:
         return get_planning_schema("event")["schema"]["related_plannings"]["planning_auto_publish"] is True
     except (KeyError, TypeError):
         return False
+
+
+def is_cancel_planning_with_event_enabled() -> bool:
+    try:
+        return get_planning_schema("event")["schema"]["related_plannings"]["cancel_plan_with_event"] is True
+    except (KeyError, TypeError):
+        return True

--- a/server/planning/events/events_post.py
+++ b/server/planning/events/events_post.py
@@ -19,7 +19,7 @@ from planning.common import (
     get_version_item_for_post,
 )
 from planning.utils import try_cast_object_id
-from planning.content_profiles.utils import is_post_planning_with_event_enabled
+from planning.content_profiles.utils import is_post_planning_with_event_enabled, is_cancel_planning_with_event_enabled
 
 
 class EventsPostResource(EventsResource):
@@ -239,6 +239,9 @@ class EventsPostService(EventsBaseService):
                     except Exception as e:
                         failed_planning_ids.append({"_id": doc["planning"], "error": getattr(e, "description", str(e))})
             return failed_planning_ids
+        elif not is_cancel_planning_with_event_enabled():
+            return
+
         for planning in plannings:
             if not planning.get("pubstatus") and planning.get("state") in [
                 WORKFLOW_STATE.INGESTED,

--- a/server/planning/types/content_profiles.py
+++ b/server/planning/types/content_profiles.py
@@ -15,6 +15,7 @@ class ContentFieldSchema(TypedDict, total=False):
     multilingual: bool
     field_type: str
     planning_auto_publish: bool  # Only available in ``related_plannings`` field
+    cancel_plan_with_event: bool  # Only available in ``related_plannings`` field
     vocabularies: List[str]  # Only available in ``custom_vocabularies`` field
 
 

--- a/server/planning/validate/planning_validate.py
+++ b/server/planning/validate/planning_validate.py
@@ -85,6 +85,12 @@ class SchemaValidator(Validator):
         """
         pass
 
+    def _validate_cancel_plan_with_event(self, cancel_plan_with_event, field, value):
+        """
+        {'type': 'boolean', 'nullable': True}
+        """
+        pass
+
     def _validate_default_language(self, default_language, field, value):
         """
         {'type': string, 'nullable': True}


### PR DESCRIPTION
### Purpose
Add new option to the Event Content Profile's Related Plannings field, that allows to turn off the feature that cancels/unposts Planning item(s) when unposting an Event.

### What has changed
* New option `Cancel planning items with Event` for the `Related Plannings` Event field
* Allow's editing a Planning item that is associated with a Cancelled Event

Resolves: [STTNHUB-376](https://sofab.atlassian.net/browse/STTNHUB-376)

## Front-end checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [x] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [x] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [x] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [x] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [x] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [x] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [x] This pull request is not adding redux based modals
- [x] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [x] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)


[STTNHUB-376]: https://sofab.atlassian.net/browse/STTNHUB-376?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ