### PR TITLE
display all related events in coverage preview

### DIFF
--- a/client/components/Assignments/AssignmentPreviewContainer/AssignmentPreviewContainer_test.tsx
+++ b/client/components/Assignments/AssignmentPreviewContainer/AssignmentPreviewContainer_test.tsx
@@ -49,8 +49,6 @@ describe('<AssignmentPreviewContainer />', () => {
         assignment.assigned_to.state = 'assigned';
         let wrapper = getWrapper().find('.AssignmentPreview');
 
-        expect(wrapper.children().length).toBe(5);
-
         expect(wrapper.hasClass('AssignmentPreview')).toBe(true);
 
         expect(wrapper.childAt(0).type()).toEqual(AssignmentPreviewHeader);
@@ -61,7 +59,6 @@ describe('<AssignmentPreviewContainer />', () => {
             showFulfilAssignment: true,
             hideItemActions: true,
         }).find('.AssignmentPreview');
-        expect(wrapper.children().length).toBe(6);
 
         expect(wrapper.hasClass('AssignmentPreview')).toBe(true);
         expect(wrapper.childAt(0).type()).toEqual(AssignmentPreviewHeader);

--- a/client/components/Assignments/AssignmentPreviewContainer/index.tsx
+++ b/client/components/Assignments/AssignmentPreviewContainer/index.tsx
@@ -21,7 +21,7 @@ import planningActions from '../../../actions/planning/api';
 import {assignmentUtils, eventUtils, planningUtils, getFileDownloadURL} from '../../../utils';
 import {ASSIGNMENTS, WORKSPACE} from '../../../constants';
 
-import {Button} from 'superdesk-ui-framework/react';
+import {Button, Spacer} from 'superdesk-ui-framework/react';
 import {AssignmentPreviewHeader} from './AssignmentPreviewHeader';
 import {AssignmentPreview} from './AssignmentPreview';
 import {ContentBlock, ContentBlockInner} from '../../UI/SidePanel';
@@ -42,7 +42,7 @@ interface IStateProps {
     users: Array<IUser>;
     desks: Array<IDesk>;
     planningItem?: IPlanningItem;
-    eventItem?: IEventItem;
+    relatedEvents: Array<IEventItem>;
 
     priorities: Array<IAssignmentPriority>;
     privileges: {[key: string]: number};
@@ -70,9 +70,11 @@ type IProps = IOwnProps & IStateProps & IDispatchProps;
 
 class AssignmentPreviewContainerComponent extends React.Component<IProps> {
     componentDidMount() {
-        if (eventUtils.shouldFetchFilesForEvent(this.props.eventItem)) {
-            this.props.fetchEventFiles(this.props.eventItem);
-        }
+        this.props.relatedEvents
+            .filter((event) => eventUtils.shouldFetchFilesForEvent(event))
+            .forEach((event) => {
+                this.props.fetchEventFiles(event);
+            });
 
         if (planningUtils.shouldFetchFilesForPlanning(this.props.planningItem)) {
             this.props.fetchPlanningFiles(this.props.planningItem);
@@ -127,7 +129,6 @@ class AssignmentPreviewContainerComponent extends React.Component<IProps> {
             users,
             desks,
             planningItem,
-            eventItem,
             priorities,
             formProfile,
             hideAvatar,
@@ -192,26 +193,34 @@ class AssignmentPreviewContainerComponent extends React.Component<IProps> {
                     />
                 </ContentBlock>
 
-                {eventItem && (
-                    <div className="sd-padding--2 sd-padding-b--0">
-                        <PreviewFieldRelatedArticles
-                            item={eventItem}
-                            languageFilter={assignment.planning.language}
-                        />
-                    </div>
-                )}
-
-                {eventItem && (
+                {this.props.relatedEvents.length > 0 && (
                     <ContentBlock className="AssignmentPreview__event" padSmall={true}>
                         <h3 className="side-panel__heading side-panel__heading--big">
-                            {gettext('Associated Event')}
+                            {gettext('Associated Events')}
                         </h3>
-                        <EventMetadata
-                            event={eventItem}
-                            createUploadLink={getFileDownloadURL}
-                            files={files}
-                            hideEditIcon={true}
-                        />
+
+                        <Spacer v gap="16">
+                            {
+                                this.props.relatedEvents.map((event) => (
+                                    <div key={event._id}>
+                                        <EventMetadata
+                                            key={event._id}
+                                            event={event}
+                                            createUploadLink={getFileDownloadURL}
+                                            files={files}
+                                            hideEditIcon={true}
+                                        />
+
+                                        <div className="sd-padding--2 sd-padding-b--0">
+                                            <PreviewFieldRelatedArticles
+                                                item={event}
+                                                languageFilter={assignment.planning.language}
+                                            />
+                                        </div>
+                                    </div>
+                                ))
+                            }
+                        </Spacer>
                     </ContentBlock>
                 )}
 
@@ -219,8 +228,8 @@ class AssignmentPreviewContainerComponent extends React.Component<IProps> {
                     <h3 className="side-panel__heading side-panel__heading--big">
                         {gettext('Planning')}
                     </h3>
+
                     <RelatedPlannings
-                        className="related-plannings"
                         plannings={[planningItem]}
                         openPlanningItem={true}
                         expandable={true}
@@ -241,9 +250,10 @@ const mapStateToProps = (state) => ({
     session: selectors.general.session(state),
     users: selectors.general.users(state),
     desks: selectors.general.desks(state),
-
     planningItem: selectors.getCurrentAssignmentPlanningItem(state),
-    eventItem: selectors.getCurrentAssignmentEventItem(state),
+
+    // coverages do not have related events; it holds related events of a planning item
+    relatedEvents: selectors.getRelatedEventsForCurrentAssignment(state),
 
     priorities: get(state, 'vocabularies.assignment_priority'),
     privileges: selectors.general.privileges(state),

--- a/client/components/fields/preview/RelatedArticles.tsx
+++ b/client/components/fields/preview/RelatedArticles.tsx
@@ -24,7 +24,7 @@ export function PreviewFieldRelatedArticles({item, languageFilter}: IProps) {
             </h3>
             {relatedItems.length === 0 ? (
                 <span className="sd-text__info">
-                    {gettext('No related articles')}
+                    {gettext('There are no articles related to this event')}
                 </span>
             ) : (
                 relatedItems.map((relatedItem) => (

--- a/client/selectors/assignments.ts
+++ b/client/selectors/assignments.ts
@@ -6,7 +6,6 @@ import {storedEvents} from './events';
 import {storedPlannings} from './planning';
 import {currentDeskId, currentUserId, currentWorkspace} from './general';
 import {getItemsById} from '../utils';
-import {getRelatedEventIdsForPlanning} from '../utils/planning';
 import {ASSIGNMENTS, SORT_DIRECTION} from '../constants';
 
 export const getStoredAssignments = (state) => get(state, 'assignment.assignments', {});
@@ -202,21 +201,15 @@ export const getCurrentAssignmentPlanningItem = createSelector(
     )
 );
 
-export const getCurrentAssignmentEventItem = createSelector<
+export const getRelatedEventsForCurrentAssignment = createSelector<
     IPlanningAppState,
     IPlanningItem | null,
     {[eventId: string]: IEventItem},
-    IEventItem | null
+    Array<IEventItem>
 >(
     [getCurrentAssignmentPlanningItem, storedEvents],
     (planning, events) => {
-        if (planning == null) {
-            return null;
-        }
-
-        const relatedEventIds = getRelatedEventIdsForPlanning(planning, 'primary');
-
-        return relatedEventIds.length > 0 ? events[relatedEventIds[0]] : null;
+        return (planning?.related_events ?? []).map(({_id}) => events[_id]).filter((event) => event != null);
     }
 );
 


### PR DESCRIPTION
STT-150

After implementing the posibility to have multiple related events and linke types, we were only showing primary linked event in coverage preview. This PR changes this so all related events are shown. We were also showing articles related to primary event, likewise now we show related artciles for all events.

[before](https://github.com/user-attachments/assets/372c8bc7-c64c-4fda-b0c3-fb772185e716) / [after](https://github.com/user-attachments/assets/2a9b6e0f-1e78-4657-ae07-41346ee4ff71)


## Front-end checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [x] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [x] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [x] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [x] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [x] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [x] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [x] This pull request is not adding redux based modals
- [x] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [x] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)
