### PR TITLE
fix clearing date using keyboard

### DIFF
--- a/client/components/Events/EventScheduleInput/index.tsx
+++ b/client/components/Events/EventScheduleInput/index.tsx
@@ -367,7 +367,6 @@ export class EventScheduleInput extends React.Component<IProps, IState> {
                     onPopupClose={onPopupClose}
                     timeField="_startTime"
                     remoteTimeZone={diff?.dates?.tz}
-                    allowInvalidTime
                     isLocalTimeZoneDifferent={isRemoteTimeZone}
                     refNode={refNode}
                     showToBeConfirmed
@@ -389,7 +388,6 @@ export class EventScheduleInput extends React.Component<IProps, IState> {
                     onPopupClose={onPopupClose}
                     timeField="_endTime"
                     remoteTimeZone={diff?.dates?.tz}
-                    allowInvalidTime
                     isLocalTimeZoneDifferent={isRemoteTimeZone}
                     showToBeConfirmed
                     onToBeConfirmed={this.handleToBeConfirmed}

--- a/client/components/UI/Form/DateTimeInput/index.tsx
+++ b/client/components/UI/Form/DateTimeInput/index.tsx
@@ -30,7 +30,6 @@ interface IProps {
     onPopupOpen?(): void;
     onPopupClose?(): void;
     remoteTimeZone?: string;
-    allowInvalidTime?: boolean;
     isLocalTimeZoneDifferent?: boolean;
     refNode?(node: HTMLElement): void;
     showToBeConfirmed?: boolean;
@@ -66,7 +65,6 @@ export const DateTimeInput = ({
     onPopupOpen,
     onPopupClose,
     remoteTimeZone,
-    allowInvalidTime,
     isLocalTimeZoneDifferent,
     refNode,
     showToBeConfirmed,
@@ -136,7 +134,7 @@ export const DateTimeInput = ({
                     onPopupClose={onPopupClose}
                     remoteTimeZone={remoteTimeZone}
                     canClear={canClear}
-                    allowInvalidText={allowInvalidTime}
+                    allowInvalidText
                     isLocalTimeZoneDifferent={isLocalTimeZoneDifferent}
                     halfWidth={!hideTime}
                     showToBeConfirmed={showToBeConfirmed}
@@ -188,7 +186,6 @@ DateTimeInput.propTypes = {
     onPopupOpen: PropTypes.func,
     onPopupClose: PropTypes.func,
     remoteTimeZone: PropTypes.string,
-    allowInvalidTime: PropTypes.bool,
     isLocalTimeZoneDifferent: PropTypes.bool,
     refNode: PropTypes.func,
     showToBeConfirmed: PropTypes.bool,


### PR DESCRIPTION
STT-160

It was allowing to clear the date using a "clear" button from datepicker, but not after clearing the field using backspace/delete.

## Front-end checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [x] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [x] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [x] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [x] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [x] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [x] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [x] This pull request is not adding redux based modals
- [x] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [x] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)
