### PR TITLE
Implement embedded events saving

### DIFF
--- a/client/components/Main/ItemEditor/Editor.tsx
+++ b/client/components/Main/ItemEditor/Editor.tsx
@@ -19,7 +19,7 @@ import {ItemManager} from './ItemManager';
 import {AutoSave} from './AutoSave';
 import {EditorHeader} from './EditorHeader';
 import {pickRelatedEventsForPlanning} from './../../../utils/planning';
-import {embeddedPlanningHasUnsavedChanges} from '../../../components/editor-standalone/save-handling';
+import {embeddedItemHasUnsavedChanges} from '../../../components/editor-standalone/save-handling';
 
 export class EditorComponent extends React.Component<IEditorProps, IEditorState> {
     autoSave: AutoSave;
@@ -204,7 +204,7 @@ export class EditorComponent extends React.Component<IEditorProps, IEditorState>
 
             this.setState({submitting: true});
 
-            if (!(dirty || embeddedPlanningHasUnsavedChanges())) {
+            if (!(dirty || embeddedItemHasUnsavedChanges(this.props.itemType))) {
                 this.onCancel();
                 return;
             }
@@ -238,7 +238,7 @@ export class EditorComponent extends React.Component<IEditorProps, IEditorState>
                 },
                 onIgnore: () => {
                     this.itemManager.unlockAndCancel(
-                        embeddedPlanningHasUnsavedChanges(this.props.itemType) ? 'HANDLE_UNSAVED_CHANGES' : 'DISCARD',
+                        embeddedItemHasUnsavedChanges(this.props.itemType) ? 'HANDLE_UNSAVED_CHANGES' : 'DISCARD',
                     );
                 },
                 onSave: onSave,
@@ -265,7 +265,7 @@ export class EditorComponent extends React.Component<IEditorProps, IEditorState>
         }
 
         return this.itemManager.unlockAndCancel(
-            embeddedPlanningHasUnsavedChanges(this.props.itemType) ? 'HANDLE_UNSAVED_CHANGES' : 'DISCARD',
+            embeddedItemHasUnsavedChanges(this.props.itemType) ? 'HANDLE_UNSAVED_CHANGES' : 'DISCARD',
         );
     }
 

--- a/client/components/Main/ItemEditor/Editor.tsx
+++ b/client/components/Main/ItemEditor/Editor.tsx
@@ -238,7 +238,7 @@ export class EditorComponent extends React.Component<IEditorProps, IEditorState>
                 },
                 onIgnore: () => {
                     this.itemManager.unlockAndCancel(
-                        embeddedPlanningHasUnsavedChanges() ? 'HANDLE_UNSAVED_CHANGES' : 'DISCARD',
+                        embeddedPlanningHasUnsavedChanges(this.props.itemType) ? 'HANDLE_UNSAVED_CHANGES' : 'DISCARD',
                     );
                 },
                 onSave: onSave,
@@ -265,7 +265,7 @@ export class EditorComponent extends React.Component<IEditorProps, IEditorState>
         }
 
         return this.itemManager.unlockAndCancel(
-            embeddedPlanningHasUnsavedChanges() ? 'HANDLE_UNSAVED_CHANGES' : 'DISCARD',
+            embeddedPlanningHasUnsavedChanges(this.props.itemType) ? 'HANDLE_UNSAVED_CHANGES' : 'DISCARD',
         );
     }
 

--- a/client/components/Main/ItemEditor/ItemManager.ts
+++ b/client/components/Main/ItemEditor/ItemManager.ts
@@ -29,7 +29,7 @@ import {AutoSave} from './AutoSave';
 import {EditorGroup} from '../../Editor/EditorGroup';
 import * as selectors from '../../../selectors';
 import {
-    handleEmbeddedPlannings,
+    handleEmbeddedItems,
     IEmbeddedPlanningsActionType,
 } from '../../../components/editor-standalone/save-handling';
 
@@ -474,7 +474,7 @@ export class ItemManager {
     }
 
     post() {
-        return handleEmbeddedPlannings(this.props.editorType, 'SAVE', this.props.itemType).then(() => {
+        return handleEmbeddedItems(this.props.editorType, 'SAVE', this.props.itemType).then(() => {
             const newState = {};
 
             this.validate(this.props, newState, this.state);
@@ -661,8 +661,7 @@ export class ItemManager {
                 });
         }
 
-        debugger;
-        const promise = handleEmbeddedPlannings(this.props.editorType, 'SAVE', this.props.itemType).then(() =>
+        const promise = handleEmbeddedItems(this.props.editorType, 'SAVE', this.props.itemType).then(() =>
             !updateStates ? Promise.resolve({}) : this.setState({submitting: true, submitFailed: false}),
         );
 
@@ -760,7 +759,7 @@ export class ItemManager {
     }
 
     startPartialSave(updates) {
-        const newState = {diff: cloneDeep(updates)};
+        const newState = {diff: cloneDeep(updates), errorMessages: []};
 
         this.validate(this.props, newState, this.state);
 
@@ -795,14 +794,14 @@ export class ItemManager {
     }
 
     setStateForPartialSave(initialValues) {
-        let newState = {
+        const newState = {
             partialSave: false,
             submitting: false,
             submitFailed: false,
         };
 
         if (initialValues) {
-            newState.initialValues = initialValues;
+            newState['initialValues'] = initialValues;
         }
 
         return this.setState(newState);
@@ -832,7 +831,7 @@ export class ItemManager {
     }
 
     unlockAndCancel(embeddedEditorAction: IEmbeddedPlanningsActionType) {
-        return handleEmbeddedPlannings(
+        return handleEmbeddedItems(
             this.props.editorType,
             embeddedEditorAction,
             this.props.itemType,

--- a/client/components/Main/ItemEditor/ItemManager.ts
+++ b/client/components/Main/ItemEditor/ItemManager.ts
@@ -474,7 +474,7 @@ export class ItemManager {
     }
 
     post() {
-        return handleEmbeddedPlannings(this.props.editorType, 'SAVE').then(() => {
+        return handleEmbeddedPlannings(this.props.editorType, 'SAVE', this.props.itemType).then(() => {
             const newState = {};
 
             this.validate(this.props, newState, this.state);
@@ -661,7 +661,8 @@ export class ItemManager {
                 });
         }
 
-        const promise = handleEmbeddedPlannings(this.props.editorType, 'SAVE').then(() =>
+        debugger;
+        const promise = handleEmbeddedPlannings(this.props.editorType, 'SAVE', this.props.itemType).then(() =>
             !updateStates ? Promise.resolve({}) : this.setState({submitting: true, submitFailed: false}),
         );
 
@@ -834,6 +835,7 @@ export class ItemManager {
         return handleEmbeddedPlannings(
             this.props.editorType,
             embeddedEditorAction,
+            this.props.itemType,
         ).then(() => {
             const {session, currentWorkspace} = this.props;
             const {initialValues, diff} = this.state;

--- a/client/components/editor-standalone/base-editor-standalone.tsx
+++ b/client/components/editor-standalone/base-editor-standalone.tsx
@@ -1,8 +1,14 @@
-import React, {createRef, RefObject} from 'react';
+import React, {RefObject} from 'react';
 import {connect} from 'react-redux';
 import {noop} from 'lodash';
 import {Button} from 'superdesk-ui-framework/react';
-import {IAuthoringStorage, ITopBarWidget, IAuthoringValidationErrors, IStorageAdapter} from 'superdesk-api';
+import {
+    IAuthoringStorage,
+    ITopBarWidget,
+    IAuthoringValidationErrors,
+    IStorageAdapter,
+    IPropsAuthoring,
+} from 'superdesk-api';
 import {planningApi, superdeskApi} from '../../superdeskApi';
 import * as selectors from '../../selectors';
 import {IAgenda, IPlanningAppState, IPlanningItem} from 'interfaces';
@@ -14,6 +20,7 @@ interface IOwnProps<T extends IPlanningItem | IEventItem> {
 
     itemId: string;
 
+    editorRef: RefObject<React.ComponentType<IPropsAuthoring<T>>>;
     authoringStorage: IAuthoringStorage<T>;
     storageAdapter: IStorageAdapter<T>;
 }
@@ -56,21 +63,13 @@ function validate<T extends IPlanningItem | IEventItem>(
 }
 
 export class BaseEditorComponent<T extends IPlanningItem | IEventItem> extends React.PureComponent<IProps<T>> {
-    editorRef: RefObject<any>;
-
-    constructor(props: IProps<T>) {
-        super(props);
-
-        this.editorRef = createRef();
-    }
-
     render() {
         const Authoring = superdeskApi.components.getAuthoringComponent<T>();
         const {gettext} = superdeskApi.localization;
 
         return (
             <Authoring
-                ref={this.editorRef}
+                ref={this.props.editorRef}
                 itemId={this.props.itemId}
                 resourceNames={[this.props.entityType]}
                 onClose={noop}

--- a/client/components/editor-standalone/event-editor-standalone.tsx
+++ b/client/components/editor-standalone/event-editor-standalone.tsx
@@ -1,27 +1,20 @@
-import React, {createRef, RefObject} from 'react';
-import {IAuthoringStorage} from 'superdesk-api';
-import {BaseEditorComponent, BaseEditorStandalone} from './base-editor-standalone';
+import React, {RefObject} from 'react';
+import {IAuthoringStorage, IPropsAuthoring} from 'superdesk-api';
+import {BaseEditorStandalone} from './base-editor-standalone';
 import {getStorageAdapter} from './storage-adapter';
 
 interface IProps {
     itemId: string;
     authoringStorage: IAuthoringStorage<IEventItem>;
+    editorRef: RefObject<React.ComponentType<IPropsAuthoring<IEventItem>>>;
 }
 
 export class EventEditorStandalone extends React.PureComponent<IProps> {
-    editorRef: RefObject<BaseEditorComponent<IEventItem>>;
-
-    constructor(props) {
-        super(props);
-
-        this.editorRef = createRef();
-    }
-
     render() {
         return (
             <BaseEditorStandalone
                 entityType="event"
-                ref={this.editorRef}
+                editorRef={this.props.editorRef}
                 itemId={this.props.itemId}
                 storageAdapter={getStorageAdapter('event', ({storageAdapterEvent}) => storageAdapterEvent)}
                 authoringStorage={this.props.authoringStorage}

--- a/client/components/editor-standalone/event-editor-standalone.tsx
+++ b/client/components/editor-standalone/event-editor-standalone.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
+import React, {createRef, RefObject} from 'react';
 import {IAuthoringStorage} from 'superdesk-api';
-import {BaseEditorStandalone} from './base-editor-standalone';
+import {BaseEditorComponent, BaseEditorStandalone} from './base-editor-standalone';
 import {getStorageAdapter} from './storage-adapter';
 
 interface IProps {
@@ -9,10 +9,19 @@ interface IProps {
 }
 
 export class EventEditorStandalone extends React.PureComponent<IProps> {
+    editorRef: RefObject<BaseEditorComponent<IEventItem>>;
+
+    constructor(props) {
+        super(props);
+
+        this.editorRef = createRef();
+    }
+
     render() {
         return (
             <BaseEditorStandalone
                 entityType="event"
+                ref={this.editorRef}
                 itemId={this.props.itemId}
                 storageAdapter={getStorageAdapter('event', ({storageAdapterEvent}) => storageAdapterEvent)}
                 authoringStorage={this.props.authoringStorage}

--- a/client/components/editor-standalone/planning-editor-standalone.tsx
+++ b/client/components/editor-standalone/planning-editor-standalone.tsx
@@ -9,18 +9,18 @@ interface IProps {
 }
 
 export class PlanningEditorStandalone extends React.PureComponent<IProps> {
-    planningEditorRef: RefObject<BaseEditorComponent<IPlanningItem>>;
+    editorRef: RefObject<BaseEditorComponent<IPlanningItem>>;
 
     constructor(props: IProps) {
         super(props);
 
-        this.planningEditorRef = React.createRef();
+        this.editorRef = React.createRef();
     }
 
     render() {
         return (
             <BaseEditorStandalone
-                ref={this.planningEditorRef}
+                ref={this.editorRef}
                 entityType="planning"
                 itemId={this.props.itemId}
                 storageAdapter={getStorageAdapter('planning', ({storageAdapterPlanning}) => storageAdapterPlanning)}

--- a/client/components/editor-standalone/planning-editor-standalone.tsx
+++ b/client/components/editor-standalone/planning-editor-standalone.tsx
@@ -1,26 +1,19 @@
-import React, {RefObject} from 'react';
-import {IAuthoringStorage} from 'superdesk-api';
-import {BaseEditorComponent, BaseEditorStandalone} from './base-editor-standalone';
+import React, {ComponentType, RefObject} from 'react';
+import {IAuthoringStorage, IPropsAuthoring} from 'superdesk-api';
+import {BaseEditorStandalone} from './base-editor-standalone';
 import {getStorageAdapter} from './storage-adapter';
 
 interface IProps {
     itemId: string;
     authoringStorage: IAuthoringStorage<IPlanningItem>;
+    editorRef: RefObject<ComponentType<IPropsAuthoring<IPlanningItem>>>;
 }
 
 export class PlanningEditorStandalone extends React.PureComponent<IProps> {
-    editorRef: RefObject<BaseEditorComponent<IPlanningItem>>;
-
-    constructor(props: IProps) {
-        super(props);
-
-        this.editorRef = React.createRef();
-    }
-
     render() {
         return (
             <BaseEditorStandalone
-                ref={this.editorRef}
+                editorRef={this.props.editorRef}
                 entityType="planning"
                 itemId={this.props.itemId}
                 storageAdapter={getStorageAdapter('planning', ({storageAdapterPlanning}) => storageAdapterPlanning)}

--- a/client/components/editor-standalone/save-handling.ts
+++ b/client/components/editor-standalone/save-handling.ts
@@ -4,35 +4,40 @@ import {planningApi} from '../../superdeskApi';
 import {RelatedPlanningItem} from '../../components/fields/editor/EventRelatedPlannings/RelatedPlanningItem';
 
 type IRelatedPlanningRefs = {[id: string]: RelatedPlanningItem};
+type ItemType = 'event' | 'planning';
 export type IEmbeddedPlanningsActionType = 'SAVE' | 'HANDLE_UNSAVED_CHANGES' | 'DISCARD';
 
-const getEmbeddedAuthoringRefs = (editorType: EDITOR_TYPE) => {
-    const embeddedEditorRef = planningApi.editor(editorType).dom.fields['related_plannings']?.current;
-    const relatedPlanningsRefs: IRelatedPlanningRefs = embeddedEditorRef?.relatedPlanningRefs;
+const getEmbeddedAuthoringRefs = (editorType: EDITOR_TYPE, itemType: ItemType) => {
+    const fieldId = itemType === 'event' ? 'related_plannings' : 'associated_event';
+    const embeddedEditorRef = planningApi.editor(editorType).dom.fields[fieldId]?.current;
+    const relatedItemRefs: IRelatedPlanningRefs = embeddedEditorRef?.relatedItemRefs;
 
-    return relatedPlanningsRefs ?? [];
+    return relatedItemRefs ?? [];
 };
 
-const getEmbeddedPlanningExposed = (editorType: EDITOR_TYPE): Array<IExposedFromAuthoring<void>> => {
-    const relatedPlanningsRefs = getEmbeddedAuthoringRefs(editorType);
+const getEmbeddedPlanningExposed = (
+    editorType: EDITOR_TYPE,
+    itemType: 'event' | 'planning',
+): Array<IExposedFromAuthoring<void>> => {
+    const relatedItemRefs = getEmbeddedAuthoringRefs(editorType, itemType);
 
     // Crashes whenever there's no embedded plannings
-    const exposedAuthoringArray = Object.values(relatedPlanningsRefs).map((x) =>
-        x?.standaloneEditorRef?.current?.planningEditorRef?.current?.editorRef?.current?.getExposed?.(),
+    const exposedAuthoringArray = Object.values(relatedItemRefs).map((x) =>
+        x?.standaloneEditorRef?.current?.editorRef?.current?.editorRef?.current?.getExposed?.(),
     );
 
     return exposedAuthoringArray;
 };
 
 
-const handleErrors = (editorType: EDITOR_TYPE, editorIndex: number) => {
+const handleErrors = (editorType: EDITOR_TYPE, editorIndex: number, itemType: ItemType) => {
     const FIRST_ERROR = 0;
-    const relatedPlanningRef = getEmbeddedAuthoringRefs(editorType)[editorIndex];
+    const relatedItemRef = getEmbeddedAuthoringRefs(editorType, itemType)[editorIndex];
     const firstEditorRef =
-        relatedPlanningRef.standaloneEditorRef.current.planningEditorRef.current.editorRef.current;
+        relatedItemRef.standaloneEditorRef.current.editorRef.current.editorRef.current;
     const fieldErrors = firstEditorRef.getExposed().getValidationErrors();
     const fieldToFocus = firstEditorRef?.fieldRefs[Object.keys(fieldErrors)[FIRST_ERROR]].current as HTMLDivElement;
-    const toggleBoxRef = relatedPlanningRef.toggleBoxRef.current;
+    const toggleBoxRef = relatedItemRef.toggleBoxRef.current;
 
     if (toggleBoxRef.isOpen() === false) {
         toggleBoxRef.toggle();
@@ -51,8 +56,9 @@ const handleErrors = (editorType: EDITOR_TYPE, editorIndex: number) => {
 export const handleEmbeddedPlannings = async(
     editorType: EDITOR_TYPE,
     action: IEmbeddedPlanningsActionType,
+    itemType: ItemType,
 ) => {
-    const planningsExposed = getEmbeddedPlanningExposed(editorType);
+    const planningsExposed = getEmbeddedPlanningExposed(editorType, itemType);
     let editorIndex = 0;
     let promiseResult = Promise.resolve();
 
@@ -60,11 +66,11 @@ export const handleEmbeddedPlannings = async(
         promiseResult = promiseResult.then(() => {
             if (planning.hasUnsavedChanges()) {
                 if (action === 'SAVE') {
-                    return planning.save().catch(() => handleErrors(editorType, editorIndex));
+                    return planning.save().catch(() => handleErrors(editorType, editorIndex, itemType));
                 } else if (action === 'DISCARD') {
                     return planning.discardUnsavedChanges();
                 } else {
-                    return planning.handleUnsavedChanges().catch(() => handleErrors(editorType, editorIndex));
+                    return planning.handleUnsavedChanges().catch(() => handleErrors(editorType, editorIndex, itemType));
                 }
             }
 
@@ -75,8 +81,8 @@ export const handleEmbeddedPlannings = async(
     return promiseResult;
 };
 
-export const embeddedPlanningHasUnsavedChanges = () => {
-    const planningsExposed = getEmbeddedPlanningExposed(EDITOR_TYPE.INLINE);
+export const embeddedPlanningHasUnsavedChanges = (itemType: ItemType) => {
+    const planningsExposed = getEmbeddedPlanningExposed(EDITOR_TYPE.INLINE, itemType);
 
     return (planningsExposed ?? []).some((x) => x.hasUnsavedChanges());
 };

--- a/client/components/editor-standalone/save-handling.ts
+++ b/client/components/editor-standalone/save-handling.ts
@@ -2,26 +2,27 @@ import {EDITOR_TYPE} from '../../interfaces';
 import {IExposedFromAuthoring} from 'superdesk-api';
 import {planningApi} from '../../superdeskApi';
 import {RelatedPlanningItem} from '../../components/fields/editor/EventRelatedPlannings/RelatedPlanningItem';
+import {AssociatedEventItem} from 'components/fields/editor/AssociatedEventItem';
 
-type IRelatedPlanningRefs = {[id: string]: RelatedPlanningItem};
+type IRelatedItemRefs = {[id: string]: RelatedPlanningItem | AssociatedEventItem};
 type ItemType = 'event' | 'planning';
 export type IEmbeddedPlanningsActionType = 'SAVE' | 'HANDLE_UNSAVED_CHANGES' | 'DISCARD';
 
 const getEmbeddedAuthoringRefs = (editorType: EDITOR_TYPE, itemType: ItemType) => {
     const fieldId = itemType === 'event' ? 'related_plannings' : 'associated_event';
     const embeddedEditorRef = planningApi.editor(editorType).dom.fields[fieldId]?.current;
-    const relatedItemRefs: IRelatedPlanningRefs = embeddedEditorRef?.relatedItemRefs;
+    const relatedItemRefs: IRelatedItemRefs = embeddedEditorRef?.relatedItemRefs;
 
     return relatedItemRefs ?? [];
 };
 
-const getEmbeddedPlanningExposed = (
+const getEmbeddedItemsExposed = (
     editorType: EDITOR_TYPE,
     itemType: 'event' | 'planning',
 ): Array<IExposedFromAuthoring<void>> => {
     const relatedItemRefs = getEmbeddedAuthoringRefs(editorType, itemType);
 
-    // Crashes whenever there's no embedded plannings
+    // Crashes whenever there's no embedded items
     const exposedAuthoringArray = Object.values(relatedItemRefs).map((x) =>
         x?.standaloneEditorRef?.current?.editorRef?.current?.editorRef?.current?.getExposed?.(),
     );
@@ -53,16 +54,16 @@ const handleErrors = (editorType: EDITOR_TYPE, editorIndex: number, itemType: It
  * Execution is cancelled on the first encounter of an editor error.
  * If an error occurs the first encountered embedded planning editor and the first error field is focused.
  */
-export const handleEmbeddedPlannings = async(
+export const handleEmbeddedItems = async(
     editorType: EDITOR_TYPE,
     action: IEmbeddedPlanningsActionType,
     itemType: ItemType,
 ) => {
-    const planningsExposed = getEmbeddedPlanningExposed(editorType, itemType);
+    const itemExposed = getEmbeddedItemsExposed(editorType, itemType);
     let editorIndex = 0;
     let promiseResult = Promise.resolve();
 
-    for (const planning of planningsExposed) {
+    for (const planning of itemExposed) {
         promiseResult = promiseResult.then(() => {
             if (planning.hasUnsavedChanges()) {
                 if (action === 'SAVE') {
@@ -81,8 +82,8 @@ export const handleEmbeddedPlannings = async(
     return promiseResult;
 };
 
-export const embeddedPlanningHasUnsavedChanges = (itemType: ItemType) => {
-    const planningsExposed = getEmbeddedPlanningExposed(EDITOR_TYPE.INLINE, itemType);
+export const embeddedItemHasUnsavedChanges = (itemType: ItemType) => {
+    const planningsExposed = getEmbeddedItemsExposed(EDITOR_TYPE.INLINE, itemType);
 
     return (planningsExposed ?? []).some((x) => x.hasUnsavedChanges());
 };

--- a/client/components/editor-standalone/save-handling.ts
+++ b/client/components/editor-standalone/save-handling.ts
@@ -24,20 +24,18 @@ const getEmbeddedItemsExposed = (
 
     // Crashes whenever there's no embedded items
     const exposedAuthoringArray = Object.values(relatedItemRefs).map((x) =>
-        x?.standaloneEditorRef?.current?.editorRef?.current?.editorRef?.current?.getExposed?.(),
+        x?.authoringRef?.current?.getExposed?.()
     );
 
     return exposedAuthoringArray;
 };
 
-
 const handleErrors = (editorType: EDITOR_TYPE, editorIndex: number, itemType: ItemType) => {
     const FIRST_ERROR = 0;
     const relatedItemRef = getEmbeddedAuthoringRefs(editorType, itemType)[editorIndex];
-    const firstEditorRef =
-        relatedItemRef.standaloneEditorRef.current.editorRef.current.editorRef.current;
-    const fieldErrors = firstEditorRef.getExposed().getValidationErrors();
-    const fieldToFocus = firstEditorRef?.fieldRefs[Object.keys(fieldErrors)[FIRST_ERROR]].current as HTMLDivElement;
+    const firstEditorRef = relatedItemRef.authoringRef.current;
+    const fieldErrors = Object.keys(firstEditorRef.getExposed().getValidationErrors() ?? {});
+    const fieldToFocus = firstEditorRef?.fieldRefs[fieldErrors[FIRST_ERROR]].current as HTMLDivElement;
     const toggleBoxRef = relatedItemRef.toggleBoxRef.current;
 
     if (toggleBoxRef.isOpen() === false) {

--- a/client/components/fields/editor/AssociatedEvent.tsx
+++ b/client/components/fields/editor/AssociatedEvent.tsx
@@ -1,30 +1,17 @@
 import * as React from 'react';
-import {connect} from 'react-redux';
-
-import {IEditorFieldProps, IEventItem, IFile, ILockedItems, IPlanningRelatedEventLink} from '../../../interfaces';
-
-import {getFileDownloadURL} from '../../../utils';
-import * as selectors from '../../../selectors';
-
-import {EventMetadata} from '../../Events';
+import {IEventItem, IPlanningRelatedEventLink} from '../../../interfaces';
 import {superdeskApi} from '../../../superdeskApi';
 import events from '../../../utils/events';
-import {ToggleBox} from 'superdesk-ui-framework/react';
-import {EventEditorStandalone} from '../../editor-standalone/event-editor-standalone';
-import {authoringStorageEventItemHttp} from '../../editor-standalone/authoring-storage-event-http';
-import {RelatedEventListItem} from '../../Events/EventMetadata/RelatedEventListItem';
+import {AssociatedEventItem} from './AssociatedEventItem';
+import {IAssociatedEventFieldProps} from './AssociatedEventWrapper';
 
-interface IProps extends IEditorFieldProps {
-    events?: Array<IEventItem>;
-    lockedItems: ILockedItems;
-    files: Array<IFile>;
-    tabEnabled?: boolean; // defaults to true
-}
+export class EditorFieldAssociatedEventComponent extends React.PureComponent<IAssociatedEventFieldProps> {
+    public relatedItemRefs: {[id: string]: AssociatedEventItem};
 
-class EditorFieldAssociatedEventComponent extends React.PureComponent<IProps> {
-    constructor(props: IProps) {
+    constructor(props: IAssociatedEventFieldProps) {
         super(props);
 
+        this.relatedItemRefs = {};
         this.getCurrentValue = this.getCurrentValue.bind(this);
         this.addRelatedEvent = this.addRelatedEvent.bind(this);
         this.removeRelatedEvent = this.removeRelatedEvent.bind(this);
@@ -44,6 +31,8 @@ class EditorFieldAssociatedEventComponent extends React.PureComponent<IProps> {
                 this.props.field,
                 nextItems,
             );
+
+            return Promise.resolve();
         });
     }
 
@@ -73,63 +62,15 @@ class EditorFieldAssociatedEventComponent extends React.PureComponent<IProps> {
                     {gettext('Related Events')}
                 </label>
 
-                {
-                    events.map((event) => {
-                        // PR-TODO: use different authoringStorage for creating a new event.
-                        return (
-                            <ToggleBox
-                                key={event._id}
-                                variant="custom-header"
-                                getToggleButtonLabel={(isOpen) => isOpen ? gettext('Show less') : gettext('Show more')}
-                                header={(
-                                    <RelatedEventListItem
-                                        item={event}
-                                        showIcon
-                                        showBorder
-                                    />
-                                )}
-                            >
-                                <EventEditorStandalone
-                                    itemId={event._id}
-                                    authoringStorage={authoringStorageEventItemHttp}
-                                />
-                            </ToggleBox>
-                        );
-                    })
-                }
-
-                {
-                    /**
-                     * PR-TODO: remove EventMetadata component bellow
-                     * I'm keeping it for verifying against new implementation
-                     * */
-                }
-                <div style={{border: '2px dashed orange', margin: '20px 0'}}>
-                    <div style={{padding: 20}}>
-                        {
-                            events.map((event) => (
-                                <EventMetadata
-                                    key={event._id}
-                                    ref={this.props.refNode}
-                                    testId={`${this.props.testId}--${event._id}`}
-                                    event={event}
-                                    navigation={{}}
-                                    createUploadLink={getFileDownloadURL}
-                                    files={this.props.files}
-                                    tabEnabled={this.props.tabEnabled ?? true}
-                                    onRemoveEvent={
-                                        disabled
-                                            ? undefined
-                                            : () => {
-                                                this.removeRelatedEvent(event._id);
-                                            }
-                                    }
-                                />
-                            ))
-                        }
-                    </div>
-                </div>
-
+                {events.map((event, i) => (
+                    <AssociatedEventItem
+                        key={event._id}
+                        event={event}
+                        ref={(ref) => {
+                            this.relatedItemRefs[i] = ref;
+                        }}
+                    />
+                ))}
                 {
                     !disabled && (
                         <DropZone
@@ -157,15 +98,3 @@ class EditorFieldAssociatedEventComponent extends React.PureComponent<IProps> {
         );
     }
 }
-
-const mapStateToProps = (state) => ({
-    lockedItems: selectors.locks.getLockedItems(state),
-    files: selectors.general.files(state),
-});
-
-export const EditorFieldAssociatedEvents = connect(
-    mapStateToProps,
-    null,
-    null,
-    {forwardRef: true}
-)(EditorFieldAssociatedEventComponent);

--- a/client/components/fields/editor/AssociatedEventItem.tsx
+++ b/client/components/fields/editor/AssociatedEventItem.tsx
@@ -1,0 +1,49 @@
+import {superdeskApi} from '../../../superdeskApi';
+import {authoringStorageEventItemHttp} from '../../../components/editor-standalone/authoring-storage-event-http';
+import {EventEditorStandalone} from '../../../components/editor-standalone/event-editor-standalone';
+import {RelatedEventListItem} from '../../../components/Events/EventMetadata/RelatedEventListItem';
+import React, {createRef} from 'react';
+import {ToggleBox} from 'superdesk-ui-framework/react';
+
+interface IProps{
+    event: IEventItem;
+}
+
+export class AssociatedEventItem extends React.PureComponent<IProps> {
+    public toggleBoxRef: React.RefObject<any>;
+    public standaloneEditorRef: React.RefObject<EventEditorStandalone>;
+
+    constructor(props) {
+        super(props);
+
+        this.toggleBoxRef = createRef();
+        this.standaloneEditorRef = createRef();
+    }
+
+    render() {
+        const {event} = this.props;
+        const {gettext} = superdeskApi.localization;
+
+        // PR-TODO: use different authoringStorage for creating a new event.
+        return (
+            <ToggleBox
+                variant="custom-header"
+                toggleBoxRef={this.toggleBoxRef}
+                getToggleButtonLabel={(isOpen) => isOpen ? gettext('Show less') : gettext('Show more')}
+                header={(
+                    <RelatedEventListItem
+                        item={event}
+                        showIcon
+                        showBorder
+                    />
+                )}
+            >
+                <EventEditorStandalone
+                    ref={this.standaloneEditorRef}
+                    itemId={event._id}
+                    authoringStorage={authoringStorageEventItemHttp}
+                />
+            </ToggleBox>
+        );
+    }
+}

--- a/client/components/fields/editor/AssociatedEventItem.tsx
+++ b/client/components/fields/editor/AssociatedEventItem.tsx
@@ -4,6 +4,7 @@ import {EventEditorStandalone} from '../../../components/editor-standalone/event
 import {RelatedEventListItem} from '../../../components/Events/EventMetadata/RelatedEventListItem';
 import React, {createRef} from 'react';
 import {ToggleBox} from 'superdesk-ui-framework/react';
+import {IPropsAuthoring} from 'superdesk-api';
 
 interface IProps{
     event: IEventItem;
@@ -11,13 +12,13 @@ interface IProps{
 
 export class AssociatedEventItem extends React.PureComponent<IProps> {
     public toggleBoxRef: React.RefObject<any>;
-    public standaloneEditorRef: React.RefObject<EventEditorStandalone>;
+    public authoringRef: React.RefObject<React.ComponentType<IPropsAuthoring<IEventItem>>>;
 
     constructor(props) {
         super(props);
 
         this.toggleBoxRef = createRef();
-        this.standaloneEditorRef = createRef();
+        this.authoringRef = createRef();
     }
 
     render() {
@@ -39,7 +40,7 @@ export class AssociatedEventItem extends React.PureComponent<IProps> {
                 )}
             >
                 <EventEditorStandalone
-                    ref={this.standaloneEditorRef}
+                    editorRef={this.authoringRef}
                     itemId={event._id}
                     authoringStorage={authoringStorageEventItemHttp}
                 />

--- a/client/components/fields/editor/AssociatedEventWrapper.tsx
+++ b/client/components/fields/editor/AssociatedEventWrapper.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import {connect} from 'react-redux';
+import * as selectors from '../../../selectors';
+import {EditorFieldAssociatedEventComponent} from './AssociatedEvent';
+import {IEditorFieldProps, IFile, ILockedItems} from 'interfaces';
+
+export interface IAssociatedEventFieldProps extends IEditorFieldProps {
+    events?: Array<IEventItem>;
+    lockedItems: ILockedItems;
+    files: Array<IFile>;
+    tabEnabled?: boolean; // defaults to true
+}
+
+export class AssociatedEventField extends React.PureComponent<IAssociatedEventFieldProps> {
+    render() {
+        return (
+            <EditorFieldAssociatedEventComponent
+                ref={this.props.refNode}
+                {...this.props}
+            />
+        );
+    }
+}
+
+const mapStateToProps = (state) => ({
+    lockedItems: selectors.locks.getLockedItems(state),
+    files: selectors.general.files(state),
+});
+
+export const EditorFieldAssociatedEvents = connect(
+    mapStateToProps,
+    null,
+    null,
+    {forwardRef: true}
+)(AssociatedEventField);

--- a/client/components/fields/editor/EventRelatedPlannings/EventRelatedPlannings.tsx
+++ b/client/components/fields/editor/EventRelatedPlannings/EventRelatedPlannings.tsx
@@ -11,15 +11,14 @@ import './style.scss';
 import {TEMP_ID_PREFIX} from '../../../../constants';
 import {addSomeRelatedPlanningsToEventEditor} from '../../../../utils/planning';
 import {IRelatedPlanningProps} from './EventRelatedPlanningWrapper';
-import {PlanningEditorStandalone} from 'components/editor-standalone/planning-editor-standalone';
 
 export class EditorFieldEventRelatedPlanningsComponent extends React.PureComponent<IRelatedPlanningProps> {
-    relatedPlanningRefs: {[id: string]: React.RefObject<PlanningEditorStandalone>};
+    relatedItemRefs: {[id: string]: RelatedPlanningItem};
 
     constructor(props: IRelatedPlanningProps) {
         super(props);
 
-        this.relatedPlanningRefs = {};
+        this.relatedItemRefs = {};
     }
 
     render() {
@@ -71,7 +70,7 @@ export class EditorFieldEventRelatedPlanningsComponent extends React.PureCompone
                             return (
                                 <RelatedPlanningItem
                                     ref={(ref) => {
-                                        this.relatedPlanningRefs[index] = ref;
+                                        this.relatedItemRefs[index] = ref;
                                     }}
                                     key={plan._id}
                                     index={index}

--- a/client/components/fields/editor/EventRelatedPlannings/RelatedPlanningItem.tsx
+++ b/client/components/fields/editor/EventRelatedPlannings/RelatedPlanningItem.tsx
@@ -17,6 +17,7 @@ import {authoringStoragePlanningItemHttp} from '../../../editor-standalone/autho
 import {
     getAuthoringStorageInMemory
 } from '../../../editor-standalone/authoring-storage-in-memory';
+import {IPropsAuthoring} from 'superdesk-api';
 
 interface IProps {
     event: IEventItem;
@@ -38,14 +39,14 @@ interface IProps {
 
 export class RelatedPlanningItem extends React.PureComponent<IProps> {
     containerNode: React.RefObject<HTMLDivElement>;
-    public standaloneEditorRef: React.RefObject<PlanningEditorStandalone>;
+    public authoringRef: React.RefObject<React.ComponentType<IPropsAuthoring<IPlanningItem>>>;
     public toggleBoxRef: React.RefObject<any>;
 
     constructor(props) {
         super(props);
 
         this.containerNode = React.createRef();
-        this.standaloneEditorRef = React.createRef();
+        this.authoringRef = React.createRef();
         this.toggleBoxRef = React.createRef();
 
         this.remove = this.remove.bind(this);
@@ -121,7 +122,7 @@ export class RelatedPlanningItem extends React.PureComponent<IProps> {
                     }
                 >
                     <PlanningEditorStandalone
-                        ref={this.standaloneEditorRef}
+                        editorRef={this.authoringRef}
                         itemId={item._id}
                         authoringStorage={
                             item._id.startsWith(TEMP_ID_PREFIX)

--- a/client/components/fields/editor/index.tsx
+++ b/client/components/fields/editor/index.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react';
-
 import {EditorFieldCategories} from './Categories';
 import {EditorFieldCoverageType} from './CoverageType';
 import {EditorFieldEndDateTime} from './EndDateTime';
@@ -40,7 +38,7 @@ import {EditorFieldEventOccurenceStatus} from './EventOccurenceStatus';
 import {EditorFieldPlanningDateTime} from './PlanningDateTime';
 import {EditorFieldNotForPublication} from './NotForPublication';
 import {EditorFieldOverrideAutoAssignToWorkflow} from './OverrideAutoAssignToWorkflow';
-import {EditorFieldAssociatedEvents} from './AssociatedEvent';
+import {EditorFieldAssociatedEvents} from './AssociatedEventWrapper';
 import {EditorFieldCoverages} from './Coverages';
 import {EditorFieldGenre} from './Genre';
 import {EditorFieldNewsCoverageStatus} from './NewsCoverageStatus';

--- a/client/interfaces.ts
+++ b/client/interfaces.ts
@@ -1924,7 +1924,7 @@ export interface IEditorState {
 export interface IEditorProps {
     item?: IEventOrPlanningItem;
     itemId?: IEventOrPlanningItem['_id'];
-    itemType: string;
+    itemType: 'event' | 'planning';
     itemAction?: IEditorAction;
     session: ISession;
     privileges: IPrivileges;


### PR DESCRIPTION
STT-31

## Front-end checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [x] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [x] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [x] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [x] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [x] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [x] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [x] This pull request is not adding redux based modals
- [x] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [x] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)
