### PR TITLE
Fix removed types

### DIFF
--- a/client/components/UI/Form/ExpandableTextAreaInput.tsx
+++ b/client/components/UI/Form/ExpandableTextAreaInput.tsx
@@ -1,11 +1,22 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import {get} from 'lodash';
-
 import {LineInput, Label, ExpandableTextArea} from './';
-import {LineInputProps, LineInputDefaultProps} from './LineInput';
-
+import {ILineInputProps} from './LineInput';
 import './style.scss';
+
+interface IProps extends ILineInputProps {
+    field: string;
+    label?: string;
+    labelIcon?: string;
+    value?: string;
+    onChange?: (event: React.ChangeEvent<HTMLTextAreaElement>) => void;
+    maxLength?: number;
+    placeholder?: string;
+    readOnly?: boolean;
+    refNode?: (node: HTMLTextAreaElement) => void;
+    nativeOnChange?: boolean;
+    initialFocus?: boolean;
+}
 
 export const ExpandableTextAreaInput = ({
     field,
@@ -13,16 +24,17 @@ export const ExpandableTextAreaInput = ({
     labelIcon,
     value,
     onChange,
-    maxLength,
+    maxLength = 0,
     placeholder,
     invalid,
     readOnly,
     refNode,
     nativeOnChange,
     initialFocus,
+    borderBottom = true,
     ...props
-}) => (
-    <LineInput {...props} invalid={invalid} readOnly={readOnly}>
+}: IProps) => (
+    <LineInput borderBottom={borderBottom} {...props} invalid={invalid} readOnly={readOnly}>
         <Label text={label} icon={labelIcon} />
         <ExpandableTextArea
             field={field}
@@ -43,26 +55,3 @@ export const ExpandableTextAreaInput = ({
     </LineInput>
 );
 
-ExpandableTextAreaInput.propTypes = {
-    field: PropTypes.string,
-    label: PropTypes.string,
-    labelIcon: PropTypes.string,
-    value: PropTypes.string,
-    onChange: PropTypes.func,
-    maxLength: PropTypes.string,
-    placeholder: PropTypes.string,
-    readOnly: PropTypes.bool,
-    refNode: PropTypes.func,
-    nativeOnChange: PropTypes.bool,
-
-    ...LineInputProps,
-};
-
-ExpandableTextAreaInput.defaultProps = {
-    readOnly: false,
-    nativeOnChange: false,
-    initialFocus: false,
-    maxLength: 0,
-
-    ...LineInputDefaultProps,
-};

--- a/client/components/UI/Form/LineInput.tsx
+++ b/client/components/UI/Form/LineInput.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-interface IProps {
+export interface ILineInputProps {
     required?: boolean;
     invalid?: boolean;
     readOnly?: boolean;
@@ -45,7 +44,7 @@ export const LineInput = ({
     message,
     className,
     onClick,
-}: IProps): JSX.Element => (
+}: ILineInputProps): JSX.Element => (
     <div
         className={classNames(
             'sd-line-input',

--- a/client/components/UI/Form/TextInput.tsx
+++ b/client/components/UI/Form/TextInput.tsx
@@ -1,30 +1,38 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import {LineInput, Label, Input} from './';
-import {LineInputProps, LineInputDefaultProps} from './LineInput';
+import {ILineInputProps} from './LineInput';
 import {get, uniqueId} from 'lodash';
 
-/**
- * @ngdoc react
- * @name TextInput
- * @description Component to recieve text input in
- */
+interface IProps extends ILineInputProps {
+    field?: string;
+    label?: string;
+    value?: string | number;
+    onChange?: (...args: any) => void;
+    maxLength?: number;
+    type?: string;
+    refNode?: (node: HTMLInputElement) => void;
+    inputClassName?: string;
+    autoFocus?: boolean;
+    testId?: string;
+    onFocus?(event: React.FocusEvent<HTMLInputElement>): void;
+}
+
 export const TextInput = ({
     field,
     label,
-    value,
+    value = '',
     onChange,
-    maxLength,
+    maxLength = 0,
     invalid,
     readOnly,
-    type,
+    type = 'text',
     inputClassName,
     refNode,
     autoFocus,
     onFocus,
     testId,
     ...props
-}) => {
+}: IProps) => {
     const inputId = uniqueId('input-');
 
     return (
@@ -38,7 +46,6 @@ export const TextInput = ({
                 readOnly={readOnly}
                 refNode={refNode}
                 className={inputClassName}
-                autoFocus={autoFocus}
                 onFocus={onFocus}
                 testId={testId}
                 id={inputId}
@@ -49,28 +56,4 @@ export const TextInput = ({
             }
         </LineInput>
     );
-};
-
-TextInput.propTypes = {
-    field: PropTypes.string,
-    label: PropTypes.string,
-    value: PropTypes.oneOfType([
-        PropTypes.string,
-        PropTypes.number,
-    ]),
-    onChange: PropTypes.func,
-    maxLength: PropTypes.number,
-    type: PropTypes.string,
-    refNode: PropTypes.func,
-    inputClassName: PropTypes.string,
-    autoFocus: PropTypes.bool,
-    testId: PropTypes.string,
-    ...LineInputProps,
-};
-
-TextInput.defaultProps = {
-    maxLength: 0,
-    type: 'text',
-    value: '',
-    ...LineInputDefaultProps,
 };

--- a/client/components/UI/Form/ToggleInput/index.tsx
+++ b/client/components/UI/Form/ToggleInput/index.tsx
@@ -1,19 +1,24 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-
 import {LineInput, Label} from '../';
-import {LineInputProps, LineInputDefaultProps} from '../LineInput';
+import {ILineInputProps} from '../LineInput';
 import {Toggle} from '../../';
 
 import './style.scss';
 
-/**
- * @ngdoc react
- * @name ToggleInput
- * @description Component to toggle input values
- */
+
+interface IProps extends ILineInputProps {
+    field: string,
+    label?: string;
+    value?: boolean;
+    onChange: (...args: any) => void;
+    className?: string;
+    labelLeftAuto?: boolean;
+    title?: string;
+    onFocus: () => void;
+}
+
 export const ToggleInput = ({field, label, value, onChange, readOnly, className, labelLeftAuto,
-    onFocus, title, ...props}) => (
+    onFocus, title, ...props}: IProps) => (
     <LineInput {...props} readOnly={readOnly} labelLeftAuto={labelLeftAuto} className="sd-line-input__toggle">
         <Label text={label} />
         <Toggle
@@ -28,19 +33,3 @@ export const ToggleInput = ({field, label, value, onChange, readOnly, className,
     </LineInput>
 );
 
-ToggleInput.propTypes = {
-    field: PropTypes.string.isRequired,
-    label: PropTypes.string,
-    value: PropTypes.bool,
-    onChange: PropTypes.func.isRequired,
-    className: PropTypes.string,
-    labelLeftAuto: PropTypes.bool,
-    title: PropTypes.string,
-    ...LineInputProps,
-};
-
-ToggleInput.defaultProps = {
-    value: false,
-    labelLeftAuto: false,
-    ...LineInputDefaultProps,
-};


### PR DESCRIPTION
STT-31
## Front-end checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)
