### PR TITLE
avoid overriding user changes via event ingest

### DIFF
--- a/server/planning/events/events.py
+++ b/server/planning/events/events.py
@@ -138,17 +138,15 @@ def is_event_updated(new_item: Event, old_item: Event) -> bool:
     return False
 
 
-def get_user_updated_keys(id: str) -> set[str]:
-    # Placeholder function definition
-    # Replace this with the actual implementation
+def get_user_updated_keys(event_id: str) -> set[str]:
     history_service = get_resource_service("events_history")
-    updates = history_service.get_by_id(id)
+    updates = history_service.get_by_id(event_id)
     updated_keys = set()
     for update in updates:
         if not update.get("user_id"):
             continue
-        for key in update.get("update", {}):
-            updated_keys.add(key)
+        if update.get("update"):
+            updated_keys.update(update["update"].keys())
     return updated_keys
 
 
@@ -168,17 +166,17 @@ class EventsService(superdesk.Service):
         self.on_created(docs)
         return ids
 
-    def patch_in_mongo(self, id: str, document, original) -> Optional[Dict[str, Any]]:
+    def patch_in_mongo(self, _id: str, document, original) -> Optional[Dict[str, Any]]:
         """Patch an ingested item onto an existing item locally"""
         content_fields = app.config.get("EVENT_INGEST_CONTENT_FIELDS", CONTENT_FIELDS)
-        updated_keys = get_user_updated_keys(id)
+        updated_keys = get_user_updated_keys(_id)
         for key in updated_keys:
             if key in document and key in content_fields and original.get(key):
                 document[key] = original[key]
 
         set_planning_schedule(document)
         update_ingest_on_patch(document, original)
-        response = self.backend.update_in_mongo(self.datasource, id, document, original)
+        response = self.backend.update_in_mongo(self.datasource, _id, document, original)
         self.on_updated(document, original, from_ingest=True)
         return response
 

--- a/server/planning/events/events.py
+++ b/server/planning/events/events.py
@@ -86,6 +86,16 @@ organizer_roles = {
     "eorol:venue": "Venue organiser",
 }
 
+# based on onclusive provided content fields for now
+CONTENT_FIELDS = {
+    "name",
+    "definition_short",
+    "definition_long",
+    "links",
+    "ednote",
+    "subject",
+}
+
 
 def get_events_embedded_planning(event: Event) -> List[EmbeddedPlanning]:
     def get_coverage_id(coverage: EmbeddedCoverageItem) -> str:
@@ -128,6 +138,20 @@ def is_event_updated(new_item: Event, old_item: Event) -> bool:
     return False
 
 
+def get_user_updated_keys(id: str) -> set[str]:
+    # Placeholder function definition
+    # Replace this with the actual implementation
+    history_service = get_resource_service("events_history")
+    updates = history_service.get_by_id(id)
+    updated_keys = set()
+    for update in updates:
+        if not update.get("user_id"):
+            continue
+        for key in update.get("update", {}):
+            updated_keys.add(key)
+    return updated_keys
+
+
 class EventsService(superdesk.Service):
     """Service class for the events model."""
 
@@ -144,8 +168,13 @@ class EventsService(superdesk.Service):
         self.on_created(docs)
         return ids
 
-    def patch_in_mongo(self, id, document, original) -> Optional[Dict[str, Any]]:
+    def patch_in_mongo(self, id: str, document, original) -> Optional[Dict[str, Any]]:
         """Patch an ingested item onto an existing item locally"""
+        content_fields = app.config.get("EVENT_INGEST_CONTENT_FIELDS", CONTENT_FIELDS)
+        updated_keys = get_user_updated_keys(id)
+        for key in updated_keys:
+            if key in document and key in content_fields and original.get(key):
+                document[key] = original[key]
 
         set_planning_schedule(document)
         update_ingest_on_patch(document, original)

--- a/server/planning/events/events_history.py
+++ b/server/planning/events/events_history.py
@@ -99,8 +99,8 @@ class EventsHistoryService(HistoryService):
     def on_update_time(self, updates, original):
         self.on_item_updated(updates, original, "update_time")
 
-    def get_by_id(self, id: str) -> list[EventHistoryRecord]:
-        records = self.find(where={"event_id": id})
+    def get_by_id(self, _id: str) -> list[EventHistoryRecord]:
+        records = self.find(where={"event_id": _id})
         return [
             {
                 "event_id": record.get("event_id"),

--- a/server/planning/events/events_history.py
+++ b/server/planning/events/events_history.py
@@ -8,6 +8,7 @@
 
 """Superdesk Files"""
 
+from typing import Any, TypedDict
 from superdesk import Resource, get_resource_service
 from planning.history import HistoryService
 import logging
@@ -22,12 +23,24 @@ class EventsHistoryResource(Resource):
     endpoint_name = "events_history"
     resource_methods = ["GET"]
     item_methods = ["GET"]
+
     schema = {
         "event_id": {"type": "string"},
         "user_id": Resource.rel("users", True),
         "operation": {"type": "string"},
         "update": {"type": "dict", "nullable": True},
     }
+
+    mongo_indexes = {
+        "event_id_1": ([("event_id", 1)], {"background": True}),
+    }
+
+
+class EventHistoryRecord(TypedDict):
+    event_id: str
+    user_id: str
+    operation: str
+    update: dict[str, Any]
 
 
 class EventsHistoryService(HistoryService):
@@ -85,3 +98,15 @@ class EventsHistoryService(HistoryService):
 
     def on_update_time(self, updates, original):
         self.on_item_updated(updates, original, "update_time")
+
+    def get_by_id(self, id: str) -> list[EventHistoryRecord]:
+        records = self.find(where={"event_id": id})
+        return [
+            {
+                "event_id": record.get("event_id"),
+                "user_id": record.get("user_id"),
+                "operation": record.get("operation"),
+                "update": record.get("update"),
+            }
+            for record in records
+        ]

--- a/server/planning/events/events_ingest_tests.py
+++ b/server/planning/events/events_ingest_tests.py
@@ -1,0 +1,35 @@
+from superdesk import get_resource_service
+from datetime import datetime, timedelta
+from planning.tests import TestCase
+from unittest.mock import patch
+from flask import g
+
+
+class EventIngestTestCase(TestCase):
+    def test_ingest_updated_event(self):
+        events_service = get_resource_service("events")
+        events_history_service = get_resource_service("events_history")
+        dates = {"start": datetime.now(), "end": datetime.now() + timedelta(days=1)}
+        old_event = {"guid": "1", "name": "bar", "ednote": "ednote1", "dates": dates}
+
+        # event is created
+        events_service.post_in_mongo([old_event])
+
+        # user updates the event
+        updates = {"definition_short": "manual", "ednote": "manual"}
+        with self.app.test_request_context():
+            g.user = {"_id": "test"}
+            events_service.patch(old_event["_id"], updates)
+            events_history_service.on_item_updated(updates, old_event)
+
+        new_event = {"guid": "1", "name": "updated", "ednote": "updated", "dates": dates, "definition_short": "updated"}
+        old_event = events_service.find_one(req=None, guid="1")
+
+        # event is updated via ingest
+        events_service.patch_in_mongo(new_event["guid"], new_event, old_event)
+
+        updated_event = events_service.find_one(req=None, _id="1")
+        assert updated_event is not None
+        assert updated_event["name"] == "updated"
+        assert updated_event["ednote"] == "manual"
+        assert updated_event["definition_short"] == "manual"

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ input_file = po/server.pot
 output_dir = server/planning/translations
 
 [mypy]
-python_version = 3.8
+python_version = 3.10
 warn_unused_configs = True
 allow_untyped_globals = True
 ignore_missing_imports = True


### PR DESCRIPTION
check event history what keys were updated
by users and ignore those when updating from
ingest.

SDCP-861

## Front-end checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)
