### PR TITLE
reingest onclusive event on location change

### DIFF
--- a/server/planning/events/events.py
+++ b/server/planning/events/events.py
@@ -119,7 +119,13 @@ def is_event_updated(new_item: Event, old_item: Event) -> bool:
         return True
     new_subject = set([get_subject_str(subject) for subject in new_item.get("subject", [])])
     old_subject = set([get_subject_str(subject) for subject in old_item.get("subject", [])])
-    return new_subject != old_subject
+    if new_subject != old_subject:
+        return True
+    old_location = old_item.get("location", [])
+    new_location = new_item.get("location", [])
+    if new_location != old_location:
+        return True
+    return False
 
 
 class EventsService(superdesk.Service):

--- a/server/planning/events/events_tests.py
+++ b/server/planning/events/events_tests.py
@@ -1,5 +1,6 @@
-from datetime import datetime, timedelta
 import pytz
+
+from datetime import datetime, timedelta
 from copy import deepcopy
 from mock import Mock, patch
 from superdesk import get_resource_service
@@ -9,6 +10,8 @@ from planning.common import format_address, POST_STATE
 from planning.item_lock import LockService
 from planning.events.events import generate_recurring_dates
 from werkzeug.exceptions import BadRequest
+
+from .events import is_event_updated
 
 
 class EventTestCase(TestCase):
@@ -698,3 +701,10 @@ class EventsRelatedPlanningAutoPublish(TestCase):
             planning_item = planning_service.find_one(req=None, _id=planning_id[0])
             self.assertEqual(len([planning_item]), 1)
             self.assertEqual(planning_item.get("state"), "scheduled")
+
+
+def test_is_event_updated():
+    new_event = {"location": [{"name": "test"}]}
+    old_events = {"location": [{"name": "test", "state": "bar"}]}
+    assert is_event_updated(new_event, old_events)
+    assert not is_event_updated(new_event, new_event)


### PR DESCRIPTION
SDCP-866

## Front-end checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)
