### PR TITLE
Categories field implementation

### DIFF
--- a/client/components/planning-editor-standalone/field-definitions/category-field.ts
+++ b/client/components/planning-editor-standalone/field-definitions/category-field.ts
@@ -1,0 +1,38 @@
+import {IDropdownConfigVocabulary, IAuthoringFieldV2, IVocabularyItem} from 'superdesk-api';
+import {superdeskApi} from '../../../superdeskApi';
+import {IFieldGetter} from '.';
+
+export const getCategoriesField: IFieldGetter = () => ({
+    fieldId: 'anpa_category',
+    getField: ({id, required}) => {
+        const fieldConfig: IDropdownConfigVocabulary = {
+            source: 'vocabulary',
+            vocabularyId: 'categories',
+            multiple: true,
+            required: required,
+        };
+
+        const field: IAuthoringFieldV2 = {
+            id: id,
+            name: superdeskApi.localization.gettext('Categories'),
+            fieldType: 'dropdown',
+            fieldConfig: fieldConfig,
+        };
+
+        return field;
+    },
+    storageAdapter: {
+        storeValue: (item, operationalValue: Array<string>) => {
+            const vocabulary = superdeskApi.entities.vocabulary.getAll().get('categories');
+            const vocabularyItems = new Map<IVocabularyItem['qcode'], IVocabularyItem>(
+                vocabulary.items.map((item) => [item.qcode, item]),
+            );
+
+            return {
+                ...item,
+                anpa_category: operationalValue.map((qcode) => vocabularyItems.get(qcode)),
+            };
+        },
+        retrieveStoredValue: (item, fieldId) => (item[fieldId] ?? []).map(({qcode}) => qcode),
+    },
+});

--- a/client/components/planning-editor-standalone/field-definitions/index.ts
+++ b/client/components/planning-editor-standalone/field-definitions/index.ts
@@ -11,6 +11,7 @@ import {getDateTimeField} from './date-time-config';
 import {IFieldDefinitions, IFieldDefinition} from './interfaces';
 import {getTextFieldConfig} from './text-field-config';
 import {getPlaceField} from './place-field';
+import {getCategoriesField} from './category-field';
 import {getAgendasField} from './agendas-field';
 
 export function getFieldDefinitions(): IFieldDefinitions {
@@ -66,6 +67,7 @@ export function getFieldDefinitions(): IFieldDefinitions {
         },
         getPlaceField(),
         getAgendasField(),
+        getCategoriesField(),
         {
             fieldId: 'coverages',
             getField: ({id, required}) => {

--- a/client/components/planning-editor-standalone/profile-fields.ts
+++ b/client/components/planning-editor-standalone/profile-fields.ts
@@ -13,6 +13,9 @@ interface ICustomVocabularyField extends IBaseField<'custom_vocabulary'> {
 
 type IFieldConverted = IBaseField<'normal'> | ICustomVocabularyField;
 
+/**
+ * Fields that don't have a planning profile schema
+ */
 const FIELDS_TO_FILTER = [
     'associated_event',
 ];

--- a/client/components/planning-editor-standalone/profile-fields.ts
+++ b/client/components/planning-editor-standalone/profile-fields.ts
@@ -1,4 +1,3 @@
-import {flatMap} from 'lodash';
 import {planningApi} from '../../superdeskApi';
 import {getEditorFormGroupsFromProfile} from '../../utils/contentProfiles';
 
@@ -14,13 +13,18 @@ interface ICustomVocabularyField extends IBaseField<'custom_vocabulary'> {
 
 type IFieldConverted = IBaseField<'normal'> | ICustomVocabularyField;
 
+const FIELDS_TO_FILTER = [
+    'associated_event',
+];
+
 /**
  * A function that handles planning profile field types so they can be used in authoring react.
  */
 export const getPlanningProfileFields = (): Array<IFieldConverted> => {
     const planningProfile = planningApi.contentProfiles.get('planning');
     const planningGroups = getEditorFormGroupsFromProfile(planningProfile);
-    const planningFieldIds = Object.values(planningGroups).flatMap((x) => x.fields);
+    const planningFieldIds = Object.values(planningGroups).flatMap((x) => x.fields)
+        .filter((x) => !FIELDS_TO_FILTER.includes(x));
     const convertedFieldIds: Array<IFieldConverted> = [];
 
     for (const fieldId of planningFieldIds) {

--- a/client/components/planning-editor-standalone/storage-adapter.ts
+++ b/client/components/planning-editor-standalone/storage-adapter.ts
@@ -6,7 +6,7 @@ import {
     IStorageAdapter,
 } from 'superdesk-api';
 import {superdeskApi} from '../../superdeskApi';
-import {getFieldDefinitions} from './field-definitions';
+import {getFieldDefinitions} from './field-definitions/index';
 
 export const storageAdapterPlanningItem: IStorageAdapter<IPlanningItem> = {
     storeValue: (value, fieldId, item, config, fieldType) => {


### PR DESCRIPTION
STT-63
## Front-end checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [x] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [x] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [x] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [x] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [x] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [x] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [x] This pull request is not adding redux based modals
- [x] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [x] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)
