### PR TITLE
avoid overriding user changes via ingest

### DIFF
--- a/server/planning/events/events.py
+++ b/server/planning/events/events.py
@@ -95,6 +95,9 @@ CONTENT_FIELDS = {
     "links",
     "ednote",
     "subject",
+    "anpa_category",
+    "location",
+    "event_contact_info",
 }
 
 

--- a/server/planning/events/events_ingest_tests.py
+++ b/server/planning/events/events_ingest_tests.py
@@ -16,6 +16,7 @@ class EventIngestTestCase(TestCase):
             "dates": dates,
             "state": "ingested",
             "versioncreated": datetime.now() - timedelta(hours=1),
+            "anpa_category": [{"name": "C1", "qcode": "c1"}],
         }
 
         # event is created
@@ -24,7 +25,7 @@ class EventIngestTestCase(TestCase):
         assert 1 == len(history)
 
         # user updates the event
-        updates = {"definition_short": "manual", "ednote": "manual"}
+        updates = {"definition_short": "manual", "ednote": "manual", "anpa_category": [{"name": "C2", "qcode": "c2"}]}
         with self.app.test_request_context():
             g.user = {"_id": "test"}
             events_service.patch(old_event["_id"], updates)
@@ -40,6 +41,7 @@ class EventIngestTestCase(TestCase):
             "dates": dates,
             "definition_short": "updated",
             "versioncreated": datetime.now() - timedelta(minutes=30),
+            "anpa_category": [{"name": "C1", "qcode": "c1"}],
         }
         old_event = events_service.find_one(req=None, guid="1")
 
@@ -53,3 +55,4 @@ class EventIngestTestCase(TestCase):
         assert updated_event["name"] == "updated"
         assert updated_event["ednote"] == "manual"
         assert updated_event["definition_short"] == "manual"
+        assert updated_event["anpa_category"] == [{"name": "C2", "qcode": "c2"}]


### PR DESCRIPTION
add additional fields to the list:
 - anpa_category
 - contacts

SDCP-861

## Front-end checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)
