### PR TITLE
Agenda field port

### DIFF
--- a/client/components/fields/editor/CustomVocabularies.tsx
+++ b/client/components/fields/editor/CustomVocabularies.tsx
@@ -6,7 +6,6 @@ import {superdeskApi} from '../../../superdeskApi';
 import {IEditorFieldProps, IProfileSchemaTypeList} from '../../../interfaces';
 import {Row} from '../../UI/Form';
 import {getVocabularyItemFieldTranslated} from '../../../utils/vocabularies';
-import {arrayToTree} from 'superdesk-core/scripts/core/helpers/tree';
 import {TreeSelect} from 'superdesk-ui-framework/react';
 
 export interface ICustomVocabulariesProps extends IEditorFieldProps {
@@ -61,7 +60,7 @@ class CustomVocabulariesComponent extends React.PureComponent<IProps> {
                         value={(item.subject ?? []).filter((x) => x.scheme === cv._id)}
                         label={gettext(cv.display_name)}
                         required={required ?? schema?.required}
-                        getOptions={() => arrayToTree(
+                        getOptions={() => superdeskApi.utilities.arrayToTree(
                             cv.items.map((cvItem) => ({
                                 ...cvItem,
                                 scheme: cv._id,

--- a/client/components/planning-editor-standalone/profile.ts
+++ b/client/components/planning-editor-standalone/profile.ts
@@ -27,7 +27,6 @@ function getTextFieldConfig(options: {id: string; label: string, required: boole
         singleLine: true,
         disallowedCharacters: [],
         showStatistics: false,
-        width: 100,
     };
 
     const field: IAuthoringFieldV2 = {
@@ -190,7 +189,6 @@ export function getFieldDefinitions(): IFieldDefinitions {
                     type: 'text',
                     multiple: true,
                     required: required,
-                    width: 100,
                 };
 
                 const field: IAuthoringFieldV2 = {

--- a/client/components/planning-editor-standalone/profile.ts
+++ b/client/components/planning-editor-standalone/profile.ts
@@ -5,8 +5,11 @@ import {
     ICommonFieldConfig,
     IContentProfileV2,
     IDateTimeFieldConfig,
+    IDropdownConfigRemoteSource,
     IDropdownConfigVocabulary,
     IEditor3Config,
+    IRestApiResponse,
+    ITreeWithLookup,
     IVocabularyItem,
 } from 'superdesk-api';
 import {superdeskApi} from '../../superdeskApi';
@@ -15,6 +18,8 @@ import {
 } from '../../planning-extension/src/authoring-react-fields/planning-attachments/interfaces';
 import {getCustomVocabularyFields} from './field-adapters/custom-vocabularies';
 import {getPlanningProfileFields} from './profile-fields';
+import {IAgenda} from 'interfaces';
+import {httpRequestJsonLocal} from 'superdesk-core/scripts/core/helpers/network';
 
 function getTextFieldConfig(options: {id: string; label: string, required: boolean}): IAuthoringFieldV2 {
     const editor3ConfigWithoutFormatting: IEditor3Config = {
@@ -172,7 +177,60 @@ export function getFieldDefinitions(): IFieldDefinitions {
 
                 return field;
             },
-        }
+        },
+        {
+            fieldId: 'agendas',
+            getField: ({id, required}) => {
+                const fieldConfig: IDropdownConfigRemoteSource = {
+                    source: 'remote-source',
+                    searchOptions: (searchTerm, _language, callback) => {
+                        httpRequestJsonLocal<IRestApiResponse<IAgenda>>({
+                            method: 'GET',
+                            path: '/agenda',
+                            urlParams: {
+                                max_results: 200,
+                                name: searchTerm,
+                            },
+                        }).then((res) => {
+                            const tree: ITreeWithLookup<IAgenda> = {
+                                nodes: res._items.map((item) => ({value: item})),
+                                lookup: {},
+                            };
+
+                            callback(tree);
+                        });
+                    },
+                    getId: (option: IAgenda) => option._id,
+                    getLabel: (option: IAgenda) => option.name,
+                    multiple: true,
+                    required: required,
+                    width: 100,
+                };
+
+                const field: IAuthoringFieldV2 = {
+                    id: id,
+                    name: gettext('Agendas'),
+                    fieldType: 'dropdown',
+                    fieldConfig: fieldConfig,
+                };
+
+                return field;
+            },
+            storageAdapter: {
+                storeValue: (item, operationalValue: Array<string>) => {
+                    const vocabulary = superdeskApi.entities.vocabulary.getAll().get('locators');
+                    const vocabularyItems = new Map<IVocabularyItem['qcode'], IVocabularyItem>(
+                        vocabulary.items.map((item) => [item.qcode, item]),
+                    );
+
+                    return {
+                        ...item,
+                        place: operationalValue.map((qcode) => vocabularyItems.get(qcode)),
+                    };
+                },
+                retrieveStoredValue: (item, fieldId) => item[fieldId].map(({qcode}) => qcode),
+            },
+        },
     ];
 
     result.push(

--- a/client/components/planning-editor-standalone/profile.ts
+++ b/client/components/planning-editor-standalone/profile.ts
@@ -5,21 +5,18 @@ import {
     ICommonFieldConfig,
     IContentProfileV2,
     IDateTimeFieldConfig,
-    IDropdownConfigRemoteSource,
+    IDropdownConfigManualSource,
     IDropdownConfigVocabulary,
     IEditor3Config,
-    IRestApiResponse,
-    ITreeWithLookup,
     IVocabularyItem,
 } from 'superdesk-api';
-import {superdeskApi} from '../../superdeskApi';
+import {planningApi, superdeskApi} from '../../superdeskApi';
 import {
     IAttachmentsFieldConfig,
 } from '../../planning-extension/src/authoring-react-fields/planning-attachments/interfaces';
 import {getCustomVocabularyFields} from './field-adapters/custom-vocabularies';
 import {getPlanningProfileFields} from './profile-fields';
 import {IAgenda} from 'interfaces';
-import {httpRequestJsonLocal} from 'superdesk-core/scripts/core/helpers/network';
 
 function getTextFieldConfig(options: {id: string; label: string, required: boolean}): IAuthoringFieldV2 {
     const editor3ConfigWithoutFormatting: IEditor3Config = {
@@ -181,27 +178,16 @@ export function getFieldDefinitions(): IFieldDefinitions {
         {
             fieldId: 'agendas',
             getField: ({id, required}) => {
-                const fieldConfig: IDropdownConfigRemoteSource = {
-                    source: 'remote-source',
-                    searchOptions: (searchTerm, _language, callback) => {
-                        httpRequestJsonLocal<IRestApiResponse<IAgenda>>({
-                            method: 'GET',
-                            path: '/agenda',
-                            urlParams: {
-                                max_results: 200,
-                                name: searchTerm,
-                            },
-                        }).then((res) => {
-                            const tree: ITreeWithLookup<IAgenda> = {
-                                nodes: res._items.map((item) => ({value: item})),
-                                lookup: {},
-                            };
-
-                            callback(tree);
-                        });
-                    },
-                    getId: (option: IAgenda) => option._id,
-                    getLabel: (option: IAgenda) => option.name,
+                const fieldConfig: IDropdownConfigManualSource = {
+                    source: 'manual-entry',
+                    options: ((planningApi.redux.store.getState().agenda.agendas ?? []) as Array<IAgenda>)
+                        .filter((item) => item.is_enabled)
+                        .map((item) => ({
+                            id: item._id,
+                            label: item.name,
+                        })),
+                    roundCorners: true,
+                    type: 'text',
                     multiple: true,
                     required: required,
                     width: 100,
@@ -215,20 +201,6 @@ export function getFieldDefinitions(): IFieldDefinitions {
                 };
 
                 return field;
-            },
-            storageAdapter: {
-                storeValue: (item, operationalValue: Array<string>) => {
-                    const vocabulary = superdeskApi.entities.vocabulary.getAll().get('locators');
-                    const vocabularyItems = new Map<IVocabularyItem['qcode'], IVocabularyItem>(
-                        vocabulary.items.map((item) => [item.qcode, item]),
-                    );
-
-                    return {
-                        ...item,
-                        place: operationalValue.map((qcode) => vocabularyItems.get(qcode)),
-                    };
-                },
-                retrieveStoredValue: (item, fieldId) => item[fieldId].map(({qcode}) => qcode),
             },
         },
     ];


### PR DESCRIPTION
STT-63
## Front-end checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [x] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [x] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [x] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [x] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [x] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [x] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [x] This pull request is not adding redux based modals
- [x] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [x] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)
