### PR TITLE
Show in embedded editor field config option

### DIFF
--- a/client/components/ContentProfiles/FieldTab/FieldEditor.tsx
+++ b/client/components/ContentProfiles/FieldTab/FieldEditor.tsx
@@ -85,6 +85,12 @@ export class FieldEditor extends React.Component<IProps, IState> {
             multilingual.isEnabled(this.props.profile);
 
         const fieldProps = {
+            'schema.show_in_embedded_editor': {
+                /**
+                 * Coverage fields don't need this field config option, only planning and event
+                 */
+                enabled: !this.props.systemRequired && this.props.profile._id !== 'coverage',
+            },
             'schema.required': {enabled: !(this.props.disableRequired || this.props.systemRequired)},
             'schema.read_only': {enabled: this.props.item.name === 'related_plannings'},
             'schema.planning_auto_publish': {enabled: this.props.item.name === 'related_plannings'},
@@ -178,21 +184,22 @@ export class FieldEditor extends React.Component<IProps, IState> {
                                         'editor',
                                         {
                                             'schema.required': {enabled: true, index: 1},
-                                            'schema.read_only': {enabled: true, index: 2},
-                                            'schema.field_type': {enabled: true, index: 3},
-                                            'schema.expandable': {enabled: true, index: 4},
-                                            'schema.minlength': {enabled: true, index: 5},
-                                            'schema.maxlength': {enabled: true, index: 6},
-                                            'schema.format_options': {enabled: true, index: 7},
-                                            'schema.vocabularies': {enabled: true, index: 8},
-                                            'field.all_day.enabled': {enabled: true, index: 9},
-                                            'field.default_duration_on_change': {enabled: true, index: 10},
-                                            'schema.multilingual': {enabled: true, index: 11},
-                                            'schema.languages': {enabled: true, index: 12},
-                                            'schema.default_language': {enabled: true, index: 13},
-                                            'schema.planning_auto_publish': {enabled: true, index: 14},
-                                            'schema.cancel_plan_with_event': {enabled: true, index: 14},
-                                            'schema.default_value': {enabled: true, index: 11},
+                                            'schema.show_in_embedded_editor': {enabled: true, index: 2},
+                                            'schema.read_only': {enabled: true, index: 3},
+                                            'schema.field_type': {enabled: true, index: 4},
+                                            'schema.expandable': {enabled: true, index: 5},
+                                            'schema.minlength': {enabled: true, index: 6},
+                                            'schema.maxlength': {enabled: true, index: 7},
+                                            'schema.format_options': {enabled: true, index: 8},
+                                            'schema.vocabularies': {enabled: true, index: 9},
+                                            'field.all_day.enabled': {enabled: true, index: 10},
+                                            'field.default_duration_on_change': {enabled: true, index: 11},
+                                            'schema.multilingual': {enabled: true, index: 12},
+                                            'schema.languages': {enabled: true, index: 13},
+                                            'schema.default_language': {enabled: true, index: 14},
+                                            'schema.planning_auto_publish': {enabled: true, index: 15},
+                                            'schema.cancel_plan_with_event': {enabled: true, index: 16},
+                                            'schema.default_value': {enabled: true, index: 17},
                                         },
                                         {
                                             item: this.props.item,

--- a/client/components/ContentProfiles/FieldTab/index.tsx
+++ b/client/components/ContentProfiles/FieldTab/index.tsx
@@ -263,7 +263,15 @@ export class FieldTab extends React.Component<IProps, IState> {
                 {this.state.selectedField == null ? null : (
                     <FieldEditor
                         key={this.state.selectedField?.name}
-                        item={this.state.selectedField}
+                        item={(() => {
+                            const profileRes = cloneDeep(this.state.selectedField);
+
+                            if (profileRes.schema?.required === true) {
+                                profileRes.schema.show_in_embedded_editor = true;
+                            }
+
+                            return profileRes;
+                        })()}
                         profile={this.props.profile}
                         isDirty={this.isEditorDirty()}
                         disableMinMax={this.props.disableMinMaxFields?.includes(this.state.selectedField.name)}

--- a/client/components/fields/editor/base/checkbox.tsx
+++ b/client/components/fields/editor/base/checkbox.tsx
@@ -8,7 +8,7 @@ import {Checkbox} from 'superdesk-ui-framework/react';
 export class EditorFieldCheckbox extends React.PureComponent<IEditorFieldProps> {
     render() {
         const field = this.props.field;
-        const value = this.props.valueOverwrite ?? get(this.props.item, field, this.props.defaultValue);
+        const value = get(this.props.item, field, this.props.defaultValue);
 
         return (
             <Row testId={this.props.testId}>

--- a/client/components/fields/editor/base/checkbox.tsx
+++ b/client/components/fields/editor/base/checkbox.tsx
@@ -8,7 +8,7 @@ import {Checkbox} from 'superdesk-ui-framework/react';
 export class EditorFieldCheckbox extends React.PureComponent<IEditorFieldProps> {
     render() {
         const field = this.props.field;
-        const value = get(this.props.item, field, this.props.defaultValue);
+        const value = this.props.valueOverwrite ?? get(this.props.item, field, this.props.defaultValue);
 
         return (
             <Row testId={this.props.testId}>

--- a/client/components/fields/editor/index.tsx
+++ b/client/components/fields/editor/index.tsx
@@ -56,8 +56,8 @@ import {EditorFieldAssignedCoverageComponent} from './AssignedCoverage';
 
 /**
  * This is the single source of truth for field definitions, allows for registering
- * other fields from a different through `registerEditorField`
- */
+ * other fields from a different place through `registerEditorField`
+*/
 export const FIELD_TO_EDITOR_COMPONENT = {
     anpa_category: EditorFieldCategories,
     featured: EditorFieldFeatured,

--- a/client/components/fields/editor/index.tsx
+++ b/client/components/fields/editor/index.tsx
@@ -54,6 +54,10 @@ import {EditorFieldScheduledUpdates} from './ScheduledUpdates';
 import {EditorFieldCustomVocabularies} from './CustomVocabularies';
 import {EditorFieldAssignedCoverageComponent} from './AssignedCoverage';
 
+/**
+ * This is the single source of truth for field definitions, allows for registering
+ * other fields from a different through `registerEditorField`
+ */
 export const FIELD_TO_EDITOR_COMPONENT = {
     anpa_category: EditorFieldCategories,
     featured: EditorFieldFeatured,

--- a/client/components/fields/resources/profiles.ts
+++ b/client/components/fields/resources/profiles.ts
@@ -25,6 +25,17 @@ registerEditorField(
 );
 
 registerEditorField(
+    'schema.show_in_embedded_editor',
+    EditorFieldCheckbox,
+    () => ({
+        label: superdeskApi.localization.gettext('Show in embedded form'),
+        field: 'schema.show_in_embedded_editor',
+    }),
+    null,
+    true
+);
+
+registerEditorField(
     'schema.read_only',
     EditorFieldCheckbox,
     () => ({

--- a/client/components/fields/resources/profiles.ts
+++ b/client/components/fields/resources/profiles.ts
@@ -31,7 +31,6 @@ registerEditorField(
         label: superdeskApi.localization.gettext('Show in embedded form'),
         field: 'schema.show_in_embedded_editor',
         disabled: props.item.schema.required,
-        valueOverwrite: props.item.schema.required === true ? true : undefined,
     }),
     null,
     true

--- a/client/components/fields/resources/profiles.ts
+++ b/client/components/fields/resources/profiles.ts
@@ -27,9 +27,11 @@ registerEditorField(
 registerEditorField(
     'schema.show_in_embedded_editor',
     EditorFieldCheckbox,
-    () => ({
+    (props) => ({
         label: superdeskApi.localization.gettext('Show in embedded form'),
         field: 'schema.show_in_embedded_editor',
+        disabled: props.item.schema.required,
+        valueOverwrite: props.item.schema.required === true ? true : undefined,
     }),
     null,
     true

--- a/client/components/planning-editor-standalone/field-adapters/custom-vocabularies.ts
+++ b/client/components/planning-editor-standalone/field-adapters/custom-vocabularies.ts
@@ -4,7 +4,7 @@ import {getPlanningProfileFields} from '../profile-fields';
 import {IFieldDefinition} from '../field-definitions/interfaces';
 
 export const getCustomVocabularyFields = () => {
-    const customVocabularyIds = getPlanningProfileFields()
+    const customVocabularyIds = getPlanningProfileFields({embeddedOnly: true})
         .filter((x) => x.type === 'custom_vocabulary')
         .map(({vocabularyId}) => vocabularyId);
     const result: Array<IFieldDefinition> = [];

--- a/client/components/planning-editor-standalone/profile-fields.ts
+++ b/client/components/planning-editor-standalone/profile-fields.ts
@@ -23,8 +23,9 @@ const unimplementedFields = new Set<string>([
 
 /**
  * A function that handles planning profile field types so they can be used in authoring react.
+ * @embeddedOnly defaults to false
  */
-export const getPlanningProfileFields = (): Array<IFieldConverted> => {
+export const getPlanningProfileFields = (options: {embeddedOnly?: boolean}): Array<IFieldConverted> => {
     const planningProfile = planningApi.contentProfiles.get('planning');
     const planningGroups = getEditorFormGroupsFromProfile(planningProfile);
     const planningFieldIds = Object.values(planningGroups)
@@ -39,7 +40,7 @@ export const getPlanningProfileFields = (): Array<IFieldConverted> => {
          * If a field does not have show_in_embedded_editor or required toggled on
          * we must not show it in the embedded editor
          */
-        if (!(fieldSchema.show_in_embedded_editor || fieldSchema.required)) {
+        if (options.embeddedOnly && !(fieldSchema.show_in_embedded_editor || fieldSchema.required)) {
             continue;
         }
 

--- a/client/components/planning-editor-standalone/profile-fields.ts
+++ b/client/components/planning-editor-standalone/profile-fields.ts
@@ -35,6 +35,14 @@ export const getPlanningProfileFields = (): Array<IFieldConverted> => {
     for (const fieldId of planningFieldIds) {
         const fieldSchema = planningProfile.schema[fieldId];
 
+        /**
+         * If a field has show_in_embedded_editor or required toggled on
+         * we must show it in the embedded editor
+         */
+        if (!(fieldSchema.show_in_embedded_editor || fieldSchema.required)) {
+            continue;
+        }
+
         if (fieldSchema?.type === 'list' && ((fieldSchema.vocabularies ?? []).length > 0)) {
             for (const vocabId of fieldSchema.vocabularies) {
                 convertedFieldIds.push({

--- a/client/components/planning-editor-standalone/profile-fields.ts
+++ b/client/components/planning-editor-standalone/profile-fields.ts
@@ -36,8 +36,8 @@ export const getPlanningProfileFields = (): Array<IFieldConverted> => {
         const fieldSchema = planningProfile.schema[fieldId];
 
         /**
-         * If a field has show_in_embedded_editor or required toggled on
-         * we must show it in the embedded editor
+         * If a field does not have show_in_embedded_editor or required toggled on
+         * we must not show it in the embedded editor
          */
         if (!(fieldSchema.show_in_embedded_editor || fieldSchema.required)) {
             continue;

--- a/client/components/planning-editor-standalone/profile.ts
+++ b/client/components/planning-editor-standalone/profile.ts
@@ -5,7 +5,7 @@ import {getPlanningProfileFields} from './profile-fields';
 import {getFieldDefinitions} from './field-definitions/index';
 
 export function getProfile() {
-    const planningFieldIds = getPlanningProfileFields();
+    const planningFieldIds = getPlanningProfileFields({embeddedOnly: true});
     const skipped = new Set<string>();
     const fieldDefinitions = getFieldDefinitions();
     const profileV2: IContentProfileV2 = {

--- a/client/interfaces.ts
+++ b/client/interfaces.ts
@@ -1031,6 +1031,7 @@ interface IProfileEditorDatesField extends IProfileEditorField {
 interface IBaseProfileSchemaType<T> {
     type: T;
     required: boolean;
+    show_in_embedded_editor?: boolean;
     validate_on_post?: boolean;
     minlength?: number;
     maxlength?: number;

--- a/client/interfaces.ts
+++ b/client/interfaces.ts
@@ -1546,6 +1546,7 @@ export interface ISearchFilter extends IBaseRestApiResponse {
 export interface IEditorFieldProps {
     item: any;
     field: string;
+    valueOverwrite?: boolean;
     label?: string;
     required?: boolean;
     disabled?: boolean;

--- a/client/interfaces.ts
+++ b/client/interfaces.ts
@@ -1546,7 +1546,6 @@ export interface ISearchFilter extends IBaseRestApiResponse {
 export interface IEditorFieldProps {
     item: any;
     field: string;
-    valueOverwrite?: boolean;
     label?: string;
     required?: boolean;
     disabled?: boolean;


### PR DESCRIPTION
STT-76

## Front-end checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [x] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [x] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [x] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [x] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [x] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [x] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [x] This pull request is not adding redux based modals
- [x] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [x] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)
