### PR TITLE
[SDESK-7487] Implement async `/planning-locks` endpoint 

### DIFF
--- a/server/planning/__init__.py
+++ b/server/planning/__init__.py
@@ -1,20 +1,9 @@
-# -*- coding: utf-8; -*-
-#
-# This file is part of Superdesk.
-#
-#  Copyright 2013, 2014 Sourcefabric z.u. and contributors.
-#
-# For the full copyright and license information, please see the
-# AUTHORS and LICENSE files distributed with this source code, or
-# at https://www.sourcefabric.org/superdesk/license
-
 """Superdesk Planning Plugin."""
 
 import logging
 import superdesk
 from quart_babel import lazy_gettext
 
-from superdesk.resource_fields import ID_FIELD
 from .agendas import AgendasResource, AgendasService
 from .planning_export_templates import (
     PlanningExportTemplatesResource,
@@ -75,12 +64,11 @@ import planning.feed_parsers  # noqa
 import planning.output_formatters  # noqa
 import planning.io  # noqa
 from planning.planning_download import init_app as init_planning_download_app
-from planning.planning_locks import init_app as init_planning_locks_app
 from planning.search.planning_autocomplete import init_app as init_planning_autocomplete_app
 
 from .module import module  # noqa
 
-__version__ = "2.8.2"
+__version__ = "3.0.0.dev0"
 
 _SERVER_PATH = os.path.dirname(os.path.realpath(__file__))
 
@@ -115,7 +103,6 @@ def init_app(app):
     init_assignments_app(app)
     init_search_app(app)
     init_planning_download_app(app)
-    init_planning_locks_app(app)
     init_planning_autocomplete_app(app)
 
     superdesk.register_resource(

--- a/server/planning/module.py
+++ b/server/planning/module.py
@@ -17,7 +17,7 @@ from planning.assignments import assignments_resource_config, delivery_resource_
 from planning.published import published_resource_config
 from planning.content_profiles import planning_types_resource_config
 
-from .planning_locks import planning_locks_endpoints
+from .planning_locks import get_planning_locks as planning_locks_endpoint
 
 
 async def cleanup_on_session_end(user_id: ObjectId, session_id: ObjectId, is_last_session: bool) -> None:
@@ -37,7 +37,7 @@ module = Module(
     "planning",
     init=init_planning,
     endpoints=[
-        planning_locks_endpoints,
+        planning_locks_endpoint,
     ],
     resources=[
         events_resource_config,

--- a/server/planning/module.py
+++ b/server/planning/module.py
@@ -17,7 +17,7 @@ from planning.assignments import assignments_resource_config, delivery_resource_
 from planning.published import published_resource_config
 from planning.content_profiles import planning_types_resource_config
 
-from .planning_locks import get_planning_locks as planning_locks_endpoint
+from .planning_locks import planning_locks as planning_locks_endpoint
 
 
 async def cleanup_on_session_end(user_id: ObjectId, session_id: ObjectId, is_last_session: bool) -> None:

--- a/server/planning/module.py
+++ b/server/planning/module.py
@@ -17,6 +17,8 @@ from planning.assignments import assignments_resource_config, delivery_resource_
 from planning.published import published_resource_config
 from planning.content_profiles import planning_types_resource_config
 
+from .planning_locks import planning_locks_endpoints
+
 
 async def cleanup_on_session_end(user_id: ObjectId, session_id: ObjectId, is_last_session: bool) -> None:
     lookup = {LOCK_USER: user_id} if is_last_session else {LOCK_SESSION: session_id}
@@ -34,6 +36,9 @@ def init_planning(app: SuperdeskAsyncApp):
 module = Module(
     "planning",
     init=init_planning,
+    endpoints=[
+        planning_locks_endpoints,
+    ],
     resources=[
         events_resource_config,
         planning_resource_config,

--- a/server/planning/planning_locks.py
+++ b/server/planning/planning_locks.py
@@ -56,8 +56,6 @@ class PlanningLocksParams(BaseModel):
 
 @endpoint("planning_locks", methods=["GET"])
 async def get_planning_locks(_: None, params: PlanningLocksParams, _r: None):
-    print("*" * 100)
-    print(params.repos)
     resp = await _get_planning_module_locks(params.repos)
     return Response(resp)
 

--- a/server/planning/planning_locks.py
+++ b/server/planning/planning_locks.py
@@ -7,8 +7,8 @@ from pydantic import BaseModel, Field, field_validator
 
 from superdesk.core import json
 from superdesk import get_resource_service
-from superdesk.core.web import EndpointGroup
-from superdesk.core.types import Response, SearchRequest, SearchArgs, ESQuery
+from superdesk.core.web import endpoint
+from superdesk.core.types import Response, SearchRequest, ESQuery, ESBoolQuery
 
 from planning.events import EventsAsyncService
 from planning.planning import PlanningAsyncService
@@ -16,9 +16,6 @@ from planning.assignments import AssignmentsAsyncService
 from planning.core.service import BasePlanningAsyncService
 from planning.utils import get_first_related_event_id_for_planning
 from planning.search.queries.elastic import ElasticQuery, field_exists
-
-
-planning_locks_endpoints = EndpointGroup("/planning_locks", __name__, url_prefix="api")
 
 
 @unique
@@ -47,7 +44,7 @@ PROJECTED_FIELDS = [
 
 
 class PlanningLocksParams(BaseModel):
-    repos: Annotated[list[PlanningLockRepos], Field(default=DEFAULT_REPOS)]
+    repos: Annotated[list[PlanningLockRepos], Field(default_factory=lambda: DEFAULT_REPOS)]
 
     @field_validator("repos", mode="before")
     def parse_repos(cls, value: list[PlanningLockRepos] | str) -> list[PlanningLockRepos]:
@@ -57,8 +54,10 @@ class PlanningLocksParams(BaseModel):
         return value
 
 
-@planning_locks_endpoints.endpoint("/planning_locks", methods=["GET"])
+@endpoint("planning_locks", methods=["GET"])
 async def get_planning_locks(_: None, params: PlanningLocksParams, _r: None):
+    print("*" * 100)
+    print(params.repos)
     resp = await _get_planning_module_locks(params.repos)
     return Response(resp)
 
@@ -130,16 +129,15 @@ def _prepare_query() -> SearchRequest:
             - Projection fields from PROJECTED_FIELDS
             - Page 1 with 1000 results per page
     """
-    elastic_query = ESQuery()
-    elastic_query.query.must.append(field_exists("lock_session"))
-
     return SearchRequest(
-        args=SearchArgs(
-            source=elastic_query.generate_query_dict(),
-            projections=json.dumps(PROJECTED_FIELDS),
-        ),
         page=1,
         max_results=1000,
+        elastic=ESQuery(
+            query=ESBoolQuery(
+                must=[field_exists("lock_session")],
+            )
+        ),
+        projections=PROJECTED_FIELDS,
     )
 
 

--- a/server/planning/planning_locks.py
+++ b/server/planning/planning_locks.py
@@ -1,45 +1,34 @@
-# -*- coding: utf-8; -*-
-#
-# This file is part of Superdesk.
-#
-#  Copyright 2023 Sourcefabric z.u. and contributors.
-#
-# For the full copyright and license information, please see the
-# AUTHORS and LICENSE files distributed with this source code, or
-# at https://www.sourcefabric.org/superdesk/license
-
-from enum import Enum
+from enum import Enum, unique
+from typing import Annotated
 
 from eve.utils import ParsedRequest
-from eve.render import send_response
+from pydantic import BaseModel, Field, field_validator
 
 from superdesk.core import json
-from superdesk.flask import request, Blueprint
-from superdesk import Resource, get_resource_service, blueprint
-from superdesk.auth.decorator import blueprint_auth
+from superdesk import get_resource_service
+from superdesk.core import get_app_config
+from superdesk.core.web import EndpointGroup
+from superdesk.core.types import Response, Request
 
 from planning.utils import get_first_related_event_id_for_planning
 from planning.search.queries.elastic import ElasticQuery, field_exists
 
 
-class PlanningLocksResource(Resource):
-    resource_methods = ["GET"]
-    item_methods = []
-    endpoint_name = "planning_locks"
-    allow_unknown = True
+planning_locks_endpoints = EndpointGroup("/planning_locks", __name__, url_prefix=get_app_config("URL_PREFIX"))
 
 
-class PlanningLockRepos(Enum):
+@unique
+class PlanningLockRepos(str, Enum):
     EVENTS_AND_PLANNING = "events_and_planning"
     FEATURED_PLANNING = "featured_planning"
     ASSIGNMENTS = "assignments"
 
 
-DEFAULT_REPOS = (
-    f"{PlanningLockRepos.EVENTS_AND_PLANNING.value},"
-    f"{PlanningLockRepos.FEATURED_PLANNING.value},"
-    f"{PlanningLockRepos.ASSIGNMENTS.value}"
-)
+DEFAULT_REPOS = [
+    PlanningLockRepos.EVENTS_AND_PLANNING,
+    PlanningLockRepos.FEATURED_PLANNING,
+    PlanningLockRepos.ASSIGNMENTS,
+]
 
 PROJECTED_FIELDS = [
     "_id",
@@ -53,32 +42,38 @@ PROJECTED_FIELDS = [
 ]
 
 
-bp = Blueprint("planning_locks", __name__)
+class PlanningLocksParams(BaseModel):
+    repos: Annotated[list[PlanningLockRepos], Field(default=DEFAULT_REPOS)]
+
+    @field_validator("repos", mode="before")
+    def parse_repos(cls, value: list[PlanningLockRepos] | str) -> list[str]:
+        """If value is not a list, then convert it to a list here"""
+
+        return value.split(",") if isinstance(value, str) else value
 
 
-@bp.route("/planning_locks", methods=["GET", "OPTIONS"])
-@blueprint_auth()
-def get_planning_locks():
-    resp = _get_planning_module_locks() if request.method == "GET" else None
-    return send_response(None, (resp, None, None, 200))
+@planning_locks_endpoints.endpoint("/planning_locks", methods=["GET"])
+def get_planning_locks(_: None, params: PlanningLocksParams, request: Request):
+    resp = _get_planning_module_locks(params.repos)
+    return Response(resp)
 
 
-def _get_planning_module_locks():
-    repos = (request.args.get("repos") or DEFAULT_REPOS).split(",")
-
+def _get_planning_module_locks(repos: list[PlanningLockRepos]):
     item_locks = []
     locks = {}
-    for repo in repos:
-        if repo == PlanningLockRepos.EVENTS_AND_PLANNING.value:
-            locks.update({"event": {}, "planning": {}, "recurring": {}})
-            item_locks.extend(list(_get_event_locks()))
-            item_locks.extend(list(_get_planning_locks()))
-        elif repo == PlanningLockRepos.FEATURED_PLANNING.value:
-            locks["featured"] = None
-            item_locks.extend(list(_get_planning_featured_lock()))
-        elif repo == PlanningLockRepos.ASSIGNMENTS.value:
-            locks["assignment"] = {}
-            item_locks.extend(list(_get_assignment_locks()))
+
+    if PlanningLockRepos.EVENTS_AND_PLANNING in repos:
+        locks.update({"event": {}, "planning": {}, "recurring": {}})
+        item_locks.extend(list(_get_event_locks()))
+        item_locks.extend(list(_get_planning_locks()))
+
+    if PlanningLockRepos.FEATURED_PLANNING in repos:
+        locks["featured"] = None
+        item_locks.extend(list(_get_planning_featured_lock()))
+
+    if PlanningLockRepos.ASSIGNMENTS in repos:
+        locks["assignment"] = {}
+        item_locks.extend(list(_get_assignment_locks()))
 
     for item in item_locks:
         if item.get("_type") == "planning_featured_lock":
@@ -145,7 +140,3 @@ def _get_planning_featured_lock():
 
 def _get_assignment_locks():
     return get_resource_service("assignments").get(req=_get_query(), lookup=None)
-
-
-def init_app(app):
-    blueprint(bp, app)

--- a/server/planning/planning_locks.py
+++ b/server/planning/planning_locks.py
@@ -55,7 +55,7 @@ class PlanningLocksParams(BaseModel):
 
 
 @endpoint("planning_locks", methods=["GET"])
-async def get_planning_locks(_: None, params: PlanningLocksParams, _r: None):
+async def planning_locks(_: None, params: PlanningLocksParams, _r: None):
     resp = await _get_planning_module_locks(params.repos)
     return Response(resp)
 

--- a/server/planning/planning_locks.py
+++ b/server/planning/planning_locks.py
@@ -1,5 +1,6 @@
+import asyncio
 from enum import Enum, unique
-from typing import Annotated
+from typing import Annotated, Any
 
 from eve.utils import ParsedRequest
 from pydantic import BaseModel, Field, field_validator
@@ -8,8 +9,12 @@ from superdesk.core import json
 from superdesk import get_resource_service
 from superdesk.core import get_app_config
 from superdesk.core.web import EndpointGroup
-from superdesk.core.types import Response, Request
+from superdesk.core.types import Response, SearchRequest, SearchArgs, ESQuery
 
+from planning.events import EventsAsyncService
+from planning.planning import PlanningAsyncService
+from planning.assignments import AssignmentsAsyncService
+from planning.core.service import BasePlanningAsyncService
 from planning.utils import get_first_related_event_id_for_planning
 from planning.search.queries.elastic import ElasticQuery, field_exists
 
@@ -46,34 +51,45 @@ class PlanningLocksParams(BaseModel):
     repos: Annotated[list[PlanningLockRepos], Field(default=DEFAULT_REPOS)]
 
     @field_validator("repos", mode="before")
-    def parse_repos(cls, value: list[PlanningLockRepos] | str) -> list[str]:
+    def parse_repos(cls, value: list[PlanningLockRepos] | str) -> list[PlanningLockRepos]:
         """If value is not a list, then convert it to a list here"""
-
-        return value.split(",") if isinstance(value, str) else value
+        if isinstance(value, str):
+            return [PlanningLockRepos(item.strip()) for item in value.split(",")]
+        return value
 
 
 @planning_locks_endpoints.endpoint("/planning_locks", methods=["GET"])
-def get_planning_locks(_: None, params: PlanningLocksParams, request: Request):
-    resp = _get_planning_module_locks(params.repos)
+async def get_planning_locks(_: None, params: PlanningLocksParams, _r: None):
+    resp = await _get_planning_module_locks(params.repos)
     return Response(resp)
 
 
-def _get_planning_module_locks(repos: list[PlanningLockRepos]):
+async def _get_planning_module_locks(repos: list[PlanningLockRepos]):
     item_locks = []
-    locks = {}
+    locks: dict[str, Any] = {}
+
+    # to be executed concurrently
+    tasks = []
 
     if PlanningLockRepos.EVENTS_AND_PLANNING in repos:
         locks.update({"event": {}, "planning": {}, "recurring": {}})
-        item_locks.extend(list(_get_event_locks()))
-        item_locks.extend(list(_get_planning_locks()))
-
-    if PlanningLockRepos.FEATURED_PLANNING in repos:
-        locks["featured"] = None
-        item_locks.extend(list(_get_planning_featured_lock()))
+        tasks.append(_get_event_locks())
+        tasks.append(_get_planning_locks())
 
     if PlanningLockRepos.ASSIGNMENTS in repos:
         locks["assignment"] = {}
-        item_locks.extend(list(_get_assignment_locks()))
+        tasks.append(_get_assignment_locks())
+
+    # execute all async tasks concurrently
+    if tasks:
+        for result in await asyncio.gather(*tasks):
+            item_locks.extend(result)
+
+    if PlanningLockRepos.FEATURED_PLANNING in repos:
+        locks["featured"] = None
+
+        # TODO-ASYNC: add to tasks once it is migrated to async
+        item_locks.extend(list(_get_planning_featured_lock()))
 
     for item in item_locks:
         if item.get("_type") == "planning_featured_lock":
@@ -106,6 +122,54 @@ def _get_planning_module_locks(repos: list[PlanningLockRepos]):
     return locks
 
 
+def _prepare_query() -> SearchRequest:
+    """Prepare a SearchRequest object for querying locked items
+
+    Returns:
+        SearchRequest: A SearchRequest object configured with:
+            - Query filter for items with lock_session field
+            - Projection fields from PROJECTED_FIELDS
+            - Page 1 with 1000 results per page
+    """
+    elastic_query = ESQuery()
+    elastic_query.query.must.append(field_exists("lock_session"))
+
+    return SearchRequest(
+        args=SearchArgs(
+            source=elastic_query.generate_query_dict(),
+            projections=json.dumps(PROJECTED_FIELDS),
+        ),
+        page=1,
+        max_results=1000,
+    )
+
+
+async def _get_locks_for_service(service_class: type[BasePlanningAsyncService]) -> list[dict[str, Any]]:
+    """Get locks for a specific service
+
+    Args:
+        service_class: The async service class to query (e.g. EventsAsyncService)
+
+    Returns:
+        list: List of locked items from the service
+    """
+    cursor = await service_class().find(req=_prepare_query())
+    return await cursor.to_list_raw()
+
+
+async def _get_event_locks():
+    return await _get_locks_for_service(EventsAsyncService)
+
+
+async def _get_planning_locks():
+    return await _get_locks_for_service(PlanningAsyncService)
+
+
+async def _get_assignment_locks():
+    return await _get_locks_for_service(AssignmentsAsyncService)
+
+
+# TODO-ASYNC: remove once it is not needed by `_get_planning_featured_lock`
 def _get_query():
     query = ElasticQuery()
     query.must.append(field_exists("lock_session"))
@@ -126,17 +190,6 @@ def _get_query():
     return req
 
 
-def _get_event_locks():
-    return get_resource_service("events").get(req=_get_query(), lookup=None)
-
-
-def _get_planning_locks():
-    return get_resource_service("planning").get(req=_get_query(), lookup=None)
-
-
+# TODO-ASYNC: update once `planning_featured_lock` is migrated to async
 def _get_planning_featured_lock():
     return get_resource_service("planning_featured_lock").get(req=_get_query(), lookup=None)
-
-
-def _get_assignment_locks():
-    return get_resource_service("assignments").get(req=_get_query(), lookup=None)

--- a/server/planning/planning_locks.py
+++ b/server/planning/planning_locks.py
@@ -7,7 +7,6 @@ from pydantic import BaseModel, Field, field_validator
 
 from superdesk.core import json
 from superdesk import get_resource_service
-from superdesk.core import get_app_config
 from superdesk.core.web import EndpointGroup
 from superdesk.core.types import Response, SearchRequest, SearchArgs, ESQuery
 
@@ -19,7 +18,7 @@ from planning.utils import get_first_related_event_id_for_planning
 from planning.search.queries.elastic import ElasticQuery, field_exists
 
 
-planning_locks_endpoints = EndpointGroup("/planning_locks", __name__, url_prefix=get_app_config("URL_PREFIX"))
+planning_locks_endpoints = EndpointGroup("/planning_locks", __name__, url_prefix="api")
 
 
 @unique


### PR DESCRIPTION
### Purpose
Convert the existing `/planning_locks` endpoint to async framework. 

### What has changed
- Converted the `/planning_locks` endpoint to use async `EndpointGroup`
- Updated the endpoint to use available async services (`EventsAsyncService`, `PlanningAsyncService`, and `AssignmentsAsyncService`) to query the list of locks.
- Implemented concurrent async database queries to fetch locks.
- Added necessary imports and refactored code to support async functionality.

Resolves: [SDESK-7487]

Thanks for checking!

[SDESK-7487]: https://sofab.atlassian.net/browse/SDESK-7487?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ