### PR TITLE
Use set validation errors so previous errors are cleared

### DIFF
--- a/client/components/editor-standalone/authoring-autosave.ts
+++ b/client/components/editor-standalone/authoring-autosave.ts
@@ -130,29 +130,3 @@ export class AutoSaveHttp<T extends IBaseRestApiResponse> implements IAuthoringA
         this.autoSaveThrottled.cancel();
     }
 }
-
-export class NoAutoSave<T> implements IAuthoringAutoSave<T> {
-    get(id: string) {
-        return Promise.resolve(null);
-    }
-
-    delete() {
-        return Promise.resolve();
-    }
-
-    schedule(
-        getItem: () => T,
-        callback: (autosaved: T) => void,
-        autosavedItem: T,
-    ) {
-        callback(getItem());
-    }
-
-    cancel() {
-        // noop
-    }
-
-    flush(): Promise<void> {
-        return Promise.resolve();
-    }
-}

--- a/client/components/editor-standalone/authoring-storage-in-memory.ts
+++ b/client/components/editor-standalone/authoring-storage-in-memory.ts
@@ -1,13 +1,40 @@
 import ng from 'superdesk-core/scripts/core/services/ng';
-import {IAuthoringStorage} from 'superdesk-api';
+import {IAuthoringAutoSave, IAuthoringStorage} from 'superdesk-api';
 import {getProfile} from './profile';
-import {NoAutoSave} from './authoring-autosave';
 
 export function getAuthoringStorageInMemory<T>(
     profile: 'event' | 'planning',
     item: T,
     onSave: (current: T, original: T) => Promise<T>,
 ): IAuthoringStorage<T> {
+    class NoAutoSave implements IAuthoringAutoSave<T> {
+        get(id: string) {
+            // return an empty object so authoring-react compares with saved item sees it as dirty
+            // otherwise, it is not seen as dirty and wouldn't trigger to fill required fields.
+            return Promise.resolve({} as T);
+        }
+
+        delete() {
+            return Promise.resolve();
+        }
+
+        schedule(
+            getItem: () => T,
+            callback: (autosaved: T) => void,
+            autosavedItem: T,
+        ) {
+            callback(getItem());
+        }
+
+        cancel() {
+            // noop
+        }
+
+        flush(): Promise<void> {
+            return Promise.resolve();
+        }
+    }
+
     const authoringStorage: IAuthoringStorage<T> = {
         autosave: new NoAutoSave(),
 

--- a/client/components/editor-standalone/base-editor-standalone.tsx
+++ b/client/components/editor-standalone/base-editor-standalone.tsx
@@ -82,7 +82,7 @@ export class BaseEditorComponent<T extends IPlanningItem | IEventItem> extends R
                 getInlineToolbarActions={({
                     hasUnsavedChanges,
                     save,
-                    addValidationErrors,
+                    setValidationErrors,
                     fieldsData,
                     getLatestItem,
                 }) => {
@@ -103,7 +103,7 @@ export class BaseEditorComponent<T extends IPlanningItem | IEventItem> extends R
                                     );
 
                                     if (Object.keys(validationErrors).length > 0) {
-                                        addValidationErrors(validationErrors);
+                                        setValidationErrors(validationErrors);
                                     } else {
                                         save();
                                     }


### PR DESCRIPTION
Depends on: https://github.com/superdesk/superdesk-client-core/pull/4746

## Front-end checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [x]This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [x] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [x] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [x] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [x] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [x] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [x] This pull request is not adding redux based modals
- [x] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [x] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)
