### PR TITLE
Coverage profiles: UI issue when a contact is selected

### DIFF
--- a/client/components/Contacts/ContactField.tsx
+++ b/client/components/Contacts/ContactField.tsx
@@ -10,6 +10,7 @@ import {IContact, Omit} from 'superdesk-api';
 import {showModal} from '@sourcefabric/common';
 import {IContactFieldProps, IContactReduxStateProps, IContactReduxDispatchProps} from './ContactField.interface';
 import {Row} from './../../components/UI/Form';
+import {Spacer} from 'superdesk-ui-framework/react';
 
 const mapStateToProps = (state) => ({
     contacts: selectors.general.contacts(state),
@@ -90,6 +91,8 @@ class ContactFieldComponent extends React.Component<IContactFieldProps> {
             field,
             privileges,
             onFocus,
+            refNode,
+            paddingTop,
             onPopupOpen,
             onPopupClose,
             readOnly,
@@ -106,24 +109,36 @@ class ContactFieldComponent extends React.Component<IContactFieldProps> {
         }
 
         return (
-            <Row testId={this.props.testId}>
-                <SelectSearchContactsField
-                    field={field}
-                    label={label}
-                    onChange={this.onChange}
-                    value={value}
-                    onAdd={privileges.contacts ? this.showEditModal : undefined}
-                    onAddText={privileges.contacts ? gettext('Add Contact') : null}
-                    onFocus={onFocus}
-                    readOnly={readOnly}
-                    onPopupOpen={onPopupOpen}
-                    onPopupClose={onPopupClose}
-                />
-                <ContactsPreviewList
-                    contactIds={value}
-                    onEditContact={privileges.contacts ? this.showEditModal : null}
-                    onRemoveContact={privileges.contacts ? this.removeContact : null}
-                />
+            <Row>
+                <div
+                    ref={refNode}
+                    className={paddingTop ? 'contact-field--padding-top' : null}
+                    data-test-id={this.props.testId}
+                >
+                    <Spacer v gap="8">
+                        <SelectSearchContactsField
+                            field={field}
+                            label={label}
+                            onChange={this.onChange}
+                            value={value}
+                            onAdd={privileges.contacts ? this.showEditModal : undefined}
+                            onAddText={privileges.contacts ? gettext('Add Contact') : null}
+                            onFocus={onFocus}
+                            readOnly={readOnly}
+                            onPopupOpen={onPopupOpen}
+                            onPopupClose={onPopupClose}
+                            noMargin
+                        />
+
+                        {value.length > 0 && (
+                            <ContactsPreviewList
+                                contactIds={value}
+                                onEditContact={privileges.contacts ? this.showEditModal : null}
+                                onRemoveContact={privileges.contacts ? this.removeContact : null}
+                            />
+                        )}
+                    </Spacer>
+                </div>
             </Row>
         );
     }

--- a/client/components/Contacts/ContactField.tsx
+++ b/client/components/Contacts/ContactField.tsx
@@ -106,7 +106,7 @@ class ContactFieldComponent extends React.Component<IContactFieldProps> {
         }
 
         return (
-            <Row testId={'contacts-preview-list'}>
+            <Row testId={this.props.testId}>
                 <SelectSearchContactsField
                     field={field}
                     label={label}

--- a/client/components/Contacts/ContactField.tsx
+++ b/client/components/Contacts/ContactField.tsx
@@ -9,6 +9,7 @@ import {ContactsPreviewList} from './ContactsPreviewList';
 import {IContact, Omit} from 'superdesk-api';
 import {showModal} from '@sourcefabric/common';
 import {IContactFieldProps, IContactReduxStateProps, IContactReduxDispatchProps} from './ContactField.interface';
+import {Row} from './../../components/UI/Form';
 
 const mapStateToProps = (state) => ({
     contacts: selectors.general.contacts(state),
@@ -89,8 +90,6 @@ class ContactFieldComponent extends React.Component<IContactFieldProps> {
             field,
             privileges,
             onFocus,
-            refNode,
-            paddingTop,
             onPopupOpen,
             onPopupClose,
             readOnly,
@@ -107,11 +106,7 @@ class ContactFieldComponent extends React.Component<IContactFieldProps> {
         }
 
         return (
-            <div
-                ref={refNode}
-                className={paddingTop ? 'contact-field--padding-top' : null}
-                data-test-id={this.props.testId}
-            >
+            <Row testId={'contacts-preview-list'}>
                 <SelectSearchContactsField
                     field={field}
                     label={label}
@@ -129,7 +124,7 @@ class ContactFieldComponent extends React.Component<IContactFieldProps> {
                     onEditContact={privileges.contacts ? this.showEditModal : null}
                     onRemoveContact={privileges.contacts ? this.removeContact : null}
                 />
-            </div>
+            </Row>
         );
     }
 }

--- a/client/components/Contacts/SelectSearchContactsField/index.tsx
+++ b/client/components/Contacts/SelectSearchContactsField/index.tsx
@@ -16,6 +16,7 @@ interface IProps {
     contactType?: string;
     minLengthPopup?: number;
     placeholder?: string;
+    noMargin?: boolean
 }
 
 export class SelectSearchContactsField extends React.Component<IProps, {openSelectPopup: boolean}> {
@@ -47,13 +48,14 @@ export class SelectSearchContactsField extends React.Component<IProps, {openSele
             contactType,
             minLengthPopup = 1,
             placeholder,
+            noMargin,
             ...props
         } = this.props;
 
         const hasLabel = (label ?? '').trim();
 
         return (
-            <LineInput readOnly={readOnly} {...props} noLabel={!hasLabel}>
+            <LineInput readOnly={readOnly} {...props} noLabel={!hasLabel} noMargin={noMargin}>
                 {hasLabel && (
                     <Label text={label} />
                 )}


### PR DESCRIPTION
STT-182

## Front-end checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [x] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [x] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [x] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [x] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [x] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [x] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [x] This pull request is not adding redux based modals
- [x] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [x] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)
