### PR TITLE
Allow event date editing after creation

### DIFF
--- a/client/actions/events/api.ts
+++ b/client/actions/events/api.ts
@@ -651,12 +651,6 @@ const save = (original, updates) => (
             const originalItem = eventUtils.modifyForServer(cloneDeep(originalEvent), true);
             const eventUpdates = eventUtils.getEventDiff(originalItem, updates);
 
-            // TODO: After BE is done, ensure things work & remove this
-            // if (get(originalItem, 'lock_action') === EVENTS.ITEM_ACTIONS.EDIT_EVENT.lock_action &&
-            //     !isTemporaryId(originalItem._id)
-            // ) {
-            //     delete eventUpdates.dates;
-            // }
             eventUpdates.update_method = eventUpdates.update_method == null ?
                 EVENTS.UPDATE_METHODS[0].value :
                 eventUpdates.update_method?.value ?? eventUpdates.update_method;

--- a/client/actions/events/api.ts
+++ b/client/actions/events/api.ts
@@ -651,11 +651,12 @@ const save = (original, updates) => (
             const originalItem = eventUtils.modifyForServer(cloneDeep(originalEvent), true);
             const eventUpdates = eventUtils.getEventDiff(originalItem, updates);
 
-            if (get(originalItem, 'lock_action') === EVENTS.ITEM_ACTIONS.EDIT_EVENT.lock_action &&
-                !isTemporaryId(originalItem._id)
-            ) {
-                delete eventUpdates.dates;
-            }
+            // TODO: After BE is done, ensure things work & remove this
+            // if (get(originalItem, 'lock_action') === EVENTS.ITEM_ACTIONS.EDIT_EVENT.lock_action &&
+            //     !isTemporaryId(originalItem._id)
+            // ) {
+            //     delete eventUpdates.dates;
+            // }
             eventUpdates.update_method = eventUpdates.update_method == null ?
                 EVENTS.UPDATE_METHODS[0].value :
                 eventUpdates.update_method?.value ?? eventUpdates.update_method;

--- a/client/actions/tests/autosave_test.ts
+++ b/client/actions/tests/autosave_test.ts
@@ -173,23 +173,20 @@ describe('actions.autosave', () => {
             }))
                 .then((updatedItem) => {
                     let expectedItem = {
-                        ...data.event_autosave[0],
                         slugline: 'Newest Event Slugline',
                         name: 'Test Name',
                         lock_action: 'edit',
                         lock_user: store.initialState.session.identity._id,
                         lock_session: store.initialState.session.sessionId,
-                        dates: {
-                            ...data.event_autosave[0].dates,
-                            tz: moment.tz.guess(),
-                        },
+                        files: [],
                     };
-
-                    delete expectedItem._etag;
 
                     const autosaveItem = jasmine.objectContaining(expectedItem);
 
                     expect(updatedItem).toEqual(autosaveItem);
+                    expect(updatedItem.dates.tz).toEqual(moment.tz.guess());
+                    expect(updatedItem.dates.start.toDate()).toEqual(data.event_autosave[0].dates.start.toDate());
+                    expect(updatedItem.dates.end.toDate()).toEqual(data.event_autosave[0].dates.end.toDate());
 
                     expect(store.dispatch.args[0]).toEqual([{
                         type: 'AUTOSAVE_RECEIVE',

--- a/client/components/Contacts/ActionBar.tsx
+++ b/client/components/Contacts/ActionBar.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {gettext} from 'core/utils';
+
+export const ActionBar: React.FunctionComponent<any> = ({svc, readOnly, dirty, valid, onSave, onCancel}) => (
+    <div className="action-bar show">
+        <div className="button-group button-group--end button-group--comfort">
+            <button
+                id="cancel-edit-btn"
+                type="button"
+                className="btn"
+                onClick={onCancel}
+            >
+                {gettext('Cancel')}
+            </button>
+
+            {!readOnly && (
+                <button
+                    id="save-edit-btn"
+                    type="button"
+                    className="btn btn--primary"
+                    onClick={onSave}
+                    disabled={!valid || !dirty}
+                >
+                    {gettext('Save')}
+                </button>
+            )}
+        </div>
+    </div>
+);
+
+ActionBar.propTypes = {
+    svc: PropTypes.object.isRequired,
+    onSave: PropTypes.func,
+    onCancel: PropTypes.func,
+    readOnly: PropTypes.bool,
+    dirty: PropTypes.bool,
+    valid: PropTypes.bool,
+};

--- a/client/components/Contacts/ContactEditor/index.tsx
+++ b/client/components/Contacts/ContactEditor/index.tsx
@@ -5,6 +5,7 @@ import {gettext} from '../../../utils';
 import * as ContactFormComponents from 'superdesk-core/scripts/apps/contacts/components/Form';
 import {IContact} from 'superdesk-core/scripts/apps/contacts/Contacts';
 import ng from 'superdesk-core/scripts/core/services/ng';
+import {ActionBar} from '../ActionBar';
 
 interface IProps {
     currentContact: IContact;
@@ -75,7 +76,7 @@ export class ContactEditor extends React.Component<IProps, IState> {
     }
 
     render() {
-        const {ContactFormContainer, ActionBar} = ContactFormComponents;
+        const {ContactFormContainer} = ContactFormComponents;
         const {currentContact} = this.props;
 
         // Provides required services for Contact components

--- a/client/components/Events/EventEditor/index.tsx
+++ b/client/components/Events/EventEditor/index.tsx
@@ -22,6 +22,7 @@ import {EventEditorHeader} from './EventEditorHeader';
 import {ContentBlock} from '../../UI/SidePanel';
 import {EventScheduleSummary} from '../EventScheduleSummary';
 import {CreateNewGeoLookup} from '../../GeoLookupInput/CreateNewGeoLookup';
+import {appConfig} from 'appConfig';
 
 interface IProps {
     original?: IEventItem;
@@ -129,6 +130,10 @@ class EventEditorComponent extends React.PureComponent<IProps> {
     }
 
     renderHeader() {
+        if (appConfig.planning_event_link_method === 'many_secondary') {
+            return null;
+        }
+
         return !this.props.itemExists ? null : (
             <React.Fragment>
                 <EventEditorHeader item={this.props.item} />
@@ -177,7 +182,9 @@ class EventEditorComponent extends React.PureComponent<IProps> {
                         required: true,
                         showAllDay: this.props.formProfile.editor.dates.all_day.enabled,
                         showTimeZone: true,
-                        enabled: !this.props.itemExists,
+                        enabled: appConfig.planning_event_link_method === 'many_secondary'
+                            ? true
+                            : !this.props.itemExists,
                         onChange: this.onDatesChanged,
                     },
                     language: {

--- a/client/components/Main/ItemEditor/ItemManager.ts
+++ b/client/components/Main/ItemEditor/ItemManager.ts
@@ -761,7 +761,7 @@ export class ItemManager {
     }
 
     startPartialSave(updates) {
-        const newState = {diff: cloneDeep(updates)};
+        const newState = {diff: cloneDeep(updates), errorMessages: []};
 
         this.validate(this.props, newState, this.state);
 

--- a/client/components/UI/Form/DateInput/index.tsx
+++ b/client/components/UI/Form/DateInput/index.tsx
@@ -31,7 +31,6 @@ interface IProps {
     remoteTimeZone?: string;
     isLocalTimeZoneDifferent?: boolean;
     inputAsLabel?: boolean;
-    dateOnly?: boolean;
 
     onChange(field: string, value: moment.Moment): void;
     popupContainer(): HTMLElement;

--- a/client/components/UI/Form/DateTimeInput/index.tsx
+++ b/client/components/UI/Form/DateTimeInput/index.tsx
@@ -37,7 +37,7 @@ interface IProps {
     onToBeConfirmed?(field: string): void;
     toBeConfirmed?: boolean;
     testId?: string;
-    dateOnly?: boolean;
+    allDay?: boolean;
 }
 
 /**
@@ -77,7 +77,7 @@ export const DateTimeInput = ({
 }: IProps) => {
     let timeValue = timeField ? diff?.timeField : value;
 
-    if (props.dateOnly) {
+    if (props.allDay) {
         timeValue = null;
     }
 
@@ -112,10 +112,9 @@ export const DateTimeInput = ({
                 onPopupOpen={onPopupOpen}
                 onPopupClose={onPopupClose}
                 remoteTimeZone={remoteTimeZone}
-                isLocalTimeZoneDifferent={isLocalTimeZoneDifferent && !props.dateOnly}
+                isLocalTimeZoneDifferent={isLocalTimeZoneDifferent && !props.allDay}
                 refNode={refNode}
                 halfWidth={!hideTime}
-                dateOnly={props.dateOnly}
             />
 
             {!hideTime && (
@@ -123,7 +122,7 @@ export const DateTimeInput = ({
                     row={false}
                     component={TimeInput}
                     field={timeField ? timeField : `${field}.time`}
-                    value={timeValue}
+                    value={props.allDay ? null : timeValue}
                     item={item}
                     diff={diff}
                     readOnly={readOnly}

--- a/client/components/UI/Form/Field.tsx
+++ b/client/components/UI/Form/Field.tsx
@@ -89,7 +89,7 @@ export class Field extends React.Component<IProps, IState> {
 
         const schema = get(formProfile, `schema["${profileField}"]`) || {};
         let currentError = (this.state.dirty || showErrors) ? (error || get(errors, field)) : null;
-        const currentValue = value || get(diff, field);
+        const currentValue = value !== undefined ? value : get(diff, field);
 
         const Component = component;
         const child = (

--- a/client/components/fields/editor/EndDateTime.tsx
+++ b/client/components/fields/editor/EndDateTime.tsx
@@ -12,7 +12,7 @@ interface IProps extends IEditorFieldProps {
     isLocalTimeZoneDifferent?: boolean;
     remoteTimeZone?: string;
     onToBeConfirmed?(field: string): void;
-    dateOnly?: boolean;
+    allDay?: boolean;
 }
 
 export class EditorFieldEndDateTime extends React.PureComponent<IProps> {

--- a/client/components/fields/editor/EventSchedule.tsx
+++ b/client/components/fields/editor/EventSchedule.tsx
@@ -223,7 +223,7 @@ export class EditorFieldEventSchedule extends React.PureComponent<IProps> {
                     toBeConfirmed={this.props.item[TO_BE_CONFIRMED_FIELD] === true}
                     isLocalTimeZoneDifferent={isLocalTimeZoneDifferent}
                     remoteTimeZone={this.props.item.dates?.tz}
-                    dateOnly={this.props.item.dates?.all_day}
+                    allDay={this.props.item.dates?.all_day}
                 />
                 <EditorFieldEndDateTime
                     {...props}
@@ -242,7 +242,7 @@ export class EditorFieldEventSchedule extends React.PureComponent<IProps> {
                     toBeConfirmed={this.props.item[TO_BE_CONFIRMED_FIELD] === true}
                     isLocalTimeZoneDifferent={isLocalTimeZoneDifferent}
                     remoteTimeZone={this.props.item.dates?.tz}
-                    dateOnly={this.props.item.dates?.no_end_time || this.props.item.dates?.all_day}
+                    allDay={this.props.item.dates?.no_end_time || this.props.item.dates?.all_day}
                 />
                 <Row
                     flex={true}

--- a/client/components/fields/editor/StartDateTime.tsx
+++ b/client/components/fields/editor/StartDateTime.tsx
@@ -12,7 +12,7 @@ interface IProps extends IEditorFieldProps {
     isLocalTimeZoneDifferent?: boolean;
     remoteTimeZone?: string;
     onToBeConfirmed?(field: string): void;
-    dateOnly?: boolean;
+    allDay?: boolean;
 }
 
 export class EditorFieldStartDateTime extends React.PureComponent<IProps> {

--- a/client/components/fields/editor/base/dateTime.tsx
+++ b/client/components/fields/editor/base/dateTime.tsx
@@ -13,7 +13,7 @@ interface IProps extends IEditorFieldProps {
     remoteTimeZone?: string;
     singleValue?: boolean;
     onToBeConfirmed?(field: string): void;
-    dateOnly?: boolean;
+    allDay?: boolean;
 }
 
 export class EditorFieldDateTime extends React.PureComponent<IProps> {
@@ -62,7 +62,7 @@ export class EditorFieldDateTime extends React.PureComponent<IProps> {
                 refNode={(node) => {
                     this.node = node;
                 }}
-                dateOnly={this.props.dateOnly}
+                allDay={this.props.allDay}
             />
         );
     }

--- a/client/constants/index.ts
+++ b/client/constants/index.ts
@@ -5,6 +5,7 @@ import {assignPlanningConstantTranslations} from './planning';
 import {assignAssignmentConstantTranslations} from './assignments';
 import {assignTooltipConstantTranslations} from './tooltips';
 import {assignCoverageConstantTranslations} from './coverages';
+import {IPlanningPubstatus, IWorkflowState} from 'interfaces';
 
 export {PRIVILEGES} from './privileges';
 export {PLANNING} from './planning';
@@ -40,7 +41,7 @@ export const DATE_FORMATS = {
     DISPLAY_CDATE_TBC_FORMAT: 'D. MMMM @ TBC',
 };
 
-export const WORKFLOW_STATE = {
+export const WORKFLOW_STATE: {[key: string]: IWorkflowState} = {
     DRAFT: 'draft',
     INGESTED: 'ingested',
     SCHEDULED: 'scheduled',
@@ -51,7 +52,7 @@ export const WORKFLOW_STATE = {
     SPIKED: 'spiked',
 };
 
-export const POST_STATE = {
+export const POST_STATE: {[key: string]: IPlanningPubstatus} = {
     USABLE: 'usable',
     CANCELLED: 'cancelled',
 };

--- a/client/utils/events.tsx
+++ b/client/utils/events.tsx
@@ -1,6 +1,6 @@
 import moment from 'moment-timezone';
 import RRule from 'rrule';
-import {get, isNil, sortBy, cloneDeep, omitBy, find, isEqual, pickBy, flatten, noop} from 'lodash';
+import {get, isNil, sortBy, cloneDeep, omitBy, find, isEqual, pickBy, flatten} from 'lodash';
 import {IMenuItem} from 'superdesk-ui-framework/react/components/Menu';
 
 import {IVocabularyItem} from 'superdesk-api';
@@ -1261,6 +1261,14 @@ function modifyForServer(event: IEventItem, removeNullLinks: boolean = false) {
                 event.dates.tz
             );
         }
+    } else {
+        if (event.dates?.start != null && moment.isMoment(event.dates.start)) {
+            event.dates.start = event.dates.start.toISOString();
+        }
+
+        if (event.dates?.end != null && moment.isMoment(event.dates.end)) {
+            event.dates.end = event.dates.end.toISOString();
+        }
     }
 
     return event;
@@ -1515,18 +1523,18 @@ function getEventDiff(original: IEventItem, updates: Partial<IEventItem>): Parti
     const originalItem = modifyForServer(cloneDeep(original), true);
 
     // clone the updates as we're going to modify it
-    let eventUpdates = modifyForServer(cloneDeep(updates), true);
+    const eventUpdates = modifyForServer(cloneDeep(updates), true);
 
     originalItem.location = originalItem.location ? [originalItem.location] : null;
 
     // remove all properties starting with `_`
     // and updates that are the same as original
-    eventUpdates = pickBy(eventUpdates, (value, key) => (
+    const diff = pickBy(eventUpdates, (value, key) => (
         (key === TO_BE_CONFIRMED_FIELD || key === '_planning_item' || !key.startsWith('_')) &&
         !isEqual(eventUpdates[key] ?? '', originalItem[key] ?? '')
     ));
 
-    return eventUpdates;
+    return diff;
 }
 
 function convertCoverageToEventEmbedded(coverage: IPlanningCoverageItem): IEmbeddedCoverageItem {

--- a/client/utils/time.ts
+++ b/client/utils/time.ts
@@ -107,7 +107,7 @@ function isEventInDifferentTimeZone(event: Partial<IEventItem>): boolean {
     const dateInEventTimeZone = getDateInRemoteTimeZone(event?.dates?.start, event?.dates?.tz);
     const dateInLocalTimeZone = getDateInRemoteTimeZone(event?.dates?.start);
 
-    return dateInEventTimeZone.format('Z') !== dateInLocalTimeZone.format('Z');
+    return dateInEventTimeZone.format('Z') !== dateInLocalTimeZone.format('Z') && !event?.dates?.all_day;
 }
 
 function localTimeZone(): string {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4124,6 +4124,27 @@
             "unpipe": "~1.0.0"
           }
         },
+        "iconv-lite": {
+          "version": "0.4.24",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+          "dev": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        },
+        "mime": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+          "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+          "dev": true
+        },
         "path-to-regexp": {
           "version": "0.1.10",
           "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
@@ -7718,6 +7739,12 @@
         "redent": "^1.0.0",
         "trim-newlines": "^1.0.0"
       }
+    },
+    "merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "dev": true
     },
     "merge2": {
       "version": "1.4.1",
@@ -12168,7 +12195,7 @@
       }
     },
     "superdesk-core": {
-      "version": "github:superdesk/superdesk-client-core#60d561e73f3f97b6249ffaac255fd35a3091fe8f",
+      "version": "github:superdesk/superdesk-client-core#5c80d6dc1e9584a3d09220a627656cd90e223725",
       "from": "github:superdesk/superdesk-client-core#develop",
       "dev": true,
       "requires": {
@@ -12256,7 +12283,7 @@
         "react-mentions": "1.2.2",
         "react-paginate": "6.3.0",
         "react-portal": "4.1.3",
-        "react-redux": "7.2.1",
+        "react-redux": "7.2.9",
         "react-sortable-hoc": "1.11.0",
         "react-textarea-autosize": "5.2.1",
         "react-virtual": "2.10.4",
@@ -12266,7 +12293,7 @@
         "sass-loader": "6.0.6",
         "shortid": "2.2.8",
         "style-loader": "0.20.2",
-        "superdesk-ui-framework": "4.0.3",
+        "superdesk-ui-framework": "4.0.4",
         "ts-loader": "3.5.0",
         "typescript": "4.9.5",
         "uuid": "8.3.1",
@@ -12332,6 +12359,12 @@
             "prop-types": "^15"
           }
         },
+        "react-is": {
+          "version": "17.0.2",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+          "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+          "dev": true
+        },
         "react-portal": {
           "version": "4.1.3",
           "resolved": "https://registry.npmjs.org/react-portal/-/react-portal-4.1.3.tgz",
@@ -12339,6 +12372,53 @@
           "dev": true,
           "requires": {
             "prop-types": "^15.5.8"
+          }
+        },
+        "react-redux": {
+          "version": "7.2.9",
+          "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.9.tgz",
+          "integrity": "sha512-Gx4L3uM182jEEayZfRbI/G11ZpYdNAnBs70lFVMNdHJI76XYtR+7m0MN+eAs7UHBPhWXcnFPaS+9owSCJQHNpQ==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.15.4",
+            "@types/react-redux": "^7.1.20",
+            "hoist-non-react-statics": "^3.3.2",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.7.2",
+            "react-is": "^17.0.2"
+          },
+          "dependencies": {
+            "@types/react-redux": {
+              "version": "7.1.34",
+              "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.34.tgz",
+              "integrity": "sha512-GdFaVjEbYv4Fthm2ZLvj1VSCedV7TqE5y1kNwnjSdBOTXuRSgowux6J8TAct15T3CKBr63UMk+2CO7ilRhyrAQ==",
+              "dev": true,
+              "requires": {
+                "@types/hoist-non-react-statics": "^3.3.0",
+                "@types/react": "*",
+                "hoist-non-react-statics": "^3.3.0",
+                "redux": "^4.0.0"
+              }
+            },
+            "prop-types": {
+              "version": "15.8.1",
+              "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+              "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+              "dev": true,
+              "requires": {
+                "loose-envify": "^1.4.0",
+                "object-assign": "^4.1.1",
+                "react-is": "^16.13.1"
+              },
+              "dependencies": {
+                "react-is": {
+                  "version": "16.13.1",
+                  "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+                  "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+                  "dev": true
+                }
+              }
+            }
           }
         },
         "react-sortable-hoc": {
@@ -12350,6 +12430,48 @@
             "@babel/runtime": "^7.2.0",
             "invariant": "^2.2.4",
             "prop-types": "^15.5.7"
+          }
+        },
+        "superdesk-ui-framework": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/superdesk-ui-framework/-/superdesk-ui-framework-4.0.4.tgz",
+          "integrity": "sha512-mm36orxkDHDYM3ID36q6fB9ImHwV2CvgEIAXmZD0BOpfy+4Yc0+7GLfuur0Zf1Vs7LIutcoe4ljsSQ0RdB9KDQ==",
+          "dev": true,
+          "requires": {
+            "@popperjs/core": "^2.4.0",
+            "@superdesk/common": "0.0.28",
+            "@superdesk/primereact": "^5.0.2-12",
+            "@superdesk/react-resizable-panels": "0.0.39",
+            "chart.js": "^2.9.3",
+            "date-fns": "2.7.0",
+            "popper-max-size-modifier": "^0.2.0",
+            "popper.js": "1.14.4",
+            "primeicons": "2.0.0",
+            "react-beautiful-dnd": "^13.0.0",
+            "react-id-generator": "^3.0.0",
+            "react-scrollspy": "^3.4.3"
+          },
+          "dependencies": {
+            "@superdesk/common": {
+              "version": "0.0.28",
+              "resolved": "https://registry.npmjs.org/@superdesk/common/-/common-0.0.28.tgz",
+              "integrity": "sha512-EhsYMm340r3FVrakH00lLvQbxVYYTzL61J5GXI3BI2xLN2dPI3N0AJEaMGqjbt0xUpUFxE3T08OtYvIC5koZvg==",
+              "dev": true,
+              "requires": {
+                "date-fns": "2.7.0",
+                "lodash": "4.17.19",
+                "primereact": "^6.0.2",
+                "react": "16.9.0",
+                "react-dom": "16.9.0",
+                "react-sortable-hoc": "^1.11.0"
+              }
+            },
+            "date-fns": {
+              "version": "2.7.0",
+              "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.7.0.tgz",
+              "integrity": "sha512-wxYp2PGoUDN5ZEACc61aOtYFvSsJUylIvCjpjDOqM1UDaKIIuMJ9fAnMYFHV3TQaDpfTVxhwNK/GiCaHKuemTA==",
+              "dev": true
+            }
           }
         }
       }
@@ -14056,47 +14178,6 @@
         "is-number-object": "^1.1.0",
         "is-string": "^1.1.0",
         "is-symbol": "^1.1.0"
-      }
-    },
-    "which-builtin-type": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.0.tgz",
-      "integrity": "sha512-I+qLGQ/vucCby4tf5HsLmGueEla4ZhwTBSqaooS+Y0BuxN4Cp+okmGuV+8mXZ84KDI9BA+oklo+RzKg0ONdSUA==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.7",
-        "function.prototype.name": "^1.1.6",
-        "has-tostringtag": "^1.0.2",
-        "is-async-function": "^2.0.0",
-        "is-date-object": "^1.0.5",
-        "is-finalizationregistry": "^1.1.0",
-        "is-generator-function": "^1.0.10",
-        "is-regex": "^1.1.4",
-        "is-weakref": "^1.0.2",
-        "isarray": "^2.0.5",
-        "which-boxed-primitive": "^1.0.2",
-        "which-collection": "^1.0.2",
-        "which-typed-array": "^1.1.15"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-          "dev": true
-        }
-      }
-    },
-    "which-collection": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
-      "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
-      "dev": true,
-      "requires": {
-        "is-map": "^2.0.3",
-        "is-set": "^2.0.3",
-        "is-weakmap": "^2.0.2",
-        "is-weakset": "^2.0.3"
       }
     },
     "which-builtin-type": {

--- a/server/planning/events/events.py
+++ b/server/planning/events/events.py
@@ -497,6 +497,10 @@ class EventsService(superdesk.Service):
             del updates["skip_on_update"]
             return
 
+        if updates.get("dates") and original.get("dates"):
+            for field in original.get("dates"):  # we need to preserve non updated values
+                updates["dates"].setdefault(field, original["dates"][field])
+
         update_method = updates.pop("update_method", UPDATE_SINGLE)
 
         user = get_user()


### PR DESCRIPTION
STT-66


## Front-end checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)
