### PR TITLE
Fix category adapter for related plannings

### DIFF
--- a/client/components/editor-standalone/field-definitions/category-field.ts
+++ b/client/components/editor-standalone/field-definitions/category-field.ts
@@ -1,7 +1,27 @@
 import {IDropdownConfigVocabulary, IAuthoringFieldV2, IVocabularyItem} from 'superdesk-api';
 import {superdeskApi} from '../../../superdeskApi';
+import {IFieldDefinition, IFieldStorageAdapter} from './interfaces';
 
-export const getCategoriesField = () => ({
+function getStorageAdapterCommon<T extends IPlanningItem | IEventItem>(): IFieldStorageAdapter<T> {
+    const storageAdapterCommon: IFieldStorageAdapter<T> = {
+        storeValue: (item, operationalValue: Array<string>) => {
+            const vocabulary = superdeskApi.entities.vocabulary.getAll().get('categories');
+            const vocabularyItems = new Map<IVocabularyItem['qcode'], IVocabularyItem>(
+                vocabulary.items.map((item) => [item.qcode, item]),
+            );
+
+            return {
+                ...item,
+                anpa_category: operationalValue.map((qcode) => vocabularyItems.get(qcode)),
+            };
+        },
+        retrieveStoredValue: (item, fieldId) => (item[fieldId] ?? []).map(({qcode}) => qcode),
+    };
+
+    return storageAdapterCommon;
+}
+
+export const getCategoriesField = (): IFieldDefinition => ({
     fieldId: 'anpa_category',
     getField: ({id, required}) => {
         const fieldConfig: IDropdownConfigVocabulary = {
@@ -20,18 +40,6 @@ export const getCategoriesField = () => ({
 
         return field;
     },
-    storageAdapter: {
-        storeValue: (item, operationalValue: Array<string>) => {
-            const vocabulary = superdeskApi.entities.vocabulary.getAll().get('categories');
-            const vocabularyItems = new Map<IVocabularyItem['qcode'], IVocabularyItem>(
-                vocabulary.items.map((item) => [item.qcode, item]),
-            );
-
-            return {
-                ...item,
-                anpa_category: operationalValue.map((qcode) => vocabularyItems.get(qcode)),
-            };
-        },
-        retrieveStoredValue: (item, fieldId) => (item[fieldId] ?? []).map(({qcode}) => qcode),
-    },
+    storageAdapterPlanning: getStorageAdapterCommon(),
+    storageAdapterEvent: getStorageAdapterCommon(),
 });

--- a/client/components/editor-standalone/field-definitions/contacts.ts
+++ b/client/components/editor-standalone/field-definitions/contacts.ts
@@ -1,7 +1,8 @@
 import {IAuthoringFieldV2} from 'superdesk-api';
 import {superdeskApi} from '../../../superdeskApi';
+import {IFieldDefinition} from './interfaces';
 
-export const getContactsField = () => ({
+export const getContactsField = (): IFieldDefinition => ({
     fieldId: 'event_contact_info',
     getField: ({id, required}) => {
         const field: IAuthoringFieldV2 = {

--- a/client/components/editor-standalone/field-definitions/locations-field.ts
+++ b/client/components/editor-standalone/field-definitions/locations-field.ts
@@ -1,7 +1,8 @@
 import {IAuthoringFieldV2} from 'superdesk-api';
 import {superdeskApi} from '../../../superdeskApi';
+import {IFieldDefinition} from './interfaces';
 
-export const getLocationsField = () => ({
+export const getLocationsField = (): IFieldDefinition => ({
     fieldId: 'location',
     getField: ({id, required}) => {
         const field: IAuthoringFieldV2 = {


### PR DESCRIPTION
STT-151

Return type wasn't defined so it was setting the `storageAdapter` property which no longer exists which in turn meant that no adapter was being used. Now we have `storageAdapterPlanning` / `storageAdapterEvent` for each item type respectively.

## Front-end checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [x] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [x] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [x] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [x] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [x] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [x] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [x] This pull request is not adding redux based modals
- [x] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [x] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)
