### PR TITLE
After "Add to Planning", Search fields do not allow search input

### DIFF
--- a/client/components/AddToPlanningModal/index.tsx
+++ b/client/components/AddToPlanningModal/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 
-import {Modal} from '../index';
+import {Modal} from 'superdesk-ui-framework/react';
 import {Button} from '../UI';
 import {AddToPlanningApp} from '../../apps';
 
@@ -55,39 +55,30 @@ export class AddToPlanningComponent extends React.Component {
 
         return (
             <Modal
-                show={true}
-                onHide={handleHide}
-                fill={true}
-            >
-                <Modal.Header>
+                visible={true}
+                onHide={actionInProgress ? null : handleCancel}
+                size="x-large"
+                contentPadding="none"
+                headerTemplate={(
                     <h3 className="modal__heading">
                         {gettext('Select an existing Planning Item or create a new one')}
                     </h3>
-                    {actionInProgress ? null : (
-                        <a className="icn-btn" onClick={handleCancel}>
-                            <i className="icon-close-small" />
-                        </a>
-                    )}
-                </Modal.Header>
-
-                <Modal.Body noPadding fullHeight noScroll>
-                    <div className="planning-app__modal AddToPlanning">
-                        <AddToPlanningApp
-                            addNewsItemToPlanning={newsItem}
-                            popupContainer={() => this.dom.popupContainer}
-                            onCancel={handleCancel}
-                        />
-                    </div>
-                </Modal.Body>
-
-                <Modal.Footer>
+                )}
+                footerTemplate={(
                     <Button
                         text={gettext('Ignore')}
                         disabled={actionInProgress}
                         onClick={handleCancel}
                     />
-                </Modal.Footer>
-                <div ref={(node) => this.dom.popupContainer = node} />
+                )}
+            >
+                <div className="planning-app__modal AddToPlanning">
+                    <AddToPlanningApp
+                        addNewsItemToPlanning={newsItem}
+                        popupContainer={() => this.dom.popupContainer}
+                        onCancel={handleCancel}
+                    />
+                </div>
             </Modal>
         );
     }


### PR DESCRIPTION
SDCP-878

## Front-end checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [x] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [x] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [x] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [x] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [x] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [x] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [x] This pull request is not adding redux based modals
- [x] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [x] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)
