### PR TITLE
Fix coverage validation

### DIFF
--- a/client/api/editor/item_planning.ts
+++ b/client/api/editor/item_planning.ts
@@ -31,8 +31,7 @@ export function getCoverageFields(
     const storeState = planningApi.redux.store.getState();
     const allProfiles = coverageProfiles(storeState);
     const newProfile = allProfiles.find((x) => x.content_type === type);
-    const profile = newProfile ? newProfile : omit(oldProfile(storeState), '_id');
-
+    const profile = newProfile ? newProfile : omit(oldProfile(storeState), '_id') as ICoverageContentProfile;
     const fields = getGroupFieldsSorted(profile).filter((item) => item.field.enabled);
     const searchProfile: ISearchProfile = {};
 

--- a/client/validators/index.ts
+++ b/client/validators/index.ts
@@ -109,7 +109,7 @@ export const validateItem = ({
                 profileName: profileName,
                 field: key,
                 value: key === '_all' ? diff : getValue(key),
-                profile: key !== 'coverages' ? profiles[profileName] : profiles.coverage,
+                profile: key !== 'coverages' ? profiles[profileName] : undefined,
                 errors: errors,
                 messages: messages,
                 diff: diff,

--- a/client/validators/planning.ts
+++ b/client/validators/planning.ts
@@ -8,7 +8,7 @@ import {gettext, getItemInArrayById} from '../utils';
 import {validateField, validators} from './index';
 import {IPlanningCoverageItem} from 'interfaces';
 import {planningApi} from '../superdeskApi';
-import {coverageProfiles, oldProfile} from '../selectors/coverageProfiles';
+import {getCoverageFields} from '../api/editor/item_planning';
 
 const validatePlanningScheduleDate = ({getState, field, value, errors, messages, diff, item}) => {
     // Only validate the schedule if it has changed
@@ -54,6 +54,16 @@ export function validateCoveragesV2(value: Array<IPlanningCoverageItem>) {
     return {errors, messages};
 }
 
+interface IValidateCoverages {
+    dispatch: any;
+    getState: any;
+    value: Array<IPlanningCoverageItem>;
+    errors: any;
+    messages: any;
+    diff: Partial<IPlanningItem>;
+    item: Partial<IPlanningItem>;
+}
+
 export const validateCoverages = ({
     dispatch,
     getState,
@@ -62,60 +72,63 @@ export const validateCoverages = ({
     messages,
     diff,
     item,
-}) => {
+}: IValidateCoverages) => {
     const error = {};
+    const handleErrors = () => {
+        if (!isEqual(error, {})) {
+            errors.coverages = error;
+        } else if (errors.coverages) {
+            delete errors.coverages;
+        }
+    };
 
-    if (Array.isArray(value)) {
-        value.forEach((coverage, index) => {
-            const originalCoverage = getItemInArrayById(
-                get(item, 'coverages') || [],
-                get(coverage, 'coverage_id'),
-                'coverage_id'
-            );
+    if (Array.isArray(value) === false) {
+        handleErrors();
+        return;
+    }
 
-            const storeState = planningApi.redux.store.getState();
-            const newProfile = coverageProfiles(storeState)
-                .find((x) => x.content_type === coverage.content_type);
-            const coverageProfile = newProfile ? newProfile : oldProfile(storeState);
+    value.forEach((coverage, index) => {
+        const originalCoverage = getItemInArrayById(
+            get(item, 'coverages') || [],
+            get(coverage, 'coverage_id'),
+            'coverage_id'
+        );
 
-            Object.entries(validators.coverage).forEach(([key, val]) => {
-                const coverageErrors = {};
-                let keyName = ['news_coverage_status', 'scheduled_updates'].includes(key) ? key : `planning.${key}`;
-                let original = get(originalCoverage, keyName);
-                let value = get(coverage, keyName);
+        const coverageProfile = getCoverageFields(coverage.planning.g2_content_type).profile;
 
-                if (key === 'scheduled' && original !== undefined && isEqual(original, value)) {
-                    // Only validate scheduled date if it has changed
-                    return;
-                } else if (get(coverage, 'planning.g2_content_type') !== 'text' && key === 'genre') {
-                    // Only validate Genre if the content type is Text
-                    return;
-                }
+        Object.entries(validators.coverage).forEach(([key, val]) => {
+            const coverageErrors = {};
+            const keyName = ['news_coverage_status', 'scheduled_updates'].includes(key) ? key : `planning.${key}`;
+            const original = get(originalCoverage, keyName);
+            const value = get(coverage, keyName);
 
-                validateField({
-                    profileName: 'coverage',
-                    dispatch: dispatch,
-                    getState: getState,
-                    field: key,
-                    value: value,
-                    profile: coverageProfile,
-                    errors: coverageErrors,
-                    messages: messages,
-                    diff: diff,
-                });
+            if (key === 'scheduled' && original !== undefined && isEqual(original, value)) {
+                // Only validate scheduled date if it has changed
+                return;
+            } else if (get(coverage, 'planning.g2_content_type') !== 'text' && key === 'genre') {
+                // Only validate Genre if the content type is Text
+                return;
+            }
 
-                if (get(coverageErrors, key)) {
-                    set(error, `${index}.${keyName}`, coverageErrors[key]);
-                }
+            validateField({
+                profileName: 'coverage',
+                dispatch: dispatch,
+                getState: getState,
+                field: key,
+                value: value,
+                profile: coverageProfile,
+                errors: coverageErrors,
+                messages: messages,
+                diff: diff,
             });
-        });
-    }
 
-    if (!isEqual(error, {})) {
-        errors.coverages = error;
-    } else if (errors.coverages) {
-        delete errors.coverages;
-    }
+            if (get(coverageErrors, key)) {
+                set(error, `${index}.${keyName}`, coverageErrors[key]);
+            }
+        });
+    });
+
+    handleErrors();
 };
 
 const validateCoverageScheduleDate = ({


### PR DESCRIPTION
STT-178

## Front-end checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)
