### PR TITLE
autopost ingested events on creation via rule handler

### DIFF
--- a/server/planning/common.py
+++ b/server/planning/common.py
@@ -8,7 +8,7 @@
 # AUTHORS and LICENSE files distributed with this source code, or
 # at https://www.sourcefabric.org/superdesk/license
 
-from typing import NamedTuple, Dict, Any, Set, Optional
+from typing import NamedTuple, Dict, Any, Set, Optional, Union
 
 import re
 import time
@@ -30,7 +30,7 @@ from superdesk.etree import parse_html
 import json
 from bson import ObjectId
 
-from planning.types import Planning, Coverage
+from planning.types import Planning, Coverage, Event
 
 ITEM_STATE = "state"
 ITEM_EXPIRY = "expiry"
@@ -856,7 +856,7 @@ def update_ingest_on_patch(updates: Dict[str, Any], original: Dict[str, Any]):
         # The local version has not been published yet
         # So remove the provided ``pubstatus``
         updates.pop("pubstatus", None)
-    elif original.get("pubstatus") == updates.get("ingest_pubstatus"):
+    elif original.get("pubstatus") == updates.get("ingest_pubstatus") or original.get("pubstatus"):
         # The local version has been published
         # and no change to ``pubstatus`` on ingested item
         updates.pop("state")
@@ -867,3 +867,8 @@ def get_coverage_from_planning(planning_item: Planning, coverage_id: str) -> Opt
         (coverage for coverage in planning_item.get("coverages") or [] if coverage.get("coverage_id") == coverage_id),
         None,
     )
+
+
+def prepare_ingested_item_for_storage(doc: Union[Event, Planning]) -> None:
+    doc.setdefault("state", "ingested")
+    doc["ingest_pubstatus"] = doc.pop("pubstatus", "usable")  # pubstatus is set when posted

--- a/server/planning/common.py
+++ b/server/planning/common.py
@@ -379,6 +379,8 @@ def update_post_item(updates, original):
     # Save&Post or Save&Unpost
     if updates.get("pubstatus"):
         pub_status = updates["pubstatus"]
+    elif updates.get("ingest_pubstatus"):
+        pub_status = updates["ingest_pubstatus"]
     elif original.get("pubstatus") == POST_STATE.USABLE:
         # From item actions
         pub_status = POST_STATE.USABLE

--- a/server/planning/common.py
+++ b/server/planning/common.py
@@ -856,7 +856,7 @@ def update_ingest_on_patch(updates: Dict[str, Any], original: Dict[str, Any]):
         # The local version has not been published yet
         # So remove the provided ``pubstatus``
         updates.pop("pubstatus", None)
-    elif original.get("pubstatus") == updates.get("pubstatus"):
+    elif original.get("pubstatus") == updates.get("ingest_pubstatus"):
         # The local version has been published
         # and no change to ``pubstatus`` on ingested item
         updates.pop("state")

--- a/server/planning/events/events.py
+++ b/server/planning/events/events.py
@@ -149,6 +149,9 @@ class EventsService(superdesk.Service):
     def patch_in_mongo(self, id, document, original) -> Optional[Dict[str, Any]]:
         """Patch an ingested item onto an existing item locally"""
         prepare_ingested_item_for_storage(document)
+        events_history = get_resource_service("events_history")
+        events_history.on_item_updated(document, original, "ingested")
+
         set_planning_schedule(document)
         update_ingest_on_patch(document, original)
         response = self.backend.update_in_mongo(self.datasource, id, document, original)

--- a/server/planning/events/events.py
+++ b/server/planning/events/events.py
@@ -54,6 +54,7 @@ from planning.common import (
     get_max_recurrent_events,
     WORKFLOW_STATE,
     ITEM_STATE,
+    prepare_ingested_item_for_storage,
     remove_lock_information,
     format_address,
     update_post_item,
@@ -128,11 +129,6 @@ def is_event_updated(new_item: Event, old_item: Event) -> bool:
     return False
 
 
-def prepare_ingested_event_for_storage(event: Event) -> None:
-    event.setdefault("state", "ingested")
-    event["ingest_pubstatus"] = event.pop("pubstatus", "usable")  # pubstatus is set when posted
-
-
 class EventsService(superdesk.Service):
     """Service class for the events model."""
 
@@ -140,7 +136,7 @@ class EventsService(superdesk.Service):
         """Post an ingested item(s)"""
 
         for doc in docs:
-            prepare_ingested_event_for_storage(doc)
+            prepare_ingested_item_for_storage(doc)
             self._resolve_defaults(doc)
             set_ingest_version_datetime(doc)
 
@@ -152,7 +148,7 @@ class EventsService(superdesk.Service):
 
     def patch_in_mongo(self, id, document, original) -> Optional[Dict[str, Any]]:
         """Patch an ingested item onto an existing item locally"""
-        prepare_ingested_event_for_storage(document)
+        prepare_ingested_item_for_storage(document)
         set_planning_schedule(document)
         update_ingest_on_patch(document, original)
         response = self.backend.update_in_mongo(self.datasource, id, document, original)

--- a/server/planning/events/events.py
+++ b/server/planning/events/events.py
@@ -128,6 +128,11 @@ def is_event_updated(new_item: Event, old_item: Event) -> bool:
     return False
 
 
+def prepare_ingested_event_for_storage(event: Event) -> None:
+    event.setdefault("state", "ingested")
+    event["ingest_pubstatus"] = event.pop("pubstatus", "usable")  # pubstatus is set when posted
+
+
 class EventsService(superdesk.Service):
     """Service class for the events model."""
 
@@ -135,6 +140,7 @@ class EventsService(superdesk.Service):
         """Post an ingested item(s)"""
 
         for doc in docs:
+            prepare_ingested_event_for_storage(doc)
             self._resolve_defaults(doc)
             set_ingest_version_datetime(doc)
 
@@ -146,7 +152,7 @@ class EventsService(superdesk.Service):
 
     def patch_in_mongo(self, id, document, original) -> Optional[Dict[str, Any]]:
         """Patch an ingested item onto an existing item locally"""
-
+        prepare_ingested_event_for_storage(document)
         set_planning_schedule(document)
         update_ingest_on_patch(document, original)
         response = self.backend.update_in_mongo(self.datasource, id, document, original)

--- a/server/planning/events/events_schema.py
+++ b/server/planning/events/events_schema.py
@@ -64,6 +64,7 @@ events_schema = {
     "ingest_provider_sequence": metadata_schema["ingest_provider_sequence"],
     "ingest_firstcreated": metadata_schema["versioncreated"],
     "ingest_versioncreated": metadata_schema["versioncreated"],
+    "ingest_pubstatus": metadata_schema["pubstatus"],
     "event_created": {"type": "datetime"},
     "event_lastmodified": {"type": "datetime"},
     # Event Details

--- a/server/planning/events/events_tests.py
+++ b/server/planning/events/events_tests.py
@@ -157,7 +157,7 @@ class EventTestCase(TestCase):
 
             event = service.find_one(req=None, guid="test")
             assert event is not None
-            assert event["pubstatus"] == "cancelled"
+            assert event["ingest_pubstatus"] == "cancelled"
 
 
 class EventLocationFormatAddress(TestCase):

--- a/server/planning/io/ingest_rule_handler.py
+++ b/server/planning/io/ingest_rule_handler.py
@@ -164,13 +164,6 @@ class PlanningRoutingRuleHandler(RoutingRuleHandler):
 
     def process_autopost(self, ingest_item: Dict[str, Any]):
         """Automatically post this item"""
-
-        if self._is_original_posted(ingest_item):
-            # No need to autopost this item
-            # As the original is already posted
-            # And any updates from ingest should automatically re-post this item
-            return
-
         item_id = ingest_item.get(config.ID_FIELD)
         update_post_item(
             {

--- a/server/planning/io/ingest_rule_handler.py
+++ b/server/planning/io/ingest_rule_handler.py
@@ -74,15 +74,18 @@ class PlanningRoutingRuleHandler(RoutingRuleHandler):
 
         if updates is not None:
             ingest_item.update(updates)
-
-        if attributes.get("autopost", False):
+        elif attributes.get("autopost", False):
             self.process_autopost(ingest_item)
 
     def _is_original_posted(self, ingest_item: Dict[str, Any]):
         service = get_resource_service("events" if ingest_item[ITEM_TYPE] == CONTENT_TYPE.EVENT else "planning")
         original = service.find_one(req=None, _id=ingest_item.get(config.ID_FIELD))
 
-        return original is not None and original.get("pubstatus") in [POST_STATE.USABLE, POST_STATE.CANCELLED]
+        return (
+            original is not None
+            and original.get("pubstatus") in [POST_STATE.USABLE, POST_STATE.CANCELLED]
+            and original["pubstatus"] == ingest_item.get("ingest_pubstatus")
+        )
 
     def add_event_calendars(self, ingest_item: Dict[str, Any], attributes: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         """Add Event Calendars from Routing Rule Action onto the ingested item"""
@@ -164,10 +167,16 @@ class PlanningRoutingRuleHandler(RoutingRuleHandler):
 
     def process_autopost(self, ingest_item: Dict[str, Any]):
         """Automatically post this item"""
+        if self._is_original_posted(ingest_item):
+            # No need to autopost this item
+            # As the original is already posted
+            # And any updates from ingest should automatically re-post this item
+            return
+
         item_id = ingest_item.get(config.ID_FIELD)
         update_post_item(
             {
-                "pubstatus": ingest_item.get("pubstatus") or POST_STATE.USABLE,
+                "pubstatus": ingest_item.get("ingest_pubstatus") or POST_STATE.USABLE,
                 "_etag": ingest_item.get("_etag"),
             },
             ingest_item,

--- a/server/planning/io/ingest_rule_handler_test.py
+++ b/server/planning/io/ingest_rule_handler_test.py
@@ -48,6 +48,7 @@ class IngestRuleHandlerTestCase(TestCase):
                 "end": "2022-07-03T14:00:00+0000",
             },
             "type": "event",
+            "pubstatus": "usable",
         },
         {
             "_id": "event2",
@@ -92,7 +93,7 @@ class IngestRuleHandlerTestCase(TestCase):
                 }
             ],
         )
-        event = self.event_items[0]
+        event = self.event_items[0].copy()
         self.app.data.insert("events", [event])
         original = self.app.data.find_one("events", req=None, _id=event["_id"])
 
@@ -115,7 +116,7 @@ class IngestRuleHandlerTestCase(TestCase):
                 }
             ],
         )
-        event = self.event_items[1]
+        event = self.event_items[1].copy()
         self.app.data.insert("events", [event])
         original = self.app.data.find_one("events", req=None, _id=event["_id"])
 
@@ -159,3 +160,13 @@ class IngestRuleHandlerTestCase(TestCase):
 
         self.assertEqual(len(updated["agendas"]), 1)
         self.assertEqual(updated["agendas"][0], self.agendas[0]["_id"])
+
+    def test_autopost(self):
+        event = self.event_items[0].copy()
+        self.app.data.insert("events", [event])
+
+        self.handler.apply_rule({"actions": {"extra": {"autopost": True}}}, event, {})
+
+        history = list(self.app.data.find_all("events_history"))
+        assert len(history) == 1
+        assert history[0]["operation"] == "post"

--- a/server/planning/io/ingest_rule_handler_test.py
+++ b/server/planning/io/ingest_rule_handler_test.py
@@ -9,6 +9,8 @@
 # at https://www.sourcefabric.org/superdesk/license
 
 from bson import ObjectId
+from datetime import datetime
+from superdesk import get_resource_service
 from superdesk.metadata.item import ITEM_TYPE, CONTENT_TYPE
 from .ingest_rule_handler import PlanningRoutingRuleHandler
 from planning.tests import TestCase
@@ -30,6 +32,8 @@ TEST_RULE = {
     },
 }
 
+AUTOPOST_RULE = {"actions": {"extra": {"autopost": True}}}
+
 
 class IngestRuleHandlerTestCase(TestCase):
     calendars = [
@@ -44,8 +48,8 @@ class IngestRuleHandlerTestCase(TestCase):
         {
             "_id": "event1",
             "dates": {
-                "start": "2022-07-02T14:00:00+0000",
-                "end": "2022-07-03T14:00:00+0000",
+                "start": datetime.fromisoformat("2022-07-02T14:00:00+00:00"),
+                "end": datetime.fromisoformat("2022-07-03T14:00:00+00:00"),
             },
             "type": "event",
             "pubstatus": "usable",
@@ -163,10 +167,48 @@ class IngestRuleHandlerTestCase(TestCase):
 
     def test_autopost(self):
         event = self.event_items[0].copy()
-        self.app.data.insert("events", [event])
+        events_service = get_resource_service("events")
+        events_service.post_in_mongo([event])
 
-        self.handler.apply_rule({"actions": {"extra": {"autopost": True}}}, event, {})
-
-        history = list(self.app.data.find_all("events_history"))
+        history = self.get_event_history()
         assert len(history) == 1
-        assert history[0]["operation"] == "post"
+        assert history[0]["operation"] == "ingested"
+
+        self.handler.apply_rule(AUTOPOST_RULE, event, {})
+
+        history = self.get_event_history()
+        assert len(history) == 2
+        assert history[-1]["operation"] == "post"
+
+        original = events_service.find_one(req=None, _id=event["_id"])
+        assert original["pubstatus"] == "usable"
+
+        event["pubstatus"] = "cancelled"
+        events_service.patch_in_mongo(event["_id"], event, original)
+
+        self.handler.apply_rule(AUTOPOST_RULE, event, {})
+
+        history = self.get_event_history()
+        assert len(history) == 3
+        assert history[-1]["operation"] == "post"
+
+        original = events_service.find_one(req=None, _id=event["_id"])
+        assert original["pubstatus"] == "cancelled"
+
+    def test_autopost_cancelled(self):
+        event = self.event_items[0].copy()
+        event["pubstatus"] = "cancelled"
+        events_service = get_resource_service("events")
+        events_service.post_in_mongo([event])
+
+        self.handler.apply_rule(AUTOPOST_RULE, event, {})
+
+        history = self.get_event_history()
+        assert len(history) == 2
+        assert history[-1]["operation"] == "post"
+
+        original = events_service.find_one(req=None, _id=event["_id"])
+        assert original["pubstatus"] == "cancelled"
+
+    def get_event_history(self):
+        return list(self.app.data.find_all("events_history"))

--- a/server/planning/io/ingest_rule_handler_test.py
+++ b/server/planning/io/ingest_rule_handler_test.py
@@ -184,12 +184,14 @@ class IngestRuleHandlerTestCase(TestCase):
         assert original["pubstatus"] == "usable"
 
         event["pubstatus"] = "cancelled"
+        event["versioncreated"] = datetime.now()
         events_service.patch_in_mongo(event["_id"], event, original)
 
         self.handler.apply_rule(AUTOPOST_RULE, event, {})
 
         history = self.get_event_history()
-        assert len(history) == 3
+        assert len(history) == 4
+        assert history[-2]["operation"] == "ingested"
         assert history[-1]["operation"] == "post"
 
         original = events_service.find_one(req=None, _id=event["_id"])

--- a/server/planning/planning/planning.py
+++ b/server/planning/planning/planning.py
@@ -1814,6 +1814,7 @@ planning_schema = {
     "ingest_provider_sequence": metadata_schema["ingest_provider_sequence"],
     "ingest_firstcreated": metadata_schema["versioncreated"],
     "ingest_versioncreated": metadata_schema["versioncreated"],
+    "ingest_pubstatus": metadata_schema["pubstatus"],
     # Agenda Item details
     "agendas": {
         "type": "list",

--- a/server/planning/planning/planning.py
+++ b/server/planning/planning/planning.py
@@ -38,6 +38,7 @@ from planning.common import (
     get_coverage_status_from_cv,
     WORKFLOW_STATE,
     ASSIGNMENT_WORKFLOW_STATE,
+    prepare_ingested_item_for_storage,
     update_post_item,
     get_coverage_type_name,
     set_original_creator,
@@ -91,8 +92,8 @@ class PlanningService(superdesk.Service):
         """Post an ingested item(s)"""
 
         for doc in docs:
+            prepare_ingested_item_for_storage(doc)
             self._resolve_defaults(doc)
-            doc.pop("pubstatus", None)
             set_ingest_version_datetime(doc)
 
         self.on_create(docs)
@@ -105,7 +106,7 @@ class PlanningService(superdesk.Service):
 
     def patch_in_mongo(self, id, document, original):
         """Patch an ingested item onto an existing item locally"""
-
+        prepare_ingested_item_for_storage(document)
         update_ingest_on_patch(document, original)
         response = self.backend.update_in_mongo(self.datasource, id, document, original)
         self.on_updated(document, original, from_ingest=True)


### PR DESCRIPTION
SDCP-903

## Front-end checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)
