### PR TITLE
Update deps

### DIFF
--- a/client/components/ItemActionConfirmation/tests/formValidations_test.tsx
+++ b/client/components/ItemActionConfirmation/tests/formValidations_test.tsx
@@ -61,7 +61,7 @@ describe('form validations', () => {
     it('forms with validation shows validation errors', () => {
         let wrapper = getWrapper(ConvertToRecurringEventForm);
         const endsField_convertToRecurringEventForm = wrapper
-            .find('[data-test-id="dates.recurring_rule.endRepeatMode"]');
+            .find('[data-test-id="dates.recurring_rule.endRepeatMode"]').at(1);
 
         expect(wrapper.find('.sd-input--invalid').length).toBe(1);
         endsField_convertToRecurringEventForm.simulate('change', {target: {value: 'count'}});
@@ -112,7 +112,7 @@ describe('form validations', () => {
         expect(wrapper.find('.sd-input--invalid').length).toBe(0);
 
         const endsField_updateEventRepetitionsForm = wrapper
-            .find('[data-test-id="dates.recurring_rule.endRepeatMode"]');
+            .find('[data-test-id="dates.recurring_rule.endRepeatMode"]').at(1);
 
         endsField_updateEventRepetitionsForm.simulate('change', {target: {value: 'count'}});
 

--- a/client/planning-extension/src/assignments-overview/index.tsx
+++ b/client/planning-extension/src/assignments-overview/index.tsx
@@ -10,7 +10,7 @@ import {
 } from 'superdesk-api';
 import {ASSIGNMENT_STATE, IAssignmentItem} from '../../../interfaces';
 import {superdesk} from '../superdesk';
-import {Badge} from 'superdesk-ui-framework';
+import {Badge} from 'superdesk-ui-framework/react';
 import {AssignmentsOverviewListItem} from './assignments-overview-list-item';
 
 const DropdownTree = superdesk.components.getDropdownTree<IAssignmentItem>();

--- a/package-lock.json
+++ b/package-lock.json
@@ -12409,7 +12409,7 @@
       }
     },
     "superdesk-core": {
-      "version": "github:superdesk/superdesk-client-core#8e3a9b5aaaa273895ac4d5cd20cfabc644ca4e4d",
+      "version": "github:superdesk/superdesk-client-core#0be54c650db60896642ab570be0c66ee5fba0e8b",
       "from": "github:superdesk/superdesk-client-core#develop",
       "dev": true,
       "requires": {
@@ -12510,7 +12510,7 @@
         "shallow-equal": "^3.1.0",
         "shortid": "2.2.8",
         "style-loader": "0.20.2",
-        "superdesk-ui-framework": "4.0.23",
+        "superdesk-ui-framework": "4.0.27",
         "ts-loader": "3.5.0",
         "typescript": "4.9.5",
         "uuid": "8.3.1",
@@ -12711,9 +12711,9 @@
           }
         },
         "superdesk-ui-framework": {
-          "version": "4.0.23",
-          "resolved": "https://registry.npmjs.org/superdesk-ui-framework/-/superdesk-ui-framework-4.0.23.tgz",
-          "integrity": "sha512-sa0befz5gYniJHdGYpsubNJooR3TIsk/0ZSNFy/g+bKXVi+91yI6GzBcBWioBzq8g5D1ulv2ECWPuei84Pn6Og==",
+          "version": "4.0.27",
+          "resolved": "https://registry.npmjs.org/superdesk-ui-framework/-/superdesk-ui-framework-4.0.27.tgz",
+          "integrity": "sha512-vbhXV3k8sL0H7j3sPtJEh1LUhUmLy88vh2+mrkGMaS7rYpo0ol7fTYra2u2lNa7n2e+rDeLmFo6df/IL+qiUMg==",
           "dev": true,
           "requires": {
             "@popperjs/core": "^2.4.0",
@@ -12756,9 +12756,9 @@
       }
     },
     "superdesk-ui-framework": {
-      "version": "4.0.23",
-      "resolved": "https://registry.npmjs.org/superdesk-ui-framework/-/superdesk-ui-framework-4.0.23.tgz",
-      "integrity": "sha512-sa0befz5gYniJHdGYpsubNJooR3TIsk/0ZSNFy/g+bKXVi+91yI6GzBcBWioBzq8g5D1ulv2ECWPuei84Pn6Og==",
+      "version": "4.0.28",
+      "resolved": "https://registry.npmjs.org/superdesk-ui-framework/-/superdesk-ui-framework-4.0.28.tgz",
+      "integrity": "sha512-IZjyrHzD/feh2zhmoHkzEsj6qFYzFNPm8NEkryNIuZJCEcabOCbSlOKh+esNbR5Tk6NXsYJrORYGaKNvGlIiUA==",
       "dev": true,
       "requires": {
         "@popperjs/core": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "sinon": "^4.5.0",
     "superdesk-code-style": "1.5.0",
     "superdesk-core": "github:superdesk/superdesk-client-core#develop",
-    "superdesk-ui-framework": "^4.0.21",
+    "superdesk-ui-framework": "^4.0.28",
     "ts-node": "~7.0.1",
     "tslint": "5.11.0",
     "typescript-eslint-parser": "^18.0.0"


### PR DESCRIPTION
## Front-end checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)
