### PR TITLE
[SDESK-7517] - Migrate the Events Postpone action from a resource/service to a web endpoint

### DIFF
--- a/server/planning/events/__init__.py
+++ b/server/planning/events/__init__.py
@@ -24,7 +24,6 @@ from .events_lock import (
 from .events_post import EventsPostService, EventsPostResource
 from .events_cancel import EventsCancelService, EventsCancelResource
 from .events_reschedule import EventsRescheduleService, EventsRescheduleResource
-from .events_postpone import EventsPostponeService, EventsPostponeResource
 from .events_update_repetitions import (
     EventsUpdateRepetitionsService,
     EventsUpdateRepetitionsResource,
@@ -87,11 +86,6 @@ def init_app(app):
         app=app,
         service=events_reschedule_service,
     )
-
-    events_postpone_service = EventsPostponeService(
-        EventsPostponeResource.endpoint_name, backend=superdesk.get_backend()
-    )
-    EventsPostponeResource(EventsPostponeResource.endpoint_name, app=app, service=events_postpone_service)
 
     events_update_repetitions_service = EventsUpdateRepetitionsService(
         EventsUpdateRepetitionsResource.endpoint_name, backend=superdesk.get_backend()

--- a/server/planning/events/__init__.py
+++ b/server/planning/events/__init__.py
@@ -124,6 +124,7 @@ def init_app(app):
     signals.event_time_updated.connect(events_history_service.on_update_time)
     signals.event_spiked.connect(events_history_service.on_spike)
     signals.event_unspiked.connect(events_history_service.on_unspike)
+    signals.event_postponed.connect(events_history_service.on_postpone)
 
     app.on_updated_events += events_history_service.on_item_updated
 
@@ -134,7 +135,6 @@ def init_app(app):
     app.on_deleted_item_events += events_history_service.on_item_deleted
     app.on_updated_events_cancel += events_history_service.on_cancel
     app.on_updated_events_reschedule += events_history_service.on_reschedule
-    app.on_updated_events_postpone += events_history_service.on_postpone
     app.on_locked_events += events_search_service.on_locked_event
 
     # Privileges

--- a/server/planning/events/events_postpone.py
+++ b/server/planning/events/events_postpone.py
@@ -9,121 +9,126 @@
 # at https://www.sourcefabric.org/superdesk/license
 
 from copy import deepcopy
+from typing import Any
 
-from superdesk.core import get_current_app
 from superdesk.resource_fields import ID_FIELD
-from superdesk import get_resource_service
 from superdesk.notification import push_notification
 from apps.archive.common import get_user, get_auth
 
+from planning import signals
 from planning.common import (
+    UPDATE_SINGLE,
     UPDATE_FUTURE,
     WORKFLOW_STATE,
     remove_lock_information,
     set_actioned_date_to_event,
 )
-from .events import EventsResource, events_schema
-from .events_base_service import EventsBaseService
+from planning.events.events_utils import (
+    get_recurring_timeline,
+    get_update_method,
+    post_update_event_actions,
+    pre_update_event_actions,
+)
+from planning.planning.planning_postpone import process_postpone_planning_item
+from planning.types.event import EventResourceModel
 from planning.utils import get_related_planning_for_events
 
 
-event_postpone_schema = deepcopy(events_schema)
-event_postpone_schema["reason"] = {
-    "type": "string",
-    "nullable": True,
-}
+def set_event_postponed(updates):
+    reason = updates.get("reason", None)
+    remove_lock_information(updates)
+    updates["state"] = WORKFLOW_STATE.POSTPONED
+    updates["state_reason"] = reason
 
 
-class EventsPostponeResource(EventsResource):
-    url = "events/postpone"
-    resource_title = endpoint_name = "events_postpone"
+async def postpone_event_plannings(updates: dict[str, Any], original: dict[str, Any]):
+    reason = updates.get("reason", None)
 
-    datasource = {"source": "events"}
-
-    resource_methods = []
-    item_methods = ["PATCH"]
-    privileges = {"PATCH": "planning_event_management"}
-
-    schema = event_postpone_schema
+    for plan in get_related_planning_for_events([original[ID_FIELD]], "primary"):
+        if plan.get("state") != WORKFLOW_STATE.CANCELLED:
+            updated_plan = await process_postpone_planning_item({"reason": reason}, plan)
+            await signals.planning_postponed.send(updated_plan, plan)
 
 
-class EventsPostponeService(EventsBaseService):
+async def postpone_single_event(updates: dict[str, Any], original: dict[str, Any]):
+    set_event_postponed(updates)
+    await postpone_event_plannings(updates, original)
+
+
+async def postpone_recurring_event(updates: dict[str, Any], original: dict[str, Any], update_method: str):
+    events_service = EventResourceModel.get_service()
+    historic, past, future = await get_recurring_timeline(original)
+
+    # Determine if the selected event is the first one, if so then
+    # act as if we're changing future events
+    if len(historic) == 0 and len(past) == 0:
+        update_method = UPDATE_FUTURE
+
+    if update_method == UPDATE_FUTURE:
+        postponed_events = future
+    else:
+        postponed_events = past + future
+
+    set_event_postponed(updates)
+
+    for event in postponed_events:
+        new_updates = deepcopy(updates)
+
+        # Mark the Event as being Postponed
+        await postpone_event_plannings(new_updates, event)
+        new_updates["skip_on_update"] = True
+        await events_service.update(event[ID_FIELD], new_updates)
+
+    await postpone_event_plannings(updates, original)
+
+
+async def process_postpone_event(updates: dict[str, Any], original: dict[str, Any]) -> dict[str, Any]:
+    """
+    Processes the event postpone, handling both single and recurring events.
+
+    :param updates: The update payload from the client.
+    :param original: The original event document.
+    :return: The updated event document.
+    """
+    events_service = EventResourceModel.get_service()
     ACTION = "postpone"
 
-    def update_single_event(self, updates, original):
-        self._set_event_postponed(updates)
-        self._postpone_event_plannings(updates, original)
+    # Perform pre update event actions
+    pre_update_event_actions(updates, original, ACTION)
 
-    def update(self, id, updates, original):
-        reason = updates.pop("reason", None)
-        set_actioned_date_to_event(updates, original)
+    # Determin update method
+    update_method = get_update_method(updates, original)
 
-        item = super().update(id, updates, original)
+    if update_method == UPDATE_SINGLE:
+        await postpone_single_event(updates, original)
+    else:
+        await postpone_recurring_event(updates, original, update_method)
 
-        # Because we require the original item being actioned against to be locked
-        # then we can check the lock information of original and updates to check if this
-        # event was the original event.
-        if self.is_original_event(original):
-            user = get_user(required=True).get(ID_FIELD, "")
-            session = get_auth().get(ID_FIELD, "")
+    # Clean updates before persisting change
+    reason = updates.pop("reason", None)
+    set_actioned_date_to_event(updates, original)
+    updates.pop("update_method", None)
+    updates.pop("skip_on_update", None)
 
-            push_notification(
-                "events:postpone",
-                item=str(original[ID_FIELD]),
-                user=str(user),
-                session=str(session),
-                reason=reason,
-                actioned_date=updates.get("actioned_date"),
-            )
+    # Update the original event in the database
+    event_id = original[ID_FIELD]
+    await events_service.update(event_id, updates)
+    postponed_event = await events_service.find_by_id_raw(event_id)
+    assert postponed_event is not None, "Expected postponed_event to be a dict, got None"
 
-        return item
+    user = get_user(required=True).get(ID_FIELD, "")
+    session = get_auth().get(ID_FIELD, "")
 
-    @staticmethod
-    def push_notification(name, updates, original):
-        """
-        Ignore this request, as we want to handle the notification separately in update
-        """
-        pass
+    push_notification(
+        "events:postpone",
+        item=str(event_id),
+        user=str(user),
+        session=str(session),
+        reason=reason,
+        actioned_date=updates.get("actioned_date"),
+    )
 
-    @staticmethod
-    def _postpone_event_plannings(updates, original):
-        planning_postpone_service = get_resource_service("planning_postpone")
-        reason = updates.get("reason", None)
-        app = get_current_app().as_any()
+    # Perform post update actions
+    post_update_event_actions(updates, original, ACTION)
 
-        for plan in get_related_planning_for_events([original[ID_FIELD]], "primary"):
-            if plan.get("state") != WORKFLOW_STATE.CANCELLED:
-                updated_plan = planning_postpone_service.patch(plan[ID_FIELD], {"reason": reason})
-                app.on_updated_planning_postpone(updated_plan, plan)
-
-    @staticmethod
-    def _set_event_postponed(updates):
-        reason = updates.get("reason", None)
-        remove_lock_information(updates)
-        updates["state"] = WORKFLOW_STATE.POSTPONED
-        updates["state_reason"] = reason
-
-    def update_recurring_events(self, updates, original, update_method):
-        historic, past, future = self.get_recurring_timeline(original)
-
-        # Determine if the selected event is the first one, if so then
-        # act as if we're changing future events
-        if len(historic) == 0 and len(past) == 0:
-            update_method = UPDATE_FUTURE
-
-        if update_method == UPDATE_FUTURE:
-            postponed_events = future
-        else:
-            postponed_events = past + future
-
-        self._set_event_postponed(updates)
-
-        for event in postponed_events:
-            new_updates = deepcopy(updates)
-
-            # Mark the Event as being Postponed
-            self._postpone_event_plannings(new_updates, event)
-            new_updates["skip_on_update"] = True
-            self.patch(event[ID_FIELD], new_updates)
-
-        self._postpone_event_plannings(updates, original)
+    return postponed_event

--- a/server/planning/events/views.py
+++ b/server/planning/events/views.py
@@ -11,14 +11,14 @@ from superdesk.core.web import EndpointGroup
 from superdesk.core.types import Request, Response
 
 
-blueprint = EndpointGroup("events", __name__)
+events_endpoints_group: EndpointGroup = EndpointGroup("events", __name__)
 
 
 class EventsArgs(BaseModel):
     event_id: str
 
 
-@blueprint.endpoint(
+@events_endpoints_group.endpoint(
     "events/update_time/<string:event_id>",
     name="events_update_time",
     methods=["PATCH"],
@@ -44,7 +44,7 @@ async def update_time(args: EventsArgs, params: None, request: Request) -> Respo
     return Response(updated_event)
 
 
-@blueprint.endpoint(
+@events_endpoints_group.endpoint(
     "events/spike/<string:event_id>",
     name="events_spike",
     methods=["PATCH"],
@@ -61,7 +61,7 @@ async def spike_event(args: EventsArgs, params: None, request: Request) -> Respo
     return Response(spiked_event)
 
 
-@blueprint.endpoint(
+@events_endpoints_group.endpoint(
     "events/unspike/<string:event_id>",
     name="events_unspike",
     methods=["PATCH"],
@@ -78,7 +78,7 @@ async def unspike_event(args: EventsArgs, params: None, request: Request) -> Res
     return Response(unspiked_event)
 
 
-@blueprint.endpoint(
+@events_endpoints_group.endpoint(
     "events/postpone/<string:event_id>",
     name="events_postpone",
     methods=["PATCH"],

--- a/server/planning/events/views.py
+++ b/server/planning/events/views.py
@@ -82,7 +82,7 @@ async def unspike_event(args: EventsArgs, params: None, request: Request) -> Res
     "events/postpone/<string:event_id>",
     name="events_postpone",
     methods=["PATCH"],
-    auth=[required_privilege_rule("planning_event_unspike")],
+    auth=[required_privilege_rule("planning_event_management")],
 )
 async def postpone_event(args: EventsArgs, params: None, request: Request) -> Response:
     original = await EventsAsyncService().find_by_id_raw(args.event_id)

--- a/server/planning/events/views.py
+++ b/server/planning/events/views.py
@@ -3,6 +3,7 @@ from pydantic import BaseModel
 from planning.events.events_service import EventsAsyncService
 from planning.events.events_update_time import process_update_time
 from planning.events.events_spike import process_spike_event, process_unspike_event
+from planning.events.events_postpone import process_postpone_event
 from planning.utils import get_json_or_400_async
 
 from superdesk.core.auth.privilege_rules import required_privilege_rule
@@ -75,3 +76,20 @@ async def unspike_event(args: EventsArgs, params: None, request: Request) -> Res
     unspiked_event = await process_unspike_event(updates, original)
 
     return Response(unspiked_event)
+
+
+@blueprint.endpoint(
+    "events/postpone/<string:event_id>",
+    name="events_postpone",
+    methods=["PATCH"],
+    auth=[required_privilege_rule("planning_event_unspike")],
+)
+async def postpone_event(args: EventsArgs, params: None, request: Request) -> Response:
+    original = await EventsAsyncService().find_by_id_raw(args.event_id)
+    if not original:
+        await request.abort(404, "Event not found")
+
+    updates = await get_json_or_400_async(request)
+    postponed_event = await process_postpone_event(updates, original)
+
+    return Response(postponed_event)

--- a/server/planning/module.py
+++ b/server/planning/module.py
@@ -18,13 +18,14 @@ from planning.planning import (
     planning_featured_resource_config,
     planning_autosave_resource_config,
 )
+from planning.events.views import events_endpoints_group
 from planning.planning.planning_autosave_async_service import PlanningAutosaveAsyncService
+from planning.planning.views import planning_endpoint_group
 from planning.assignments import assignments_resource_config, delivery_resource_config
 from planning.published import published_resource_config
 from planning.content_profiles import planning_types_resource_config
 from planning.locations import locations_resource_config
 from .planning_locks import planning_locks as planning_locks_endpoint
-from .planning.views import planning_endpoint_group
 
 
 async def cleanup_on_session_end(user_id: ObjectId, session_id: ObjectId, is_last_session: bool) -> None:
@@ -59,7 +60,7 @@ def init_planning(app: SuperdeskAsyncApp):
 module = Module(
     "planning",
     init=init_planning,
-    endpoints=[planning_locks_endpoint, planning_endpoint_group],
+    endpoints=[planning_locks_endpoint, planning_endpoint_group, events_endpoints_group],
     resources=[
         events_resource_config,
         planning_resource_config,

--- a/server/planning/signals.py
+++ b/server/planning/signals.py
@@ -60,3 +60,6 @@ planning_unspiked = AsyncSignal[dict, dict]("planning:unspiked")
 
 #: Signal for when an Planning Item is postponed
 planning_postponed = AsyncSignal[dict, dict]("planning:postponed")
+
+#: Signal for when an Event is postponed
+event_postponed = AsyncSignal[dict, dict]("events:postponed")


### PR DESCRIPTION
### Purpose
This PR upgrades planning events action resources to async endpoints

- Create endpoints for events postpone action
- Applied auth rules to the new endpoint
- Updated the pure functions for events postpone action based off old implementation.
- Remove old resource/service code
- Registered endpoint to events module

Solves: [SDESK-7517](https://sofab.atlassian.net/browse/SDESK-7517)

[SDESK-7517]: https://sofab.atlassian.net/browse/SDESK-7517