### PR TITLE
Links field

### DIFF
--- a/client/components/planning-editor-standalone/field-definitions/link-field.ts
+++ b/client/components/planning-editor-standalone/field-definitions/link-field.ts
@@ -1,0 +1,19 @@
+import {IAuthoringFieldV2, IUrlsFieldConfig} from 'superdesk-api';
+
+export function getLinksField(options: {id: string; label: string, required: boolean}): IAuthoringFieldV2 {
+    const config: IUrlsFieldConfig = {
+        hideDescription: true,
+    };
+
+    const field: IAuthoringFieldV2 = {
+        id: options.id,
+        name: options.label,
+        fieldType: 'urls',
+        fieldConfig: {
+            ...config,
+            required: options.required,
+        },
+    };
+
+    return field;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1687,51 +1687,37 @@
       }
     },
     "call-bound": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.2.tgz",
-      "integrity": "sha512-0lk0PHFe/uz0vl527fG9CgdE9WdafjDbCXvBbs+LUv000TVt2Jjhqbs4Jwm8gz070w8xXyEAxrPOMullsxXeGg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.3.tgz",
+      "integrity": "sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==",
       "dev": true,
       "requires": {
-        "call-bind": "^1.0.8",
-        "get-intrinsic": "^1.2.5"
+        "call-bind-apply-helpers": "^1.0.1",
+        "get-intrinsic": "^1.2.6"
       },
       "dependencies": {
-        "call-bind": {
-          "version": "1.0.8",
-          "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
-          "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
-          "dev": true,
-          "requires": {
-            "call-bind-apply-helpers": "^1.0.0",
-            "es-define-property": "^1.0.0",
-            "get-intrinsic": "^1.2.4",
-            "set-function-length": "^1.2.2"
-          }
+        "es-define-property": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+          "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+          "dev": true
         },
         "get-intrinsic": {
-          "version": "1.2.6",
-          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.6.tgz",
-          "integrity": "sha512-qxsEs+9A+u85HhllWJJFicJfPDhRmjzoYdl64aMWW9yRIJmSyxdn8IEkuIM530/7T+lv0TIHd8L6Q/ra0tEoeA==",
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
+          "integrity": "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==",
           "dev": true,
           "requires": {
             "call-bind-apply-helpers": "^1.0.1",
-            "dunder-proto": "^1.0.0",
             "es-define-property": "^1.0.1",
             "es-errors": "^1.3.0",
             "es-object-atoms": "^1.0.0",
             "function-bind": "^1.1.2",
+            "get-proto": "^1.0.0",
             "gopd": "^1.2.0",
             "has-symbols": "^1.1.0",
             "hasown": "^2.0.2",
-            "math-intrinsics": "^1.0.0"
-          },
-          "dependencies": {
-            "es-define-property": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-              "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-              "dev": true
-            }
+            "math-intrinsics": "^1.1.0"
           }
         },
         "gopd": {
@@ -1804,9 +1790,9 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30001688",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30001688.tgz",
-      "integrity": "sha512-A/Iczixdj5egZW0TNw9DYS/sqKvKDLAbLEZa5wadHzQy2q0DtCIdB7d4PAeKluWbwmE+f5orWbduaTMYcMQCag==",
+      "version": "1.0.30001690",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30001690.tgz",
+      "integrity": "sha512-9Jw0YwFL5OJlEQzfznw033GzuoIv7XfWoLX0MgjuUTFJydhHanHcMt2zohwdPOgvMz4ssJa9WTiR+cT8IsgfnQ==",
       "dev": true
     },
     "caseless": {
@@ -3210,12 +3196,12 @@
       "dev": true
     },
     "dunder-proto": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.0.tgz",
-      "integrity": "sha512-9+Sj30DIu+4KvHqMfLUGLFYL2PkURSYMVXJyXe92nFRvlYq5hBjLEhblKB+vkd/WVlUYMWigiY07T91Fkk0+4A==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
       "dev": true,
       "requires": {
-        "call-bind-apply-helpers": "^1.0.0",
+        "call-bind-apply-helpers": "^1.0.1",
         "es-errors": "^1.3.0",
         "gopd": "^1.2.0"
       },
@@ -3279,9 +3265,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.5.73",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.73.tgz",
-      "integrity": "sha512-8wGNxG9tAG5KhGd3eeA0o6ixhiNdgr0DcHWm85XPCphwZgD1lIEoi6t3VERayWao7SF7AAZTw6oARGJeVjH8Kg==",
+      "version": "1.5.78",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.78.tgz",
+      "integrity": "sha512-UmwIt7HRKN1rsJfddG5UG7rCTCTAKoS9JeOy/R0zSenAyaZ8SU3RuXlwcratxhdxGRNpk03iq8O7BA3W7ibLVw==",
       "dev": true
     },
     "elliptic": {
@@ -4905,6 +4891,16 @@
         "has-proto": "^1.0.1",
         "has-symbols": "^1.0.3",
         "hasown": "^2.0.0"
+      }
+    },
+    "get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "requires": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
       }
     },
     "get-stdin": {
@@ -7683,9 +7679,9 @@
       "dev": true
     },
     "math-intrinsics": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.0.0.tgz",
-      "integrity": "sha512-4MqMiKP90ybymYvsut0CH2g4XWbfLtmlCkXmtmdcDCxNB+mQcu1w/1+L/VD7vi/PSv7X2JYV7SCcR+jiPXnQtA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
       "dev": true
     },
     "math-random": {
@@ -12276,8 +12272,8 @@
       }
     },
     "superdesk-core": {
-      "version": "github:thecalcc/superdesk-client-core#215f57f8e3b4bea67bdbf18b05c47fd726570b80",
-      "from": "github:thecalcc/superdesk-client-core#rework-dropdown-fields",
+      "version": "github:superdesk/superdesk-client-core#2a37784a81dfd2e7dcebb7e1cb1c29a1d144a235",
+      "from": "github:superdesk/superdesk-client-core#develop",
       "dev": true,
       "requires": {
         "@metadata/exif": "github:superdesk/exif#431066d",
@@ -12364,7 +12360,7 @@
         "react-mentions": "1.2.2",
         "react-paginate": "6.3.0",
         "react-portal": "4.1.3",
-        "react-redux": "7.2.1",
+        "react-redux": "7.2.9",
         "react-sortable-hoc": "1.11.0",
         "react-textarea-autosize": "5.2.1",
         "react-virtual": "2.10.4",
@@ -12374,7 +12370,7 @@
         "sass-loader": "6.0.6",
         "shortid": "2.2.8",
         "style-loader": "0.20.2",
-        "superdesk-ui-framework": "4.0.3",
+        "superdesk-ui-framework": "4.0.4",
         "ts-loader": "3.5.0",
         "typescript": "4.9.5",
         "uuid": "8.3.1",
@@ -12440,6 +12436,12 @@
             "prop-types": "^15"
           }
         },
+        "react-is": {
+          "version": "17.0.2",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+          "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+          "dev": true
+        },
         "react-portal": {
           "version": "4.1.3",
           "resolved": "https://registry.npmjs.org/react-portal/-/react-portal-4.1.3.tgz",
@@ -12447,6 +12449,53 @@
           "dev": true,
           "requires": {
             "prop-types": "^15.5.8"
+          }
+        },
+        "react-redux": {
+          "version": "7.2.9",
+          "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.9.tgz",
+          "integrity": "sha512-Gx4L3uM182jEEayZfRbI/G11ZpYdNAnBs70lFVMNdHJI76XYtR+7m0MN+eAs7UHBPhWXcnFPaS+9owSCJQHNpQ==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.15.4",
+            "@types/react-redux": "^7.1.20",
+            "hoist-non-react-statics": "^3.3.2",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.7.2",
+            "react-is": "^17.0.2"
+          },
+          "dependencies": {
+            "@types/react-redux": {
+              "version": "7.1.34",
+              "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.34.tgz",
+              "integrity": "sha512-GdFaVjEbYv4Fthm2ZLvj1VSCedV7TqE5y1kNwnjSdBOTXuRSgowux6J8TAct15T3CKBr63UMk+2CO7ilRhyrAQ==",
+              "dev": true,
+              "requires": {
+                "@types/hoist-non-react-statics": "^3.3.0",
+                "@types/react": "*",
+                "hoist-non-react-statics": "^3.3.0",
+                "redux": "^4.0.0"
+              }
+            },
+            "prop-types": {
+              "version": "15.8.1",
+              "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+              "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+              "dev": true,
+              "requires": {
+                "loose-envify": "^1.4.0",
+                "object-assign": "^4.1.1",
+                "react-is": "^16.13.1"
+              },
+              "dependencies": {
+                "react-is": {
+                  "version": "16.13.1",
+                  "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+                  "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+                  "dev": true
+                }
+              }
+            }
           }
         },
         "react-sortable-hoc": {
@@ -12461,9 +12510,9 @@
           }
         },
         "superdesk-ui-framework": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/superdesk-ui-framework/-/superdesk-ui-framework-4.0.3.tgz",
-          "integrity": "sha512-LUNR1u3sK4Ayiq74hXZ5fqp7k9OK/MJogsEXJfeaJQyBWzRdbzwyYjljIXh7gJJExtDEBokLxU33IpjuXuITJA==",
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/superdesk-ui-framework/-/superdesk-ui-framework-4.0.4.tgz",
+          "integrity": "sha512-mm36orxkDHDYM3ID36q6fB9ImHwV2CvgEIAXmZD0BOpfy+4Yc0+7GLfuur0Zf1Vs7LIutcoe4ljsSQ0RdB9KDQ==",
           "dev": true,
           "requires": {
             "@popperjs/core": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "simulant": "^0.2.2",
     "sinon": "^4.5.0",
     "superdesk-code-style": "1.5.0",
-    "superdesk-core": "github:thecalcc/superdesk-client-core#rework-dropdown-fields",
+    "superdesk-core": "github:superdesk/superdesk-client-core#develop",
     "superdesk-ui-framework": "^4.0.7",
     "ts-node": "~7.0.1",
     "tslint": "5.11.0",


### PR DESCRIPTION
STT-31

## Front-end checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [x] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [x] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [x] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [x] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [x] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [x] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [x] This pull request is not adding redux based modals
- [x] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [x] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)
