### PR TITLE
Add Agendas to list of available Content Filter fields

### DIFF
--- a/server/planning/events/events_service.py
+++ b/server/planning/events/events_service.py
@@ -142,7 +142,7 @@ class EventsAsyncService(BasePlanningAsyncService[EventResourceModel]):
         for event, embedded_planning in embedded_planning_list:
             sync_event_metadata_with_planning_items(None, event.to_dict(), embedded_planning)
 
-    async def create(self, docs: list[EventResourceModel]):
+    async def create(self, docs: list[EventResourceModel]) -> list[EventResourceModel]:
         """
         Extracts out the ``embedded_planning`` before saving the Event(s)
         And then uses them to synchronise/process the associated Planning item(s)
@@ -152,11 +152,11 @@ class EventsAsyncService(BasePlanningAsyncService[EventResourceModel]):
 
         embedded_planning_list = self._extract_embedded_planning(docs)
         await self.prepare_events_data(docs)
-        ids = await super().create(docs)
+        new_events = await super().create(docs)
 
         self._synchronise_associated_plannings(embedded_planning_list)
 
-        return ids
+        return new_events
 
     async def prepare_events_data(self, docs: list[EventResourceModel]) -> None:
         """

--- a/server/planning/events/events_tests.py
+++ b/server/planning/events/events_tests.py
@@ -608,7 +608,7 @@ class EventsRelatedPlanningAutoPublish(EventsBaseTestCase):
             ]
         )
 
-        event_item = await self.events_service.find_by_id_raw(new_events.id)
+        event_item = await self.events_service.find_by_id_raw(new_events[0].id)
         self.assertIsNotNone(event_item)
         self.assertEqual(event_item["pubstatus"], POST_STATE.USABLE)
 

--- a/server/planning/events/events_tests.py
+++ b/server/planning/events/events_tests.py
@@ -388,7 +388,7 @@ class EventPlanningSchedule(EventsBaseTestCase):
             },
         }
 
-        ids = await self.events_service.create([event])
+        await self.events_service.create([event])
         events = await self._get_all_events_raw()
         self.assertPlanningSchedule(events, 3)
 
@@ -489,7 +489,7 @@ class EventsRelatedPlanningAutoPublish(EventsBaseTestCase):
             "name": "Demo ",
             "update_method": "single",
         }
-        event_id = await self.events_service.create([event])
+        new_events = await self.events_service.create([event])
         planning = {
             "planning_date": datetime(2099, 11, 21, 12, 00, 00, tzinfo=pytz.UTC),
             "name": "Demo 1",
@@ -500,7 +500,7 @@ class EventsRelatedPlanningAutoPublish(EventsBaseTestCase):
             "agendas": [],
             "languages": ["en"],
             "user": "12234553",
-            "related_events": [PlanningRelatedEventLink(_id=event_id[0], link_type="primary")],
+            "related_events": [PlanningRelatedEventLink(_id=new_events[0].id, link_type="primary")],
             "coverages": [
                 {
                     "coverage_id": "urn:newsml:localhost:5000:2023-09-08T17:40:56.290922:e264a179-5b1a-4b52-b73b-332660848cae",
@@ -520,7 +520,7 @@ class EventsRelatedPlanningAutoPublish(EventsBaseTestCase):
                 }
             ],
         }
-        planning_id = await planning_service.create([planning])
+        new_plannings = await planning_service.create([planning])
         schema = {
             "language": {
                 "languages": ["en", "de"],
@@ -549,14 +549,14 @@ class EventsRelatedPlanningAutoPublish(EventsBaseTestCase):
         )
         now = utcnow()
         get_resource_service("events_post").post(
-            [{"event": event_id[0], "pubstatus": "usable", "update_method": "single", "failed_planning_ids": []}]
+            [{"event": new_events[0].id, "pubstatus": "usable", "update_method": "single", "failed_planning_ids": []}]
         )
 
-        event_item = await self.events_service.find_by_id_raw(event_id[0])
+        event_item = await self.events_service.find_by_id_raw(new_events[0].id)
         self.assertEqual(len([event_item]), 1)
         self.assertEqual(event_item.get("state"), "scheduled")
 
-        planning_item = await planning_service.find_by_id_raw(planning_id[0])
+        planning_item = await planning_service.find_by_id_raw(new_plannings[0].id)
         self.assertEqual(len([planning_item]), 1)
         self.assertEqual(planning_item.get("state"), "scheduled")
         assert now <= arrow.get(planning_item.get("versionposted")).datetime < now + timedelta(seconds=5)
@@ -575,7 +575,7 @@ class EventsRelatedPlanningAutoPublish(EventsBaseTestCase):
                 }
             ],
         )
-        event_id = await self.events_service.create(
+        new_events = await self.events_service.create(
             [
                 {
                     "type": "event",
@@ -595,24 +595,24 @@ class EventsRelatedPlanningAutoPublish(EventsBaseTestCase):
             ]
         )
         get_resource_service("events_post").post(
-            [{"event": event_id[0], "pubstatus": "usable", "update_method": "single", "failed_planning_ids": []}]
+            [{"event": new_events[0].id, "pubstatus": "usable", "update_method": "single", "failed_planning_ids": []}]
         )
-        planning_id = await planning_service.create(
+        new_plannings = await planning_service.create(
             [
                 {
                     "planning_date": datetime(2099, 11, 21, 12, 00, 00, tzinfo=pytz.UTC),
                     "name": "Demo 1",
                     "type": "planning",
-                    "related_events": [RelatedEvent(id=event_id[0], link_type="primary")],
+                    "related_events": [RelatedEvent(id=new_events[0].id, link_type="primary")],
                 }
             ]
         )
 
-        event_item = await self.events_service.find_by_id_raw(event_id)
+        event_item = await self.events_service.find_by_id_raw(new_events.id)
         self.assertIsNotNone(event_item)
         self.assertEqual(event_item["pubstatus"], POST_STATE.USABLE)
 
-        planning_item = await planning_service.find_by_id_raw(planning_id[0])
+        planning_item = await planning_service.find_by_id_raw(new_plannings[0].id)
         self.assertIsNotNone(planning_item)
 
         # TODO-ASYNC: fix once `events_post` is migrated
@@ -644,7 +644,7 @@ class EventsRelatedPlanningAutoPublish(EventsBaseTestCase):
             "name": "Demo ",
             "update_method": "single",
         }
-        event_id = await self.events_service.create([event])
+        new_events = await self.events_service.create([event])
         planning = {
             "planning_date": datetime(2099, 11, 21, 12, 00, 00, tzinfo=pytz.UTC),
             "name": "Demo 1",
@@ -654,7 +654,7 @@ class EventsRelatedPlanningAutoPublish(EventsBaseTestCase):
             "slugline": "slug",
             "agendas": [],
             "languages": ["en"],
-            "event_item": event_id[0],
+            "event_item": new_events[0].id,
             "coverages": [
                 {
                     "coverage_id": "urn:newsmle264a179-5b1a-4b52-b73b-332660848cae",
@@ -674,7 +674,7 @@ class EventsRelatedPlanningAutoPublish(EventsBaseTestCase):
                 }
             ],
         }
-        planning_id = await planning_service.create([planning])
+        new_plannings = await planning_service.create([planning])
         self.app.data.insert(
             "planning_types",
             [
@@ -697,13 +697,13 @@ class EventsRelatedPlanningAutoPublish(EventsBaseTestCase):
             ],
         )
         get_resource_service("events_post").post(
-            [{"event": event_id[0], "pubstatus": "usable", "update_method": "single", "failed_planning_ids": []}]
+            [{"event": new_events[0].id, "pubstatus": "usable", "update_method": "single", "failed_planning_ids": []}]
         )
 
-        event_item = await self.events_service.find_by_id_raw(event_id[0])
+        event_item = await self.events_service.find_by_id_raw(new_events[0].id)
         self.assertEqual(len([event_item]), 1)
         self.assertEqual(event_item.get("state"), "scheduled")
 
-        planning_item = await planning_service.find_by_id_raw(planning_id[0])
+        planning_item = await planning_service.find_by_id_raw(new_plannings[0].id)
         self.assertEqual(len([planning_item]), 1)
         self.assertEqual(planning_item.get("state"), "scheduled")

--- a/server/planning/module.py
+++ b/server/planning/module.py
@@ -1,8 +1,14 @@
 from asyncio import gather
 from bson import ObjectId
+from quart_babel import gettext
 
-from apps.item_lock.components.item_lock import LOCK_SESSION, LOCK_USER
 from superdesk.core.module import Module, SuperdeskAsyncApp
+
+from superdesk.types import FilterConditionFieldParam, FilterConditionOperator
+from superdesk.publish_async.signals import on_get_available_filter_params
+from apps.item_lock.components.item_lock import LOCK_SESSION, LOCK_USER
+
+from planning.types import AgendasResourceModel
 from planning.agendas_async import agendas_resource_config
 from planning.events import events_resource_config, events_history_resource_config, events_autosave_resource_config
 from planning.events.events_autosave_async_service import EventsAutosaveAsyncService
@@ -28,9 +34,25 @@ async def cleanup_on_session_end(user_id: ObjectId, session_id: ObjectId, is_las
     )
 
 
+async def add_agenda_to_filter_params(fields: list[FilterConditionFieldParam]) -> None:
+    """Add agendas filter to the available list of filter params."""
+
+    enabled_agendas = await AgendasResourceModel.get_service().get_all_list_raw({"is_enabled": True})
+    fields.append(
+        FilterConditionFieldParam(
+            field="agendas",
+            label=gettext("Agendas"),
+            operators=[FilterConditionOperator.IN, FilterConditionOperator.NOT_IN],
+            values=enabled_agendas,
+            value_field="_id",
+        )
+    )
+
+
 def init_planning(app: SuperdeskAsyncApp):
     wsgi_app = app.wsgi.as_any()
     wsgi_app.on_session_end += cleanup_on_session_end
+    on_get_available_filter_params.connect(add_agenda_to_filter_params)
 
 
 module = Module(

--- a/server/planning/planning/planning_service.py
+++ b/server/planning/planning/planning_service.py
@@ -170,7 +170,7 @@ class PlanningAsyncService(BasePlanningAsyncService[PlanningResourceModel]):
                 },
             )
 
-    async def create(self, _docs: list[PlanningResourceModel | dict[str, Any]]) -> list[str]:
+    async def create(self, _docs: list[PlanningResourceModel | dict[str, Any]]) -> list[PlanningResourceModel]:
         docs = await self._convert_dicts_to_model(_docs)
         await self.prepare_planning_data(docs)
         return await super().create(docs)


### PR DESCRIPTION
### Purpose
Prior to https://github.com/superdesk/superdesk-core/pull/2829 PR, Agendas was added into the list of available content filters in core. That PR removed it and replaced it with a signal for other repos/modules to register their own.

### What has changed
Add a signal listener to add Agendas as an available field for Content Filters (for publishing).
[Original code](https://github.com/superdesk/superdesk-core/blob/develop/apps/content_filters/filter_condition/filter_condition_parameters.py#L167)
