### PR TITLE
Fix `CORS` issue and `hits` missing data

### DIFF
--- a/server/planning/agendas_async/module.py
+++ b/server/planning/agendas_async/module.py
@@ -10,5 +10,9 @@ agendas_resource_config = ResourceConfig(
     name="agenda",
     data_class=AgendasResourceModel,
     service=AgendasAsyncService,
-    rest_endpoints=RestEndpointConfig(resource_methods=["GET", "POST"], item_methods=["GET", "PATCH", "DELETE"]),
+    rest_endpoints=RestEndpointConfig(
+        resource_methods=["GET", "POST"],
+        item_methods=["GET", "PATCH", "DELETE"],
+        enable_cors=True,
+    ),
 )

--- a/server/planning/content_profiles/module.py
+++ b/server/planning/content_profiles/module.py
@@ -8,5 +8,9 @@ planning_types_resource_config = ResourceConfig(
     name="planning_types",
     data_class=PlanningTypesResourceModel,
     service=PlanningTypesAsyncService,
-    rest_endpoints=RestEndpointConfig(resource_methods=["GET", "POST"], item_methods=["GET", "PATCH"]),
+    rest_endpoints=RestEndpointConfig(
+        resource_methods=["GET", "POST"],
+        item_methods=["GET", "PATCH"],
+        enable_cors=True,
+    ),
 )

--- a/server/planning/content_profiles/planning_types_async_service.py
+++ b/server/planning/content_profiles/planning_types_async_service.py
@@ -110,7 +110,8 @@ class PlanningTypesAsyncService(AsyncResourceService[PlanningTypesResourceModel]
                 self.merge_planning_type(planning_type, default_planning_type)
                 merged_planning_types.append(planning_type)
 
-        return ElasticsearchResourceCursorAsync(data_class=PlanningTypesResourceModel, hits=merged_planning_types)
+        hits = {"hits": {"hits": merged_planning_types, "total": len(merged_planning_types)}}
+        return ElasticsearchResourceCursorAsync(data_class=PlanningTypesResourceModel, hits=hits)
 
     def merge_planning_type(self, planning_type: dict[str, Any], default_planning_type: dict[str, Any]):
         # Update schema fields with database schema fields

--- a/server/planning/events/module.py
+++ b/server/planning/events/module.py
@@ -45,7 +45,11 @@ events_history_resource_config: ResourceConfig = ResourceConfig(
             ),
         ],
     ),
-    rest_endpoints=RestEndpointConfig(resource_methods=["GET"], item_methods=["GET"]),
+    rest_endpoints=RestEndpointConfig(
+        resource_methods=["GET"],
+        item_methods=["GET"],
+        enable_cors=True,
+    ),
 )
 
 events_autosave_resource_config: ResourceConfig = ResourceConfig(
@@ -58,5 +62,9 @@ events_autosave_resource_config: ResourceConfig = ResourceConfig(
             MongoIndexOptions(name="event_autosave_session", keys=[("lock_session", 1)], background=True, unique=False),
         ],
     ),
-    rest_endpoints=RestEndpointConfig(resource_methods=["GET", "POST"], item_methods=["GET", "PUT", "PATCH", "DELETE"]),
+    rest_endpoints=RestEndpointConfig(
+        resource_methods=["GET", "POST"],
+        item_methods=["GET", "PUT", "PATCH", "DELETE"],
+        enable_cors=True,
+    ),
 )

--- a/server/planning/planning/module.py
+++ b/server/planning/planning/module.py
@@ -76,5 +76,9 @@ planning_autosave_resource_config: ResourceConfig = ResourceConfig(
             ),
         ],
     ),
-    rest_endpoints=RestEndpointConfig(resource_methods=["GET", "POST"], item_methods=["GET", "PUT", "PATCH", "DELETE"]),
+    rest_endpoints=RestEndpointConfig(
+        resource_methods=["GET", "POST"],
+        item_methods=["GET", "PUT", "PATCH", "DELETE"],
+        enable_cors=True,
+    ),
 )


### PR DESCRIPTION
- Fixes a CORS problem generated when the frontend tried to access `agenda` and `planning_types` resources from the planning screen
- Fixes missing `hits` data provided to the `ElasticsearchResourceCursorAsync` in `planning_types` service


<img width="1511" alt="image" src="https://github.com/user-attachments/assets/a8c31b6a-4124-4318-83fa-932748431005" />

