### PR TITLE
fix events time TBC handling

### DIFF
--- a/client/components/fields/editor/EventSchedule.tsx
+++ b/client/components/fields/editor/EventSchedule.tsx
@@ -88,6 +88,7 @@ export class EditorFieldEventSchedule extends React.PureComponent<IProps> {
                 'dates.end': endDate ? localDateToUtc(endDate, this.props.item?.dates?.tz) : null,
                 'dates.all_day': true,
                 'dates.no_end_time': false,
+                [TO_BE_CONFIRMED_FIELD]: false,
             };
 
             this.props.onChange(changes);
@@ -99,10 +100,10 @@ export class EditorFieldEventSchedule extends React.PureComponent<IProps> {
             'dates.start': newStartDate,
             'dates.all_day': false,
             'dates.no_end_time': this.props.item.dates.no_end_time ?? true,
+            [TO_BE_CONFIRMED_FIELD]: false,
         };
 
         changes['_startTime'] = newStartDate;
-        this.setToBeConfirmed(changes);
         this.props.onChange(changes);
     }
 
@@ -143,6 +144,7 @@ export class EditorFieldEventSchedule extends React.PureComponent<IProps> {
                     : null,
                 'dates.all_day': !hasStartTime,
                 'dates.no_end_time': hasStartTime,
+                [TO_BE_CONFIRMED_FIELD]: false,
             };
 
             this.props.onChange(changes);
@@ -159,17 +161,10 @@ export class EditorFieldEventSchedule extends React.PureComponent<IProps> {
             'dates.end': newEndDate,
             'dates.all_day': false,
             'dates.no_end_time': false,
+            [TO_BE_CONFIRMED_FIELD]: false,
         };
 
-        this.setToBeConfirmed(changes);
         this.props.onChange(changes);
-    }
-
-    setToBeConfirmed(changes) {
-        if ((changes['_startTime'] || this.props.item._startTime) &&
-            (changes['_endTime'] || this.props.item._endTime)) {
-            changes[TO_BE_CONFIRMED_FIELD] = false;
-        }
     }
 
     changeTimezone(_: string, timezone?: string) {


### PR DESCRIPTION
STT-40

## Front-end checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)
