### PR TITLE
fix planning date without time showing previous date by default

### DIFF
--- a/client/components/fields/editor/base/dateTime.tsx
+++ b/client/components/fields/editor/base/dateTime.tsx
@@ -45,8 +45,15 @@ export class EditorFieldDateTime extends React.PureComponent<IProps> {
     render() {
         const field = this.props.field;
         const value = get(this.props.item, field, this.props.defaultValue);
-        const momentValue = value != null ? moment(value) : undefined;
         const error = get(this.props.errors ?? {}, field);
+
+        let momentValue : moment.Moment;
+
+        if (value != null) {
+            momentValue = this.props.allDay ? moment.utc(value) : moment(value);
+        } else {
+            momentValue = undefined;
+        }
 
         return (
             <DateTimeInput

--- a/client/utils/planning.tsx
+++ b/client/utils/planning.tsx
@@ -1249,9 +1249,11 @@ function getPlanningByDate(
     plansInList.forEach((plan) => {
         let dates = {};
         let groupDate = null;
+        const planningDate = getPlanningDate(plan);
 
         const setCoverageToDate = (coverage) => {
-            groupDate = getGroupDate(moment(get(coverage, 'planning.scheduled', plan.planning_date)).clone());
+            groupDate = getGroupDate(moment(get(coverage, 'planning.scheduled', planningDate)).clone());
+
             if (!isDateInRange(groupDate, startDate, endDate)) {
                 return;
             }
@@ -1276,7 +1278,7 @@ function getPlanningByDate(
         });
 
         if (isEmpty(dates)) {
-            groupDate = getGroupDate(moment(plan.planning_date).clone());
+            groupDate = getGroupDate(planningDate);
             if (isDateInRange(groupDate, startDate, endDate)) {
                 dates[groupDate.format('YYYY-MM-DD')] = groupDate;
             }
@@ -1295,6 +1297,10 @@ function getPlanningByDate(
     });
 
     return sortBasedOnTBC(days);
+}
+
+function getPlanningDate(planning: IPlanningItem): moment.Moment {
+    return planning.all_day ? moment.utc(planning.planning_date) : moment(planning.planning_date);
 }
 
 function getFeaturedPlanningItemsForDate(items: Array<IPlanningItem>, date: moment.Moment): Array<IPlanningItem> {


### PR DESCRIPTION
STT-139

## Front-end checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)
