### PR TITLE
Coverage validation for embedded events

### DIFF
--- a/client/actions/events/api.ts
+++ b/client/actions/events/api.ts
@@ -567,32 +567,9 @@ function updateLinkedPlanningsForEvent(
 
         const toUnlink: Array<IPlanningItem> = currentlyLinked
             .filter((item) => {
-                const createdAt = new Date(item._created);
-                const now = new Date();
+                const needToUnlink = associatedPlannings.find(({_id}) => _id === item._id) == null;
 
-                const ageSeconds = (now.getTime() - createdAt.getTime()) / 1000;
-                const tooRecent = ageSeconds < 30;
-
-                if (tooRecent) {
-                    /**
-                     * This is a hack to workaround our existing "fake ID" workaround.
-                     * In event editor it is possible to create a planning item and relate it to current event at once.
-                     * It would happen only after saving, thus while it's not saved yet, we use a fake ID
-                     * - which will not remain the same after saving.
-                     * This function computes a list of planning items which have to be linked
-                     * and which have to be unlinked based on a desired outcome
-                     * which is that only items specified in {@link associatedPlannings} must remain linked.
-                     * The problem arises that when item with a fake ID is saved, and ID changes,
-                     * that item will immediately get unlinked by this function, because there is no way that
-                     * the new ID could have been a part of {@link associatedPlannings}
-                     * (which is computed before saving).
-                     */
-                    return false;
-                } else {
-                    const needToUnlink = associatedPlannings.find(({_id}) => _id === item._id) == null;
-
-                    return needToUnlink;
-                }
+                return needToUnlink;
             });
 
         return Promise.all(

--- a/client/actions/events/api.ts
+++ b/client/actions/events/api.ts
@@ -566,11 +566,7 @@ function updateLinkedPlanningsForEvent(
             associatedPlannings.filter(({_id}) => currentLinkedIds.has(_id) !== true);
 
         const toUnlink: Array<IPlanningItem> = currentlyLinked
-            .filter((item) => {
-                const needToUnlink = associatedPlannings.find(({_id}) => _id === item._id) == null;
-
-                return needToUnlink;
-            });
+            .filter((item) => associatedPlannings.find(({_id}) => _id === item._id) == null);
 
         return Promise.all(
             [

--- a/client/actions/events/api.ts
+++ b/client/actions/events/api.ts
@@ -20,6 +20,7 @@ import {
     isPublishedItemId,
     isTemporaryId,
     gettext,
+    planningUtils,
 } from '../../utils';
 
 import planningApis from '../planning/api';
@@ -661,7 +662,7 @@ const save = (original, updates) => (
                 eventUpdates.update_method?.value ?? eventUpdates.update_method;
 
             const [planningsToCreate, planningsToUpdate] = partition(
-                eventUpdates.associated_plannings ?? [],
+                (eventUpdates.associated_plannings ?? []).map((planning) => planningUtils.modifyForServer(planning)),
                 (item) => item._id.startsWith(TEMP_ID_PREFIX),
             );
 

--- a/client/components/Main/ItemEditor/ItemManager.ts
+++ b/client/components/Main/ItemEditor/ItemManager.ts
@@ -661,101 +661,104 @@ export class ItemManager {
                 });
         }
 
-        const promise = handleEmbeddedItems(this.props.editorType, 'SAVE', this.props.itemType).then(() =>
-            !updateStates ? Promise.resolve({}) : this.setState({submitting: true, submitFailed: false}),
-        );
+        const promise: Promise<any> = handleEmbeddedItems(this.props.editorType, 'SAVE', this.props.itemType)
+            .then(() =>
+                !updateStates ? Promise.resolve({}) : this.setState({submitting: true, submitFailed: false}),
+            );
 
-        if (this.props.addNewsItemToPlanning) {
-            return promise.then(() => this._saveFromAuthoring({post, unpost}));
-        }
-
-        // Only remove the autosave if item is temp or we're in AUTHORING
-        const isTemporary = isTemporaryId(this.props.itemId);
-
-        // If we are posting or unposting, we are setting 'pubstatus' to 'usable' from client side
-        const updates = cloneDeep(this.state.diff);
-
-        if (post) {
-            if (updates.pubstatus !== POST_STATE.USABLE) {
-                updates.state = WORKFLOW_STATE.SCHEDULED;
+        return promise.then(() => {
+            if (this.props.addNewsItemToPlanning) {
+                return this._saveFromAuthoring({post, unpost});
             }
 
-            updates.pubstatus = POST_STATE.USABLE;
-            updates._post = true;
-        } else if (unpost) {
-            updates.state = WORKFLOW_STATE.KILLED;
-            updates.pubstatus = POST_STATE.CANCELLED;
-        }
+            // Only remove the autosave if item is temp or we're in AUTHORING
+            const isTemporary = isTemporaryId(this.props.itemId);
 
-        if (updates.type === 'event') {
-            updates.update_method = updateMethod;
+            // If we are posting or unposting, we are setting 'pubstatus' to 'usable' from client side
+            const updates = cloneDeep(this.state.diff);
 
-            if (Object.keys(planningUpdateMethods).length > 0) {
-                updates.associated_plannings?.forEach((planningItem) => {
-                    if (planningUpdateMethods[planningItem._id] != null) {
-                        planningItem.update_method = planningUpdateMethods[planningItem._id];
-                    }
-                });
+            if (post) {
+                if (updates.pubstatus !== POST_STATE.USABLE) {
+                    updates.state = WORKFLOW_STATE.SCHEDULED;
+                }
+
+                updates.pubstatus = POST_STATE.USABLE;
+                updates._post = true;
+            } else if (unpost) {
+                updates.state = WORKFLOW_STATE.KILLED;
+                updates.pubstatus = POST_STATE.CANCELLED;
             }
-        }
 
-        return promise.then(() => this.autoSave.flushAutosave())
-            .then(() => (
-                this.dispatch<any>(actions.main.save(
-                    isTemporary ? {} : this.state.initialValues,
-                    updates,
-                    withConfirmation
+            if (updates.type === 'event') {
+                updates.update_method = updateMethod;
+
+                if (Object.keys(planningUpdateMethods).length > 0) {
+                    updates.associated_plannings?.forEach((planningItem) => {
+                        if (planningUpdateMethods[planningItem._id] != null) {
+                            planningItem.update_method = planningUpdateMethods[planningItem._id];
+                        }
+                    });
+                }
+            }
+
+            return this.autoSave.flushAutosave()
+                .then(() => (
+                    this.dispatch<any>(actions.main.save(
+                        isTemporary ? {} : this.state.initialValues,
+                        updates,
+                        withConfirmation
+                    ))
                 ))
-            ))
-            .then((updatedItem) => {
-                if (!updatedItem) {
-                    // This occurs during an 'Ignore/Cancel/Save' from ModalEditor
-                    // And the user clicks on 'Cancel'
-                    return this.setState({submitting: false});
-                } else if (isTemporary) {
-                    this.autoSave.remove();
+                .then((updatedItem) => {
+                    if (!updatedItem) {
+                        // This occurs during an 'Ignore/Cancel/Save' from ModalEditor
+                        // And the user clicks on 'Cancel'
+                        return this.setState({submitting: false});
+                    } else if (isTemporary) {
+                        this.autoSave.remove();
 
-                    // If event was created by a planning item, unlock the planning item
-                    if (updates.type === 'event' && updates._planning_item != null) {
-                        planningApi.locks.unlockItemById(updates._planning_item, 'planning');
-                    }
+                        // If event was created by a planning item, unlock the planning item
+                        if (updates.type === 'event' && updates._planning_item != null) {
+                            planningApi.locks.unlockItemById(updates._planning_item, 'planning');
+                        }
 
-                    if (closeAfter) {
+                        if (closeAfter) {
+                            return this.editor.onCancel(updateStates);
+                        } else {
+                            return this.changeAction('edit', updatedItem);
+                        }
+                    } else if (closeAfter) {
                         return this.editor.onCancel(updateStates);
                     } else {
-                        return this.changeAction('edit', updatedItem);
+                        const newState: Partial<IEditorState> = {
+                            initialValues: updatedItem,
+                            diff: cloneDeep(updatedItem),
+                            dirty: false,
+                            submitting: false,
+                            submitFailed: false,
+                            errors: {},
+                            errorMessages: [],
+                            itemReady: true,
+                            loading: false,
+                        };
+
+                        this.editorApi.events.onItemUpdated(newState);
+
+                        return this.setState(newState, null, true);
                     }
-                } else if (closeAfter) {
-                    return this.editor.onCancel(updateStates);
-                } else {
-                    const newState: Partial<IEditorState> = {
-                        initialValues: updatedItem,
-                        diff: cloneDeep(updatedItem),
-                        dirty: false,
-                        submitting: false,
-                        submitFailed: false,
-                        errors: {},
-                        errorMessages: [],
-                        itemReady: true,
-                        loading: false,
-                    };
+                }, (error) => {
+                    if (get(error, 'status') === 412) {
+                        // If etag error, then notify user and change editor to read-only
+                        this.dispatch<any>(
+                            actions.main.notifyPreconditionFailed(this.props.inModalView)
+                        );
+                    }
 
-                    this.editorApi.events.onItemUpdated(newState);
-
-                    return this.setState(newState, null, true);
-                }
-            }, (error) => {
-                if (get(error, 'status') === 412) {
-                    // If etag error, then notify user and change editor to read-only
-                    this.dispatch<any>(
-                        actions.main.notifyPreconditionFailed(this.props.inModalView)
-                    );
-                }
-
-                if (updateStates) {
-                    this.setState({submitting: false});
-                }
-            });
+                    if (updateStates) {
+                        this.setState({submitting: false});
+                    }
+                });
+        });
     }
 
     startPartialSave(updates) {

--- a/client/components/editor-standalone/authoring-storage-in-memory.ts
+++ b/client/components/editor-standalone/authoring-storage-in-memory.ts
@@ -1,6 +1,7 @@
 import ng from 'superdesk-core/scripts/core/services/ng';
 import {IAuthoringAutoSave, IAuthoringStorage} from 'superdesk-api';
 import {getProfile} from './profile';
+import {cloneDeep} from 'lodash';
 
 export function getAuthoringStorageInMemory<T>(
     profile: 'event' | 'planning',
@@ -9,9 +10,9 @@ export function getAuthoringStorageInMemory<T>(
 ): IAuthoringStorage<T> {
     class NoAutoSave implements IAuthoringAutoSave<T> {
         get(id: string) {
-            // return an empty object so authoring-react compares with saved item sees it as dirty
-            // otherwise, it is not seen as dirty and wouldn't trigger to fill required fields.
-            return Promise.resolve({} as T);
+            // return a different reference so authoring-react sees it as having unsaved changes.
+            // otherwise, it will consider all saved and won't attempt to save - which won't trigger validation.
+            return Promise.resolve({...item});
         }
 
         delete() {

--- a/client/components/editor-standalone/authoring-storage-in-memory.ts
+++ b/client/components/editor-standalone/authoring-storage-in-memory.ts
@@ -1,7 +1,6 @@
 import ng from 'superdesk-core/scripts/core/services/ng';
 import {IAuthoringAutoSave, IAuthoringStorage} from 'superdesk-api';
 import {getProfile} from './profile';
-import {cloneDeep} from 'lodash';
 
 export function getAuthoringStorageInMemory<T>(
     profile: 'event' | 'planning',

--- a/client/components/editor-standalone/base-editor-standalone.tsx
+++ b/client/components/editor-standalone/base-editor-standalone.tsx
@@ -8,6 +8,7 @@ import {
     IAuthoringValidationErrors,
     IStorageAdapter,
     IAuthoringReact,
+    IPropsAuthoring,
 } from 'superdesk-api';
 import {planningApi, superdeskApi} from '../../superdeskApi';
 import * as selectors from '../../selectors';
@@ -25,6 +26,8 @@ interface IOwnProps<T extends IPlanningItem | IEventItem> {
     editorRef: RefObject<IAuthoringReact<T>>;
     authoringStorage: IAuthoringStorage<T>;
     storageAdapter: IStorageAdapter<T>;
+
+    makeVisible: IPropsAuthoring<T>['makeVisible'];
 }
 
 interface IReduxProps {
@@ -129,6 +132,7 @@ export class BaseEditorComponent<T extends IPlanningItem | IEventItem> extends R
                 getSidePanel={() => null}
                 getSideWidgetIdAtIndex={(_item) => 'no-id-available'}
                 fieldTemplate={FieldTemplate}
+                makeVisible={this.props.makeVisible}
             />
         );
     }

--- a/client/components/editor-standalone/event-editor-standalone.tsx
+++ b/client/components/editor-standalone/event-editor-standalone.tsx
@@ -1,5 +1,5 @@
 import React, {RefObject} from 'react';
-import {IAuthoringReact, IAuthoringStorage} from 'superdesk-api';
+import {IAuthoringReact, IAuthoringStorage, IPropsAuthoring} from 'superdesk-api';
 import {BaseEditorStandalone} from './base-editor-standalone';
 import {getStorageAdapter} from './storage-adapter';
 
@@ -7,6 +7,7 @@ interface IProps {
     itemId: string;
     authoringStorage: IAuthoringStorage<IEventItem>;
     editorRef: RefObject<IAuthoringReact<IEventItem>>;
+    makeVisible: IPropsAuthoring<IEventItem>['makeVisible'];
 }
 
 export class EventEditorStandalone extends React.PureComponent<IProps> {
@@ -18,6 +19,7 @@ export class EventEditorStandalone extends React.PureComponent<IProps> {
                 itemId={this.props.itemId}
                 storageAdapter={getStorageAdapter('event', ({storageAdapterEvent}) => storageAdapterEvent)}
                 authoringStorage={this.props.authoringStorage}
+                makeVisible={this.props.makeVisible}
             />
         );
     }

--- a/client/components/editor-standalone/field-definitions/planning-date.ts
+++ b/client/components/editor-standalone/field-definitions/planning-date.ts
@@ -16,7 +16,7 @@ export const getPlanningDate = (): IFieldDefinition => {
             const field: IAuthoringFieldV2 = {
                 id: id,
                 name: gettext('Planning Date'),
-                fieldType: 'datetime',
+                fieldType: 'datetime-v2',
                 fieldConfig: {
                     ...config,
                     required: required,

--- a/client/components/editor-standalone/field-template.tsx
+++ b/client/components/editor-standalone/field-template.tsx
@@ -10,8 +10,26 @@ export class FieldTemplate extends React.PureComponent<IPropsAuthoringFieldTempl
     render() {
         const {field, input, validationError, miniToolbar} = this.props;
 
-        const labelJsx = miniToolbar != null
+        const compactMode = miniToolbar == null;
+
+        const labelJsx = compactMode
             ? (
+                <div
+                    style={{
+                        color: 'var(--color-label-text)',
+                        fontSize: '1.1rem',
+                        textTransform: 'uppercase',
+                        fontWeight: 500,
+                        letterSpacing: 0.08,
+                    }}
+                >
+                    <Spacer h gap="4" justifyContent="start" noWrap>
+                        {field.name}
+                        {field.fieldConfig.required && requiredIndicator}
+                    </Spacer>
+                </div>
+            )
+            : (
                 <Spacer h gap="4" justifyContent="space-between" noWrap>
                     <Spacer h gap="4" justifyContent="start" noWrap>
                         <div
@@ -30,40 +48,46 @@ export class FieldTemplate extends React.PureComponent<IPropsAuthoringFieldTempl
                         {miniToolbar}
                     </div>
                 </Spacer>
-            )
-            : (
-                <div
-                    style={{
-                        color: 'var(--color-label-text)',
-                        fontSize: '1.1rem',
-                        textTransform: 'uppercase',
-                        fontWeight: 500,
-                        letterSpacing: 0.08,
-                    }}
-                >
-                    <Spacer h gap="4" justifyContent="start" noWrap>
-                        {field.name}
-                        {field.fieldConfig.required && requiredIndicator}
-                    </Spacer>
-                </div>
             );
 
-        return (
-            <div>
-                {labelJsx}
+        if (compactMode) {
+            return (
+                <div>
+                    {labelJsx}
 
-                {input != null && input}
+                    {input != null && input}
 
-                {validationError != null && (
-                    <>
-                        <SpacerBlock v gap="4" />
+                    {validationError != null && (
+                        <>
+                            <SpacerBlock v gap="4" />
 
-                        <div style={{color: 'var(--sd-colour-alert)'}}>
-                            {validationError}
-                        </div>
-                    </>
-                )}
-            </div>
-        );
+                            <div style={{color: 'var(--sd-colour-alert)'}}>
+                                {validationError}
+                            </div>
+                        </>
+                    )}
+                </div>
+            );
+        } else {
+            return (
+                <div>
+                    {labelJsx}
+
+                    {validationError != null && (
+                        <>
+                            <SpacerBlock v gap="4" />
+
+                            <div style={{color: 'var(--sd-colour-alert)'}}>
+                                {validationError}
+                            </div>
+
+                            <SpacerBlock v gap="4" />
+                        </>
+                    )}
+
+                    {input != null && input}
+                </div>
+            );
+        }
     }
 }

--- a/client/components/editor-standalone/planning-editor-standalone.tsx
+++ b/client/components/editor-standalone/planning-editor-standalone.tsx
@@ -1,5 +1,5 @@
 import React, {RefObject} from 'react';
-import {IAuthoringStorage, IAuthoringReact} from 'superdesk-api';
+import {IAuthoringStorage, IAuthoringReact, IPropsAuthoring} from 'superdesk-api';
 import {BaseEditorStandalone} from './base-editor-standalone';
 import {getStorageAdapter} from './storage-adapter';
 
@@ -7,6 +7,7 @@ interface IProps {
     itemId: string;
     authoringStorage: IAuthoringStorage<IPlanningItem>;
     editorRef: RefObject<IAuthoringReact<IPlanningItem>>;
+    makeVisible: IPropsAuthoring<IPlanningItem>['makeVisible'];
 }
 
 export class PlanningEditorStandalone extends React.PureComponent<IProps> {
@@ -18,6 +19,7 @@ export class PlanningEditorStandalone extends React.PureComponent<IProps> {
                 itemId={this.props.itemId}
                 storageAdapter={getStorageAdapter('planning', ({storageAdapterPlanning}) => storageAdapterPlanning)}
                 authoringStorage={this.props.authoringStorage}
+                makeVisible={this.props.makeVisible}
             />
         );
     }

--- a/client/components/editor-standalone/save-handling.ts
+++ b/client/components/editor-standalone/save-handling.ts
@@ -3,6 +3,7 @@ import {IExposedFromAuthoring} from 'superdesk-api';
 import {planningApi, superdeskApi} from '../../superdeskApi';
 import {RelatedPlanningItem} from '../../components/fields/editor/EventRelatedPlannings/RelatedPlanningItem';
 import {AssociatedEventItem} from 'components/fields/editor/AssociatedEventItem';
+import {notNullOrUndefined} from 'core/helpers/typescript-helpers';
 
 type IRelatedItemRefs = {[id: string]: RelatedPlanningItem | AssociatedEventItem};
 type ItemType = 'event' | 'planning';
@@ -19,7 +20,7 @@ const getEmbeddedAuthoringRefs = (editorType: EDITOR_TYPE, itemType: ItemType) =
 const getEmbeddedItemsExposed = (
     editorType: EDITOR_TYPE,
     itemType: 'event' | 'planning',
-): Array<IExposedFromAuthoring<void>> => {
+): Array<IExposedFromAuthoring<any>> => {
     const relatedItemRefs = getEmbeddedAuthoringRefs(editorType, itemType);
 
     // Use Object.values instead of Object.keys because when refs are removed value becomes null and keys stay
@@ -30,9 +31,11 @@ const getEmbeddedItemsExposed = (
         return [];
     }
 
-    const exposedAuthoringArray = Object.values(relatedItemRefs).map((x) =>
-        x?.authoringRef?.current?.getExposed?.() as unknown as IExposedFromAuthoring<void>
-    );
+    const exposedAuthoringArray = Object.values(relatedItemRefs)
+        .map((x) =>
+            x?.authoringRef?.current?.getExposed?.()
+        )
+        .filter(notNullOrUndefined);
 
     return exposedAuthoringArray;
 };

--- a/client/components/editor-standalone/save-handling.ts
+++ b/client/components/editor-standalone/save-handling.ts
@@ -3,7 +3,6 @@ import {IExposedFromAuthoring} from 'superdesk-api';
 import {planningApi, superdeskApi} from '../../superdeskApi';
 import {RelatedPlanningItem} from '../../components/fields/editor/EventRelatedPlannings/RelatedPlanningItem';
 import {AssociatedEventItem} from 'components/fields/editor/AssociatedEventItem';
-import {notNullOrUndefined} from 'core/helpers/typescript-helpers';
 
 type IRelatedItemRefs = {[id: string]: RelatedPlanningItem | AssociatedEventItem};
 type ItemType = 'event' | 'planning';
@@ -22,6 +21,7 @@ const getEmbeddedItemsExposed = (
     itemType: 'event' | 'planning',
 ): Array<IExposedFromAuthoring<any>> => {
     const relatedItemRefs = getEmbeddedAuthoringRefs(editorType, itemType);
+    const {notNullOrUndefined} = superdeskApi.helpers;
 
     // Use Object.values instead of Object.keys because when refs are removed value becomes null and keys stay
     if (

--- a/client/components/editor-standalone/save-handling.ts
+++ b/client/components/editor-standalone/save-handling.ts
@@ -37,59 +37,29 @@ const getEmbeddedItemsExposed = (
     return exposedAuthoringArray;
 };
 
-const handleErrors = (editorType: EDITOR_TYPE, editorIndex: number, itemType: ItemType) => {
-    const FIRST_ERROR = 0;
-    const relatedItemRef = getEmbeddedAuthoringRefs(editorType, itemType)[editorIndex];
-    const firstEditorRef = relatedItemRef.authoringRef.current;
-    const fieldErrors = Object.keys(firstEditorRef.getExposed().getValidationErrors() ?? {});
-    const fieldToFocus = firstEditorRef?.fieldRefs[fieldErrors[FIRST_ERROR]].current as HTMLDivElement;
-    const toggleBoxRef = relatedItemRef.toggleBoxRef.current;
-
-    if (toggleBoxRef.isOpen() === false) {
-        toggleBoxRef.toggle();
-    }
-
-    fieldToFocus?.scrollIntoView?.({behavior: 'smooth'});
-
-    return Promise.reject();
-};
-
 /**
- * Function that handles editor changes using editor refs.
- * Execution is cancelled on the first encounter of an editor error.
- * If an error occurs the first encountered embedded planning editor and the first error field is focused.
+ * Iterate over related items and perform chosen action.
+ * Will stop on first error.
+ * User will be prompted about the issue in the UI and is expected to try again.
  */
 export const handleEmbeddedItems = async(
     editorType: EDITOR_TYPE,
     action: IEmbeddedPlanningsActionType,
     itemType: ItemType,
-) => {
-    const itemExposed = getEmbeddedItemsExposed(editorType, itemType);
-    let editorIndex = 0;
-    let promiseResult = Promise.resolve();
+): Promise<void> => {
+    for (const exposed of getEmbeddedItemsExposed(editorType, itemType)) {
+        if (!exposed.hasUnsavedChanges()) {
+            continue;
+        }
 
-    for (const planning of itemExposed) {
-        promiseResult = promiseResult.then(() => {
-            if (planning.hasUnsavedChanges()) {
-                if (action === 'SAVE') {
-                    return planning
-                        .save()
-                        .catch(() => handleErrors(editorType, editorIndex, itemType));
-                } else if (action === 'DISCARD') {
-                    return planning.discardUnsavedChanges();
-                } else {
-                    return planning
-                        .handleUnsavedChanges()
-                        .catch(() => handleErrors(editorType, editorIndex, itemType));
-                }
-            } else {
-                editorIndex++;
-                return Promise.resolve();
-            }
-        });
+        if (action === 'SAVE') {
+            await exposed.save();
+        } else if (action === 'DISCARD') {
+            await exposed.discardUnsavedChanges();
+        } else {
+            await exposed.handleUnsavedChanges();
+        }
     }
-
-    return promiseResult;
 };
 
 export const embeddedItemHasUnsavedChanges = (itemType: ItemType) => {

--- a/client/components/editor-standalone/save-handling.ts
+++ b/client/components/editor-standalone/save-handling.ts
@@ -1,6 +1,7 @@
+import {notNullOrUndefined} from '@sourcefabric/common';
 import {EDITOR_TYPE} from '../../interfaces';
 import {IExposedFromAuthoring} from 'superdesk-api';
-import {planningApi, superdeskApi} from '../../superdeskApi';
+import {planningApi} from '../../superdeskApi';
 import {RelatedPlanningItem} from '../../components/fields/editor/EventRelatedPlannings/RelatedPlanningItem';
 import {AssociatedEventItem} from 'components/fields/editor/AssociatedEventItem';
 
@@ -21,7 +22,6 @@ const getEmbeddedItemsExposed = (
     itemType: 'event' | 'planning',
 ): Array<IExposedFromAuthoring<any>> => {
     const relatedItemRefs = getEmbeddedAuthoringRefs(editorType, itemType);
-    const {notNullOrUndefined} = superdeskApi.helpers;
 
     const exposedAuthoringArray = Object.values(relatedItemRefs ?? {})
         .map((x) =>

--- a/client/components/editor-standalone/save-handling.ts
+++ b/client/components/editor-standalone/save-handling.ts
@@ -23,15 +23,7 @@ const getEmbeddedItemsExposed = (
     const relatedItemRefs = getEmbeddedAuthoringRefs(editorType, itemType);
     const {notNullOrUndefined} = superdeskApi.helpers;
 
-    // Use Object.values instead of Object.keys because when refs are removed value becomes null and keys stay
-    if (
-        relatedItemRefs == null
-        || Object.values(relatedItemRefs).filter(superdeskApi.helpers.notNullOrUndefined).length < 1
-    ) {
-        return [];
-    }
-
-    const exposedAuthoringArray = Object.values(relatedItemRefs)
+    const exposedAuthoringArray = Object.values(relatedItemRefs ?? {})
         .map((x) =>
             x?.authoringRef?.current?.getExposed?.()
         )

--- a/client/components/fields/editor/AssociatedEventItem.tsx
+++ b/client/components/fields/editor/AssociatedEventItem.tsx
@@ -60,6 +60,20 @@ export class AssociatedEventItem extends React.PureComponent<IProps> {
                         editorRef={this.authoringRef}
                         itemId={event._id}
                         authoringStorage={authoringStorageEventItemHttp}
+                        makeVisible={() => {
+                            if (this.toggleBoxRef.current.isOpen()) {
+                                return Promise.resolve();
+                            } else {
+                                return new Promise((resolve) => {
+                                    this.toggleBoxRef.current.toggle();
+
+                                    // PR-TODO: improve toggleBox so `toggle` method returns a promise
+                                    setTimeout(() => {
+                                        resolve();
+                                    }, 500);
+                                });
+                            }
+                        }}
                     />
                 </ToggleBox>
             </div>

--- a/client/components/fields/editor/EventRelatedPlannings/RelatedPlanningItem.tsx
+++ b/client/components/fields/editor/EventRelatedPlannings/RelatedPlanningItem.tsx
@@ -18,6 +18,7 @@ import {
     getAuthoringStorageInMemory
 } from '../../../editor-standalone/authoring-storage-in-memory';
 import {IAuthoringReact} from 'superdesk-api';
+import {CustomHeaderToggleBox} from 'superdesk-ui-framework/react/components/ToggleBox/CustomHeaderToggleBox';
 
 interface IProps {
     event: IEventItem;
@@ -40,7 +41,7 @@ interface IProps {
 export class RelatedPlanningItem extends React.PureComponent<IProps> {
     containerNode: React.RefObject<HTMLDivElement>;
     public authoringRef: React.RefObject<IAuthoringReact<IPlanningItem>>;;
-    public toggleBoxRef: React.RefObject<any>;
+    public toggleBoxRef: React.RefObject<CustomHeaderToggleBox>;
 
     constructor(props) {
         super(props);
@@ -139,6 +140,20 @@ export class RelatedPlanningItem extends React.PureComponent<IProps> {
                                 )
                                 : authoringStoragePlanningItemHttp
                         }
+                        makeVisible={() => {
+                            if (this.toggleBoxRef.current.isOpen()) {
+                                return Promise.resolve();
+                            } else {
+                                return new Promise((resolve) => {
+                                    this.toggleBoxRef.current.toggle();
+
+                                    // PR-TODO: improve toggleBox so `toggle` method returns a promise
+                                    setTimeout(() => {
+                                        resolve();
+                                    }, 500);
+                                });
+                            }
+                        }}
                     />
                 </ToggleBox>
             </div>

--- a/client/extension_bridge.ts
+++ b/client/extension_bridge.ts
@@ -23,8 +23,9 @@ import {IContactPropsNoRedux} from './components/Contacts/ContactField.interface
 import {EditorFieldLocation} from './components/fields/editor/Location';
 import {IEditorFieldLocationProps} from 'components/fields/editor/Location.interface';
 
-import {IAssignmentItem, IEditorFieldProps, IPlanningAppState} from 'interfaces';
+import {IAssignmentItem, IEditorFieldProps, IPlanningAppState, IPlanningCoverageItem} from 'interfaces';
 import {registerEditorField} from './components/fields/resources/registerEditorFields';
+import {validateCoveragesV2} from './validators/planning';
 
 // KEEP IN SYNC WITH client/planning-extension/src/extension_bridge.ts
 interface IExtensionBridge {
@@ -45,6 +46,9 @@ interface IExtensionBridge {
     planning: {
         getItemPlanningInfo(item: {assignment_id?: string}): Promise<IPlanningItem>;
     },
+    coverages: {
+        validateCoverages(coverages: Array<IPlanningCoverageItem>): {errors: {}; messages: Array<string>};
+    };
     editor: {
         fields: {
             EditorFieldContact: React.ComponentType<IContactPropsNoRedux>;
@@ -104,6 +108,9 @@ export const extensionBridge: IExtensionBridge = {
     },
     planning: {
         getItemPlanningInfo,
+    },
+    coverages: {
+        validateCoverages: validateCoveragesV2,
     },
     editor: {
         fields: {

--- a/client/planning-extension/src/authoring-react-fields/coverages/editor.tsx
+++ b/client/planning-extension/src/authoring-react-fields/coverages/editor.tsx
@@ -66,12 +66,6 @@ export class Editor extends React.PureComponent<IProps> {
                         const item = cloneDeep({coverages: this.props.value});
                         const nextValue = set(item, fieldPath, value);
 
-                        for (const coverage of nextValue.coverages) {
-                            if (coverage.planning != null) {
-                                delete coverage.planning['_scheduledTime'];
-                            }
-                        }
-
                         this.props.onChange(nextValue.coverages);
                     });
                 }}

--- a/client/planning-extension/src/authoring-react-fields/coverages/index.tsx
+++ b/client/planning-extension/src/authoring-react-fields/coverages/index.tsx
@@ -9,6 +9,7 @@ import {
     ICoveragesValueStorage,
 } from './interfaces';
 import {superdesk} from '../../superdesk';
+import {extensionBridge} from '../../extension_bridge';
 
 const {gettext} = superdesk.localization;
 
@@ -18,6 +19,8 @@ ICoveragesValueStorage,
 ICoveragesFieldConfig,
 ICoveragesFieldUserPreferences
 > {
+    const {validateCoverages} = extensionBridge.coverages;
+
     const field: ReturnType<typeof getCoveragesField> = {
         id: 'coverages',
         generic: false,
@@ -26,6 +29,9 @@ ICoveragesFieldUserPreferences
         previewComponent: Preview,
 
         hasValue: (valueOperational) => valueOperational != null && valueOperational.length > 0,
+
+        validate: (value) => value.length < 1 ? null : validateCoverages(value).messages[0] ?? null,
+
         getEmptyValue: () => [],
 
         differenceComponent: Difference,

--- a/client/planning-extension/src/extension_bridge.ts
+++ b/client/planning-extension/src/extension_bridge.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {IArticle, IVocabularyItem} from 'superdesk-api';
-import {IAssignmentItem, IEditorFieldProps, IPlanningAppState, IPlanningItem} from '../../interfaces';
+import {IAssignmentItem, IEditorFieldProps, IPlanningAppState, IPlanningCoverageItem, IPlanningItem} from '../../interfaces';
 import {IPropsAttachmentsEditorStandalone} from '../../components/AttachmentsInputStandalone.interface';
 import {IContactPropsNoRedux} from '../../components/Contacts/ContactField.interface';
 import {IPropsEditorFieldCoverages} from '../../components/fields/editor/coverages.interface';
@@ -35,6 +35,9 @@ interface IExtensionBridge {
     planning: {
         getItemPlanningInfo(item: {assignment_id?: string}): Promise<IPlanningItem>;
     },
+    coverages: {
+        validateCoverages(coverages: Array<IPlanningCoverageItem>): {errors: {}; messages: Array<string>};
+    };
     editor: {
         fields: {
             EditorFieldLocation: React.ComponentType<IEditorFieldLocationProps>;

--- a/client/planning-extension/src/extension_bridge.ts
+++ b/client/planning-extension/src/extension_bridge.ts
@@ -1,6 +1,12 @@
 import * as React from 'react';
 import {IArticle, IVocabularyItem} from 'superdesk-api';
-import {IAssignmentItem, IEditorFieldProps, IPlanningAppState, IPlanningCoverageItem, IPlanningItem} from '../../interfaces';
+import {
+    IAssignmentItem,
+    IEditorFieldProps,
+    IPlanningAppState,
+    IPlanningCoverageItem,
+    IPlanningItem,
+} from '../../interfaces';
 import {IPropsAttachmentsEditorStandalone} from '../../components/AttachmentsInputStandalone.interface';
 import {IContactPropsNoRedux} from '../../components/Contacts/ContactField.interface';
 import {IPropsEditorFieldCoverages} from '../../components/fields/editor/coverages.interface';

--- a/client/validators/index.ts
+++ b/client/validators/index.ts
@@ -174,7 +174,8 @@ export const validators = {
         internal_note: [formProfile],
         keyword: [formProfile],
         scheduled: [planningValidators.validateCoverageScheduleDate],
-        _scheduledTime: [planningValidators.validateCoverageScheduleDate],
+        // PR-TODO: re-enable validation
+        // _scheduledTime: [planningValidators.validateCoverageScheduleDate],
         slugline: [formProfile],
         scheduled_updates: [planningValidators.validateScheduledUpdatesDate],
         language: [formProfile],

--- a/client/validators/index.ts
+++ b/client/validators/index.ts
@@ -177,6 +177,7 @@ export const validators = {
         _scheduledTime: [planningValidators.validateCoverageScheduleDate],
         slugline: [formProfile],
         scheduled_updates: [planningValidators.validateScheduledUpdatesDate],
+        language: [formProfile],
     },
     assignment: {
         _all: [validateAssignment],

--- a/client/validators/planning.ts
+++ b/client/validators/planning.ts
@@ -6,6 +6,9 @@ import * as selectors from '../selectors';
 import {gettext, getItemInArrayById} from '../utils';
 
 import {validateField, validators} from './index';
+import {coverages} from '../api/coverages';
+import {IPlanningCoverageItem} from 'interfaces';
+import {planningApi} from '../superdeskApi';
 
 const validatePlanningScheduleDate = ({getState, field, value, errors, messages, diff, item}) => {
     // Only validate the schedule if it has changed
@@ -26,10 +29,35 @@ const validatePlanningScheduleDate = ({getState, field, value, errors, messages,
     }
 };
 
+/**
+ * The purpose of v2 is to have a interface cleaner
+ * and reduce the number of arguments that have to be passed.
+ */
+export function validateCoveragesV2(value: Array<IPlanningCoverageItem>) {
+    let errors = {};
+    let messages = [];
+
+    const store = planningApi.redux.store;
+
+    validateCoverages({
+        dispatch: store.dispatch,
+        getState: store.getState,
+        profile: coverages.getEditorProfile(),
+        value: value,
+        diff: {
+            coverages: value,
+        },
+        item: {},
+        errors: errors,
+        messages: messages,
+    });
+
+    return {errors, messages};
+}
+
 export const validateCoverages = ({
     dispatch,
     getState,
-    field,
     value,
     profile,
     errors,
@@ -190,11 +218,11 @@ const validateScheduledUpdatesDate = ({
         delete errors.scheduled_updates;
     } else {
         if (scheduleConflict) {
-            messages.push(gettext('Scheduled Upates have to be after the previous updates.'));
+            messages.push(gettext('Scheduled updates have to be after the previous updates.'));
         }
 
         if (requiredMissing) {
-            messages.push(gettext('Scheduled Upates should have a date/time.'));
+            messages.push(gettext('Scheduled updates should have a date/time.'));
         }
     }
 };

--- a/client/validators/tests/planning_test.ts
+++ b/client/validators/tests/planning_test.ts
@@ -101,7 +101,7 @@ describe('planningValidators', () => {
             messages: errorMessages,
             diff: planningDiff,
         });
-        expect(errorMessages).toEqual(['Scheduled Upates have to be after the previous updates.']);
+        expect(errorMessages).toEqual(['Scheduled updates have to be after the previous updates.']);
         expect(errors).toEqual({
             scheduled_updates: {
                 1: {
@@ -128,7 +128,7 @@ describe('planningValidators', () => {
             messages: errorMessages,
             diff: planningDiff,
         });
-        expect(errorMessages).toEqual(['Scheduled Upates have to be after the previous updates.']);
+        expect(errorMessages).toEqual(['Scheduled updates have to be after the previous updates.']);
         expect(errors).toEqual({
             scheduled_updates: {
                 0: {

--- a/e2e/cypress/e2e/related_events.cy.ts
+++ b/e2e/cypress/e2e/related_events.cy.ts
@@ -1,0 +1,26 @@
+describe('Related events', () => {
+    /**
+     * Create and save a new event.
+     * Add a related item.
+     * Add a coverage to a related item.
+     * Save the main event.
+     *
+     * Reopen the event and ensure that data was saved successfully.
+     */
+    it('can add a related planning to an event', () => {
+        // PR-TODO: implement test
+    });
+
+    /**
+     * Open an event that already has a related planning.
+     * Change data in related planning including coverage data.
+     * Save the event.
+     *
+     * Reopen the event and ensure that data was saved successfully.
+     *
+     * NOTE: implementation of saving a newly added vs existing related planning item is different.
+     */
+    it('can edit a related planning', () => {
+        // PR-TODO: implement test
+    });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -2253,9 +2253,9 @@
       }
     },
     "compression": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.5.tgz",
-      "integrity": "sha512-bQJ0YRck5ak3LgtnpKkiabX5pNF7tMUh1BSy2ZBOTh0Dim0BUu6aPPwByIns6/A5Prh8PufSPerMDUklpzes2Q==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.0.tgz",
+      "integrity": "sha512-k6WLKfunuqCYD3t6AsuPGvQWaKwuLLh2/xHNcX4qE+vIfDNXpSqnrhwA7O53R7WVQUnt8dVAIW+YHr7xTgOgGA==",
       "dev": true,
       "requires": {
         "bytes": "3.1.2",
@@ -3194,9 +3194,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.5.96",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.96.tgz",
-      "integrity": "sha512-8AJUW6dh75Fm/ny8+kZKJzI1pgoE8bKLZlzDU2W1ENd+DXKJrx7I7l9hb8UWR4ojlnb5OlixMt00QWiYJoVw1w==",
+      "version": "1.5.97",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.97.tgz",
+      "integrity": "sha512-HKLtaH02augM7ZOdYRuO19rWDeY+QSJ1VxnXFa/XDFLf07HvM90pALIJFgrO+UVaajI3+aJMMpojoUTLZyQ7JQ==",
       "dev": true
     },
     "elliptic": {
@@ -12341,7 +12341,7 @@
       }
     },
     "superdesk-core": {
-      "version": "github:superdesk/superdesk-client-core#a23876ab909a4c12df50ecc88a675ebfbf0017d0",
+      "version": "github:superdesk/superdesk-client-core#57300cfb9fcf383412e3a1b697bde13c28ca8a80",
       "from": "github:superdesk/superdesk-client-core#develop",
       "dev": true,
       "requires": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -152,9 +152,9 @@
       "dev": true
     },
     "@sourcefabric/common": {
-      "version": "0.0.46",
-      "resolved": "https://registry.npmjs.org/@sourcefabric/common/-/common-0.0.46.tgz",
-      "integrity": "sha512-haUaeOLErSfj3tqLCQEsz6ePvbKDiP9NLzjT9P4lBi6+pO9WFuJJjnSTrMOWQF0hnVlNPzXWF9OVtL7JZHGLkA==",
+      "version": "0.0.47",
+      "resolved": "https://registry.npmjs.org/@sourcefabric/common/-/common-0.0.47.tgz",
+      "integrity": "sha512-2B9AMMskIIl0Y6qQN91Rl/5880CGDglLhNTli1DXfm5QBCiqqW+K3V/zZpFM11k15KOORb+xC38AQL6F+OWDUQ==",
       "requires": {
         "date-fns": "2.7.0",
         "lodash": "4.17.19",
@@ -217,7 +217,6 @@
       "version": "5.0.2-12",
       "resolved": "https://registry.npmjs.org/@superdesk/primereact/-/primereact-5.0.2-12.tgz",
       "integrity": "sha512-cyaek+NgIDg5AXxn29BwHprnHZB+pe3Ll2w2KlP2rmICm3cgbdVtjYJTT5d9Yxfioor6vVulo3O9BOxEmxpgnw==",
-      "dev": true,
       "requires": {
         "react-transition-group": "^4.4.1"
       },
@@ -225,14 +224,12 @@
         "csstype": {
           "version": "3.1.3",
           "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-          "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-          "dev": true
+          "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
         },
         "dom-helpers": {
           "version": "5.2.1",
           "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
           "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
-          "dev": true,
           "requires": {
             "@babel/runtime": "^7.8.7",
             "csstype": "^3.0.2"
@@ -242,7 +239,6 @@
           "version": "4.4.5",
           "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
           "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
-          "dev": true,
           "requires": {
             "@babel/runtime": "^7.5.5",
             "dom-helpers": "^5.0.1",
@@ -256,7 +252,6 @@
       "version": "0.0.39",
       "resolved": "https://registry.npmjs.org/@superdesk/react-resizable-panels/-/react-resizable-panels-0.0.39.tgz",
       "integrity": "sha512-/aoKBYqNzzMACY82y7znr9v1jM63hvi0fglKU6IHWMvEpwQllsk/QHGzDNQb2lj8BOILfey4CRhRrDVXE3Rxmg==",
-      "dev": true,
       "requires": {
         "@swc/helpers": "0.4.14"
       }
@@ -265,7 +260,6 @@
       "version": "0.4.14",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.14.tgz",
       "integrity": "sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==",
-      "dev": true,
       "requires": {
         "tslib": "^2.4.0"
       },
@@ -273,8 +267,7 @@
         "tslib": {
           "version": "2.8.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-          "dev": true
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
         }
       }
     },
@@ -334,7 +327,6 @@
       "version": "3.3.6",
       "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.6.tgz",
       "integrity": "sha512-lPByRJUer/iN/xa4qpyL0qmL11DqNW81iU/IG1S3uvRUq4oKagz8VCxZjiWkumgt66YT3vOdDgZ0o32sGKtCEw==",
-      "dev": true,
       "requires": {
         "@types/react": "*",
         "hoist-non-react-statics": "^3.3.0"
@@ -364,14 +356,12 @@
     "@types/prop-types": {
       "version": "15.7.14",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
-      "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==",
-      "dev": true
+      "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ=="
     },
     "@types/react": {
       "version": "16.8.23",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-16.8.23.tgz",
       "integrity": "sha512-abkEOIeljniUN9qB5onp++g0EY38h7atnDHxwKUFz1r3VH1+yG1OKi2sNPTyObL40goBmfKFpdii2lEzwLX1cA==",
-      "dev": true,
       "requires": {
         "@types/prop-types": "*",
         "csstype": "^2.2.0"
@@ -1371,6 +1361,16 @@
       "integrity": "sha512-nbE1WxOTTrUWIfsfZ4aHGYu5DOuNkbxGokjV6Z2kxfJK3uaAb8zNK1muzOeipoLHZjInT4Br88BHpzevc681xA==",
       "dev": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "block-stream": {
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
@@ -1822,7 +1822,6 @@
       "version": "2.9.4",
       "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-2.9.4.tgz",
       "integrity": "sha512-B07aAzxcrikjAPyV+01j7BmOpxtQETxTSlQ26BEYJ+3iUkbNKaOJ/nDbT6JjyqYxseM0ON12COHYdU2cTIjC7A==",
-      "dev": true,
       "requires": {
         "chartjs-color": "^2.1.0",
         "moment": "^2.10.2"
@@ -1832,7 +1831,6 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/chartjs-color/-/chartjs-color-2.4.1.tgz",
       "integrity": "sha512-haqOg1+Yebys/Ts/9bLo/BqUcONQOdr/hoEr2LLTRl6C5LXctUdHxsCYfvQVg5JIxITrfCNUDr4ntqmQk9+/0w==",
-      "dev": true,
       "requires": {
         "chartjs-color-string": "^0.6.0",
         "color-convert": "^1.9.3"
@@ -1842,7 +1840,6 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/chartjs-color-string/-/chartjs-color-string-0.6.0.tgz",
       "integrity": "sha512-TIB5OKn1hPJvO7JcteW4WY/63v6KwEdt6udfnDE9iCAZgy+V4SrbSxoIbTw/xkUIapjEI4ExGtD0+6D3KyFd7A==",
-      "dev": true,
       "requires": {
         "color-name": "^1.0.0"
       }
@@ -2531,7 +2528,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/css-box-model/-/css-box-model-1.2.1.tgz",
       "integrity": "sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==",
-      "dev": true,
       "requires": {
         "tiny-invariant": "^1.0.6"
       }
@@ -2652,8 +2648,7 @@
     "csstype": {
       "version": "2.6.17",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.17.tgz",
-      "integrity": "sha512-u1wmTI1jJGzCJzWndZo8mk4wnPTZd1eOIYTYvuEyOQGfmDl3TrabCCfKnOC86FZwW/9djqTl933UF/cS425i9A==",
-      "dev": true
+      "integrity": "sha512-u1wmTI1jJGzCJzWndZo8mk4wnPTZd1eOIYTYvuEyOQGfmDl3TrabCCfKnOC86FZwW/9djqTl933UF/cS425i9A=="
     },
     "currently-unhandled": {
       "version": "0.4.1",
@@ -4466,6 +4461,13 @@
       "integrity": "sha512-0k45oWBokCqh2MOexeYKpyqmGKG+8mQ2Wd8iawx+uWd/weWJQAZ6SoPybagdCI4xFisag8iAR77WPm4h3pTfxA==",
       "dev": true
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
+    },
     "filename-regex": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
@@ -5730,7 +5732,6 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
       "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-      "dev": true,
       "requires": {
         "react-is": "^16.7.0"
       }
@@ -9019,14 +9020,12 @@
     "popper-max-size-modifier": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/popper-max-size-modifier/-/popper-max-size-modifier-0.2.0.tgz",
-      "integrity": "sha512-UerPt9pZfTFnpSpIBVJrR3ibHMuU1k5K01AyNLfMUWCr4z1MFH+dsayPlAF9ZeYExa02HPiQn5OIMqUSVtJEbg==",
-      "dev": true
+      "integrity": "sha512-UerPt9pZfTFnpSpIBVJrR3ibHMuU1k5K01AyNLfMUWCr4z1MFH+dsayPlAF9ZeYExa02HPiQn5OIMqUSVtJEbg=="
     },
     "popper.js": {
       "version": "1.14.4",
       "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.14.4.tgz",
-      "integrity": "sha512-VKAPR2KCx8Uw0oVn0Rt4iggzat+MJ1wu1uJiDnfnMiQcGQRBIopZLfXMKsK/K8NPEerY5kefaYtYjTLb3F6ncw==",
-      "dev": true
+      "integrity": "sha512-VKAPR2KCx8Uw0oVn0Rt4iggzat+MJ1wu1uJiDnfnMiQcGQRBIopZLfXMKsK/K8NPEerY5kefaYtYjTLb3F6ncw=="
     },
     "portfinder": {
       "version": "1.0.32",
@@ -9572,8 +9571,7 @@
     "primeicons": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/primeicons/-/primeicons-2.0.0.tgz",
-      "integrity": "sha512-GJTCeMSQU8UU1GqbsaDrg/IH+b/vSinJQl52NVpdJ7sShYLZA8Eq6jLF48Ye3N/dQloGrE07i7XsZvxQ9pNbqg==",
-      "dev": true
+      "integrity": "sha512-GJTCeMSQU8UU1GqbsaDrg/IH+b/vSinJQl52NVpdJ7sShYLZA8Eq6jLF48Ye3N/dQloGrE07i7XsZvxQ9pNbqg=="
     },
     "primereact": {
       "version": "6.6.0",
@@ -9781,8 +9779,7 @@
     "raf-schd": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/raf-schd/-/raf-schd-4.0.3.tgz",
-      "integrity": "sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==",
-      "dev": true
+      "integrity": "sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ=="
     },
     "railroad-diagrams": {
       "version": "1.0.0",
@@ -9903,7 +9900,6 @@
       "version": "13.1.1",
       "resolved": "https://registry.npmjs.org/react-beautiful-dnd/-/react-beautiful-dnd-13.1.1.tgz",
       "integrity": "sha512-0Lvs4tq2VcrEjEgDXHjT98r+63drkKEgqyxdA7qD3mvKwga6a5SscbdLPO2IExotU1jW8L0Ksdl0Cj2AF67nPQ==",
-      "dev": true,
       "requires": {
         "@babel/runtime": "^7.9.2",
         "css-box-model": "^1.2.0",
@@ -9917,8 +9913,7 @@
         "memoize-one": {
           "version": "5.2.1",
           "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
-          "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
-          "dev": true
+          "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="
         }
       }
     },
@@ -9981,8 +9976,7 @@
     "react-id-generator": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/react-id-generator/-/react-id-generator-3.0.2.tgz",
-      "integrity": "sha512-d0rqWzZ6g0P9agHtA7wX/ErQ4iV/657/0Oz+SX3kid7nR4d0YwaWjjOTIrgYHv2lICZKrxIH4BaKppKrM8fRfw==",
-      "dev": true
+      "integrity": "sha512-d0rqWzZ6g0P9agHtA7wX/ErQ4iV/657/0Oz+SX3kid7nR4d0YwaWjjOTIrgYHv2lICZKrxIH4BaKppKrM8fRfw=="
     },
     "react-is": {
       "version": "16.13.1",
@@ -10062,7 +10056,6 @@
       "version": "7.2.9",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.9.tgz",
       "integrity": "sha512-Gx4L3uM182jEEayZfRbI/G11ZpYdNAnBs70lFVMNdHJI76XYtR+7m0MN+eAs7UHBPhWXcnFPaS+9owSCJQHNpQ==",
-      "dev": true,
       "requires": {
         "@babel/runtime": "^7.15.4",
         "@types/react-redux": "^7.1.20",
@@ -10076,7 +10069,6 @@
           "version": "7.1.34",
           "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.34.tgz",
           "integrity": "sha512-GdFaVjEbYv4Fthm2ZLvj1VSCedV7TqE5y1kNwnjSdBOTXuRSgowux6J8TAct15T3CKBr63UMk+2CO7ilRhyrAQ==",
-          "dev": true,
           "requires": {
             "@types/hoist-non-react-statics": "^3.3.0",
             "@types/react": "*",
@@ -10087,8 +10079,7 @@
         "react-is": {
           "version": "17.0.2",
           "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-          "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-          "dev": true
+          "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
         }
       }
     },
@@ -10096,7 +10087,6 @@
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/react-scrollspy/-/react-scrollspy-3.4.3.tgz",
       "integrity": "sha512-c2QZpMPWxm1HF71h1EqaxBldx2zLYO0aZ24Bcuo2mUWF79T+F6qOtr7XJCzUDm99NOwhVKQD01a7A8VC6c90CQ==",
-      "dev": true,
       "requires": {
         "babel-runtime": "^6.26.0",
         "classnames": "^2.2.5",
@@ -10304,7 +10294,6 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
       "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
-      "dev": true,
       "requires": {
         "@babel/runtime": "^7.9.2"
       }
@@ -12460,7 +12449,6 @@
         "shallow-equal": "^3.1.0",
         "shortid": "2.2.8",
         "style-loader": "0.20.2",
-        "superdesk-ui-framework": "4.0.20",
         "ts-loader": "3.5.0",
         "typescript": "4.9.5",
         "uuid": "8.3.1",
@@ -12472,8 +12460,7 @@
         "@popperjs/core": {
           "version": "2.10.2",
           "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.10.2.tgz",
-          "integrity": "sha512-IXf3XA7+XyN7CP9gGh/XB0UxVMlvARGEgGXLubFICsUMGz6Q+DU+i4gGlpOxTjKvXjkJDJC8YdqdKkDj9qZHEQ==",
-          "dev": true
+          "integrity": "sha512-IXf3XA7+XyN7CP9gGh/XB0UxVMlvARGEgGXLubFICsUMGz6Q+DU+i4gGlpOxTjKvXjkJDJC8YdqdKkDj9qZHEQ=="
         },
         "@sourcefabric/common": {
           "version": "0.0.44",
@@ -12512,8 +12499,7 @@
         "core-js": {
           "version": "1.2.7",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-          "integrity": "sha512-ZiPp9pZlgxpWRu0M+YWbm6+aQ84XEfH1JRXvfOc/fILWI0VKhLC2LX13X1NYq4fULzLMq7Hfh43CSo2/aIaUPA==",
-          "dev": true
+          "integrity": "sha512-ZiPp9pZlgxpWRu0M+YWbm6+aQ84XEfH1JRXvfOc/fILWI0VKhLC2LX13X1NYq4fULzLMq7Hfh43CSo2/aIaUPA=="
         },
         "date-fns": {
           "version": "2.30.0",
@@ -12528,7 +12514,6 @@
           "version": "0.8.18",
           "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.18.tgz",
           "integrity": "sha512-EQaWFK+fEPSoibjNy8IxUtaFOMXcWsY0JaVrQoZR9zC8N2Ygf9iDITPWjUTVIax95b6I742JFLqASHfsag/vKA==",
-          "dev": true,
           "requires": {
             "core-js": "^1.0.0",
             "isomorphic-fetch": "^2.1.1",
@@ -12558,7 +12543,6 @@
           "version": "15.6.1",
           "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
           "integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
-          "dev": true,
           "requires": {
             "fbjs": "^0.8.16",
             "loose-envify": "^1.3.1",
@@ -12641,7 +12625,6 @@
           "version": "1.11.0",
           "resolved": "https://registry.npmjs.org/react-sortable-hoc/-/react-sortable-hoc-1.11.0.tgz",
           "integrity": "sha512-v1CDCvdfoR3zLGNp6qsBa4J1BWMEVH25+UKxF/RvQRh+mrB+emqtVHMgZ+WreUiKJoEaiwYoScaueIKhMVBHUg==",
-          "dev": true,
           "requires": {
             "@babel/runtime": "^7.2.0",
             "invariant": "^2.2.4",
@@ -12649,10 +12632,9 @@
           }
         },
         "superdesk-ui-framework": {
-          "version": "4.0.4",
-          "resolved": "https://registry.npmjs.org/superdesk-ui-framework/-/superdesk-ui-framework-4.0.4.tgz",
-          "integrity": "sha512-mm36orxkDHDYM3ID36q6fB9ImHwV2CvgEIAXmZD0BOpfy+4Yc0+7GLfuur0Zf1Vs7LIutcoe4ljsSQ0RdB9KDQ==",
-          "dev": true,
+          "version": "4.0.20",
+          "resolved": "https://registry.npmjs.org/superdesk-ui-framework/-/superdesk-ui-framework-4.0.20.tgz",
+          "integrity": "sha512-IRUEZfj0CB0w95iC6KVKkqsv5gEQprlBywtOPFNdXHcqzD1xyAsMa3FDgmZK1rqLqE7TDEflV6u45JMANmR+Aw==",
           "requires": {
             "@popperjs/core": "^2.4.0",
             "@superdesk/common": "0.0.28",
@@ -12665,14 +12647,14 @@
             "primeicons": "2.0.0",
             "react-beautiful-dnd": "^13.0.0",
             "react-id-generator": "^3.0.0",
-            "react-scrollspy": "^3.4.3"
+            "react-scrollspy": "^3.4.3",
+            "tippy.js": "^6.3.7"
           },
           "dependencies": {
             "@superdesk/common": {
               "version": "0.0.28",
               "resolved": "https://registry.npmjs.org/@superdesk/common/-/common-0.0.28.tgz",
               "integrity": "sha512-EhsYMm340r3FVrakH00lLvQbxVYYTzL61J5GXI3BI2xLN2dPI3N0AJEaMGqjbt0xUpUFxE3T08OtYvIC5koZvg==",
-              "dev": true,
               "requires": {
                 "date-fns": "2.7.0",
                 "lodash": "4.17.19",
@@ -12685,8 +12667,7 @@
             "date-fns": {
               "version": "2.7.0",
               "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.7.0.tgz",
-              "integrity": "sha512-wxYp2PGoUDN5ZEACc61aOtYFvSsJUylIvCjpjDOqM1UDaKIIuMJ9fAnMYFHV3TQaDpfTVxhwNK/GiCaHKuemTA==",
-              "dev": true
+              "integrity": "sha512-wxYp2PGoUDN5ZEACc61aOtYFvSsJUylIvCjpjDOqM1UDaKIIuMJ9fAnMYFHV3TQaDpfTVxhwNK/GiCaHKuemTA=="
             }
           }
         }
@@ -12892,8 +12873,7 @@
     "tiny-invariant": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
-      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
-      "dev": true
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="
     },
     "tippy.js": {
       "version": "6.3.7",
@@ -13525,8 +13505,7 @@
     "use-memo-one": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.3.tgz",
-      "integrity": "sha512-g66/K7ZQGYrI6dy8GLpVcMsBp4s17xNkYJVSMvTEevGy3nDxHOfE6z8BVE22+5G5x7t3+bhzrlTDB7ObrEE0cQ==",
-      "dev": true
+      "integrity": "sha512-g66/K7ZQGYrI6dy8GLpVcMsBp4s17xNkYJVSMvTEevGy3nDxHOfE6z8BVE22+5G5x7t3+bhzrlTDB7ObrEE0cQ=="
     },
     "util": {
       "version": "0.11.1",
@@ -13709,6 +13688,7 @@
           "dev": true,
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         },
@@ -14229,6 +14209,7 @@
           "dev": true,
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,12 +28,12 @@
       "dev": true
     },
     "@babel/parser": {
-      "version": "7.26.8",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.8.tgz",
-      "integrity": "sha512-TZIQ25pkSoaKEYYaHbbxkfL36GNsQ6iFiBbeuzAkLnXayKR1yP1zFe+NxuZWWsUyvt8icPU9CCq0sgWGXR1GEw==",
+      "version": "7.26.9",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.9.tgz",
+      "integrity": "sha512-81NWa1njQblgZbQHxWHpxxCzNsa3ZwvFqpUg7P+NNUU6f3UU2jBEg4OlF/J6rl8+PQGh1q6/zWScd001YwcA5A==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.26.8"
+        "@babel/types": "^7.26.9"
       }
     },
     "@babel/runtime": {
@@ -45,9 +45,9 @@
       }
     },
     "@babel/types": {
-      "version": "7.26.8",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.8.tgz",
-      "integrity": "sha512-eUuWapzEGWFEpHFxgEaBG8e3n6S8L3MSu0oda755rOfabWPnh0Our1AozNFVUxGFIhbKgd1ksprsoDGMinTOTA==",
+      "version": "7.26.9",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.9.tgz",
+      "integrity": "sha512-Y3IR1cRnOxOCDvMmNiym7XpXQ93iGDDPHx+Zj+NM+rg0fBaShfQLkg+hKPaZCEvg5N/LeCo4+Rj/i3FuJsIQaw==",
       "dev": true,
       "requires": {
         "@babel/helper-string-parser": "^7.25.9",
@@ -1370,16 +1370,6 @@
       "resolved": "https://registry.npmjs.org/binary-search/-/binary-search-1.3.6.tgz",
       "integrity": "sha512-nbE1WxOTTrUWIfsfZ4aHGYu5DOuNkbxGokjV6Z2kxfJK3uaAb8zNK1muzOeipoLHZjInT4Br88BHpzevc681xA==",
       "dev": true
-    },
-    "bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "file-uri-to-path": "1.0.0"
-      }
     },
     "block-stream": {
       "version": "0.0.9",
@@ -3204,9 +3194,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.5.97",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.97.tgz",
-      "integrity": "sha512-HKLtaH02augM7ZOdYRuO19rWDeY+QSJ1VxnXFa/XDFLf07HvM90pALIJFgrO+UVaajI3+aJMMpojoUTLZyQ7JQ==",
+      "version": "1.5.100",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.100.tgz",
+      "integrity": "sha512-u1z9VuzDXV86X2r3vAns0/5ojfXBue9o0+JDUDBKYqGLjxLkSqsSUoPU/6kW0gx76V44frHaf6Zo+QF74TQCMg==",
       "dev": true
     },
     "elliptic": {
@@ -4457,13 +4447,6 @@
       "resolved": "https://registry.npmjs.org/file-sync-cmp/-/file-sync-cmp-0.1.1.tgz",
       "integrity": "sha512-0k45oWBokCqh2MOexeYKpyqmGKG+8mQ2Wd8iawx+uWd/weWJQAZ6SoPybagdCI4xFisag8iAR77WPm4h3pTfxA==",
       "dev": true
-    },
-    "file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "dev": true,
-      "optional": true
     },
     "filename-regex": {
       "version": "2.0.1",
@@ -12358,7 +12341,7 @@
       }
     },
     "superdesk-core": {
-      "version": "github:superdesk/superdesk-client-core#57300cfb9fcf383412e3a1b697bde13c28ca8a80",
+      "version": "github:superdesk/superdesk-client-core#6bf9e83800ac22937fb46f1dbed1531d59020617",
       "from": "github:superdesk/superdesk-client-core#develop",
       "dev": true,
       "requires": {
@@ -13613,7 +13596,6 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         },
@@ -14134,7 +14116,6 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         },

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "author": "Edouard Richard",
   "dependencies": {
-    "@sourcefabric/common": "0.0.46",
+    "@sourcefabric/common": "0.0.47",
     "@sourcefabric/draft-js": "^0.11.5",
     "dompurify": "^1.0.11",
     "moment": "^2.30.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lint": "eslint client --ext=jsx --ext=js --ext=tsx --ext=ts --ext=spec --quiet",
     "test": "karma start karma.conf.js --log-level debug --display-error-details --single-run",
     "karma": "karma start karma.conf.js",
-    "debug_unit_test": "karma start karma.conf.js --browsers=Chrome"
+    "debug_unit_tests": "karma start karma.conf.js --browsers=Chrome"
   },
   "author": "Edouard Richard",
   "dependencies": {


### PR DESCRIPTION
1. Validates coverages when editing an embedded planning item
2. `handleEmbeddedItems` function is updated not to handle scrolling to invalid fields anymore since it is now done by authoring-react

DEPENDS ON: https://github.com/superdesk/superdesk-client-core/pull/4751

## Front-end checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [x] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [x] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [x] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [x] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [x] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [x] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [x] This pull request is not adding redux based modals
- [x] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [x] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)
