### PR TITLE
set all_day on embedded planning when configured

### DIFF
--- a/client/actions/agenda.ts
+++ b/client/actions/agenda.ts
@@ -11,6 +11,7 @@ import {planning, showModal, main} from './index';
 import {convertStringFields} from '../utils/strings';
 import planningApis from '../actions/planning/api';
 import eventsApis from '../actions/events/api';
+import {appConfig} from 'appConfig';
 
 const openAgenda = () => (
     (dispatch) => (
@@ -258,6 +259,7 @@ export function convertEventToPlanningItem(event: IEventItem): Partial<IPlanning
         type: 'planning',
         related_events: [eventLink],
         planning_date: event._sortDate || event.dates?.start,
+        all_day: appConfig.planning.all_day === true,
         place: event.place || defaultPlace,
         subject: event.subject,
         anpa_category: event.anpa_category,

--- a/server/planning/events/events_sync/embedded_planning.py
+++ b/server/planning/events/events_sync/embedded_planning.py
@@ -10,6 +10,7 @@
 
 from typing import List, Iterator, Tuple, Dict
 from copy import deepcopy
+from flask import current_app as app
 import logging
 
 from superdesk import get_resource_service
@@ -101,6 +102,7 @@ def create_new_plannings_from_embedded_planning(
             "state": "draft",
             "type": "planning",
             "planning_date": event["dates"]["start"],
+            "all_day": app.config.get("PLANNING_PLANNING_ALL_DAY") or False,
             "related_events": [related_event],
             "coverages": [],
         }


### PR DESCRIPTION
STT-48

## Front-end checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)
