### PR TITLE
Update empty states

### DIFF
--- a/client/components/Coverages/CoverageArrayInput.tsx
+++ b/client/components/Coverages/CoverageArrayInput.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {connect} from 'react-redux';
-import {isEmpty, noop} from 'lodash';
+import {isEmpty} from 'lodash';
 
 import {
     EDITOR_TYPE,
@@ -192,7 +192,6 @@ class CoverageArrayInputComponent extends React.Component<IProps, IState> {
 
         const {desks, users, coverageAddAdvancedMode} = this.props;
         const language = this.props.item.language;
-        const {DropZone} = superdeskApi.components;
 
         return (
             <InputArray
@@ -203,11 +202,6 @@ class CoverageArrayInputComponent extends React.Component<IProps, IState> {
                 value={value}
                 coverages={value}
                 onChange={onChange}
-                emptyValueElement={(
-                    <DropZone disabled canDrop={() => false} onDrop={noop}>
-                        {gettext('No Coverages Yet')}
-                    </DropZone>
-                )}
                 addButtonText={addButtonText}
                 addButtonComponent={CoverageAddButton}
                 addButtonProps={{

--- a/client/components/Coverages/CoverageArrayInput.tsx
+++ b/client/components/Coverages/CoverageArrayInput.tsx
@@ -204,14 +204,9 @@ class CoverageArrayInputComponent extends React.Component<IProps, IState> {
                 coverages={value}
                 onChange={onChange}
                 emptyStateElement={(
-                    <EmptyState
-                        title={superdeskApi.localization.gettext('No coverages have been added')}
-                        description={
-                            superdeskApi.localization.gettext('To add some, click the plus icon')
-                        }
-                        illustration="2"
-                        size="small"
-                    />
+                    <div className="sd-border--medium border-dashed p-1-5 radius-md d-flex items-center justify-center">
+                        <span className="text-sm text-color-subdued">No Coverages yet</span>
+                    </div>
                 )}
                 addButtonText={addButtonText}
                 addButtonComponent={CoverageAddButton}

--- a/client/components/Coverages/CoverageArrayInput.tsx
+++ b/client/components/Coverages/CoverageArrayInput.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {connect} from 'react-redux';
-import {isEmpty} from 'lodash';
+import {isEmpty, noop} from 'lodash';
 
 import {
     EDITOR_TYPE,
@@ -23,7 +23,6 @@ import {InputArray} from '../UI/Form';
 import {CoverageEditor} from './CoverageEditor';
 import {CoverageAddButton} from './CoverageAddButton';
 import planningActions from '../../actions/planning/api';
-import {EmptyState} from 'superdesk-ui-framework/react';
 
 
 interface IOwnProps {
@@ -193,6 +192,7 @@ class CoverageArrayInputComponent extends React.Component<IProps, IState> {
 
         const {desks, users, coverageAddAdvancedMode} = this.props;
         const language = this.props.item.language;
+        const {DropZone} = superdeskApi.components;
 
         return (
             <InputArray
@@ -203,10 +203,10 @@ class CoverageArrayInputComponent extends React.Component<IProps, IState> {
                 value={value}
                 coverages={value}
                 onChange={onChange}
-                emptyStateElement={(
-                    <div className="sd-border--medium border-dashed p-1-5 radius-md d-flex items-center justify-center">
-                        <span className="text-sm text-color-subdued">No Coverages yet</span>
-                    </div>
+                emptyValueElement={(
+                    <DropZone disabled canDrop={() => false} onDrop={noop}>
+                        {gettext('No Coverages Yet')}
+                    </DropZone>
                 )}
                 addButtonText={addButtonText}
                 addButtonComponent={CoverageAddButton}

--- a/client/components/UI/Form/InputArray/index.tsx
+++ b/client/components/UI/Form/InputArray/index.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/no-multi-comp */
 import React from 'react';
 import classNames from 'classnames';
-import {get} from 'lodash';
+import {get, noop} from 'lodash';
 
 import {Button} from '../../';
 import {Row, LineInput} from '../';
@@ -20,7 +20,6 @@ interface IProps {
     value: Array<any>;
     onChange(field: string, value: Array<any>): void;
     addButtonComponent: React.ComponentClass;
-    emptyValueElement: React.ReactNode;
     addButtonProps: any;
     addButtonText: string;
     maxCount: number;
@@ -184,7 +183,14 @@ export class InputArray extends React.PureComponent<IProps> {
             />
         );
 
-        const {emptyValueElement} = this.props;
+        const {DropZone} = superdeskApi.components;
+        const {gettext} = superdeskApi.localization;
+
+        const emptyValueElement = (
+            <DropZone disabled canDrop={() => false} onDrop={noop}>
+                {gettext('No Coverages Yet')}
+            </DropZone>
+        );
 
         if (typeof this.props.children === 'function') {
             return this.props.children({

--- a/client/components/UI/Form/InputArray/index.tsx
+++ b/client/components/UI/Form/InputArray/index.tsx
@@ -20,7 +20,7 @@ interface IProps {
     value: Array<any>;
     onChange(field: string, value: Array<any>): void;
     addButtonComponent: React.ComponentClass;
-    emptyStateElement: React.ReactNode;
+    emptyValueElement: React.ReactNode;
     addButtonProps: any;
     addButtonText: string;
     maxCount: number;
@@ -151,8 +151,8 @@ export class InputArray extends React.PureComponent<IProps> {
         const addButton = this.renderButton();
 
         const hasLabel = (label ?? '').length > 0;
-        const addButtonElement: React.ReactNode = showAddButton && addButton;
-        const labelElement: React.ReactNode = !hasLabel ? null : (
+        const addButtonElement = showAddButton && addButton;
+        const labelElement = !hasLabel ? null : (
             <div>
                 <div className={classNames('InputArray__label', labelClassName)}>{label}</div>
                 {buttonWithLabel && addButtonElement}
@@ -184,12 +184,15 @@ export class InputArray extends React.PureComponent<IProps> {
             />
         );
 
+        const {emptyValueElement} = this.props;
+
         if (typeof this.props.children === 'function') {
             return this.props.children({
                 itemsElement,
                 addButtonElement,
                 errorMessageElement,
                 labelElement,
+                emptyValueElement,
             });
         } else {
             return (
@@ -203,7 +206,7 @@ export class InputArray extends React.PureComponent<IProps> {
                         {itemsElement}
                         {!buttonWithLabel && addButtonElement}
                     </Row>
-                    {(this.props.value?.length ?? 0) < 1 && this.props.emptyStateElement}
+                    {(this.props.value?.length ?? 0) < 1 && emptyValueElement}
                 </>
             );
         }

--- a/client/components/fields/editor/AssociatedEvent.tsx
+++ b/client/components/fields/editor/AssociatedEvent.tsx
@@ -1,14 +1,12 @@
-/* eslint-disable no-nested-ternary */
 import * as React from 'react';
 import {IEventItem, IPlanningRelatedEventLink} from '../../../interfaces';
 import {planningApi, superdeskApi} from '../../../superdeskApi';
 import events from '../../../utils/events';
 import {AssociatedEventItem} from './AssociatedEventItem';
 import {IAssociatedEventFieldProps} from './AssociatedEventWrapper';
-import {Spacer, Button, EmptyState} from 'superdesk-ui-framework/react';
+import {Spacer, Button} from 'superdesk-ui-framework/react';
 import {isTemporaryId, removeAutosaveFields} from '../../../utils';
 import {convertPlanningToEvent} from '../../../actions/events/ui';
-import {Tooltip} from '@sourcefabric/common';
 
 export class EditorFieldAssociatedEventComponent extends React.PureComponent<IAssociatedEventFieldProps> {
     public relatedItemRefs: {[id: string]: AssociatedEventItem};

--- a/client/components/fields/editor/AssociatedEvent.tsx
+++ b/client/components/fields/editor/AssociatedEvent.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-nested-ternary */
 import * as React from 'react';
 import {IEventItem, IPlanningRelatedEventLink} from '../../../interfaces';
 import {planningApi, superdeskApi} from '../../../superdeskApi';
@@ -70,6 +71,15 @@ export class EditorFieldAssociatedEventComponent extends React.PureComponent<IAs
         const events = this.props.events ?? [];
         const disabled = this.props.disabled ?? false;
         const planningItemCreated = !isTemporaryId(this.props.item._id);
+        const dropZoneText = (() => {
+            if (planningItemCreated === false) {
+                return gettext('Event has to be created before adding related plannings');
+            } else if (events.length < 1) {
+                return gettext('No events yet, drop some here, or click the plus button');
+            } else {
+                return gettext('Drop events here');
+            }
+        })();
 
         return (
             <Spacer v gap="16">
@@ -77,13 +87,7 @@ export class EditorFieldAssociatedEventComponent extends React.PureComponent<IAs
                     <label className="side-panel__heading side-panel__heading--big">
                         {gettext('Related Events')}
                     </label>
-                    <Tooltip
-                        content={
-                            planningItemCreated
-                                ? null
-                                : gettext('Planning item has to be created before adding related events')
-                        }
-                    >
+                    {planningItemCreated && !disabled && (
                         <Button
                             type="primary"
                             icon="plus-large"
@@ -92,35 +96,23 @@ export class EditorFieldAssociatedEventComponent extends React.PureComponent<IAs
                             size="small"
                             iconOnly={true}
                             onClick={this.addNewRelatedEvent}
-                            disabled={disabled || !planningItemCreated}
                         />
-                    </Tooltip>
+                    )}
                 </Spacer>
-                {events.length > 0 ? (
-                    <Spacer gap="8" v>
-                        {events.map((event, i) => (
-                            <AssociatedEventItem
-                                index={i}
-                                key={event._id}
-                                event={event}
-                                removeEventItem={this.props.removeEventItem}
-                                disabled={this.props.disabled}
-                                ref={(ref) => {
-                                    this.relatedItemRefs[i] = ref;
-                                }}
-                            />
-                        ))}
-                    </Spacer>
-                ) : (
-                    <EmptyState
-                        title={gettext('No associated events have been added')}
-                        description={
-                            gettext('To add some, click the plus icon at the top right or drop an existing one')
-                        }
-                        illustration="1"
-                        size="small"
-                    />
-                )}
+                <Spacer gap="8" v>
+                    {events.map((event, i) => (
+                        <AssociatedEventItem
+                            index={i}
+                            key={event._id}
+                            event={event}
+                            removeEventItem={this.props.removeEventItem}
+                            disabled={this.props.disabled}
+                            ref={(ref) => {
+                                this.relatedItemRefs[i] = ref;
+                            }}
+                        />
+                    ))}
+                </Spacer>
                 {!disabled && (
                     <DropZone
                         canDrop={
@@ -139,7 +131,7 @@ export class EditorFieldAssociatedEventComponent extends React.PureComponent<IAs
                         }}
                         multiple={true}
                     >
-                        {gettext('Drop events here')}
+                        {dropZoneText}
                     </DropZone>
                 )}
             </Spacer>

--- a/client/components/fields/editor/EventRelatedPlannings/EventRelatedPlannings.tsx
+++ b/client/components/fields/editor/EventRelatedPlannings/EventRelatedPlannings.tsx
@@ -76,7 +76,7 @@ export class EditorFieldEventRelatedPlanningsComponent extends React.PureCompone
                         {gettext('Related Plannings')}
                     </label>
 
-                    <Tooltip content={canAddItems.error}>
+                    {canAddItems.allowed && (
                         <Button
                             type="primary"
                             icon="plus-large"
@@ -84,73 +84,59 @@ export class EditorFieldEventRelatedPlanningsComponent extends React.PureCompone
                             shape="round"
                             size="small"
                             iconOnly={true}
-                            disabled={!canAddItems.allowed}
                             onClick={() => {
                                 this.props.addPlanningItem();
                             }}
                         />
-                    </Tooltip>
+                    )}
                 </Spacer>
-
                 {disabled ? planningItemsMetadata : (
                     <>
-                        {planningItems.length > 0 ? (
-                            planningItems.map((plan, index) => {
-                                const isNewlyCreatedItem =
-                            index === planningItems.length - 1
-                            && plan._id.startsWith(TEMP_ID_PREFIX);
+                        {planningItems.map((plan, index) => {
+                            const isNewlyCreatedItem = index === planningItems.length - 1
+                                && plan._id.startsWith(TEMP_ID_PREFIX);
 
-                                return (
-                                    <RelatedPlanningItem
-                                        ref={(ref) => {
-                                            this.relatedItemRefs[index] = ref;
-                                        }}
-                                        key={plan._id}
-                                        index={index}
-                                        event={this.props.item}
-                                        item={plan}
-                                        removePlan={this.props.removePlanningItem}
-                                        updatePlanningItem={this.props.updatePlanningItem}
-                                        disabled={false}
-                                        editorType={this.props.editorType}
-                                        profile={this.props.profile}
-                                        coverageProfile={this.props.coverageProfile}
-                                        isAgendaEnabled={isAgendaEnabled}
-                                        initiallyExpanded={isNewlyCreatedItem && (plan.coverages ?? []).length < 1}
-                                    />
-                                );
-                            })
-                        ) : (
-                            <EmptyState
-                                title={gettext('No planning items have been added')}
-                                description={
-                                    gettext('To add some, click the plus icon at the top right or drop an existing one')
-                                }
-                                illustration="2"
-                                size="small"
-                            />
-                        )}
-                        <DropZone
-                            canDrop={
-                                (event) => event.dataTransfer.getData(
-                                    'application/superdesk.planning.planning_item',
-                                ) != null
-                            }
-                            onDrop={(event) => {
-                                event.preventDefault();
-                                const planningItem: IPlanningItem = JSON.parse(
-                                    event.dataTransfer.getData('application/superdesk.planning.planning_item'),
-                                );
-
-                                addSomeRelatedPlanningsToEventEditor([planningItem], this.props.lockedItems);
-                            }}
-                            multiple={true}
-                            disabled={!canAddItems.allowed}
-                        >
-                            {canAddItems.allowed ? gettext('Drop planning items here') : canAddItems.error}
-                        </DropZone>
+                            return (
+                                <RelatedPlanningItem
+                                    ref={(ref) => {
+                                        this.relatedItemRefs[index] = ref;
+                                    }}
+                                    key={plan._id}
+                                    index={index}
+                                    event={this.props.item}
+                                    item={plan}
+                                    removePlan={this.props.removePlanningItem}
+                                    updatePlanningItem={this.props.updatePlanningItem}
+                                    disabled={false}
+                                    editorType={this.props.editorType}
+                                    profile={this.props.profile}
+                                    coverageProfile={this.props.coverageProfile}
+                                    isAgendaEnabled={isAgendaEnabled}
+                                    initiallyExpanded={isNewlyCreatedItem && (plan.coverages ?? []).length < 1}
+                                />
+                            );
+                        })}
                     </>
                 )}
+                <DropZone
+                    canDrop={
+                        (event) => event.dataTransfer.getData(
+                            'application/superdesk.planning.planning_item',
+                        ) != null
+                    }
+                    onDrop={(event) => {
+                        event.preventDefault();
+                        const planningItem: IPlanningItem = JSON.parse(
+                            event.dataTransfer.getData('application/superdesk.planning.planning_item'),
+                        );
+
+                        addSomeRelatedPlanningsToEventEditor([planningItem], this.props.lockedItems);
+                    }}
+                    multiple={true}
+                    disabled={!canAddItems.allowed}
+                >
+                    {canAddItems.allowed ? gettext('Drop planning items here') : canAddItems.error}
+                </DropZone>
             </div>
         );
     }

--- a/client/interfaces.ts
+++ b/client/interfaces.ts
@@ -2032,9 +2032,10 @@ export abstract class IEditorHeaderComponent {
 
 export interface IInputArrayHocModeOptions {
     itemsElement: React.ReactNode;
-    addButtonElement: JSX.Element;
+    addButtonElement: React.ReactNode;
     errorMessageElement: React.ReactNode;
     labelElement: React.ReactNode;
+    emptyValueElement: React.ReactNode;
 }
 
 export interface IWebsocketMessageData {

--- a/client/planning-extension/src/authoring-react-fields/coverages/editor.tsx
+++ b/client/planning-extension/src/authoring-react-fields/coverages/editor.tsx
@@ -76,7 +76,7 @@ export class Editor extends React.PureComponent<IProps> {
                     });
                 }}
             >
-                {({addButtonElement, itemsElement, errorMessageElement}) => {
+                {({addButtonElement, itemsElement, errorMessageElement, emptyValueElement}) => {
                     const miniToolbar = (
                         <div
                             data-test-id="editor--planning-item__add-coverage"
@@ -88,8 +88,14 @@ export class Editor extends React.PureComponent<IProps> {
 
                     return (
                         <Container miniToolbar={miniToolbar}>
-                            {errorMessageElement}
-                            {itemsElement}
+                            {this.props.value.length < 1 ? (
+                                emptyValueElement
+                            ) : (
+                                <>
+                                    {errorMessageElement}
+                                    {itemsElement}
+                                </>
+                            )}
                         </Container>
                     );
                 }}

--- a/client/planning-extension/src/authoring-react-fields/coverages/editor.tsx
+++ b/client/planning-extension/src/authoring-react-fields/coverages/editor.tsx
@@ -88,7 +88,7 @@ export class Editor extends React.PureComponent<IProps> {
 
                     return (
                         <Container miniToolbar={miniToolbar}>
-                            {this.props.value.length < 1 ? (
+                            {(this.props.value ?? []).length < 1 ? (
                                 emptyValueElement
                             ) : (
                                 <>

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -21,5 +21,8 @@
     "clean": "grunt clean",
     "build": "npx @superdesk/build-tools build-root-repo ./",
     "serve": "node --max-old-space-size=8192 ./node_modules/.bin/grunt server"
+  },
+  "volta": {
+    "node": "14.21.3"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1371,6 +1371,16 @@
       "integrity": "sha512-nbE1WxOTTrUWIfsfZ4aHGYu5DOuNkbxGokjV6Z2kxfJK3uaAb8zNK1muzOeipoLHZjInT4Br88BHpzevc681xA==",
       "dev": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "block-stream": {
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
@@ -2253,9 +2263,9 @@
       }
     },
     "compression": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.5.tgz",
-      "integrity": "sha512-bQJ0YRck5ak3LgtnpKkiabX5pNF7tMUh1BSy2ZBOTh0Dim0BUu6aPPwByIns6/A5Prh8PufSPerMDUklpzes2Q==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.0.tgz",
+      "integrity": "sha512-k6WLKfunuqCYD3t6AsuPGvQWaKwuLLh2/xHNcX4qE+vIfDNXpSqnrhwA7O53R7WVQUnt8dVAIW+YHr7xTgOgGA==",
       "dev": true,
       "requires": {
         "bytes": "3.1.2",
@@ -3194,9 +3204,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.5.96",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.96.tgz",
-      "integrity": "sha512-8AJUW6dh75Fm/ny8+kZKJzI1pgoE8bKLZlzDU2W1ENd+DXKJrx7I7l9hb8UWR4ojlnb5OlixMt00QWiYJoVw1w==",
+      "version": "1.5.97",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.97.tgz",
+      "integrity": "sha512-HKLtaH02augM7ZOdYRuO19rWDeY+QSJ1VxnXFa/XDFLf07HvM90pALIJFgrO+UVaajI3+aJMMpojoUTLZyQ7JQ==",
       "dev": true
     },
     "elliptic": {
@@ -4448,6 +4458,13 @@
       "integrity": "sha512-0k45oWBokCqh2MOexeYKpyqmGKG+8mQ2Wd8iawx+uWd/weWJQAZ6SoPybagdCI4xFisag8iAR77WPm4h3pTfxA==",
       "dev": true
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
+    },
     "filename-regex": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
@@ -4596,9 +4613,9 @@
       }
     },
     "for-each": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.4.tgz",
-      "integrity": "sha512-kKaIINnFpzW6ffJNDjjyjrk21BkDx38c0xa/klsT8VzLCaMEefv4ZTacrcVR4DmgTeBra++jMDAfS/tS799YDw==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
       "dev": true,
       "requires": {
         "is-callable": "^1.2.7"
@@ -13596,6 +13613,7 @@
           "dev": true,
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         },
@@ -14116,6 +14134,7 @@
           "dev": true,
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         },


### PR DESCRIPTION
STT-31

## Front-end checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)
