### PR TITLE
Allow event date editing after creation

### DIFF
--- a/client/actions/events/api.ts
+++ b/client/actions/events/api.ts
@@ -564,11 +564,12 @@ const save = (original, updates) => (
             const originalItem = eventUtils.modifyForServer(cloneDeep(originalEvent), true);
             const eventUpdates = eventUtils.getEventDiff(originalItem, updates);
 
-            if (get(originalItem, 'lock_action') === EVENTS.ITEM_ACTIONS.EDIT_EVENT.lock_action &&
-                !isTemporaryId(originalItem._id)
-            ) {
-                delete eventUpdates.dates;
-            }
+            // TODO: After BE is done, ensure things work & remove this
+            // if (get(originalItem, 'lock_action') === EVENTS.ITEM_ACTIONS.EDIT_EVENT.lock_action &&
+            //     !isTemporaryId(originalItem._id)
+            // ) {
+            //     delete eventUpdates.dates;
+            // }
             eventUpdates.update_method = eventUpdates.update_method == null ?
                 EVENTS.UPDATE_METHODS[0].value :
                 eventUpdates.update_method?.value ?? eventUpdates.update_method;

--- a/client/components/Events/EventEditor/index.tsx
+++ b/client/components/Events/EventEditor/index.tsx
@@ -22,6 +22,7 @@ import {EventEditorHeader} from './EventEditorHeader';
 import {ContentBlock} from '../../UI/SidePanel';
 import {EventScheduleSummary} from '../EventScheduleSummary';
 import {CreateNewGeoLookup} from '../../GeoLookupInput/CreateNewGeoLookup';
+import {appConfig} from 'appConfig';
 
 interface IProps {
     original?: IEventItem;
@@ -133,6 +134,10 @@ class EventEditorComponent extends React.PureComponent<IProps> {
     }
 
     renderHeader() {
+        if (appConfig.planning_event_link_method === 'many_secondary') {
+            return null;
+        }
+
         return !this.props.itemExists ? null : (
             <React.Fragment>
                 <EventEditorHeader item={this.props.item} />
@@ -181,7 +186,9 @@ class EventEditorComponent extends React.PureComponent<IProps> {
                         required: true,
                         showAllDay: this.props.formProfile.editor.dates.all_day.enabled,
                         showTimeZone: true,
-                        enabled: !this.props.itemExists,
+                        enabled: appConfig.planning_event_link_method === 'many_secondary'
+                            ? true
+                            : !this.props.itemExists,
                         onChange: this.onDatesChanged,
                     },
                     language: {

--- a/client/components/Main/ItemEditor/ItemManager.ts
+++ b/client/components/Main/ItemEditor/ItemManager.ts
@@ -761,7 +761,7 @@ export class ItemManager {
     }
 
     startPartialSave(updates) {
-        const newState = {diff: cloneDeep(updates)};
+        const newState = {diff: cloneDeep(updates), errorMessages: []};
 
         this.validate(this.props, newState, this.state);
 

--- a/client/constants/index.ts
+++ b/client/constants/index.ts
@@ -5,6 +5,7 @@ import {assignPlanningConstantTranslations} from './planning';
 import {assignAssignmentConstantTranslations} from './assignments';
 import {assignTooltipConstantTranslations} from './tooltips';
 import {assignCoverageConstantTranslations} from './coverages';
+import {IPlanningPubstatus, IWorkflowState} from 'interfaces';
 
 export {PRIVILEGES} from './privileges';
 export {PLANNING} from './planning';
@@ -40,7 +41,7 @@ export const DATE_FORMATS = {
     DISPLAY_CDATE_TBC_FORMAT: 'D. MMMM @ TBC',
 };
 
-export const WORKFLOW_STATE = {
+export const WORKFLOW_STATE: {[key: string]: IWorkflowState} = {
     DRAFT: 'draft',
     INGESTED: 'ingested',
     SCHEDULED: 'scheduled',
@@ -51,7 +52,7 @@ export const WORKFLOW_STATE = {
     SPIKED: 'spiked',
 };
 
-export const POST_STATE = {
+export const POST_STATE: {[key: string]: IPlanningPubstatus} = {
     USABLE: 'usable',
     CANCELLED: 'cancelled',
 };


### PR DESCRIPTION
STT-66

## Front-end checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)
