### PR TITLE
[SDESK-7519] - Migrate the Planning Duplicate action from a resource/service to a web endpoint

### DIFF
--- a/server/planning/module.py
+++ b/server/planning/module.py
@@ -24,7 +24,7 @@ from planning.published import published_resource_config
 from planning.content_profiles import planning_types_resource_config
 from planning.locations import locations_resource_config
 from .planning_locks import planning_locks as planning_locks_endpoint
-from .planning.views import duplicate_planning_item_endpoint
+from .planning.views import planning_blueprint
 
 
 async def cleanup_on_session_end(user_id: ObjectId, session_id: ObjectId, is_last_session: bool) -> None:
@@ -59,7 +59,7 @@ def init_planning(app: SuperdeskAsyncApp):
 module = Module(
     "planning",
     init=init_planning,
-    endpoints=[planning_locks_endpoint, duplicate_planning_item_endpoint],
+    endpoints=[planning_locks_endpoint, planning_blueprint],
     resources=[
         events_resource_config,
         planning_resource_config,

--- a/server/planning/module.py
+++ b/server/planning/module.py
@@ -24,6 +24,7 @@ from planning.published import published_resource_config
 from planning.content_profiles import planning_types_resource_config
 
 from .planning_locks import planning_locks as planning_locks_endpoint
+from .planning.views import planning_endpoints
 
 
 async def cleanup_on_session_end(user_id: ObjectId, session_id: ObjectId, is_last_session: bool) -> None:
@@ -58,9 +59,7 @@ def init_planning(app: SuperdeskAsyncApp):
 module = Module(
     "planning",
     init=init_planning,
-    endpoints=[
-        planning_locks_endpoint,
-    ],
+    endpoints=[planning_locks_endpoint, planning_endpoints],
     resources=[
         events_resource_config,
         planning_resource_config,

--- a/server/planning/module.py
+++ b/server/planning/module.py
@@ -24,7 +24,7 @@ from planning.published import published_resource_config
 from planning.content_profiles import planning_types_resource_config
 from planning.locations import locations_resource_config
 from .planning_locks import planning_locks as planning_locks_endpoint
-from .planning.views import planning_endpoints
+from .planning.views import duplicate_planning_item_endpoint
 
 
 async def cleanup_on_session_end(user_id: ObjectId, session_id: ObjectId, is_last_session: bool) -> None:
@@ -59,7 +59,7 @@ def init_planning(app: SuperdeskAsyncApp):
 module = Module(
     "planning",
     init=init_planning,
-    endpoints=[planning_locks_endpoint, planning_endpoints],
+    endpoints=[planning_locks_endpoint, duplicate_planning_item_endpoint],
     resources=[
         events_resource_config,
         planning_resource_config,

--- a/server/planning/module.py
+++ b/server/planning/module.py
@@ -24,7 +24,7 @@ from planning.published import published_resource_config
 from planning.content_profiles import planning_types_resource_config
 from planning.locations import locations_resource_config
 from .planning_locks import planning_locks as planning_locks_endpoint
-from .planning.views import planning_blueprint
+from .planning.views import planning_endpoint_group
 
 
 async def cleanup_on_session_end(user_id: ObjectId, session_id: ObjectId, is_last_session: bool) -> None:
@@ -59,7 +59,7 @@ def init_planning(app: SuperdeskAsyncApp):
 module = Module(
     "planning",
     init=init_planning,
-    endpoints=[planning_locks_endpoint, planning_blueprint],
+    endpoints=[planning_locks_endpoint, planning_endpoint_group],
     resources=[
         events_resource_config,
         planning_resource_config,

--- a/server/planning/planning/__init__.py
+++ b/server/planning/planning/__init__.py
@@ -27,7 +27,6 @@ from .planning_lock import (
     PlanningUnlockService,
 )
 from .planning_post import PlanningPostService, PlanningPostResource
-from .planning_duplicate import PlanningDuplicateService, PlanningDuplicateResource
 from .planning_cancel import PlanningCancelService, PlanningCancelResource
 from .planning_reschedule import PlanningRescheduleService, PlanningRescheduleResource
 from .planning_postpone import PlanningPostponeService, PlanningPostponeResource
@@ -84,9 +83,6 @@ def init_app(app):
 
     planning_post_service = PlanningPostService("planning_post", backend=superdesk.get_backend())
     PlanningPostResource("planning_post", app=app, service=planning_post_service)
-
-    planning_duplicate_service = PlanningDuplicateService("planning_duplicate", backend=superdesk.get_backend())
-    PlanningDuplicateResource("planning_duplicate", app=app, service=planning_duplicate_service)
 
     files_service = PlanningFilesService("planning_files", backend=superdesk.get_backend())
     PlanningFilesResource("planning_files", app=app, service=files_service)

--- a/server/planning/planning/planning_duplicate.py
+++ b/server/planning/planning/planning_duplicate.py
@@ -100,7 +100,7 @@ def duplicate_planning_item(original: dict[str, Any]) -> PlanningResourceModel:
     return PlanningResourceModel(**new_plan)
 
 
-async def process_planning_item_duplicate(original: dict[str, Any]) -> list[str]:
+async def process_planning_item_duplicate(parent_plan: dict[str, Any]) -> list[str]:
     """
     Function to duplicate planning item.
 
@@ -110,9 +110,7 @@ async def process_planning_item_duplicate(original: dict[str, Any]) -> list[str]
     planning_service = PlanningAsyncService()
     history_service = PlanningHistoryAsyncService()
 
-    parent_id = original[ID_FIELD]
-    parent_plan = await planning_service.find_by_id_raw(parent_id)
-    assert parent_plan is not None, "Expected parent_plan to be a dict, got None"
+    parent_id = parent_plan[ID_FIELD]
     new_plan = duplicate_planning_item(parent_plan)
 
     await planning_service.on_create([new_plan])

--- a/server/planning/planning/planning_duplicate.py
+++ b/server/planning/planning/planning_duplicate.py
@@ -10,18 +10,14 @@
 
 import logging
 from copy import deepcopy
+from typing import Any
 
 from superdesk.core import get_app_config
 from superdesk.resource_fields import ID_FIELD
-from superdesk.flask import request
-from superdesk import get_resource_service
-from superdesk.resource import Resource
-from superdesk.services import BaseService
-from superdesk.metadata.utils import item_url, generate_guid
+from superdesk.metadata.utils import generate_guid
 from superdesk.metadata.item import GUID_NEWSML
 from superdesk.utc import utcnow, utc_to_local
 
-from planning.utils import get_related_event_links_for_planning, get_related_event_items_for_planning
 from planning.common import (
     ITEM_STATE,
     WORKFLOW_STATE,
@@ -29,104 +25,101 @@ from planning.common import (
     get_coverage_status_from_cv,
     get_config_planning_duplicate_retain_assignee_details,
 )
+from planning.planning import PlanningAsyncService, PlanningHistoryAsyncService
+from planning.types.planning import PlanningResourceModel
+from planning.utils import get_related_event_links_for_planning, get_related_event_items_for_planning
 
 
 logger = logging.getLogger(__name__)
 
 
-class PlanningDuplicateResource(Resource):
-    endpoint_name = "planning_duplicate"
-    resource_title = endpoint_name
+def duplicate_planning_item(original: dict[str, Any]) -> PlanningResourceModel:
+    new_plan = deepcopy(original)
+    related_events = get_related_event_links_for_planning(original)
 
-    url = "planning/<{0}:item_id>/duplicate".format(item_url)
+    if len(related_events):
+        if original.get("expired") or original.get(ITEM_STATE) == WORKFLOW_STATE.RESCHEDULED:
+            # If the Planning item has expired, or has been rescheduled, and is associated with an Event
+            # then we remove the link to the associated Events as the Event would have been expired also.
+            new_plan["related_events"] = []
+        elif original.get(ITEM_STATE) == WORKFLOW_STATE.CANCELLED:
+            events_to_remove = []
 
-    resource_methods = ["POST"]
-    item_methods = []
+            for related_event in get_related_event_items_for_planning(original):
+                if related_event.get(ITEM_STATE) == WORKFLOW_STATE.CANCELLED:
+                    # If both the Planning and Events are cancelled, then unlink this Event
+                    events_to_remove.append(related_event[ID_FIELD])
 
-    privileges = {"POST": "planning_planning_management"}
+            # Remove any of the Event's flagged to be removed from above
+            if len(events_to_remove):
+                new_plan["related_events"] = [
+                    related_event for related_event in related_events if related_event["_id"] not in events_to_remove
+                ]
+
+    for f in (
+        "_id",
+        "guid",
+        "lock_user",
+        "lock_time",
+        "original_creator",
+        "_planning_schedule",
+        "lock_session",
+        "lock_action",
+        "_created",
+        "_updated",
+        "_etag",
+        "pubstatus",
+        "expired",
+        "featured",
+        "state_reason",
+        "_updates_schedule",
+    ):
+        new_plan.pop(f, None)
+
+    new_plan[ITEM_STATE] = WORKFLOW_STATE.DRAFT
+    new_plan["guid"] = generate_guid(type=GUID_NEWSML)
+
+    default_timezone = get_app_config("DEFAULT_TIMEZONE")
+    planning_datetime = utc_to_local(default_timezone, new_plan.get("planning_date"))
+    local_datetime = utc_to_local(default_timezone, utcnow())
+    if planning_datetime.date() < local_datetime.date():
+        new_plan["planning_date"] = new_plan["planning_date"] + (local_datetime.date() - planning_datetime.date())
+
+    for cov in new_plan.get("coverages") or []:
+        cov.get("planning", {}).pop("workflow_status_reason", None)
+        cov.pop("scheduled_updates", None)
+        cov.get("planning", {})["scheduled"] = new_plan.get("planning_date")
+        cov["coverage_id"] = TEMP_ID_PREFIX + "duplicate"
+        cov["workflow_status"] = WORKFLOW_STATE.DRAFT
+        cov["news_coverage_status"] = get_coverage_status_from_cv("ncostat:int")
+        cov["news_coverage_status"].pop("is_active", None)
+
+        if not get_config_planning_duplicate_retain_assignee_details():
+            cov.pop("assigned_to", None)
+
+    return PlanningResourceModel(**new_plan)
 
 
-class PlanningDuplicateService(BaseService):
-    def create(self, docs, **kwargs):
-        history_service = get_resource_service("planning_history")
-        planning_service = get_resource_service("planning")
+async def process_planning_item_duplicate(original: dict[str, Any]) -> list[str]:
+    """
+    Function to duplicate planning item.
 
-        parent_id = request.view_args["item_id"]
-        parent_plan = planning_service.find_one(req=None, _id=parent_id)
-        new_plan = self._duplicate_planning(parent_plan)
+    :param original: The original planning item.
+    :return: List of new planning item guid.
+    """
+    planning_service = PlanningAsyncService()
+    history_service = PlanningHistoryAsyncService()
 
-        planning_service.on_create([new_plan])
-        planning_service.create([new_plan])
+    parent_id = original[ID_FIELD]
+    parent_plan = await planning_service.find_by_id_raw(parent_id)
+    assert parent_plan is not None, "Expected parent_plan to be a dict, got None"
+    new_plan = duplicate_planning_item(parent_plan)
 
-        history_service.on_duplicate(parent_plan, new_plan)
-        history_service.on_duplicate_from(new_plan, parent_id)
-        planning_service.on_duplicated(new_plan, parent_id)
+    await planning_service.on_create([new_plan])
+    await planning_service.create([new_plan])
 
-        return [new_plan["guid"]]
+    await history_service.on_duplicate(parent_plan, new_plan.to_dict())
+    await history_service.on_duplicate_from(new_plan.to_dict(), parent_id)
+    await planning_service.on_duplicated(new_plan.to_dict(), parent_id)
 
-    def _duplicate_planning(self, original):
-        new_plan = deepcopy(original)
-        related_events = get_related_event_links_for_planning(original)
-
-        if len(related_events):
-            if original.get("expired") or original.get(ITEM_STATE) == WORKFLOW_STATE.RESCHEDULED:
-                # If the Planning item has expired, or has been rescheduled, and is associated with an Event
-                # then we remove the link to the associated Events as the Event would have been expired also.
-                new_plan["related_events"] = []
-            elif original.get(ITEM_STATE) == WORKFLOW_STATE.CANCELLED:
-                events_to_remove = []
-
-                for related_event in get_related_event_items_for_planning(original):
-                    if related_event.get(ITEM_STATE) == WORKFLOW_STATE.CANCELLED:
-                        # If both the Planning and Events are cancelled, then unlink this Event
-                        events_to_remove.append(related_event[ID_FIELD])
-
-                # Remove any of the Event's flagged to be removed from above
-                if len(events_to_remove):
-                    new_plan["related_events"] = [
-                        related_event
-                        for related_event in related_events
-                        if related_event["_id"] not in events_to_remove
-                    ]
-
-        for f in (
-            "_id",
-            "guid",
-            "lock_user",
-            "lock_time",
-            "original_creator",
-            "_planning_schedule" "lock_session",
-            "lock_action",
-            "_created",
-            "_updated",
-            "_etag",
-            "pubstatus",
-            "expired",
-            "featured",
-            "state_reason",
-            "_updates_schedule",
-        ):
-            new_plan.pop(f, None)
-
-        new_plan[ITEM_STATE] = WORKFLOW_STATE.DRAFT
-        new_plan["guid"] = generate_guid(type=GUID_NEWSML)
-
-        default_timezone = get_app_config("DEFAULT_TIMEZONE")
-        planning_datetime = utc_to_local(default_timezone, new_plan.get("planning_date"))
-        local_datetime = utc_to_local(default_timezone, utcnow())
-        if planning_datetime.date() < local_datetime.date():
-            new_plan["planning_date"] = new_plan["planning_date"] + (local_datetime.date() - planning_datetime.date())
-
-        for cov in new_plan.get("coverages") or []:
-            cov.get("planning", {}).pop("workflow_status_reason", None)
-            cov.pop("scheduled_updates", None)
-            cov.get("planning", {})["scheduled"] = new_plan.get("planning_date")
-            cov["coverage_id"] = TEMP_ID_PREFIX + "duplicate"
-            cov["workflow_status"] = WORKFLOW_STATE.DRAFT
-            cov["news_coverage_status"] = get_coverage_status_from_cv("ncostat:int")
-            cov["news_coverage_status"].pop("is_active", None)
-
-            if not get_config_planning_duplicate_retain_assignee_details():
-                cov.pop("assigned_to", None)
-
-        return new_plan
+    return [new_plan.guid]

--- a/server/planning/planning/planning_duplicate.py
+++ b/server/planning/planning/planning_duplicate.py
@@ -100,7 +100,7 @@ def duplicate_planning_item(original: dict[str, Any]) -> PlanningResourceModel:
     return PlanningResourceModel(**new_plan)
 
 
-async def process_planning_item_duplicate(parent_plan: dict[str, Any]) -> list[str]:
+async def process_planning_item_duplicate(parent_plan: dict[str, Any]) -> dict[str, Any]:
     """
     Function to duplicate planning item.
 
@@ -112,12 +112,13 @@ async def process_planning_item_duplicate(parent_plan: dict[str, Any]) -> list[s
 
     parent_id = parent_plan[ID_FIELD]
     new_plan = duplicate_planning_item(parent_plan)
+    new_plan_dict = new_plan.to_dict()
 
     await planning_service.on_create([new_plan])
     await planning_service.create([new_plan])
 
-    await history_service.on_duplicate(parent_plan, new_plan.to_dict())
-    await history_service.on_duplicate_from(new_plan.to_dict(), parent_id)
-    await planning_service.on_duplicated(new_plan.to_dict(), parent_id)
+    await history_service.on_duplicate(parent_plan, new_plan_dict)
+    await history_service.on_duplicate_from(new_plan_dict, parent_id)
+    await planning_service.on_duplicated(new_plan_dict, parent_id)
 
-    return [new_plan.guid]
+    return new_plan_dict

--- a/server/planning/planning/planning_service.py
+++ b/server/planning/planning/planning_service.py
@@ -54,6 +54,7 @@ from planning.utils import (
     get_planning_event_link_method,
     get_first_related_event_id_for_planning,
     get_related_event_ids_for_planning,
+    get_related_event_items_for_planning,
 )
 
 from .planning_utils import get_coverage_by_id
@@ -1559,3 +1560,37 @@ class PlanningAsyncService(BasePlanningAsyncService[PlanningResourceModel]):
             logger.exception("Error creating media file. {}. Exception: {}".format(coverage_msg, e))
 
         return None
+
+    async def on_duplicated(self, doc: dict[str, Any], parent_id: str):
+        await self._update_event_history(doc)
+        session_id = get_auth().get("_id")
+        push_notification(
+            "planning:duplicated",
+            item=str(doc.get(ID_FIELD)),
+            original=str(parent_id),
+            user=str(doc.get("original_creator", "")),
+            added_agendas=doc.get("agendas") or [],
+            removed_agendas=[],
+            session=session_id,
+        )
+
+    async def _update_event_history(self, doc: dict[str, Any]):
+        from planning.events import EventsAsyncService, EventsHistoryAsyncService
+
+        events_service = EventsAsyncService()
+        events_history_service = EventsHistoryAsyncService()
+
+        for original_event in get_related_event_items_for_planning(doc, "primary"):
+            await events_service.system_update(
+                original_event[ID_FIELD],
+                {
+                    "expiry": None,
+                    # Event hasn't actually been updated
+                    # So we leave these version dates alone
+                    "_updated": original_event["_updated"],
+                    "versioncreated": original_event["versioncreated"],
+                },
+            )
+            await events_history_service.on_item_updated(
+                {"planning_id": doc[ID_FIELD]}, original_event, "planning_created"
+            )

--- a/server/planning/planning/views.py
+++ b/server/planning/planning/views.py
@@ -10,14 +10,14 @@ from superdesk.core.web import EndpointGroup
 from superdesk.core.types import Request, Response
 
 
-planning_blueprint: EndpointGroup = EndpointGroup("planning", __name__)
+planning_endpoint_group: EndpointGroup = EndpointGroup("planning", __name__)
 
 
 class PlanningArgs(BaseModel):
     planning_id: str
 
 
-@planning_blueprint.endpoint(
+@planning_endpoint_group.endpoint(
     "planning/spike/<string:planning_id>",
     name="planning_spike",
     methods=["PATCH"],
@@ -34,7 +34,7 @@ async def spike_planning_item(args: PlanningArgs, params: None, request: Request
     return Response(spiked_planning_item)
 
 
-@planning_blueprint.endpoint(
+@planning_endpoint_group.endpoint(
     "planning/unspike/<string:planning_id>",
     name="planning_unspike",
     methods=["PATCH"],
@@ -51,7 +51,7 @@ async def unspike_planning_item(args: PlanningArgs, params: None, request: Reque
     return Response(unspiked_planning_item)
 
 
-@planning_blueprint.endpoint(
+@planning_endpoint_group.endpoint(
     "planning/<string:planning_id>/duplicate",
     name="planning_duplicate",
     methods=["POST"],

--- a/server/planning/planning/views.py
+++ b/server/planning/planning/views.py
@@ -1,3 +1,4 @@
+from planning.planning.planning_duplicate import process_planning_item_duplicate
 from pydantic import BaseModel
 
 from planning.planning import PlanningAsyncService
@@ -48,3 +49,19 @@ async def unspike_planning_item(args: PlanningArgs, params: None, request: Reque
     unspiked_planning_item = await process_unspike_planning_item(updates, original)
 
     return Response(unspiked_planning_item)
+
+
+@blueprint.endpoint(
+    "planning/<string:planning_id>/duplicate",
+    name="planning_duplicate",
+    methods=["POST"],
+    auth=[required_privilege_rule("planning_planning_management")],
+)
+async def duplicate_planning_item(args: PlanningArgs, params: None, request: Request) -> Response:
+    original = await PlanningAsyncService().find_by_id_raw(args.planning_id)
+    if not original:
+        await request.abort(404, "Planning Item not found")
+
+    duplicated_planning_item = await process_planning_item_duplicate(original)
+
+    return Response(duplicated_planning_item)

--- a/server/planning/planning/views.py
+++ b/server/planning/planning/views.py
@@ -10,14 +10,14 @@ from superdesk.core.web import EndpointGroup
 from superdesk.core.types import Request, Response
 
 
-blueprint = EndpointGroup("planning", __name__)
+planning_blueprint: EndpointGroup = EndpointGroup("planning", __name__)
 
 
 class PlanningArgs(BaseModel):
     planning_id: str
 
 
-@blueprint.endpoint(
+@planning_blueprint.endpoint(
     "planning/spike/<string:planning_id>",
     name="planning_spike",
     methods=["PATCH"],
@@ -34,7 +34,7 @@ async def spike_planning_item(args: PlanningArgs, params: None, request: Request
     return Response(spiked_planning_item)
 
 
-@blueprint.endpoint(
+@planning_blueprint.endpoint(
     "planning/unspike/<string:planning_id>",
     name="planning_unspike",
     methods=["PATCH"],
@@ -51,13 +51,13 @@ async def unspike_planning_item(args: PlanningArgs, params: None, request: Reque
     return Response(unspiked_planning_item)
 
 
-@blueprint.endpoint(
+@planning_blueprint.endpoint(
     "planning/<string:planning_id>/duplicate",
     name="planning_duplicate",
     methods=["POST"],
     auth=[required_privilege_rule("planning_planning_management")],
 )
-async def duplicate_planning_item_endpoint(args: PlanningArgs, params: None, request: Request) -> Response:
+async def duplicate_planning_item(args: PlanningArgs, params: None, request: Request) -> Response:
     original = await PlanningAsyncService().find_by_id_raw(args.planning_id)
     if not original:
         await request.abort(404, "Planning Item not found")

--- a/server/planning/planning/views.py
+++ b/server/planning/planning/views.py
@@ -1,8 +1,8 @@
-from planning.planning.planning_duplicate import process_planning_item_duplicate
 from pydantic import BaseModel
 
 from planning.planning import PlanningAsyncService
 from planning.planning.planning_spike_async import process_spike_planning_item, process_unspike_planning_item
+from planning.planning.planning_duplicate import process_planning_item_duplicate
 from planning.utils import get_json_or_400_async
 
 from superdesk.core.auth.privilege_rules import required_privilege_rule
@@ -10,14 +10,14 @@ from superdesk.core.web import EndpointGroup
 from superdesk.core.types import Request, Response
 
 
-planning_endpoints = EndpointGroup("planning", __name__)
+blueprint = EndpointGroup("planning", __name__)
 
 
 class PlanningArgs(BaseModel):
     planning_id: str
 
 
-@planning_endpoints.endpoint(
+@blueprint.endpoint(
     "planning/spike/<string:planning_id>",
     name="planning_spike",
     methods=["PATCH"],
@@ -34,7 +34,7 @@ async def spike_planning_item(args: PlanningArgs, params: None, request: Request
     return Response(spiked_planning_item)
 
 
-@planning_endpoints.endpoint(
+@blueprint.endpoint(
     "planning/unspike/<string:planning_id>",
     name="planning_unspike",
     methods=["PATCH"],
@@ -51,13 +51,13 @@ async def unspike_planning_item(args: PlanningArgs, params: None, request: Reque
     return Response(unspiked_planning_item)
 
 
-@planning_endpoints.endpoint(
+@blueprint.endpoint(
     "planning/<string:planning_id>/duplicate",
     name="planning_duplicate",
     methods=["POST"],
     auth=[required_privilege_rule("planning_planning_management")],
 )
-async def duplicate_planning_item(args: PlanningArgs, params: None, request: Request) -> Response:
+async def duplicate_planning_item_endpoint(args: PlanningArgs, params: None, request: Request) -> Response:
     original = await PlanningAsyncService().find_by_id_raw(args.planning_id)
     if not original:
         await request.abort(404, "Planning Item not found")

--- a/server/planning/planning/views.py
+++ b/server/planning/planning/views.py
@@ -10,14 +10,14 @@ from superdesk.core.web import EndpointGroup
 from superdesk.core.types import Request, Response
 
 
-blueprint = EndpointGroup("planning", __name__)
+planning_endpoints = EndpointGroup("planning", __name__)
 
 
 class PlanningArgs(BaseModel):
     planning_id: str
 
 
-@blueprint.endpoint(
+@planning_endpoints.endpoint(
     "planning/spike/<string:planning_id>",
     name="planning_spike",
     methods=["PATCH"],
@@ -34,7 +34,7 @@ async def spike_planning_item(args: PlanningArgs, params: None, request: Request
     return Response(spiked_planning_item)
 
 
-@blueprint.endpoint(
+@planning_endpoints.endpoint(
     "planning/unspike/<string:planning_id>",
     name="planning_unspike",
     methods=["PATCH"],
@@ -51,7 +51,7 @@ async def unspike_planning_item(args: PlanningArgs, params: None, request: Reque
     return Response(unspiked_planning_item)
 
 
-@blueprint.endpoint(
+@planning_endpoints.endpoint(
     "planning/<string:planning_id>/duplicate",
     name="planning_duplicate",
     methods=["POST"],


### PR DESCRIPTION
### Purpose
This PR upgrades planning duplicate action resources to async endpoints

- Create endpoints for planning duplicate action
- Applied auth rules to the new endpoint
- Updated the pure functions for planning duplicate action based off old implementation.
- Remove old resource/service code
- Regitered endpoint to planning module
- Extra: Added async `on_duplicated` function to PlanningAsyncService as it is used by planning duplicate and was in old planning service.

Solves: [SDESK-7519](https://sofab.atlassian.net/browse/SDESK-7519)

[SDESK-7519]: https://sofab.atlassian.net/browse/SDESK-7519
