### PR TITLE
avoid extra fields mapped in elastic

### DIFF
--- a/server/planning/events/events_schema.py
+++ b/server/planning/events/events_schema.py
@@ -78,7 +78,20 @@ events_schema = {
     "accreditation_deadline": {"type": "datetime"},
     # Reference can be used to hold for example a court case reference number
     "reference": {"type": "string"},
-    "anpa_category": metadata_schema["anpa_category"],
+    "anpa_category": {
+        "type": "list",
+        "nullable": True,
+        "mapping": {
+            "type": "object",
+            "dynamic": False,
+            "properties": {
+                "qcode": not_analyzed,
+                "name": not_analyzed,
+                "scheme": not_analyzed,
+                "translations": {"enabled": False},  # explicitly disable
+            },
+        },
+    },
     "files": {
         "type": "list",
         "nullable": True,
@@ -209,6 +222,7 @@ events_schema = {
                 "address": {"type": "object", "dynamic": True},
                 "geo": {"type": "string"},
                 "location": {"type": "geo_point"},
+                "translations": {"enabled": False},  # explicitly disable
             },
         },
         "nullable": True,
@@ -268,6 +282,7 @@ events_schema = {
             "properties": {
                 "qcode": not_analyzed,
                 "name": not_analyzed,
+                "translations": {"enabled": False},  # explicitly disable
             },
         },
     },


### PR DESCRIPTION
trying to explicitly avoid those fields,
they still get auto created.

## Front-end checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)
