### PR TITLE
Location field

### DIFF
--- a/client/components/Events/EventEditor/index.tsx
+++ b/client/components/Events/EventEditor/index.tsx
@@ -66,8 +66,6 @@ class EventEditorComponent extends React.PureComponent<IProps> {
     constructor(props) {
         super(props);
 
-        this.showAddLocationForm = this.showAddLocationForm.bind(this);
-        this.onCloseAddNewLocation = this.onCloseAddNewLocation.bind(this);
         this.onDatesChanged = this.onDatesChanged.bind(this);
     }
 
@@ -94,24 +92,6 @@ class EventEditorComponent extends React.PureComponent<IProps> {
                 planning_ids: this.props.original?.planning_ids ?? [],
             });
         }
-    }
-
-    showAddLocationForm(props: any): Promise<ILocation | undefined> {
-        const editor = planningApi.editor(this.props.editorType);
-
-        return editor.form.showPopupForm(CreateNewGeoLookup, props)
-            .finally(() => {
-                // Re-focus the location text input
-                const editor = planningApi.editor(this.props.editorType);
-
-                editor.form.scrollToBookmarkGroup('location');
-            });
-    }
-
-    onCloseAddNewLocation() {
-        const editor = planningApi.editor(this.props.editorType);
-
-        editor.form.closePopupForm();
     }
 
     onDatesChanged(value: {[key: string]: any}) {
@@ -191,9 +171,6 @@ class EventEditorComponent extends React.PureComponent<IProps> {
                     },
                     location: {
                         enableExternalSearch: true,
-                        showAddLocationForm: this.showAddLocationForm,
-                        onPopupClose: this.onCloseAddNewLocation,
-                        onCancel: this.onCloseAddNewLocation,
                     },
                     name: {
                         label: gettext('Event Name'),

--- a/client/components/GeoLookupInput/AddGeoLookupInput.tsx
+++ b/client/components/GeoLookupInput/AddGeoLookupInput.tsx
@@ -233,8 +233,7 @@ export class AddGeoLookupInput extends React.Component<IProps, IState> {
                 translations: location.translations,
             };
 
-            // external address might not be there.
-            if (location.address.external != null) {
+            if (location.address?.external != null) {
                 delete value.address.external;
             }
 

--- a/client/components/GeoLookupInput/CreateNewGeoLookup.tsx
+++ b/client/components/GeoLookupInput/CreateNewGeoLookup.tsx
@@ -19,17 +19,18 @@ import {renderFieldsForPanel} from '../fields';
 
 import './style.scss';
 
-interface IProps {
+interface IReduxStoreProps {
+    defaultCountry: string;
+}
+
+interface IOwnProps {
     initialName?: string;
     initialAddressIsName?: boolean;
-
-    // Redux states
-    defaultCountry?: IVocabularyItem['name'];
-
-    // functions to close the popup (and resolve/reject the Promise)
-    resolve(location: ILocation): void;
-    reject(error?: any): void;
+    onSuccess(location: ILocation): void;
+    onError(error?: any): void;
 }
+
+type IProps = IReduxStoreProps & IOwnProps;
 
 interface IState {
     formInvalid: boolean;
@@ -111,9 +112,9 @@ class CreateNewGeoLookupComponent extends React.Component<IProps, IState> {
     onSave() {
         planningApi.locations.getOrCreate(this.getLocationFromState(this.state.item))
             .then((newLocation) => {
-                this.props.resolve(newLocation);
+                this.props.onSuccess(newLocation);
             }, (error) => {
-                this.props.reject(error);
+                this.props.onError(error);
             });
     }
 
@@ -130,7 +131,7 @@ class CreateNewGeoLookupComponent extends React.Component<IProps, IState> {
                     <a
                         className="icn-btn"
                         aria-label={gettext('Close')}
-                        onClick={this.props.reject}
+                        onClick={this.props.onError}
                     >
                         <i className="icon-close-small" />
                     </a>
@@ -172,7 +173,7 @@ class CreateNewGeoLookupComponent extends React.Component<IProps, IState> {
                     <ButtonGroup align="end">
                         <Button
                             text={gettext('Cancel')}
-                            onClick={this.props.reject}
+                            onClick={this.props.onError}
                             data-test-id="location-form__cancel-button"
                         />
                         <Button
@@ -189,4 +190,5 @@ class CreateNewGeoLookupComponent extends React.Component<IProps, IState> {
     }
 }
 
-export const CreateNewGeoLookup = connect(mapStateToProps)(CreateNewGeoLookupComponent);
+export const CreateNewGeoLookup =
+    connect<IReduxStoreProps, {}, IOwnProps>(mapStateToProps)(CreateNewGeoLookupComponent);

--- a/client/components/GeoLookupInput/index.tsx
+++ b/client/components/GeoLookupInput/index.tsx
@@ -3,6 +3,10 @@ import {AddGeoLookupInput} from './AddGeoLookupInput';
 
 import {LineInput, Label} from '../UI/Form';
 import {ILocation} from '../../interfaces';
+import {showModal} from '@sourcefabric/common';
+import {CreateNewGeoLookup} from './CreateNewGeoLookup';
+import {Provider} from 'react-redux';
+import {planningApi} from '../../superdeskApi';
 
 interface IProps {
     field: string;
@@ -24,7 +28,6 @@ interface IProps {
     popupContainer?(): HTMLElement;
     onPopupOpen?(): void;
     onPopupClose?(): void;
-    showAddLocationForm?(props: any): Promise<ILocation | undefined>;
 }
 
 export class GeoLookupInput extends React.PureComponent<IProps> {
@@ -41,7 +44,6 @@ export class GeoLookupInput extends React.PureComponent<IProps> {
             onFocus,
             popupContainer,
             refNode,
-            showAddLocationForm,
             ...props
         } = this.props;
 
@@ -66,7 +68,24 @@ export class GeoLookupInput extends React.PureComponent<IProps> {
                     popupContainer={popupContainer}
                     onPopupOpen={props.onPopupOpen}
                     onPopupClose={props.onPopupClose}
-                    showAddLocationForm={showAddLocationForm}
+                    showAddLocationForm={(props) => {
+                        let newLocation: ILocation;
+
+                        return showModal(({closeModal}) => (
+                            <Provider store={planningApi.redux.store}>
+                                <CreateNewGeoLookup
+                                    {...props}
+                                    onError={() => {
+                                        closeModal();
+                                    }}
+                                    onSuccess={(location) => {
+                                        newLocation = location;
+                                        closeModal();
+                                    }}
+                                />
+                            </Provider>
+                        )).then(() => newLocation);
+                    }}
                 />
             </LineInput>
         );

--- a/client/components/GeoLookupInput/index.tsx
+++ b/client/components/GeoLookupInput/index.tsx
@@ -69,22 +69,22 @@ export class GeoLookupInput extends React.PureComponent<IProps> {
                     onPopupOpen={props.onPopupOpen}
                     onPopupClose={props.onPopupClose}
                     showAddLocationForm={(props) => {
-                        let newLocation: ILocation;
-
-                        return showModal(({closeModal}) => (
-                            <Provider store={planningApi.redux.store}>
-                                <CreateNewGeoLookup
-                                    {...props}
-                                    onError={() => {
-                                        closeModal();
-                                    }}
-                                    onSuccess={(location) => {
-                                        newLocation = location;
-                                        closeModal();
-                                    }}
-                                />
-                            </Provider>
-                        )).then(() => newLocation);
+                        return new Promise((resolve) => {
+                            showModal(({closeModal}) => (
+                                <Provider store={planningApi.redux.store}>
+                                    <CreateNewGeoLookup
+                                        {...props}
+                                        onError={() => {
+                                            closeModal();
+                                        }}
+                                        onSuccess={(location) => {
+                                            resolve(location);
+                                            closeModal();
+                                        }}
+                                    />
+                                </Provider>
+                            ));
+                        });
                     }}
                 />
             </LineInput>

--- a/client/components/Modal/Footer.tsx
+++ b/client/components/Modal/Footer.tsx
@@ -1,9 +1,13 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import {Modal as _Modal} from 'react-bootstrap';
 import classNames from 'classnames';
 
-export default function Footer({children, flex}) {
+interface IProps {
+    children: React.ReactNode;
+    flex?: boolean;
+}
+
+export default function Footer({children, flex}: IProps) {
     return (
         <_Modal.Footer
             className={classNames(
@@ -15,11 +19,3 @@ export default function Footer({children, flex}) {
         </_Modal.Footer>
     );
 }
-
-Footer.propTypes = {
-    children: PropTypes.oneOfType([
-        PropTypes.element,
-        PropTypes.arrayOf(PropTypes.element),
-    ]),
-    flex: PropTypes.bool,
-};

--- a/client/components/Modal/Header.tsx
+++ b/client/components/Modal/Header.tsx
@@ -1,18 +1,14 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import {Modal as _Modal} from 'react-bootstrap';
 
-export default function Header({children}) {
+interface IProps {
+    children: React.ReactNode;
+}
+
+export default function Header({children}: IProps) {
     return (
         <_Modal.Header className="modal__header modal__header--flex">
             {children}
         </_Modal.Header>
     );
 }
-
-Header.propTypes = {
-    children: PropTypes.oneOfType([
-        PropTypes.element,
-        PropTypes.arrayOf(PropTypes.element),
-    ]),
-};

--- a/client/components/Modal/ModalDialog.tsx
+++ b/client/components/Modal/ModalDialog.tsx
@@ -1,9 +1,15 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import {pickBy} from 'lodash';
 
-export default function ModalDialog({dialogClassName, children, style, className, ...props}) {
+interface IProps {
+    dialogClassName?: string;
+    children: React.ReactNode;
+    style?: any;
+    className?: string;
+}
+
+export default function ModalDialog({dialogClassName, children, style, className, ...props}: IProps) {
     const modalStyle = {
         display: 'block',
         ...style,
@@ -19,7 +25,6 @@ export default function ModalDialog({dialogClassName, children, style, className
     return (
         <div
             {...elementProps}
-            tabIndex="-1"
             role="dialog"
             style={modalStyle}
             className={className}
@@ -32,13 +37,3 @@ export default function ModalDialog({dialogClassName, children, style, className
         </div>
     );
 }
-
-ModalDialog.propTypes = {
-    children: PropTypes.oneOfType([
-        PropTypes.element,
-        PropTypes.arrayOf(PropTypes.element),
-    ]),
-    style: PropTypes.object,
-    className: PropTypes.string,
-    dialogClassName: PropTypes.string,
-};

--- a/client/components/fields/editor/Location.tsx
+++ b/client/components/fields/editor/Location.tsx
@@ -1,17 +1,16 @@
 import * as React from 'react';
-import {get} from 'lodash';
-import {IEditorFieldProps} from '../../../interfaces';
+import {IEditorFieldProps, ILocation} from '../../../interfaces';
 
 import {superdeskApi} from '../../../superdeskApi';
 import {GeoLookupInput} from '../../GeoLookupInput';
 import {Row} from '../../UI/Form';
 
-interface IProps extends IEditorFieldProps {
+export interface IEditorFieldLocationProps extends IEditorFieldProps {
     enableExternalSearch?: boolean;
     disableAddLocation?: boolean;
 }
 
-export class EditorFieldLocation extends React.PureComponent<IProps> {
+export class EditorFieldLocation extends React.PureComponent<IEditorFieldLocationProps> {
     render() {
         const {gettext} = superdeskApi.localization;
         const field = this.props.field ?? 'location';

--- a/client/components/planning-editor-standalone/field-definitions/index.ts
+++ b/client/components/planning-editor-standalone/field-definitions/index.ts
@@ -15,6 +15,7 @@ import {getCategoriesField} from './category-field';
 import {getAgendasField} from './agendas-field';
 import {getSubjectField} from './subject';
 import {getPriorityField} from './priority-field';
+import {getLocationsField} from './locations-field';
 
 export function getFieldDefinitions(): IFieldDefinitions {
     const {gettext} = superdeskApi.localization;
@@ -72,6 +73,7 @@ export function getFieldDefinitions(): IFieldDefinitions {
         getSubjectField(),
         getCategoriesField(),
         getPriorityField(),
+        getLocationsField(),
         {
             fieldId: 'coverages',
             getField: ({id, required}) => {

--- a/client/components/planning-editor-standalone/field-definitions/locations-field.ts
+++ b/client/components/planning-editor-standalone/field-definitions/locations-field.ts
@@ -1,0 +1,20 @@
+import {IAuthoringFieldV2} from 'superdesk-api';
+import {superdeskApi} from '../../../superdeskApi';
+
+export const getLocationsField = () => {
+    return {
+        fieldId: 'location',
+        getField: ({id, required}) => {
+            const field: IAuthoringFieldV2 = {
+                id: id,
+                name: superdeskApi.localization.gettext('Location'),
+                fieldType: 'location',
+                fieldConfig: {
+                    required: required,
+                },
+            };
+
+            return field;
+        },
+    };
+};

--- a/client/components/planning-editor-standalone/profile-fields.ts
+++ b/client/components/planning-editor-standalone/profile-fields.ts
@@ -62,5 +62,9 @@ export const getPlanningProfileFields = (options: {embeddedOnly?: boolean}): Arr
         }
     }
 
-    return convertedFieldIds;
+    return convertedFieldIds.concat({
+        fieldId: 'location',
+        required: false,
+        type: 'normal',
+    });
 };

--- a/client/components/planning-editor-standalone/profile-fields.ts
+++ b/client/components/planning-editor-standalone/profile-fields.ts
@@ -62,9 +62,5 @@ export const getPlanningProfileFields = (options: {embeddedOnly?: boolean}): Arr
         }
     }
 
-    return convertedFieldIds.concat({
-        fieldId: 'location',
-        required: false,
-        type: 'normal',
-    });
+    return convertedFieldIds;
 };

--- a/client/extension_bridge.ts
+++ b/client/extension_bridge.ts
@@ -1,27 +1,22 @@
 import React from 'react';
 
 import {IArticle, IVocabularyItem} from 'superdesk-api';
-
 import {getAssignmentTypeInfo} from './utils/assignments';
 import {SluglineComponent} from './components/Assignments/AssignmentItem/fields/Slugline';
 import {DueDateComponent} from './components/Assignments/AssignmentItem/fields/DueDate';
 import {StateComponent} from './components/Assignments/AssignmentItem/fields/State';
 import {EditorFieldVocabulary, IEditorFieldVocabularyProps} from './components/fields/editor/base/vocabulary';
-
 import {getVocabularyItemFieldTranslated} from './utils/vocabularies';
 import {getUserInterfaceLanguageFromCV} from './utils/users';
-
-import {registerEditorField} from './components/fields/resources/registerEditorFields';
-import {IAssignmentItem, IEditorFieldProps, IPlanningAppState, IPlanningItem} from 'interfaces';
 import {isContentLinkToCoverageAllowed} from './utils/archive';
-
 import PlanningDetailsWidget, {getItemPlanningInfo} from './components/PlanningDetailsWidget';
 import {AttachmentsInputStandalone} from './components/AttachmentsInputStandalone';
-import {IPropsAttachmentsEditorStandalone} from './components/AttachmentsInputStandalone.interface';
-import {IPropsEditorFieldCoverages} from './components/fields/editor/coverages.interface';
 import {EditorFieldCoverages} from './components/fields/editor/Coverages';
 import {EditorFieldLocation} from './components/fields/editor/Location';
-import {IEditorFieldLocationProps} from './components/fields/editor/Location';
+import type {IAssignmentItem, IEditorFieldProps, IPlanningAppState, IPlanningItem} from 'interfaces';
+import type {IPropsAttachmentsEditorStandalone} from './components/AttachmentsInputStandalone.interface';
+import type {IPropsEditorFieldCoverages} from './components/fields/editor/coverages.interface';
+import type {IEditorFieldLocationProps} from './components/fields/editor/Location';
 
 // KEEP IN SYNC WITH client/planning-extension/src/extension_bridge.ts
 interface IExtensionBridge {

--- a/client/extension_bridge.ts
+++ b/client/extension_bridge.ts
@@ -20,6 +20,8 @@ import {AttachmentsInputStandalone} from './components/AttachmentsInputStandalon
 import {IPropsAttachmentsEditorStandalone} from './components/AttachmentsInputStandalone.interface';
 import {IPropsEditorFieldCoverages} from './components/fields/editor/coverages.interface';
 import {EditorFieldCoverages} from './components/fields/editor/Coverages';
+import {EditorFieldLocation} from './components/fields/editor/Location';
+import {IEditorFieldLocationProps} from './components/fields/editor/Location';
 
 // KEEP IN SYNC WITH client/planning-extension/src/extension_bridge.ts
 interface IExtensionBridge {
@@ -42,6 +44,7 @@ interface IExtensionBridge {
     },
     editor: {
         fields: {
+            EditorFieldLocation: React.ComponentType<IEditorFieldLocationProps>;
             EditorFieldCoverages: React.ComponentType<IPropsEditorFieldCoverages>;
         },
     }
@@ -100,6 +103,7 @@ export const extensionBridge: IExtensionBridge = {
     },
     editor: {
         fields: {
+            EditorFieldLocation: EditorFieldLocation,
             EditorFieldCoverages: EditorFieldCoverages,
         },
     },

--- a/client/planning-extension/src/authoring-react-fields/location/editor.tsx
+++ b/client/planning-extension/src/authoring-react-fields/location/editor.tsx
@@ -13,7 +13,9 @@ export class Editor extends React.PureComponent<IProps> {
             <EditorFieldLocation
                 field="location"
                 enableExternalSearch
-                item={this.props.item}
+                item={{
+                    location: this.props.value,
+                }}
                 required={this.props.config.required}
                 disabled={this.props.config.readOnly}
                 onChange={(_field, value) => this.props.onChange(value)}

--- a/client/planning-extension/src/authoring-react-fields/location/editor.tsx
+++ b/client/planning-extension/src/authoring-react-fields/location/editor.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react';
+import {IEditorComponentProps} from 'superdesk-api';
+import {ILocationFieldConfig, ILocationFieldUserPreferences, ILocationValueOperational} from './interfaces';
+import {extensionBridge} from '../../extension_bridge';
+
+type IProps = IEditorComponentProps<ILocationValueOperational, ILocationFieldConfig, ILocationFieldUserPreferences>;
+
+export class Editor extends React.PureComponent<IProps> {
+    render() {
+        const {EditorFieldLocation} = extensionBridge.editor.fields;
+
+        return (
+            <EditorFieldLocation
+                field="location"
+                enableExternalSearch
+                item={this.props.item}
+                required={this.props.config.required}
+                disabled={this.props.config.readOnly}
+                onChange={(_field, value) => this.props.onChange(value)}
+            />
+        );
+    }
+}

--- a/client/planning-extension/src/authoring-react-fields/location/index.tsx
+++ b/client/planning-extension/src/authoring-react-fields/location/index.tsx
@@ -1,0 +1,32 @@
+import {ICustomFieldType} from 'superdesk-api';
+import {Editor} from './editor';
+import {Preview} from './preview';
+import {
+    ILocationFieldConfig,
+    ILocationFieldUserPreferences,
+    ILocationValueOperational,
+    ILocationValueStorage,
+} from './interfaces';
+import {superdesk} from '../../superdesk';
+
+const {gettext} = superdesk.localization;
+
+export function getLocationField(): ICustomFieldType<
+    ILocationValueOperational,
+    ILocationValueStorage,
+    ILocationFieldConfig,
+    ILocationFieldUserPreferences
+> {
+    const field: ReturnType<typeof getLocationField> = {
+        id: 'location',
+        generic: false,
+        label: gettext('Location'),
+        editorComponent: Editor,
+        previewComponent: Preview,
+        hasValue: (valueOperational) => valueOperational != null && valueOperational.length > 0,
+        getEmptyValue: () => [],
+        configComponent: () => null,
+    };
+
+    return field;
+}

--- a/client/planning-extension/src/authoring-react-fields/location/interfaces.ts
+++ b/client/planning-extension/src/authoring-react-fields/location/interfaces.ts
@@ -1,0 +1,7 @@
+import {ICommonFieldConfig} from 'superdesk-api';
+import {ILocation} from '../../../../interfaces';
+
+export type ILocationValueOperational = Array<ILocation>;
+export type ILocationValueStorage = ILocationValueOperational;
+export type ILocationFieldUserPreferences = never;
+export type ILocationFieldConfig = ICommonFieldConfig;

--- a/client/planning-extension/src/authoring-react-fields/location/preview.tsx
+++ b/client/planning-extension/src/authoring-react-fields/location/preview.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import {IPreviewComponentProps} from 'superdesk-api';
+import {ILocationFieldConfig, ILocationValueOperational} from './interfaces';
+
+type IProps = IPreviewComponentProps<ILocationValueOperational, ILocationFieldConfig>;
+
+export class Preview extends React.PureComponent<IProps> {
+    render() {
+        // not implemented
+        return null;
+    }
+}

--- a/client/planning-extension/src/extension.ts
+++ b/client/planning-extension/src/extension.ts
@@ -22,6 +22,7 @@ import {
 import {getAttachmentsField} from './authoring-react-fields/planning-attachments';
 import {AssignmentsCountTracker} from './assignments-overview/hiddenAssignmentsList';
 import {getCoveragesField} from './authoring-react-fields/coverages';
+import {getLocationField} from './authoring-react-fields/location';
 
 function onSpike(superdesk: ISuperdesk, item: IArticle) {
     const {gettext} = superdesk.localization;
@@ -257,6 +258,7 @@ const extension: IExtension = {
                 customFieldTypes: [
                     getAttachmentsField(),
                     getCoveragesField(),
+                    getLocationField(),
                 ],
             },
         };

--- a/client/planning-extension/src/extension_bridge.ts
+++ b/client/planning-extension/src/extension_bridge.ts
@@ -3,6 +3,7 @@ import {IArticle, IVocabularyItem} from 'superdesk-api';
 import {IAssignmentItem, IEditorFieldProps, IPlanningAppState, IPlanningItem} from '../../interfaces';
 import {IPropsAttachmentsEditorStandalone} from '../../components/AttachmentsInputStandalone.interface';
 import {IPropsEditorFieldCoverages} from '../../components/fields/editor/coverages.interface';
+import {IEditorFieldLocationProps} from '../../components/fields/editor/Location';
 
 interface IEditorFieldVocabularyProps extends IEditorFieldProps {
     options: Array<any>;
@@ -35,6 +36,7 @@ interface IExtensionBridge {
     },
     editor: {
         fields: {
+            EditorFieldLocation: React.ComponentType<IEditorFieldLocationProps>;
             EditorFieldCoverages: React.ComponentType<IPropsEditorFieldCoverages>;
         },
     }

--- a/client/planning-extension/src/extension_bridge.ts
+++ b/client/planning-extension/src/extension_bridge.ts
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import {IArticle, IVocabularyItem} from 'superdesk-api';
-import {IAssignmentItem, IEditorFieldProps, IPlanningAppState, IPlanningItem} from '../../interfaces';
-import {IPropsAttachmentsEditorStandalone} from '../../components/AttachmentsInputStandalone.interface';
-import {IPropsEditorFieldCoverages} from '../../components/fields/editor/coverages.interface';
-import {IEditorFieldLocationProps} from '../../components/fields/editor/Location';
+import type {IAssignmentItem, IEditorFieldProps, IPlanningAppState, IPlanningItem} from '../../interfaces';
+import type {IPropsAttachmentsEditorStandalone} from '../../components/AttachmentsInputStandalone.interface';
+import type {IPropsEditorFieldCoverages} from '../../components/fields/editor/coverages.interface';
+import type {IEditorFieldLocationProps} from '../../components/fields/editor/Location';
 
 interface IEditorFieldVocabularyProps extends IEditorFieldProps {
     options: Array<any>;


### PR DESCRIPTION
STT-31

## Front-end checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [x] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [x] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [x] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [x] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [x] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [x] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [x] This pull request is not adding redux based modals
- [x] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [x] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)
