### PR TITLE
fix ingest rule handling

### DIFF
--- a/server/planning/io/ingest_rule_handler.py
+++ b/server/planning/io/ingest_rule_handler.py
@@ -19,7 +19,7 @@ from superdesk import get_resource_service
 from superdesk.metadata.item import ITEM_TYPE, CONTENT_TYPE
 from apps.rules.rule_handlers import RoutingRuleHandler, register_routing_rule_handler
 
-from planning.common import POST_STATE, update_post_item
+from planning.common import POST_STATE, update_post_item, WORKFLOW_STATE
 
 logger = logging.getLogger(__name__)
 
@@ -114,6 +114,8 @@ class PlanningRoutingRuleHandler(RoutingRuleHandler):
             return None
 
         updates = {"calendars": ingest_item["calendars"] + calendars_to_add}
+        if attributes.get("autopost", False):
+            updates.update({"state": WORKFLOW_STATE.SCHEDULED, "pubstatus": POST_STATE.USABLE})
         updated_item = get_resource_service("events").patch(ingest_item.get(config.ID_FIELD), updates)
         updates["_etag"] = updated_item["_etag"]
 
@@ -161,6 +163,8 @@ class PlanningRoutingRuleHandler(RoutingRuleHandler):
 
         # Append Agenda IDs found onto the item
         updates = {"agendas": ingest_item["agendas"] + new_agenda_ids}
+        if attributes.get("autopost", False):
+            updates.update({"state": WORKFLOW_STATE.SCHEDULED, "pubstatus": POST_STATE.USABLE})
         updated_item = get_resource_service("planning").patch(ingest_item.get(config.ID_FIELD), updates)
         updates["_etag"] = updated_item["_etag"]
         return updates

--- a/server/planning/io/ingest_rule_handler.py
+++ b/server/planning/io/ingest_rule_handler.py
@@ -74,8 +74,9 @@ class PlanningRoutingRuleHandler(RoutingRuleHandler):
 
         if updates is not None:
             ingest_item.update(updates)
-        elif attributes.get("autopost", False):
-            self.process_autopost(ingest_item)
+
+        if attributes.get("autopost", False):
+            self.process_autopost(ingest_item, updates)
 
     def _is_original_posted(self, ingest_item: Dict[str, Any]):
         service = get_resource_service("events" if ingest_item[ITEM_TYPE] == CONTENT_TYPE.EVENT else "planning")
@@ -114,8 +115,6 @@ class PlanningRoutingRuleHandler(RoutingRuleHandler):
             return None
 
         updates = {"calendars": ingest_item["calendars"] + calendars_to_add}
-        if attributes.get("autopost", False):
-            updates.update({"state": WORKFLOW_STATE.SCHEDULED, "pubstatus": POST_STATE.USABLE})
         updated_item = get_resource_service("events").patch(ingest_item.get(config.ID_FIELD), updates)
         updates["_etag"] = updated_item["_etag"]
 
@@ -163,13 +162,11 @@ class PlanningRoutingRuleHandler(RoutingRuleHandler):
 
         # Append Agenda IDs found onto the item
         updates = {"agendas": ingest_item["agendas"] + new_agenda_ids}
-        if attributes.get("autopost", False):
-            updates.update({"state": WORKFLOW_STATE.SCHEDULED, "pubstatus": POST_STATE.USABLE})
         updated_item = get_resource_service("planning").patch(ingest_item.get(config.ID_FIELD), updates)
         updates["_etag"] = updated_item["_etag"]
         return updates
 
-    def process_autopost(self, ingest_item: Dict[str, Any]):
+    def process_autopost(self, ingest_item: Dict[str, Any], updates: Optional[Dict[str, Any]]):
         """Automatically post this item"""
         if self._is_original_posted(ingest_item):
             # No need to autopost this item
@@ -177,15 +174,24 @@ class PlanningRoutingRuleHandler(RoutingRuleHandler):
             # And any updates from ingest should automatically re-post this item
             return
 
-        item_id = ingest_item.get(config.ID_FIELD)
-        update_post_item(
+        if not updates:
+            updates = {}
+
+        updates.update(
             {
-                "pubstatus": ingest_item.get("ingest_pubstatus") or POST_STATE.USABLE,
+                "pubstatus": get_pubstatus(ingest_item),
                 "_etag": ingest_item.get("_etag"),
-            },
-            ingest_item,
+            }
         )
+
+        item_id = ingest_item.get(config.ID_FIELD)
+        update_post_item(updates, ingest_item)
         logger.info(f"Posted item {item_id}")
+
+
+def get_pubstatus(ingest_item: Dict[str, Any]) -> str:
+    """Get the pubstatus from the ingest item"""
+    return ingest_item.get("ingest_pubstatus") or POST_STATE.USABLE
 
 
 register_routing_rule_handler(PlanningRoutingRuleHandler())

--- a/server/planning/io/ingest_rule_handler_test.py
+++ b/server/planning/io/ingest_rule_handler_test.py
@@ -214,3 +214,29 @@ class IngestRuleHandlerTestCase(TestCase):
 
     def get_event_history(self):
         return list(self.app.data.find_all("events_history"))
+
+    def test_autopost_with_calendars(self):
+        event = self.event_items[0].copy()
+        events_service = get_resource_service("events")
+        events_service.post_in_mongo([event])
+
+        self.app.data.insert(
+            "vocabularies",
+            [
+                {
+                    "_id": "event_calendars",
+                    "items": self.calendars,
+                }
+            ],
+        )
+
+        calendars_rule = {"actions": {"extra": {"autopost": True, "calendars": ["sports"]}}}
+        self.handler.apply_rule(calendars_rule, event, {})
+
+        history = self.get_event_history()
+        assert len(history) == 2
+        assert history[-1]["operation"] == "post"
+
+        original = events_service.find_one(req=None, _id=event["_id"])
+        assert original["pubstatus"] == "usable"
+        assert original["state"] == "scheduled"


### PR DESCRIPTION
fix events not being auto posted with proper state when also setting calendars

## Front-end checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)
