### PR TITLE
Hide show in embedded form for coverages

### DIFF
--- a/client/components/ContentProfiles/CoverageProfileModal.tsx
+++ b/client/components/ContentProfiles/CoverageProfileModal.tsx
@@ -42,7 +42,7 @@ const allCoverageTypesObject: {[key in ICoverageType]: 1} = {
     liveVideo: 1,
 };
 
-const allCoverageTypes: Array<ICoverageType> = Object.keys(allCoverageTypesObject) as Array<ICoverageType>;
+export const ALL_COVERAGE_TYPES: Array<ICoverageType> = Object.keys(allCoverageTypesObject) as Array<ICoverageType>;
 
 export class CoverageProfilesModal extends React.Component<IProps, IState> {
     constructor(props) {
@@ -267,7 +267,7 @@ export class CoverageProfilesModal extends React.Component<IProps, IState> {
             >
                 <Spacer gap="0" h justifyContent="center" alignItems="start" noWrap style={{height: '500px'}}>
                     <Spacer gap="4" v style={{height: 'auto', width: '200px', padding: 12}} noWrap>
-                        {allCoverageTypes.map((type) => (
+                        {ALL_COVERAGE_TYPES.map((type) => (
                             <Button
                                 key={type}
                                 onClick={() => {

--- a/client/components/ContentProfiles/CoverageProfileModal.tsx
+++ b/client/components/ContentProfiles/CoverageProfileModal.tsx
@@ -282,6 +282,7 @@ export class CoverageProfilesModal extends React.Component<IProps, IState> {
                         ))}
                     </Spacer>
                     <FieldTab
+                        isProfileCoverage={true}
                         profile={this.state.profile}
                         groupFields={false}
                         systemRequiredFields={COVERAGE_SYSTEM_REQUIRED_FIELDS}

--- a/client/components/ContentProfiles/FieldTab/FieldEditor.tsx
+++ b/client/components/ContentProfiles/FieldTab/FieldEditor.tsx
@@ -1,6 +1,11 @@
 import * as React from 'react';
 
-import {IProfileFieldEntry, IPlanningContentProfile, IProfileSchemaTypeString} from '../../../interfaces';
+import {
+    IProfileFieldEntry,
+    IPlanningContentProfile,
+    IProfileSchemaTypeString,
+    ICoverageContentProfile,
+} from '../../../interfaces';
 import {superdeskApi, planningApi} from '../../../superdeskApi';
 
 import {getFieldNameTranslated} from '../../../utils/contentProfiles';
@@ -8,6 +13,7 @@ import {getFieldNameTranslated} from '../../../utils/contentProfiles';
 import {Button, ButtonGroup, Checkbox, Alert} from 'superdesk-ui-framework/react';
 import {renderFieldsForPanel} from '../../fields';
 import {coverageProfiles} from '../../../selectors/coverageProfiles';
+import {ALL_COVERAGE_TYPES} from '../CoverageProfileModal';
 
 interface IProps {
     item: IProfileFieldEntry;
@@ -84,17 +90,15 @@ export class FieldEditor extends React.Component<IProps, IState> {
         const isMultilingual = this.props.item.name === 'language' ?
             (this.props.item.schema as IProfileSchemaTypeString).multilingual === true :
             multilingual.isEnabled(this.props.profile);
-        const storeState = planningApi.redux.store.getState();
-        const allCoverageProfileIds = coverageProfiles(storeState).map((x) => x._id);
 
         const fieldProps = {
             'schema.show_in_embedded_editor': {
                 /**
                  * Coverage fields don't need this field config option, only planning and event
                  */
-                enabled: !this.props.systemRequired
-                    && this.props.profile._id !== 'coverage'
-                    && allCoverageProfileIds.includes(this.props.profile._id) === false,
+                enabled: !this.props.systemRequired &&
+                    !ALL_COVERAGE_TYPES.includes((this.props.profile as ICoverageContentProfile).content_type)
+                    && this.props.profile.name !== 'coverage', // handle old profile
             },
             'schema.required': {enabled: !(this.props.disableRequired || this.props.systemRequired)},
             'schema.read_only': {enabled: this.props.item.name === 'related_plannings'},

--- a/client/components/ContentProfiles/FieldTab/FieldEditor.tsx
+++ b/client/components/ContentProfiles/FieldTab/FieldEditor.tsx
@@ -4,20 +4,18 @@ import {
     IProfileFieldEntry,
     IPlanningContentProfile,
     IProfileSchemaTypeString,
-    ICoverageContentProfile,
 } from '../../../interfaces';
-import {superdeskApi, planningApi} from '../../../superdeskApi';
 
+import {superdeskApi, planningApi} from '../../../superdeskApi';
 import {getFieldNameTranslated} from '../../../utils/contentProfiles';
 
 import {Button, ButtonGroup, Checkbox, Alert} from 'superdesk-ui-framework/react';
 import {renderFieldsForPanel} from '../../fields';
-import {coverageProfiles} from '../../../selectors/coverageProfiles';
-import {ALL_COVERAGE_TYPES} from '../CoverageProfileModal';
 
 interface IProps {
     item: IProfileFieldEntry;
     profile: IPlanningContentProfile;
+    isProfileCoverage?: boolean;
     isDirty: boolean;
     disableMinMax: boolean;
     disableRequired: boolean;
@@ -96,9 +94,7 @@ export class FieldEditor extends React.Component<IProps, IState> {
                 /**
                  * Coverage fields don't need this field config option, only planning and event
                  */
-                enabled: !this.props.systemRequired &&
-                    !ALL_COVERAGE_TYPES.includes((this.props.profile as ICoverageContentProfile).content_type)
-                    && this.props.profile.name !== 'coverage', // handle old profile
+                enabled: !this.props.systemRequired && this.props.isProfileCoverage != true
             },
             'schema.required': {enabled: !(this.props.disableRequired || this.props.systemRequired)},
             'schema.read_only': {enabled: this.props.item.name === 'related_plannings'},

--- a/client/components/ContentProfiles/FieldTab/index.tsx
+++ b/client/components/ContentProfiles/FieldTab/index.tsx
@@ -23,6 +23,7 @@ import {FieldEditor} from './FieldEditor';
 
 interface IProps {
     profile: IEditorProfile;
+    isProfileCoverage?: boolean;
     groupFields: boolean;
     systemRequiredFields: Array<string>;
     disableMinMaxFields?: Array<string>;
@@ -264,6 +265,7 @@ export class FieldTab extends React.Component<IProps, IState> {
 
                             return profileRes;
                         })()}
+                        isProfileCoverage={this.props.isProfileCoverage}
                         profile={this.props.profile}
                         isDirty={this.isEditorDirty()}
                         disableMinMax={this.props.disableMinMaxFields?.includes(this.state.selectedField.name)}


### PR DESCRIPTION
STT-177

## Front-end checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)
