### PR TITLE
Priority field

### DIFF
--- a/client/components/planning-editor-standalone/field-adapters/custom-vocabularies.ts
+++ b/client/components/planning-editor-standalone/field-adapters/custom-vocabularies.ts
@@ -1,6 +1,6 @@
 import {IDropdownConfigVocabulary, IAuthoringFieldV2, ISubject, IVocabularyItem} from 'superdesk-api';
 import {superdeskApi} from '../../../superdeskApi';
-import {IFieldDefinition} from '../profile';
+import {IFieldDefinition} from '../field-definitions/interfaces';
 import {getPlanningProfileFields} from '../profile-fields';
 
 export const getCustomVocabularyFields = () => {

--- a/client/components/planning-editor-standalone/field-definitions/index.ts
+++ b/client/components/planning-editor-standalone/field-definitions/index.ts
@@ -13,6 +13,7 @@ import {getTextFieldConfig} from './text-field-config';
 import {getPlaceField} from './place-field';
 import {getCategoriesField} from './category-field';
 import {getAgendasField} from './agendas-field';
+import {getPriorityField} from './priority-field';
 
 export function getFieldDefinitions(): IFieldDefinitions {
     const {gettext} = superdeskApi.localization;
@@ -68,6 +69,7 @@ export function getFieldDefinitions(): IFieldDefinitions {
         getPlaceField(),
         getAgendasField(),
         getCategoriesField(),
+        getPriorityField(),
         {
             fieldId: 'coverages',
             getField: ({id, required}) => {

--- a/client/components/planning-editor-standalone/field-definitions/priority-field.ts
+++ b/client/components/planning-editor-standalone/field-definitions/priority-field.ts
@@ -1,6 +1,6 @@
 import {IAuthoringFieldV2, IDropdownConfigManualSource} from 'superdesk-api';
 import {IFieldDefinition} from './interfaces';
-import {superdeskApi} from '../../../superdeskApi';
+import {planningApi, superdeskApi} from '../../../superdeskApi';
 
 export const getPriorityField = (): IFieldDefinition => {
     const {gettext} = superdeskApi.localization;
@@ -8,34 +8,14 @@ export const getPriorityField = (): IFieldDefinition => {
     return {
         fieldId: 'priority',
         getField: ({id, required}) => {
+            const options = planningApi.redux.store.getState().vocabularies.priority.map((x) => ({
+                id: x.qcode,
+                label: x.name,
+            }));
+
             const fieldConfig: IDropdownConfigManualSource = {
                 source: 'manual-entry',
-                options: [
-                    {
-                        id: '1',
-                        label: gettext('1'),
-                    },
-                    {
-                        id: '2',
-                        label: gettext('2'),
-                    },
-                    {
-                        id: '3',
-                        label: gettext('3'),
-                    },
-                    {
-                        id: '4',
-                        label: gettext('4'),
-                    },
-                    {
-                        id: '5',
-                        label: gettext('5'),
-                    },
-                    {
-                        id: '6',
-                        label: gettext('6'),
-                    },
-                ],
+                options: options,
                 roundCorners: true,
                 type: 'text',
                 multiple: false,

--- a/client/components/planning-editor-standalone/field-definitions/priority-field.ts
+++ b/client/components/planning-editor-standalone/field-definitions/priority-field.ts
@@ -1,0 +1,55 @@
+import {IAuthoringFieldV2, IDropdownConfigManualSource} from 'superdesk-api';
+import {IFieldDefinition} from './interfaces';
+import {superdeskApi} from '../../../superdeskApi';
+
+export const getPriorityField = (): IFieldDefinition => {
+    const {gettext} = superdeskApi.localization;
+
+    return {
+        fieldId: 'priority',
+        getField: ({id, required}) => {
+            const fieldConfig: IDropdownConfigManualSource = {
+                source: 'manual-entry',
+                options: [
+                    {
+                        id: '1',
+                        label: gettext('1'),
+                    },
+                    {
+                        id: '2',
+                        label: gettext('2'),
+                    },
+                    {
+                        id: '3',
+                        label: gettext('3'),
+                    },
+                    {
+                        id: '4',
+                        label: gettext('4'),
+                    },
+                    {
+                        id: '5',
+                        label: gettext('5'),
+                    },
+                    {
+                        id: '6',
+                        label: gettext('6'),
+                    },
+                ],
+                roundCorners: true,
+                type: 'text',
+                multiple: false,
+                required: required,
+            };
+
+            const field: IAuthoringFieldV2 = {
+                id: id,
+                name: gettext('Priority'),
+                fieldType: 'dropdown',
+                fieldConfig: fieldConfig,
+            };
+
+            return field;
+        },
+    };
+};


### PR DESCRIPTION
STT-63

## Front-end checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [x] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [x] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [x] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [x] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [x] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [x] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [x] This pull request is not adding redux based modals
- [x] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [x] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)
