### PR TITLE
allow updates of events edited by user

### DIFF
--- a/server/planning/events/events.py
+++ b/server/planning/events/events.py
@@ -851,7 +851,6 @@ class EventsService(superdesk.Service):
     def should_update(self, old_item, new_item, provider):
         return old_item is None or not any(
             [
-                old_item.get("version_creator"),
                 old_item.get("pubstatus") == "cancelled",
                 old_item.get("state") == "killed",
             ]

--- a/server/planning/events/events_ingest_tests.py
+++ b/server/planning/events/events_ingest_tests.py
@@ -1,7 +1,6 @@
 from superdesk import get_resource_service
 from datetime import datetime, timedelta
 from planning.tests import TestCase
-from unittest.mock import patch
 from flask import g
 
 
@@ -10,20 +9,41 @@ class EventIngestTestCase(TestCase):
         events_service = get_resource_service("events")
         events_history_service = get_resource_service("events_history")
         dates = {"start": datetime.now(), "end": datetime.now() + timedelta(days=1)}
-        old_event = {"guid": "1", "name": "bar", "ednote": "ednote1", "dates": dates}
+        old_event = {
+            "guid": "1",
+            "name": "bar",
+            "ednote": "ednote1",
+            "dates": dates,
+            "state": "ingested",
+            "versioncreated": datetime.now() - timedelta(hours=1),
+        }
 
         # event is created
         events_service.post_in_mongo([old_event])
+        history = events_history_service.get_by_id("1")
+        assert 1 == len(history)
 
         # user updates the event
         updates = {"definition_short": "manual", "ednote": "manual"}
         with self.app.test_request_context():
             g.user = {"_id": "test"}
             events_service.patch(old_event["_id"], updates)
-            events_history_service.on_item_updated(updates, old_event)
+            events_history_service.on_item_updated(updates, old_event, "edited")
 
-        new_event = {"guid": "1", "name": "updated", "ednote": "updated", "dates": dates, "definition_short": "updated"}
+        history = events_history_service.get_by_id("1")
+        assert 2 == len(history)
+
+        new_event = {
+            "guid": "1",
+            "name": "updated",
+            "ednote": "updated",
+            "dates": dates,
+            "definition_short": "updated",
+            "versioncreated": datetime.now() - timedelta(minutes=30),
+        }
         old_event = events_service.find_one(req=None, guid="1")
+
+        assert events_service.should_update(old_event, new_event, {})
 
         # event is updated via ingest
         events_service.patch_in_mongo(new_event["guid"], new_event, old_event)


### PR DESCRIPTION
SDCP-861

## Front-end checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)
