### PR TITLE
fix default date for all day planning items

### DIFF
--- a/client/actions/tests/agenda_test.ts
+++ b/client/actions/tests/agenda_test.ts
@@ -340,6 +340,7 @@ describe('agenda', () => {
                                     _id: events[0]._id,
                                 }],
                                 planning_date: events[0].dates.start,
+                                all_day: false,
                                 slugline: events[0].slugline,
                                 name: events[0].name,
                                 subject: events[0].subject,

--- a/client/components/Main/ItemEditor/tests/ItemManager_test.ts
+++ b/client/components/Main/ItemEditor/tests/ItemManager_test.ts
@@ -49,6 +49,7 @@ describe('components.Main.ItemManager', () => {
             type: 'planning',
             state: 'draft',
             planning_date: jasmine.any(moment),
+            all_day: false,
             agendas: [],
             flags: {
                 marked_for_not_publication: false,

--- a/client/utils/planning.tsx
+++ b/client/utils/planning.tsx
@@ -1008,7 +1008,8 @@ function createNewPlanningFromNewsItem(
         type: 'planning',
         slugline: addNewsItemToPlanning.slugline,
         headline: get(addNewsItemToPlanning, 'headline'),
-        planning_date: moment(),
+        planning_date: getDefaultPlanningDate(),
+        all_day: appConfig.planning?.all_day || false,
         ednote: get(addNewsItemToPlanning, 'ednote'),
         subject: get(addNewsItemToPlanning, 'subject'),
         anpa_category: get(addNewsItemToPlanning, 'anpa_category'),
@@ -1496,6 +1497,10 @@ function shouldLockPlanningForEdit(item: IPlanningItem, privileges: IPrivileges)
     );
 }
 
+function getDefaultPlanningDate(): moment.Moment {
+    return appConfig.planning?.all_day ? moment.utc(moment().format('YYYY-MM-DD')) : moment();
+}
+
 function defaultPlanningValues(currentAgenda?: IAgenda, defaultPlaceList?: Array<IPlace>): Partial<IPlanningItem> {
     const {contentProfiles} = planningApi;
     const planningProfile = contentProfiles.get('planning');
@@ -1504,7 +1509,8 @@ function defaultPlanningValues(currentAgenda?: IAgenda, defaultPlaceList?: Array
     const newPlanning: Partial<IPlanningItem> = Object.assign(
         {
             type: 'planning',
-            planning_date: moment(),
+            planning_date: getDefaultPlanningDate(),
+            all_day: appConfig.planning?.all_day || false,
             agendas: get(currentAgenda, 'is_enabled') ?
                 [getItemId(currentAgenda)] : [],
             state: 'draft',


### PR DESCRIPTION
STT-48

## Front-end checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)
