### PR TITLE
[SDESK-7518] - Migrate the Planning Postpone action from a resource/service to a web endpoint

### DIFF
--- a/server/planning/planning/__init__.py
+++ b/server/planning/planning/__init__.py
@@ -29,7 +29,6 @@ from .planning_lock import (
 from .planning_post import PlanningPostService, PlanningPostResource
 from .planning_cancel import PlanningCancelService, PlanningCancelResource
 from .planning_reschedule import PlanningRescheduleService, PlanningRescheduleResource
-from .planning_postpone import PlanningPostponeService, PlanningPostponeResource
 from .planning_autosave import PlanningAutosaveResource, PlanningAutosaveService
 from .planning_featured_lock import (
     PlanningFeaturedLockResource,
@@ -99,15 +98,6 @@ def init_app(app):
         PlanningRescheduleResource.endpoint_name,
         app=app,
         service=planning_reschedule_service,
-    )
-
-    planning_postpone_service = PlanningPostponeService(
-        PlanningPostponeResource.endpoint_name, backend=superdesk.get_backend()
-    )
-    PlanningPostponeResource(
-        PlanningPostponeResource.endpoint_name,
-        app=app,
-        service=planning_postpone_service,
     )
 
     planning_history_service = PlanningHistoryService("planning_history", backend=superdesk.get_backend())

--- a/server/planning/planning/__init__.py
+++ b/server/planning/planning/__init__.py
@@ -128,11 +128,11 @@ def init_app(app):
     signals.planning_updated.connect(planning_history_service.on_item_updated)
     signals.planning_spiked.connect(planning_history_service.on_spike)
     signals.planning_unspiked.connect(planning_history_service.on_unspike)
+    signals.planning_postponed.connect(planning_history_service.on_postpone)
 
     app.on_inserted_planning += planning_history_service.on_item_created
     app.on_updated_planning_cancel += planning_history_service.on_cancel
     app.on_updated_planning_reschedule += planning_history_service.on_reschedule
-    app.on_updated_planning_postpone += planning_history_service.on_postpone
 
     app.on_locked_planning += planning_service.on_locked_planning
 

--- a/server/planning/planning/planning_postpone.py
+++ b/server/planning/planning/planning_postpone.py
@@ -8,88 +8,74 @@
 # AUTHORS and LICENSE files distributed with this source code, or
 # at https://www.sourcefabric.org/superdesk/license
 
+from typing import Any
+from copy import deepcopy
 from superdesk.resource_fields import ID_FIELD
-from superdesk.services import BaseService
 from superdesk.notification import push_notification
 from apps.archive.common import get_user, get_auth
-from copy import deepcopy
-from .planning import PlanningResource, planning_schema
+from planning.assignments import AssignmentsAsyncService
 from planning.common import WORKFLOW_STATE, ITEM_STATE, get_coverage_type_name
-from superdesk import get_resource_service
+from planning.planning import PlanningAsyncService
 from planning.planning_notifications import PlanningNotifications
 
-planning_postpone_schema = deepcopy(planning_schema)
-planning_postpone_schema["reason"] = {
-    "type": "string",
-    "nullable": True,
-    "planning_reason": True,
-}
 
+async def postpone_coverage(updates: dict[str, Any], coverage: dict[str, Any]):
+    assignment_service = AssignmentsAsyncService()
 
-class PlanningPostponeResource(PlanningResource):
-    url = "planning/postpone"
-    resource_title = endpoint_name = "planning_postpone"
+    if coverage.get("workflow_status") != WORKFLOW_STATE.CANCELLED:
+        coverage["planning"]["workflow_status_reason"] = updates.get("reason")
 
-    datasource = {"source": "planning"}
-    resource_methods = []
-    item_methods = ["PATCH"]
-    privileges = {"PATCH": "planning_planning_management"}
-    internal_resource = True
-
-    schema = planning_postpone_schema
-
-    merge_nested_documents = True
-
-
-class PlanningPostponeService(BaseService):
-    def update(self, id, updates, original):
-        self._postpone_plan(updates)
-        updates["coverages"] = deepcopy(original.get("coverages"))
-        coverages = updates.get("coverages") or []
-
-        for coverage in coverages:
-            self._postpone_coverage(updates, coverage)
-
-        reason = updates.get("reason", None)
-        if "reason" in updates:
-            del updates["reason"]
-
-        item = self.backend.update(self.datasource, id, updates, original)
-
-        user = get_user(required=True).get(ID_FIELD, "")
-        session = get_auth().get(ID_FIELD, "")
-
-        push_notification(
-            "planning:postponed",
-            item=str(original[ID_FIELD]),
-            user=str(user),
-            session=str(session),
-            reason=reason,
-        )
-
-        return item
-
-    def _postpone_plan(self, updates):
-        updates["state_reason"] = updates.get("reason")
-        updates[ITEM_STATE] = WORKFLOW_STATE.POSTPONED
-
-    def _postpone_coverage(self, updates, coverage):
-        if coverage.get("workflow_status") != WORKFLOW_STATE.CANCELLED:
-            coverage["planning"]["workflow_status_reason"] = updates.get("reason")
-
-        assigned_to = coverage.get("assigned_to")
-        if assigned_to:
-            assignment_service = get_resource_service("assignments")
-            assignment = assignment_service.find_one(req=None, _id=assigned_to.get("assignment_id"))
-            slugline = assignment.get("planning").get("slugline", "")
-            coverage_type = assignment.get("planning").get("g2_content_type", "")
+    assigned_to = coverage.get("assigned_to")
+    if assigned_to:
+        assignment = await assignment_service.find_by_id_raw(assigned_to.get("assignment_id"))
+        if assignment:
+            slugline = assignment.get("planning", {}).get("slugline", "")
+            coverage_type = assignment.get("planning", {}).get("g2_content_type", "")
             PlanningNotifications().notify_assignment(
-                coverage_status=assignment.get("assigned_to").get("state"),
-                target_user=assignment.get("assigned_to").get("user"),
-                target_desk=assignment.get("assigned_to").get("desk")
-                if not assignment.get("assigned_to").get("user")
-                else None,
+                coverage_status=assignment.get("assigned_to", {}).get("state"),
+                target_user=assignment.get("assigned_to", {}).get("user"),
+                target_desk=(
+                    assignment.get("assigned_to", {}).get("desk")
+                    if not assignment.get("assigned_to", {}).get("user")
+                    else None
+                ),
                 message="assignment_postponed_msg",
                 slugline=slugline,
                 coverage_type=get_coverage_type_name(coverage_type),
             )
+
+
+async def process_postpone_planning_item(updates: dict[str, Any], original: dict[str, Any]) -> dict[str, Any]:
+    planning_service = PlanningAsyncService()
+
+    # Postpone the planning_item using reason in updates
+    updates["state_reason"] = updates.get("reason")
+    updates[ITEM_STATE] = WORKFLOW_STATE.POSTPONED
+
+    updates["coverages"] = deepcopy(original.get("coverages"))
+    coverages = updates.get("coverages") or []
+
+    for coverage in coverages:
+        await postpone_coverage(updates, coverage)
+
+    reason = updates.get("reason", None)
+    if "reason" in updates:
+        del updates["reason"]
+
+    planning_item_id = original[ID_FIELD]
+    await planning_service.system_update(planning_item_id, updates)
+    postponed_planning_item = await planning_service.find_by_id_raw(planning_item_id)
+    assert postponed_planning_item is not None, "Expected postponed_planning_item to be a dict, got None"
+
+    user = get_user(required=True).get(ID_FIELD, "")
+    session = get_auth().get(ID_FIELD, "")
+
+    push_notification(
+        "planning:postponed",
+        item=str(planning_item_id),
+        user=str(user),
+        session=str(session),
+        reason=reason,
+    )
+
+    return postponed_planning_item

--- a/server/planning/planning/views.py
+++ b/server/planning/planning/views.py
@@ -3,6 +3,7 @@ from pydantic import BaseModel
 from planning.planning import PlanningAsyncService
 from planning.planning.planning_spike_async import process_spike_planning_item, process_unspike_planning_item
 from planning.planning.planning_duplicate import process_planning_item_duplicate
+from planning.planning.planning_postpone import process_postpone_planning_item
 from planning.utils import get_json_or_400_async
 
 from superdesk.core.auth.privilege_rules import required_privilege_rule
@@ -65,3 +66,20 @@ async def duplicate_planning_item(args: PlanningArgs, params: None, request: Req
     duplicated_planning_item = await process_planning_item_duplicate(original)
 
     return Response(duplicated_planning_item)
+
+
+@planning_endpoint_group.endpoint(
+    "planning/postpone/<string:planning_id>",
+    name="planning_postpone",
+    methods=["PATCH"],
+    auth=[required_privilege_rule("planning_planning_management")],
+)
+async def postpone_planning_item(args: PlanningArgs, params: None, request: Request) -> Response:
+    original = await PlanningAsyncService().find_by_id_raw(args.planning_id)
+    if not original:
+        await request.abort(404, "Planning Item not found")
+
+    updates = await get_json_or_400_async(request)
+    postponed_planning_item = await process_postpone_planning_item(updates, original)
+
+    return Response(postponed_planning_item)

--- a/server/planning/signals.py
+++ b/server/planning/signals.py
@@ -57,3 +57,6 @@ planning_spiked = AsyncSignal[dict, dict]("planning:spiked")
 
 #: Signal for when an Planning Item is unspiked
 planning_unspiked = AsyncSignal[dict, dict]("planning:unspiked")
+
+#: Signal for when an Planning Item is postponed
+planning_postponed = AsyncSignal[dict, dict]("planning:postponed")


### PR DESCRIPTION
### Purpose
This PR upgrades planning postpone action resources to async endpoints

- Create endpoints for planning postpone action
- Applied auth rules to the new endpoint
- Updated the pure functions for planning postpone action based off old implementation.
- Remove old resource/service code
- Registered endpoint to planning module

**NOTE:** Even though PlanningPostpone service has been removed, `planning_postpone` is still referenced in EventsPostpone service which will be changed in the next ticket [SDESK-7517](https://sofab.atlassian.net/browse/SDESK-7517)

Solves: [SDESK-7518](https://sofab.atlassian.net/browse/SDESK-7518)

[SDESK-7518]: https://sofab.atlassian.net/browse/SDESK-7518


[SDESK-7517]: https://sofab.atlassian.net/browse/SDESK-7517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ