### PR TITLE
[SDESK-7515] - Upgrade the Event and Planning search endpoint to async

### DIFF
--- a/server/planning/commands/export_scheduled_filters.py
+++ b/server/planning/commands/export_scheduled_filters.py
@@ -139,6 +139,7 @@ class ExportScheduledFilters(Command):
     def _export_filter(self, search_filter, schedule):
         start_of_week = get_app_config("START_OF_WEEK") or 0
 
+        # TODO-ASYNC[EventsPlanningSearch] - Convert `search_by_filter_id` to async when upgrading command
         items = get_resource_service("events_planning_search").search_by_filter_id(
             search_filter["_id"], projections=["_id"], args={"start_of_week": start_of_week}
         )

--- a/server/planning/planning_article_export.py
+++ b/server/planning/planning_article_export.py
@@ -61,6 +61,7 @@ class PlanningArticleExportResource(Resource):
 
 def get_items(ids, resource_type):
     ids_string = [str(item_id) for item_id in ids]
+    # TODO-ASYNC[EventsPlanningSearch] - Convert `search_repos` to async when upgrading module
     items = get_resource_service("events_planning_search").search_repos(
         resource_type, {"item_ids": ",".join(ids_string), "only_future": False}
     )

--- a/server/planning/search/eventsplanning_search.py
+++ b/server/planning/search/eventsplanning_search.py
@@ -18,13 +18,15 @@ from copy import deepcopy
 from werkzeug.datastructures import MultiDict, ImmutableMultiDict
 from eve.utils import ParsedRequest
 
-from superdesk import Resource, Service, get_resource_service
+from superdesk import Resource, get_resource_service
+from superdesk.eve_async.service import AsyncBaseService
 from superdesk.resource_fields import ITEMS
 from superdesk.resource import build_custom_hateoas
 from superdesk.errors import SuperdeskApiError
 
-from planning.planning.planning import planning_schema
 from planning.events.events_schema import events_schema
+from planning.planning.planning import planning_schema
+from planning.search.eventsplanning_filters_service import EventsPlanningFiltersAsyncService
 
 from .queries.planning import PLANNING_PARAMS, PLANNING_SEARCH_FILTERS
 from .queries.events import EVENT_PARAMS, EVENT_SEARCH_FILTERS
@@ -36,76 +38,27 @@ from .queries.elastic import ElasticQuery, field_exists
 logger = logging.getLogger(__name__)
 
 
-class EventsPlanningService(Service):
+class EventsPlanningService(AsyncBaseService):
     default_page_size = 100
 
-    def get(self, req, lookup):
-        """Retrieve a list of events and planning that match the filter criteria (if any) passed along the HTTP request.
+    def _get_sort(self):
+        """Get the sort"""
+        return {
+            "_planning_schedule.scheduled": {
+                "order": "asc",
+                "nested": {"path": "_planning_schedule"},
+            }
+        }
 
-        :param req: object representing the HTTP request
-        :type req: `eve.utils.ParsedRequest`
-        :param dict lookup: sub-resource lookup from the endpoint URL
+    def _get_page_size(self, request, search_filter):
+        """Get the page size"""
 
-        :return: database results cursor object
-        :rtype: `pymongo.cursor.Cursor`
-        """
-
-        params = req.args or MultiDict()
-
-        if isinstance(params, ImmutableMultiDict):
-            params = params.copy()
-
-        repo = params.get("repo", "combined")
-        search_filter = self._get_search_filter(repo, params)
-        self._check_for_unknown_params(params, search_filter, self._get_whitelist(repo))
-        query = self._construct_search_query(repo, params, search_filter)
-
-        if repo == "events" or repo == "event":
-            return self._search_events(req, params, query, search_filter)
-        elif repo == "planning":
-            return self._search_planning(req, params, query, search_filter)
+        if search_filter["params"].get("max_results"):
+            return search_filter["params"]["max_results"]
+        elif request.max_results:
+            return request.max_results
         else:
-            return self._get_events_and_planning(req, params, query, search_filter)
-
-    def on_fetched(self, doc):
-        """
-        Overriding to set HATEOAS to specific resource endpoint for each individual item in the response.
-
-        :param doc: response doc
-        :type doc: dict
-        """
-
-        docs = doc[ITEMS]
-        for item in docs:
-            build_custom_hateoas(
-                {
-                    "self": {
-                        "title": item["_type"],
-                        "href": "/{}/{{_id}}".format(item["_type"]),
-                    }
-                },
-                item,
-            )
-
-    def _get_search_filter(self, repo: str, params: Dict[str, Any]):
-        filter_id = params.get("filter_id")
-        if not filter_id or filter_id == "ALL_EVENTS_PLANNING":
-            return {"params": {}}
-
-        search_filter = get_resource_service("events_planning_filters").find_one(req=None, _id=filter_id)
-        if not search_filter:
-            logger.warning(f"Event filter {filter_id} not found")
-            return {"params": {}}
-
-        item_type = search_filter.get("item_type", "combined")
-        if item_type != repo:
-            logger.warning(f"Incorrect filter type supplied ({item_type})")
-            return {"params": {}}
-        elif not len(search_filter.get("params") or {}):
-            logger.warning(f"Search filter {filter_id} has no params")
-            return {"params": {}}
-
-        return search_filter
+            return self.default_page_size
 
     def _construct_search_query(
         self, repo: str, params: Dict[str, Any], search_filter: Optional[Dict[str, Any]]
@@ -118,72 +71,6 @@ class EventsPlanningService(Service):
             filters = COMBINED_SEARCH_FILTERS
 
         return construct_search_query(repo, filters, params, search_filter)
-
-    def _get_events_and_planning(self, request, params, query, search_filter):
-        """Get list of event and planning based on the search criteria
-
-        :param request: object representing the HTTP request
-        """
-
-        page = request.page or 1
-        page_size = self._get_page_size(request, search_filter)
-        req = ParsedRequest()
-        req.args = MultiDict()
-        req.args["source"] = json.dumps(
-            {
-                "query": query["query"],
-                "sort": query["sort"] if query.get("sort") else self._get_sort(),
-                "size": page_size,
-                "from": (page - 1) * page_size,
-            }
-        )
-        req.page = page
-        req.max_results = page_size
-        if params.get("projections"):
-            req.args["projections"] = params["projections"]
-        return get_resource_service("planning_search").get(req=req, lookup=None)
-
-    def _search_events(self, request, params, query, search_filter):
-        page = request.page or 1
-        page_size = self._get_page_size(request, search_filter)
-        req = ParsedRequest()
-        req.args = MultiDict()
-        req.args["source"] = json.dumps(
-            {
-                "query": query["query"],
-                "sort": query["sort"] if query.get("sort") else {"dates.start": {"order": "asc"}},
-                "size": page_size,
-                "from": (page - 1) * page_size,
-            }
-        )
-        req.args["repos"] = "events"
-        req.page = page
-        req.max_results = page_size
-        if params.get("projections"):
-            req.args["projections"] = params["projections"]
-        return get_resource_service("planning_search").get(req=req, lookup=None)
-
-    def _search_planning(self, request, params, query, search_filter):
-        # params = request.args or MultiDict()
-        # query = construct_planning_search_query(params)
-        page = request.page or 1
-        page_size = self._get_page_size(request, search_filter)
-        req = ParsedRequest()
-        req.args = MultiDict()
-        req.args["source"] = json.dumps(
-            {
-                "query": query["query"],
-                "sort": query["sort"] if query.get("sort") else self._get_sort(),
-                "size": page_size,
-                "from": (page - 1) * page_size,
-            }
-        )
-        req.args["repos"] = "planning"
-        req.page = page
-        req.max_results = page_size
-        if params.get("projections"):
-            req.args["projections"] = params["projections"]
-        return get_resource_service("planning_search").get(req=req, lookup=None)
 
     def _get_whitelist(self, repo):
         if repo == "events":
@@ -215,27 +102,143 @@ class EventsPlanningService(Service):
                 logger.warning(f"Search filter {search_filter_id} contains unsupported param {param_name}")
                 search_filter["params"].pop(param_name, None)
 
-    def _get_sort(self):
-        """Get the sort"""
-        return {
-            "_planning_schedule.scheduled": {
-                "order": "asc",
-                "nested": {"path": "_planning_schedule"},
+    async def _get_search_filter(self, repo: str, params: Dict[str, Any]):
+        filter_id = params.get("filter_id")
+        if not filter_id or filter_id == "ALL_EVENTS_PLANNING":
+            return {"params": {}}
+
+        search_filter = await EventsPlanningFiltersAsyncService().find_by_id_raw(filter_id)
+
+        if not search_filter:
+            logger.warning(f"Event filter {filter_id} not found")
+            return {"params": {}}
+
+        item_type = search_filter.get("item_type", "combined")
+        if item_type != repo:
+            logger.warning(f"Incorrect filter type supplied ({item_type})")
+            return {"params": {}}
+        elif not len(search_filter.get("params") or {}):
+            logger.warning(f"Search filter {filter_id} has no params")
+            return {"params": {}}
+
+        return search_filter
+
+    async def _search_events(self, request, params, query, search_filter):
+        page = request.page or 1
+        page_size = self._get_page_size(request, search_filter)
+        req = ParsedRequest()
+        req.args = MultiDict()
+        req.args["source"] = json.dumps(
+            {
+                "query": query["query"],
+                "sort": query["sort"] if query.get("sort") else {"dates.start": {"order": "asc"}},
+                "size": page_size,
+                "from": (page - 1) * page_size,
             }
-        }
+        )
+        req.args["repos"] = "events"
+        req.page = page
+        req.max_results = page_size
+        if params.get("projections"):
+            req.args["projections"] = params["projections"]
+        return await get_resource_service("planning_search").get_async(req=req, lookup=None)
 
-    def _get_page_size(self, request, search_filter):
-        """Get the page size"""
+    async def _search_planning(self, request, params, query, search_filter):
+        # params = request.args or MultiDict()
+        # query = construct_planning_search_query(params)
+        page = request.page or 1
+        page_size = self._get_page_size(request, search_filter)
+        req = ParsedRequest()
+        req.args = MultiDict()
+        req.args["source"] = json.dumps(
+            {
+                "query": query["query"],
+                "sort": query["sort"] if query.get("sort") else self._get_sort(),
+                "size": page_size,
+                "from": (page - 1) * page_size,
+            }
+        )
+        req.args["repos"] = "planning"
+        req.page = page
+        req.max_results = page_size
+        if params.get("projections"):
+            req.args["projections"] = params["projections"]
+        return await get_resource_service("planning_search").get_async(req=req, lookup=None)
 
-        if search_filter["params"].get("max_results"):
-            return search_filter["params"]["max_results"]
-        elif request.max_results:
-            return request.max_results
+    async def _get_events_and_planning(self, request, params, query, search_filter):
+        """Get list of event and planning based on the search criteria
+
+        :param request: object representing the HTTP request
+        """
+
+        page = request.page or 1
+        page_size = self._get_page_size(request, search_filter)
+        req = ParsedRequest()
+        req.args = MultiDict()
+        req.args["source"] = json.dumps(
+            {
+                "query": query["query"],
+                "sort": query["sort"] if query.get("sort") else self._get_sort(),
+                "size": page_size,
+                "from": (page - 1) * page_size,
+            }
+        )
+        req.page = page
+        req.max_results = page_size
+        if params.get("projections"):
+            req.args["projections"] = params["projections"]
+        return await get_resource_service("planning_search").get_async(req=req, lookup=None)
+
+    async def get_async(self, req, lookup):
+        """Retrieve a list of events and planning that match the filter criteria (if any) passed along the HTTP request.
+
+        :param req: object representing the HTTP request
+        :type req: `eve.utils.ParsedRequest`
+        :param dict lookup: sub-resource lookup from the endpoint URL
+
+        :return: database results cursor object
+        :rtype: `pymongo.cursor.Cursor`
+        """
+
+        params = req.args or MultiDict()
+
+        if isinstance(params, ImmutableMultiDict):
+            params = params.copy()
+
+        repo = params.get("repo", "combined")
+        search_filter = await self._get_search_filter(repo, params)
+        self._check_for_unknown_params(params, search_filter, self._get_whitelist(repo))
+        query = self._construct_search_query(repo, params, search_filter)
+
+        if repo == "events" or repo == "event":
+            return await self._search_events(req, params, query, search_filter)
+        elif repo == "planning":
+            return await self._search_planning(req, params, query, search_filter)
         else:
-            return self.default_page_size
+            return await self._get_events_and_planning(req, params, query, search_filter)
+
+    async def on_fetched_async(self, doc):
+        """
+        Overriding to set HATEOAS to specific resource endpoint for each individual item in the response.
+
+        :param doc: response doc
+        :type doc: dict
+        """
+
+        docs = doc[ITEMS]
+        for item in docs:
+            build_custom_hateoas(
+                {
+                    "self": {
+                        "title": item["_type"],
+                        "href": "/{}/{{_id}}".format(item["_type"]),
+                    }
+                },
+                item,
+            )
 
     # Helper methods for use with other internal services or commands
-    def search_repos(self, repo, args, page=1, page_size=None, projections=None):
+    async def search_repos(self, repo, args, page=1, page_size=None, projections=None):
         req = ParsedRequest()
         req.args = MultiDict()
         req.args["repo"] = repo
@@ -246,9 +249,9 @@ class EventsPlanningService(Service):
 
         req.page = page
         req.max_results = page_size or self.default_page_size
-        return self.get(req=req, lookup=None)
+        return await self.get_async(req=req, lookup=None)
 
-    def search_raw(self, repo, query, sort=None, page=1, page_size=None, projections=None):
+    async def search_raw(self, repo, query, sort=None, page=1, page_size=None, projections=None):
         """Send raw elasticsearch query to `planning_search` service
 
         :param repo: Comma separated list of repos to search, defaults to ``events,planning``
@@ -283,10 +286,10 @@ class EventsPlanningService(Service):
         if projections is not None:
             req.args["projections"] = json.dumps(projections)
 
-        return get_resource_service("planning_search").get(req=req, lookup=None)
+        return await get_resource_service("planning_search").get_async(req=req, lookup=None)
 
-    def search_by_filter_id(self, filter_id, args=None, page=1, page_size=None, projections=None):
-        search_filter = get_resource_service("events_planning_filters").find_one(req=None, _id=filter_id)
+    async def search_by_filter_id(self, filter_id, args=None, page=1, page_size=None, projections=None):
+        search_filter = await EventsPlanningFiltersAsyncService().find_by_id_raw(filter_id)
 
         if not search_filter:
             raise SuperdeskApiError.notFoundError("EventPlanning Filter {} not found".format(filter_id))
@@ -296,9 +299,9 @@ class EventsPlanningService(Service):
 
         args["filter_id"] = filter_id
 
-        return self.search_repos(search_filter["item_type"], args, page, page_size, projections)
+        return await self.search_repos(search_filter["item_type"], args, page, page_size, projections)
 
-    def get_locked_items(self, repo=None, page=None, page_size=None, projections=None):
+    async def get_locked_items(self, repo=None, page=None, page_size=None, projections=None):
         """Return the list of locked items in the provided ``repo``
 
         :param repo: Comma separated list of repos to search, defaults to ``events,planning``
@@ -311,7 +314,7 @@ class EventsPlanningService(Service):
 
         query = ElasticQuery()
         query.must.append(field_exists("lock_session"))
-        return self.search_raw(
+        return await self.search_raw(
             repo=repo,
             query=query.build(),
             page=page or 1,

--- a/server/planning/search/eventsplanning_search.py
+++ b/server/planning/search/eventsplanning_search.py
@@ -20,8 +20,8 @@ from eve.utils import ParsedRequest
 
 from superdesk import Resource, get_resource_service
 from superdesk.eve_async.service import AsyncBaseService
-from superdesk.resource_fields import ITEMS
 from superdesk.resource import build_custom_hateoas
+from superdesk.resource_fields import ITEMS
 from superdesk.errors import SuperdeskApiError
 
 from planning.events.events_schema import events_schema

--- a/server/planning/search/eventsplanning_search.py
+++ b/server/planning/search/eventsplanning_search.py
@@ -301,7 +301,8 @@ class EventsPlanningService(AsyncBaseService):
 
         return await self.search_repos(search_filter["item_type"], args, page, page_size, projections)
 
-    async def get_locked_items(self, repo=None, page=None, page_size=None, projections=None):
+    # TODO-ASYNC[EventsPlanningSearch] - Convert `get_locked_items` to async when adding support for search param async callbacks
+    def get_locked_items(self, repo=None, page=None, page_size=None, projections=None):
         """Return the list of locked items in the provided ``repo``
 
         :param repo: Comma separated list of repos to search, defaults to ``events,planning``
@@ -314,7 +315,7 @@ class EventsPlanningService(AsyncBaseService):
 
         query = ElasticQuery()
         query.must.append(field_exists("lock_session"))
-        return await self.search_raw(
+        return self.search_raw(
             repo=repo,
             query=query.build(),
             page=page or 1,

--- a/server/planning/search/planning_search.py
+++ b/server/planning/search/planning_search.py
@@ -15,6 +15,7 @@ from copy import deepcopy
 
 import superdesk
 from superdesk.core import json, get_current_app, get_app_config
+from superdesk.eve_async.service import AsyncBaseService
 from superdesk.resource_fields import ITEMS
 from superdesk.metadata.utils import item_url
 
@@ -25,7 +26,7 @@ from typing import Any, Dict
 logger = logging.getLogger(__name__)
 
 
-class PlanningSearchService(superdesk.Service):
+class PlanningSearchService(AsyncBaseService):
     repos = ["events", "planning"]
 
     @property
@@ -35,7 +36,7 @@ class PlanningSearchService(superdesk.Service):
     def _get_query(self, req):
         """Get elastic query."""
         args = getattr(req, "args", {})
-        query = json.loads(args.get("source")) if args.get("source") else {"query": {"filtered": {}}}
+        query = json.loads(args.get("source", {})) if args.get("source") else {"query": {"filtered": {}}}
         return query
 
     def _get_types(self, req):
@@ -49,44 +50,19 @@ class PlanningSearchService(superdesk.Service):
             repos = repos.split(",")
             return [repo for repo in repos if repo in self.repos]
 
-    def get(self, req, lookup):
-        """Run the query against events and planning indexes"""
-        query = self._get_query(req)
-        types = self._get_types(req)
-        fields = self._get_projected_fields(req)
+    def _get_projected_fields(self, req):
+        """Get elastic projected fields."""
+        app = get_current_app()
+        if app.data.elastic.should_project(req):
+            return app.data.elastic.get_projected_fields(req)
 
-        params = {}
-        if fields:
-            # If projections are provided, make sure `type` is always included
-            if "type" not in fields:
-                fields += ",type"
-
-            params["_source"] = fields
-
-        docs = self.elastic.search(query, types, params)
-        self._format_docs(docs)
-
-        # to avoid call on_fetched_resource callback from some internal resource
-        on_fetched_resource = True
-        try:
-            on_fetched_resource = req.exec_on_fetched_resource
-        except AttributeError:
-            pass
-
-        if on_fetched_resource:
-            app = get_current_app().as_any()
-            for resource in types:
-                response = {
-                    ITEMS: [
-                        doc
-                        for doc in docs
-                        if doc["type"] == resource or (resource == "events" and doc["type"] == "event")
-                    ]
-                }
-                getattr(app, "on_fetched_resource")(resource, response)
-                getattr(app, "on_fetched_resource_%s" % resource)(response)
-
-        return docs
+    def _get_index(self, repos):
+        """Get index id for all repos."""
+        app = get_current_app()
+        indexes = {app.data.elastic.index}
+        for repo in repos:
+            indexes.add(app.config["ELASTICSEARCH_INDEXES"].get(repo, app.data.elastic.index))
+        return ",".join(indexes)
 
     def _get_date_fields(self, resource: str):
         datasource = self.elastic.get_datasource(resource)
@@ -118,19 +94,44 @@ class PlanningSearchService(superdesk.Service):
                 if (doc["dates"].get("recurring_rule") or {}).get("until"):
                     doc["dates"]["recurring_rule"]["until"] = parse_date(doc["dates"]["recurring_rule"]["until"])
 
-    def _get_projected_fields(self, req):
-        """Get elastic projected fields."""
-        app = get_current_app()
-        if app.data.elastic.should_project(req):
-            return app.data.elastic.get_projected_fields(req)
+    async def get_async(self, req, lookup):
+        """Run the query against events and planning indexes"""
+        query = self._get_query(req)
+        types = self._get_types(req)
+        fields = self._get_projected_fields(req)
 
-    def _get_index(self, repos):
-        """Get index id for all repos."""
-        app = get_current_app()
-        indexes = {app.data.elastic.index}
-        for repo in repos:
-            indexes.add(app.config["ELASTICSEARCH_INDEXES"].get(repo, app.data.elastic.index))
-        return ",".join(indexes)
+        params = {}
+        if fields:
+            # If projections are provided, make sure `type` is always included
+            if "type" not in fields:
+                fields += ",type"
+
+            params["_source"] = fields
+
+        docs = await self.elastic.search_async(query, types, params)
+        self._format_docs(docs)
+
+        # to avoid call on_fetched_resource callback from some internal resource
+        on_fetched_resource = True
+        try:
+            on_fetched_resource = req.exec_on_fetched_resource
+        except AttributeError:
+            pass
+
+        if on_fetched_resource:
+            app = get_current_app().as_any()
+            for resource in types:
+                response = {
+                    ITEMS: [
+                        doc
+                        for doc in docs
+                        if doc["type"] == resource or (resource == "events" and doc["type"] == "event")
+                    ]
+                }
+                getattr(app, "on_fetched_resource")(resource, response)
+                getattr(app, "on_fetched_resource_%s" % resource)(response)
+
+        return docs
 
 
 class PlanningSearchResource(superdesk.Resource):

--- a/server/planning/search/planning_search.py
+++ b/server/planning/search/planning_search.py
@@ -19,8 +19,8 @@ from superdesk.eve_async.service import AsyncBaseService
 from superdesk.resource_fields import ITEMS
 from superdesk.metadata.utils import item_url
 
-from planning.planning.planning import planning_schema
 from planning.events.events_schema import events_schema
+from planning.planning.planning import planning_schema
 from typing import Any, Dict
 
 logger = logging.getLogger(__name__)

--- a/server/planning/search/planning_search.py
+++ b/server/planning/search/planning_search.py
@@ -12,6 +12,7 @@
 import logging
 from eve_elastic.elastic import parse_date, get_dates
 from copy import deepcopy
+from typing import Any, Dict
 
 import superdesk
 from superdesk.core import json, get_current_app, get_app_config
@@ -21,7 +22,7 @@ from superdesk.metadata.utils import item_url
 
 from planning.events.events_schema import events_schema
 from planning.planning.planning import planning_schema
-from typing import Any, Dict
+from planning.types import EventResourceModel, PlanningResourceModel
 
 logger = logging.getLogger(__name__)
 
@@ -94,21 +95,33 @@ class PlanningSearchService(AsyncBaseService):
                 if (doc["dates"].get("recurring_rule") or {}).get("until"):
                     doc["dates"]["recurring_rule"]["until"] = parse_date(doc["dates"]["recurring_rule"]["until"])
 
+    def get_indexes_for_search(self, repos: list[str]) -> list[str]:
+        indexes = []
+        if "events" in repos:
+            indexes += EventResourceModel.get_service().elastic.config.index
+        if "planning" in repos:
+            indexes += PlanningResourceModel.get_service().elastic.config.index
+        return indexes
+
+    def get_projection(self, req) -> list[str] | None:
+        fields = self._get_projected_fields(req)
+        projection = None if not fields else fields.split(",")
+
+        if projection and "type" not in projection:
+            # Make sure `type` is always included in the projection
+            projection.append("type")
+
+        return projection
+
     async def get_async(self, req, lookup):
         """Run the query against events and planning indexes"""
         query = self._get_query(req)
         types = self._get_types(req)
-        fields = self._get_projected_fields(req)
+        indexes = self.get_indexes_for_search(types)
+        projection = self.get_projection(req)
 
-        params = {}
-        if fields:
-            # If projections are provided, make sure `type` is always included
-            if "type" not in fields:
-                fields += ",type"
-
-            params["_source"] = fields
-
-        docs = await self.elastic.search_async(query, types, params)
+        elastic = EventResourceModel.get_service().elastic
+        docs = await elastic.search(query, indexes, projection)
         self._format_docs(docs)
 
         # to avoid call on_fetched_resource callback from some internal resource

--- a/server/planning/search/planning_search.py
+++ b/server/planning/search/planning_search.py
@@ -10,7 +10,7 @@
 
 """Superdesk Planning Search."""
 import logging
-from eve_elastic.elastic import parse_date, get_dates
+from eve_elastic.elastic import parse_date, get_dates, fix_query
 from copy import deepcopy
 from typing import Any, Dict
 
@@ -121,7 +121,9 @@ class PlanningSearchService(AsyncBaseService):
         projection = self.get_projection(req)
 
         elastic = EventResourceModel.get_service().elastic
-        docs = await elastic.search(query, indexes, projection)
+        hits = await elastic.search(fix_query(query), indexes, projection)
+        docs = self.elastic._parse_hits(hits, types[0])
+
         self._format_docs(docs)
 
         # to avoid call on_fetched_resource callback from some internal resource

--- a/server/planning/search/queries/common.py
+++ b/server/planning/search/queries/common.py
@@ -224,6 +224,7 @@ def search_locked(params: Dict[str, Any], query: elastic.ElasticQuery):
         ids = set()
         event_items = set()
         recurrence_ids = set()
+        # TODO-ASYNC[EventsPlanningSearch] - Convert `get_locked_items` to async when upgrading this function
         locked_items = search_service.get_locked_items(projections=["_id", "type", "recurrence_id", "related_events"])
 
         if not locked_items.count():

--- a/server/planning/search/queries/common.py
+++ b/server/planning/search/queries/common.py
@@ -224,7 +224,6 @@ def search_locked(params: Dict[str, Any], query: elastic.ElasticQuery):
         ids = set()
         event_items = set()
         recurrence_ids = set()
-        # TODO-ASYNC[EventsPlanningSearch] - Convert `get_locked_items` to async when upgrading this function
         locked_items = search_service.get_locked_items(projections=["_id", "type", "recurrence_id", "related_events"])
 
         if not locked_items.count():

--- a/server/planning/types/event.py
+++ b/server/planning/types/event.py
@@ -2,11 +2,11 @@ from pydantic import Field
 from datetime import datetime
 from typing import Annotated, Any
 
-from content_api.items.model import CVItem, Place
 
 from superdesk.utc import utcnow
 from superdesk.core.resources import fields, dataclass, Dataclass
 from superdesk.core.resources.validators import validate_data_relation_async
+from superdesk.types.base import CVItem, Place
 
 from .base import BasePlanningModel
 from .event_dates import EventDates, OccurStatus

--- a/server/planning/types/planning.py
+++ b/server/planning/types/planning.py
@@ -2,12 +2,11 @@ from datetime import datetime
 from typing import Annotated, Any
 from pydantic import Field, model_validator
 
-from content_api.items.model import CVItem, Place
-
 from superdesk.utc import utcnow
 from superdesk.core.resources import fields, dataclass
 from superdesk.core.utils import generate_guid, GUID_NEWSML
 from superdesk.core.resources.validators import validate_data_relation_async
+from superdesk.types.base import CVItem, Place
 
 from .event import Translation
 from .base import BasePlanningModel


### PR DESCRIPTION
### Purpose
This PR upgrades events and planning search endpoints to async

- Convert EventsPlanningService to use the AsyncBaseService
- Convert PlanningSearchService to use the AsyncBaseService
- Updated code using `planning_search` and `events_planning_search` to use await where possible

**NOTE:** Makes use of new search with projections added in this [PR SDESK-7531](https://github.com/superdesk/superdesk-core/pull/2862/files) which needs to be merged first.

Solves: [SDESK-7515](https://sofab.atlassian.net/browse/SDESK-7515)

[SDESK-7515]: https://sofab.atlassian.net/browse/SDESK-7515