### PR TITLE
Fix associated events field content profile sidebar opening

### DIFF
--- a/client/components/ContentProfiles/FieldTab/FieldEditor.tsx
+++ b/client/components/ContentProfiles/FieldTab/FieldEditor.tsx
@@ -4,6 +4,7 @@ import {
     IProfileFieldEntry,
     IPlanningContentProfile,
     IProfileSchemaTypeString,
+    IEventFormProfile,
 } from '../../../interfaces';
 
 import {superdeskApi, planningApi} from '../../../superdeskApi';
@@ -11,6 +12,7 @@ import {getFieldNameTranslated} from '../../../utils/contentProfiles';
 
 import {Button, ButtonGroup, Checkbox, Alert} from 'superdesk-ui-framework/react';
 import {renderFieldsForPanel} from '../../fields';
+import {coverageProfiles} from '../../../selectors/coverageProfiles';
 
 interface IProps {
     item: IProfileFieldEntry;
@@ -88,18 +90,28 @@ export class FieldEditor extends React.Component<IProps, IState> {
         const isMultilingual = this.props.item.name === 'language' ?
             (this.props.item.schema as IProfileSchemaTypeString).multilingual === true :
             multilingual.isEnabled(this.props.profile);
+        const storeState = planningApi.redux.store.getState();
+        const allCoverageProfileIds = coverageProfiles(storeState).map((x) => x._id);
+        const nameof = superdeskApi.helpers.nameof<IEventFormProfile['editor']>;
 
         const fieldProps = {
             'schema.show_in_embedded_editor': {
                 /**
                  * Coverage fields don't need this field config option, only planning and event
                  */
-                enabled: !this.props.systemRequired && this.props.isProfileCoverage != true
+                enabled: !([nameof('related_plannings'), 'associated_event'].includes(this.props.item.name))
+                    && !this.props.systemRequired
+                    && this.props.profile._id !== 'coverage'
+                    && allCoverageProfileIds.includes(this.props.profile._id) === false,
             },
             'schema.required': {enabled: !(this.props.disableRequired || this.props.systemRequired)},
-            'schema.read_only': {enabled: this.props.item.name === 'related_plannings'},
-            'schema.planning_auto_publish': {enabled: this.props.item.name === 'related_plannings'},
-            'schema.cancel_plan_with_event': {enabled: this.props.item.name === 'related_plannings'},
+            'schema.read_only': {enabled: this.props.item.name === nameof('related_plannings')},
+            'schema.planning_auto_publish': {
+                enabled: this.props.item.name === nameof('related_plannings')
+            },
+            'schema.cancel_plan_with_event': {
+                enabled: this.props.item.name === nameof('related_plannings')
+            },
             'schema.field_type': {enabled: fieldType != null},
             'schema.minlength': {enabled: !disableMinMax},
             'schema.maxlength': {enabled: !disableMinMax},

--- a/client/components/fields/resources/profiles.ts
+++ b/client/components/fields/resources/profiles.ts
@@ -30,7 +30,7 @@ registerEditorField(
     (props) => ({
         label: superdeskApi.localization.gettext('Show in embedded form'),
         field: 'schema.show_in_embedded_editor',
-        disabled: props.item.schema.required,
+        disabled: props.item.schema?.required ?? true,
     }),
     null,
     true


### PR DESCRIPTION
STT-168

## Front-end checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)
