### PR TITLE
Improve drag and drop for content profile fields, improve options menu

### DIFF
--- a/client/components/ContentProfiles/FieldTab/AddFieldsMenu.tsx
+++ b/client/components/ContentProfiles/FieldTab/AddFieldsMenu.tsx
@@ -16,6 +16,7 @@ export default class AddFieldsMenu extends React.PureComponent<IProps, any> {
 
         return (
             <TreeMenu
+                data-test-id="menu"
                 getId={(field) => field.name}
                 optionTemplate={(item) => item.schema?.type === 'custom_vocabulary' ? (
                     <>

--- a/client/components/ContentProfiles/FieldTab/AddFieldsMenu.tsx
+++ b/client/components/ContentProfiles/FieldTab/AddFieldsMenu.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import {IProfileFieldEntry} from 'interfaces';
+import {TreeMenu, Button} from 'superdesk-ui-framework/react';
+import {superdeskApi} from '../../../superdeskApi';
+import {getFieldNameTranslated} from '../../../utils/contentProfiles';
+
+interface IProps {
+    options: Array<{value: IProfileFieldEntry; onSelect: () => void;}>;
+    buttonLabel: string;
+}
+
+export default class AddFieldsMenu extends React.PureComponent<IProps, any> {
+    render(): React.ReactNode {
+        const {gettext} = superdeskApi.localization;
+        const {options, buttonLabel} = this.props;
+
+        return (
+            <TreeMenu
+                getId={(field) => field.name}
+                optionTemplate={(item) => item.schema?.type === 'custom_vocabulary' ? (
+                    <>
+                        {item.name}
+                        <span className="sd-text--italic sd-text--light">
+                            &nbsp;({gettext('custom vocabulary')})
+                        </span>
+                    </>
+                ) : (
+                    <>
+                        {item.name}
+                    </>
+                )}
+                getLabel={(item) => getFieldNameTranslated(item.name)}
+                getOptions={() => options}
+            >
+                {(toggle) => (
+                    <Button
+                        text={buttonLabel}
+                        iconOnly={true}
+                        icon="plus-large"
+                        shape="round"
+                        type="primary"
+                        onClick={toggle}
+                    />
+                )}
+            </TreeMenu>
+        );
+    }
+}

--- a/client/components/ContentProfiles/FieldTab/AddFieldsMenu.tsx
+++ b/client/components/ContentProfiles/FieldTab/AddFieldsMenu.tsx
@@ -20,14 +20,14 @@ export default class AddFieldsMenu extends React.PureComponent<IProps, any> {
                 getId={(field) => field.name}
                 optionTemplate={(item) => item.schema?.type === 'custom_vocabulary' ? (
                     <>
-                        {item.name}
+                        {getFieldNameTranslated(item.name)}
                         <span className="sd-text--italic sd-text--light">
                             &nbsp;({gettext('custom vocabulary')})
                         </span>
                     </>
                 ) : (
                     <>
-                        {item.name}
+                        {getFieldNameTranslated(item.name)}
                     </>
                 )}
                 getLabel={(item) => getFieldNameTranslated(item.name)}

--- a/client/components/ContentProfiles/FieldTab/FieldEditor.tsx
+++ b/client/components/ContentProfiles/FieldTab/FieldEditor.tsx
@@ -81,7 +81,7 @@ export class FieldEditor extends React.Component<IProps, IState> {
 
     render() {
         const {gettext} = superdeskApi.localization;
-        const disableMinMax = this.props.disableMinMax || !['string', 'list'].includes(this.props.item.schema.type);
+        const disableMinMax = this.props.disableMinMax || !['string', 'list'].includes(this.props.item.schema?.type);
         const fieldType = this.props.item.schema?.type !== 'string' ?
             null :
             this.props.item.schema.field_type;

--- a/client/components/ContentProfiles/FieldTab/FieldList.tsx
+++ b/client/components/ContentProfiles/FieldTab/FieldList.tsx
@@ -5,9 +5,10 @@ import {superdeskApi} from '../../../superdeskApi';
 
 import {getFieldNameTranslated, getProfileGroupNameTranslated} from '../../../utils/contentProfiles';
 
-import {Button, IconButton, ToggleBox, Menu, Label} from 'superdesk-ui-framework/react';
+import {Button, IconButton, ToggleBox, Label, TreeMenu} from 'superdesk-ui-framework/react';
 import * as List from '../../UI/List';
-import SortItems from '../../SortItems';
+import {arrayMove, WithSortable} from '@sourcefabric/common';
+import {shouldNotStartDragging} from '../utils';
 
 interface IProps {
     profile: IEditorProfile;
@@ -28,6 +29,48 @@ export class FieldList extends React.PureComponent<IProps> {
         super(props);
 
         this.getListElement = this.getListElement.bind(this);
+        this.getTreeMenu = this.getTreeMenu.bind(this);
+    }
+
+    getTreeMenu(options: Array<{value: IProfileFieldEntry; onSelect: () => void;}>, buttonLabel: string) {
+        const {gettext} = superdeskApi.localization;
+
+        return (
+            <TreeMenu
+                getId={(field) => field.name}
+                optionTemplate={(item) => item.schema?.type === 'custom_vocabulary' ? (
+                    <>
+                        {item.name}
+                        <span className="sd-text--italic sd-text--light">
+                            &nbsp;({gettext('custom vocabulary')})
+                        </span>
+                    </>
+                ) : (
+                    <>
+                        {item.name}
+                    </>
+                )}
+                getLabel={(item) => getFieldNameTranslated(item.name)}
+                getOptions={() => options}
+            >
+                {(toggle) => (
+                    <Button
+                        text={buttonLabel}
+                        iconOnly={true}
+                        icon="plus-large"
+                        shape="round"
+                        type="primary"
+                        onClick={(e) => {
+                            e.preventDefault();
+                            e.stopPropagation();
+
+                            toggle(e);
+                        }}
+
+                    />
+                )}
+            </TreeMenu>
+        );
     }
 
     getListElement(item: IProfileFieldEntry) {
@@ -38,8 +81,8 @@ export class FieldList extends React.PureComponent<IProps> {
         const isLastField = item.name === fields[fields.length - 1]?.name;
         const getAddFieldMenuItems = (offset) => this.props.unusedFields.map(
             (itemToAdd) => ({
-                label: getFieldNameTranslated(itemToAdd.name),
-                onClick: () => {
+                value: itemToAdd,
+                onSelect: () => {
                     this.props.insertField(itemToAdd, this.props.group?._id, item.field.index + offset);
                 },
             })
@@ -51,9 +94,9 @@ export class FieldList extends React.PureComponent<IProps> {
 
         return (
             <List.Item
+                zIndex={2000}
                 testId={`content-list--field-${item.name}`}
                 shadow={1}
-                draggable={true}
                 activated={this.props.selectedField === item.name}
                 onClick={(e) => {
                     // don't trigger editor if click went to a three dot menu
@@ -66,25 +109,11 @@ export class FieldList extends React.PureComponent<IProps> {
                     }
                     this.props.onClick(item);
                 }}
+                className="mt-1"
             >
                 {!menuItems.before.length ? null : (
                     <div className="profile-item__add-btn">
-                        <div>
-                            <Menu items={menuItems.before}>
-                                {(toggle) => (
-                                    <Button
-                                        text={gettext('Add field before')}
-                                        iconOnly={true}
-                                        icon="plus-large"
-                                        shape="round"
-                                        type="primary"
-                                        onClick={(event) => {
-                                            toggle(event);
-                                        }}
-                                    />
-                                )}
-                            </Menu>
-                        </div>
+                        {this.getTreeMenu(menuItems.after, gettext('Add field before'))}
                     </div>
                 )}
                 <List.Column
@@ -123,22 +152,7 @@ export class FieldList extends React.PureComponent<IProps> {
                 </List.ActionMenu>
                 {(!isLastField || !menuItems.after.length) ? null : (
                     <div className="profile-item__add-btn profile-item__add-btn--bottom">
-                        <div>
-                            <Menu items={menuItems.after}>
-                                {(toggle) => (
-                                    <Button
-                                        text={gettext('Add field after')}
-                                        iconOnly={true}
-                                        icon="plus-large"
-                                        shape="round"
-                                        type="primary"
-                                        onClick={(event) => {
-                                            toggle(event);
-                                        }}
-                                    />
-                                )}
-                            </Menu>
-                        </div>
+                        {this.getTreeMenu(menuItems.after, gettext('Add field after'))}
                     </div>
                 )}
             </List.Item>
@@ -150,40 +164,31 @@ export class FieldList extends React.PureComponent<IProps> {
 
         return !this.props.fields.length ? (
             <div className="planning-profile__empty-list">
-                <div>
-                    <Menu
-                        items={this.props.unusedFields.map((item) => ({
-                            label: item.name,
-                            onClick: () => {
-                                this.props.insertField(item, this.props.group?._id, 0);
-                            }
-                        }))}
-                    >
-                        {(toggle) => (
-                            <Button
-                                text={gettext('Add first field')}
-                                iconOnly={true}
-                                icon="plus-large"
-                                shape="round"
-                                type="primary"
-                                onClick={(event) => {
-                                    toggle(event);
-                                }}
-                            />
-                        )}
-                    </Menu>
-                </div>
+                {this.getTreeMenu(
+                    this.props.unusedFields.map((item) => ({
+                        value: item,
+                        onSelect: () => this.props.insertField(item, this.props.group?._id, 0),
+                    })),
+                    gettext('Add first field')
+                )}
             </div>
         ) : (
-            <List.Group spaceBetween={true}>
-                <SortItems
-                    onSortChange={this.props.onSortChange}
+            <List.Group spaceBetween>
+                <WithSortable
                     items={this.props.fields}
-                    getListElement={this.getListElement}
-                    useCustomStyle={true}
-                    lockAxis="y"
-                    lockToContainerEdges={true}
-                    distance={10}
+                    getId={(item) => item.name}
+                    itemTemplate={(item) => <>{this.getListElement(item.item)}</>}
+                    options={{
+                        shouldCancelStart: shouldNotStartDragging,
+                        onSortEnd: ({
+                            oldIndex,
+                            newIndex
+                        }) => {
+                            const itemsSorted = arrayMove(this.props.fields, oldIndex, newIndex);
+
+                            this.props.onSortChange(itemsSorted);
+                        }
+                    }}
                 />
             </List.Group>
         );

--- a/client/components/ContentProfiles/FieldTab/FieldList.tsx
+++ b/client/components/ContentProfiles/FieldTab/FieldList.tsx
@@ -1,14 +1,15 @@
 import * as React from 'react';
 
 import {IEditorProfile, IEditorProfileGroup, IProfileFieldEntry} from '../../../interfaces';
+
+import {getProfileGroupNameTranslated} from '../../../utils/contentProfiles';
 import {superdeskApi} from '../../../superdeskApi';
 
-import {getFieldNameTranslated, getProfileGroupNameTranslated} from '../../../utils/contentProfiles';
-
-import {Button, IconButton, ToggleBox, Label, TreeMenu} from 'superdesk-ui-framework/react';
-import * as List from '../../UI/List';
+import {ToggleBox} from 'superdesk-ui-framework/react';
 import {arrayMove, WithSortable} from '@sourcefabric/common';
-import {shouldNotStartDragging} from '../utils';
+import AddFieldsMenu from './AddFieldsMenu';
+import * as List from '../../UI/List';
+import ProfileFieldTemplate from './ListElementTemplate';
 
 interface IProps {
     profile: IEditorProfile;
@@ -25,161 +26,36 @@ interface IProps {
 }
 
 export class FieldList extends React.PureComponent<IProps> {
-    constructor(props) {
-        super(props);
-
-        this.getListElement = this.getListElement.bind(this);
-        this.getTreeMenu = this.getTreeMenu.bind(this);
-    }
-
-    getTreeMenu(options: Array<{value: IProfileFieldEntry; onSelect: () => void;}>, buttonLabel: string) {
-        const {gettext} = superdeskApi.localization;
-
-        return (
-            <TreeMenu
-                getId={(field) => field.name}
-                optionTemplate={(item) => item.schema?.type === 'custom_vocabulary' ? (
-                    <>
-                        {item.name}
-                        <span className="sd-text--italic sd-text--light">
-                            &nbsp;({gettext('custom vocabulary')})
-                        </span>
-                    </>
-                ) : (
-                    <>
-                        {item.name}
-                    </>
-                )}
-                getLabel={(item) => getFieldNameTranslated(item.name)}
-                getOptions={() => options}
-            >
-                {(toggle) => (
-                    <Button
-                        text={buttonLabel}
-                        iconOnly={true}
-                        icon="plus-large"
-                        shape="round"
-                        type="primary"
-                        onClick={(e) => {
-                            e.preventDefault();
-                            e.stopPropagation();
-
-                            toggle(e);
-                        }}
-
-                    />
-                )}
-            </TreeMenu>
-        );
-    }
-
-    getListElement(item: IProfileFieldEntry) {
-        const {gettext} = superdeskApi.localization;
-        const {notify} = superdeskApi.ui;
-        const {querySelectorParent} = superdeskApi.utilities;
-        const {fields} = this.props;
-        const isLastField = item.name === fields[fields.length - 1]?.name;
-        const getAddFieldMenuItems = (offset) => this.props.unusedFields.map(
-            (itemToAdd) => ({
-                value: itemToAdd,
-                onSelect: () => {
-                    this.props.insertField(itemToAdd, this.props.group?._id, item.field.index + offset);
-                },
-            })
-        );
-        const menuItems = {
-            before: getAddFieldMenuItems(-0.1),
-            after: getAddFieldMenuItems(0.1),
-        };
-
-        return (
-            <List.Item
-                zIndex={2000}
-                testId={`content-list--field-${item.name}`}
-                shadow={1}
-                activated={this.props.selectedField === item.name}
-                onClick={(e) => {
-                    // don't trigger editor if click went to a three dot menu
-                    // or other button inside the list item
-                    if (
-                        e.target instanceof HTMLElement &&
-                        querySelectorParent(e.target, 'button', {self: true})
-                    ) {
-                        return;
-                    }
-                    this.props.onClick(item);
-                }}
-                className="mt-1"
-            >
-                {!menuItems.before.length ? null : (
-                    <div className="profile-item__add-btn">
-                        {this.getTreeMenu(menuItems.after, gettext('Add field before'))}
-                    </div>
-                )}
-                <List.Column
-                    border={false}
-                    grow={true}
-                >
-                    <List.Row>
-                        <span className="sd-text__strong">
-                            {getFieldNameTranslated(item.name)}
-                        </span>
-                    </List.Row>
-                </List.Column>
-                {!item.schema?.required ? null : (
-                    <List.Column border={false}>
-                        <List.Row>
-                            <Label
-                                text={gettext('Required')}
-                                type="alert"
-                                style="translucent"
-                            />
-                        </List.Row>
-                    </List.Column>
-                )}
-                <List.ActionMenu>
-                    <IconButton
-                        icon="trash"
-                        ariaValue={gettext('Remove field')}
-                        onClick={() => {
-                            if (this.props.systemRequiredFields?.includes(item.name)) {
-                                notify.error(gettext('Delete failed! Field is required by the system'));
-                            } else {
-                                this.props.removeField(item);
-                            }
-                        }}
-                    />
-                </List.ActionMenu>
-                {(!isLastField || !menuItems.after.length) ? null : (
-                    <div className="profile-item__add-btn profile-item__add-btn--bottom">
-                        {this.getTreeMenu(menuItems.after, gettext('Add field after'))}
-                    </div>
-                )}
-            </List.Item>
-        );
-    }
-
     renderList() {
         const {gettext} = superdeskApi.localization;
 
-        return !this.props.fields.length ? (
+        return (this.props.fields ?? []).length < 1 ? (
             <div className="planning-profile__empty-list">
-                {this.getTreeMenu(
-                    this.props.unusedFields.map((item) => ({
+                <AddFieldsMenu
+                    options={this.props.unusedFields.map((item) => ({
                         value: item,
                         onSelect: () => this.props.insertField(item, this.props.group?._id, 0),
-                    })),
-                    gettext('Add first field')
-                )}
+                    }))}
+                    buttonLabel={gettext('Add first field')}
+                />
             </div>
         ) : (
             <List.Group spaceBetween>
                 <WithSortable
                     items={this.props.fields}
                     getId={(item) => item.name}
-                    itemTemplate={(item) => <>{this.getListElement(item.item)}</>}
+                    itemTemplate={(item) => (
+                        <ProfileFieldTemplate
+                            fieldEntry={item.item}
+                            fields={this.props.fields}
+                            insertField={this.props.insertField}
+                            onClick={this.props.onClick}
+                            removeField={this.props.removeField}
+                            unusedFields={this.props.unusedFields}
+                        />
+                    )}
                     options={{
-                        shouldCancelStart: shouldNotStartDragging,
+                        distance: 10,
                         onSortEnd: ({
                             oldIndex,
                             newIndex

--- a/client/components/ContentProfiles/FieldTab/FieldList.tsx
+++ b/client/components/ContentProfiles/FieldTab/FieldList.tsx
@@ -46,6 +46,9 @@ export class FieldList extends React.PureComponent<IProps> {
                     getId={(item) => item.name}
                     itemTemplate={(item) => (
                         <ProfileFieldTemplate
+                            group={this.props.group}
+                            selectedField={this.props.selectedField}
+                            systemRequiredFields={this.props.systemRequiredFields}
                             fieldEntry={item.item}
                             fields={this.props.fields}
                             insertField={this.props.insertField}

--- a/client/components/ContentProfiles/FieldTab/ListElementTemplate.tsx
+++ b/client/components/ContentProfiles/FieldTab/ListElementTemplate.tsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import {List} from '../../../components/UI';
+import {Label, IconButton} from 'superdesk-ui-framework/react';
+import {superdeskApi} from '../../../superdeskApi';
+import {getFieldNameTranslated} from '../../../utils/contentProfiles';
+import AddFieldsMenu from './AddFieldsMenu';
+import {IEditorProfileGroup, IProfileFieldEntry} from 'interfaces';
+
+interface IProps {
+    selectedField?: string;
+    group?: IEditorProfileGroup;
+    fieldEntry: IProfileFieldEntry;
+    fields: Array<IProfileFieldEntry>;
+    systemRequiredFields?: Array<IProfileFieldEntry['name']>;
+    onClick(item: IProfileFieldEntry): void;
+    unusedFields: Array<IProfileFieldEntry>;
+    removeField(item: IProfileFieldEntry): void;
+    insertField(item: IProfileFieldEntry, groupId: IEditorProfileGroup['_id'], index: number): void;
+}
+
+export default class ProfileFieldTemplate extends React.PureComponent<IProps, any> {
+    render(): React.ReactNode {
+        const {gettext} = superdeskApi.localization;
+        const {notify} = superdeskApi.ui;
+        const {querySelectorParent} = superdeskApi.utilities;
+        const {fields, fieldEntry} = this.props;
+
+        const isLastField = fieldEntry.name === fields[fields.length - 1]?.name;
+        const getAddFieldMenuItems = (offset) => this.props.unusedFields.map(
+            (itemToAdd) => ({
+                value: itemToAdd,
+                onSelect: () => {
+                    this.props.insertField(itemToAdd, this.props.group?._id, fieldEntry.field.index + offset);
+                },
+            })
+        );
+        const menuItems = {
+            before: getAddFieldMenuItems(-0.1),
+            after: getAddFieldMenuItems(0.1),
+        };
+
+        return (
+            <List.Item
+                zIndex={2000}
+                flexRow
+                testId={`content-list--field-${fieldEntry.name}`}
+                shadow={1}
+                activated={this.props.selectedField === fieldEntry.name}
+                onClick={(e) => {
+                    // don't trigger editor if click went to a three dot menu
+                    // or other button inside the list item
+                    if (
+                        e.target instanceof HTMLElement &&
+                                    querySelectorParent(e.target, 'button', {self: true})
+                    ) {
+                        return;
+                    }
+                    this.props.onClick(fieldEntry);
+                }}
+                className="mt-1"
+            >
+                {!menuItems.before.length ? null : (
+                    <div className="profile-item__add-btn">
+                        <AddFieldsMenu
+                            options={menuItems.before}
+                            buttonLabel={gettext('Add field before')}
+                        />
+                    </div>
+                )}
+                <List.Column
+                    border={false}
+                    grow={true}
+                >
+                    <List.Row>
+                        <span className="sd-text__strong">
+                            {getFieldNameTranslated(fieldEntry.name)}
+                        </span>
+                    </List.Row>
+                </List.Column>
+                {!fieldEntry.schema?.required ? null : (
+                    <List.Column border={false}>
+                        <List.Row>
+                            <Label
+                                text={gettext('Required')}
+                                type="alert"
+                                style="translucent"
+                            />
+                        </List.Row>
+                    </List.Column>
+                )}
+                <List.ActionMenu>
+                    <IconButton
+                        icon="trash"
+                        ariaValue={gettext('Remove field')}
+                        onClick={() => {
+                            if (this.props.systemRequiredFields?.includes(fieldEntry.name)) {
+                                notify.error(gettext('Delete failed! Field is required by the system'));
+                            } else {
+                                this.props.removeField(fieldEntry);
+                            }
+                        }}
+                    />
+                </List.ActionMenu>
+                {(!isLastField || !menuItems.after.length) ? null : (
+                    <div className="profile-item__add-btn profile-item__add-btn--bottom">
+                        <AddFieldsMenu
+                            options={menuItems.after}
+                            buttonLabel={gettext('Add field after')}
+                        />
+                    </div>
+                )}
+            </List.Item>
+        );
+    }
+}

--- a/client/components/ContentProfiles/FieldTab/ListElementTemplate.tsx
+++ b/client/components/ContentProfiles/FieldTab/ListElementTemplate.tsx
@@ -51,7 +51,7 @@ export default class ProfileFieldTemplate extends React.PureComponent<IProps, an
                     // or other button inside the list item
                     if (
                         e.target instanceof HTMLElement &&
-                                    querySelectorParent(e.target, 'button', {self: true})
+                        querySelectorParent(e.target, 'button', {self: true})
                     ) {
                         return;
                     }

--- a/client/components/ContentProfiles/GroupTab/GroupElementTemplate.tsx
+++ b/client/components/ContentProfiles/GroupTab/GroupElementTemplate.tsx
@@ -1,16 +1,12 @@
-import * as React from 'react';
-
-import {IEditorProfileGroup} from '../../../interfaces';
+import React from 'react';
+import {List} from '../../../components/UI';
 import {superdeskApi} from '../../../superdeskApi';
-
+import {Button, Icon, IconButton} from 'superdesk-ui-framework/react';
 import {getProfileGroupNameTranslated} from '../../../utils/contentProfiles';
-
-import {Icon, Button, IconButton} from 'superdesk-ui-framework/react';
-import * as List from '../../UI/List';
-import {arrayMove, WithSortable} from '@sourcefabric/common';
-import GroupElementTemplate from './GroupElementTemplate';
+import {IEditorProfileGroup} from 'interfaces';
 
 interface IProps {
+    group: IEditorProfileGroup;
     groups: Array<IEditorProfileGroup>;
     selectedGroup?: IEditorProfileGroup;
     onClick(group: IEditorProfileGroup): void;
@@ -19,17 +15,11 @@ interface IProps {
     removeGroup(group: IEditorProfileGroup): void;
 }
 
-export class GroupList extends React.PureComponent<IProps> {
-    constructor(props) {
-        super(props);
-
-        this.getListElement = this.getListElement.bind(this);
-    }
-
-    getListElement(group: IEditorProfileGroup) {
+export default class GroupElementTemplate extends React.PureComponent<IProps, any> {
+    render(): React.ReactNode {
         const {gettext} = superdeskApi.localization;
         const {querySelectorParent} = superdeskApi.utilities;
-        const {groups} = this.props;
+        const {groups, group} = this.props;
         const isLastGroup = group._id === groups[groups.length - 1]?._id;
 
         return (
@@ -43,7 +33,7 @@ export class GroupList extends React.PureComponent<IProps> {
                     // or other button inside the list item
                     if (
                         e.target instanceof HTMLElement &&
-                        querySelectorParent(e.target, 'button', {self: true})
+                                querySelectorParent(e.target, 'button', {self: true})
                     ) {
                         return;
                     }
@@ -57,8 +47,7 @@ export class GroupList extends React.PureComponent<IProps> {
                         icon="plus-large"
                         shape="round"
                         type="primary"
-                        onClick={(e) => {
-                            e.stopPropagation();
+                        onClick={() => {
                             this.props.insertGroup(group.index - 0.1);
                         }}
                     />
@@ -82,8 +71,7 @@ export class GroupList extends React.PureComponent<IProps> {
                     <IconButton
                         icon="trash"
                         ariaValue={gettext('Remove group')}
-                        onClick={(e) => {
-                            e.stopPropagation();
+                        onClick={() => {
                             this.props.removeGroup(group);
                         }}
                     />
@@ -96,62 +84,13 @@ export class GroupList extends React.PureComponent<IProps> {
                             icon="plus-large"
                             shape="round"
                             type="primary"
-                            onClick={(e) => {
-                                e.stopPropagation();
+                            onClick={() => {
                                 this.props.insertGroup(group.index + 0.1);
                             }}
                         />
                     </div>
                 )}
             </List.Item>
-        );
-    }
-
-    render() {
-        const {gettext} = superdeskApi.localization;
-
-        return !this.props.groups.length ? (
-            <div className="planning-profile__empty-list sd-padding-x--2 sd-padding-y--3">
-                <Button
-                    text={gettext('Add first group')}
-                    iconOnly={true}
-                    icon="plus-large"
-                    shape="round"
-                    type="primary"
-                    onClick={() => this.props.insertGroup(0)}
-                />
-            </div>
-        ) : (
-            <List.Group
-                spaceBetween={true}
-                className="sd-padding-x--2 sd-padding-y--3"
-            >
-                <WithSortable
-                    items={this.props.groups}
-                    getId={(item) => item._id}
-                    itemTemplate={(item) => (
-                        <GroupElementTemplate
-                            group={item.item}
-                            groups={this.props.groups}
-                            insertGroup={this.props.insertGroup}
-                            onClick={this.props.onClick}
-                            onSortChange={this.props.onSortChange}
-                            removeGroup={this.props.removeGroup}
-                        />
-                    )}
-                    options={{
-                        distance: 20,
-                        onSortEnd: ({
-                            oldIndex,
-                            newIndex
-                        }) => {
-                            const itemsSorted = arrayMove(this.props.groups, oldIndex, newIndex);
-
-                            this.props.onSortChange(itemsSorted);
-                        }
-                    }}
-                />
-            </List.Group>
         );
     }
 }

--- a/client/components/ContentProfiles/GroupTab/GroupList.tsx
+++ b/client/components/ContentProfiles/GroupTab/GroupList.tsx
@@ -7,7 +7,8 @@ import {getProfileGroupNameTranslated} from '../../../utils/contentProfiles';
 
 import {Icon, Button, IconButton} from 'superdesk-ui-framework/react';
 import * as List from '../../UI/List';
-import SortItems from '../../SortItems';
+import {arrayMove, WithSortable} from '@sourcefabric/common';
+import {shouldNotStartDragging} from '../utils';
 
 interface IProps {
     groups: Array<IEditorProfileGroup>;
@@ -33,6 +34,7 @@ export class GroupList extends React.PureComponent<IProps> {
 
         return (
             <List.Item
+                className="mt-1"
                 shadow={1}
                 draggable={true}
                 activated={this.props.selectedGroup?._id === group._id}
@@ -55,7 +57,10 @@ export class GroupList extends React.PureComponent<IProps> {
                         icon="plus-large"
                         shape="round"
                         type="primary"
-                        onClick={() => this.props.insertGroup(group.index - 0.1)}
+                        onClick={(e) => {
+                            e.stopPropagation();
+                            this.props.insertGroup(group.index - 0.1);
+                        }}
                     />
                 </div>
                 {!group.icon.length ? null : (
@@ -77,7 +82,10 @@ export class GroupList extends React.PureComponent<IProps> {
                     <IconButton
                         icon="trash"
                         ariaValue={gettext('Remove group')}
-                        onClick={() => this.props.removeGroup(group)}
+                        onClick={(e) => {
+                            e.stopPropagation();
+                            this.props.removeGroup(group);
+                        }}
                     />
                 </List.ActionMenu>
                 {!isLastGroup ? null : (
@@ -88,7 +96,10 @@ export class GroupList extends React.PureComponent<IProps> {
                             icon="plus-large"
                             shape="round"
                             type="primary"
-                            onClick={() => this.props.insertGroup(group.index + 0.1)}
+                            onClick={(e) => {
+                                e.stopPropagation();
+                                this.props.insertGroup(group.index + 0.1);
+                            }}
                         />
                     </div>
                 )}
@@ -115,15 +126,21 @@ export class GroupList extends React.PureComponent<IProps> {
                 spaceBetween={true}
                 className="sd-padding-x--2 sd-padding-y--3"
             >
-                <SortItems
-                    key={this.props.selectedGroup?._id}
-                    onSortChange={this.props.onSortChange}
+                <WithSortable
                     items={this.props.groups}
-                    getListElement={this.getListElement}
-                    useCustomStyle={true}
-                    lockAxis="y"
-                    lockToContainerEdges={true}
-                    distance={10}
+                    getId={(item) => item._id}
+                    itemTemplate={(item) => <>{this.getListElement(item.item)}</>}
+                    options={{
+                        shouldCancelStart: shouldNotStartDragging,
+                        onSortEnd: ({
+                            oldIndex,
+                            newIndex
+                        }) => {
+                            const itemsSorted = arrayMove(this.props.groups, oldIndex, newIndex);
+
+                            this.props.onSortChange(itemsSorted);
+                        }
+                    }}
                 />
             </List.Group>
         );

--- a/client/components/ContentProfiles/GroupTab/GroupList.tsx
+++ b/client/components/ContentProfiles/GroupTab/GroupList.tsx
@@ -57,8 +57,7 @@ export class GroupList extends React.PureComponent<IProps> {
                         icon="plus-large"
                         shape="round"
                         type="primary"
-                        onClick={(e) => {
-                            e.stopPropagation();
+                        onClick={() => {
                             this.props.insertGroup(group.index - 0.1);
                         }}
                     />
@@ -82,8 +81,7 @@ export class GroupList extends React.PureComponent<IProps> {
                     <IconButton
                         icon="trash"
                         ariaValue={gettext('Remove group')}
-                        onClick={(e) => {
-                            e.stopPropagation();
+                        onClick={() => {
                             this.props.removeGroup(group);
                         }}
                     />
@@ -97,7 +95,6 @@ export class GroupList extends React.PureComponent<IProps> {
                             shape="round"
                             type="primary"
                             onClick={(e) => {
-                                e.stopPropagation();
                                 this.props.insertGroup(group.index + 0.1);
                             }}
                         />

--- a/client/components/ContentProfiles/style.scss
+++ b/client/components/ContentProfiles/style.scss
@@ -17,19 +17,6 @@
     }
 
     .sd-list-item {
-        .profile-item__add-btn {
-            display: flex;
-            justify-content: center;
-            width: 100%;
-            position: absolute;
-            top: -19px;
-
-            &--bottom {
-                top: unset;
-                bottom: -17px;
-            }
-        }
-
         .btn--icon-only-circle {
             opacity: 0.25;
             transition: opacity 0.2s ease-out;
@@ -60,13 +47,26 @@
     }
 }
 
+.profile-item__add-btn {
+    display: flex;
+    justify-content: center;
+    width: 100%;
+    position: absolute;
+    top: -17px;
+
+    &--bottom {
+        top: unset;
+        bottom: -17px;
+    }
+}
+
 .toggle-box--no-line {
     .toggle-box__line {
         background: none;
     }
 }
 
-body > .sd-list-item--draggable {
+body>.sd-list-item--draggable {
     z-index: 1060;
 
     .btn--icon-only-circle {

--- a/client/components/ContentProfiles/style.scss
+++ b/client/components/ContentProfiles/style.scss
@@ -50,7 +50,6 @@
 .profile-item__add-btn {
     display: flex;
     justify-content: center;
-    width: 100%;
     position: absolute;
     top: -17px;
 

--- a/client/components/ContentProfiles/utils.ts
+++ b/client/components/ContentProfiles/utils.ts
@@ -24,13 +24,3 @@ export function validateAndNotifyForRequiredFields(
 
     return valid;
 }
-
-export function shouldNotStartDragging(event: SyntheticEvent<HTMLElement>) {
-    const target = event.target as HTMLElement;
-    const addButton = target.closest('.profile-item__add-btn');
-    const removeButton = target.closest('.sd-list-item__action-menu');
-
-    // if user is trying to click the bottom or top plus button,
-    // or the remove button don't start dragging
-    return addButton !== null || removeButton !== null;
-}

--- a/client/components/ContentProfiles/utils.ts
+++ b/client/components/ContentProfiles/utils.ts
@@ -1,4 +1,3 @@
-import {SyntheticEvent} from 'react';
 import {ICoverageContentProfile, IPlanningContentProfile} from '../../interfaces';
 import {superdeskApi} from '../../superdeskApi';
 import {isProfileFieldEnabled, getFieldNameTranslated} from '../../utils/contentProfiles';

--- a/client/components/ContentProfiles/utils.ts
+++ b/client/components/ContentProfiles/utils.ts
@@ -1,3 +1,4 @@
+import {SyntheticEvent} from 'react';
 import {ICoverageContentProfile, IPlanningContentProfile} from '../../interfaces';
 import {superdeskApi} from '../../superdeskApi';
 import {isProfileFieldEnabled, getFieldNameTranslated} from '../../utils/contentProfiles';
@@ -22,4 +23,14 @@ export function validateAndNotifyForRequiredFields(
     });
 
     return valid;
+}
+
+export function shouldNotStartDragging(event: SyntheticEvent<HTMLElement>) {
+    const target = event.target as HTMLElement;
+    const addButton = target.closest('.profile-item__add-btn');
+    const removeButton = target.closest('.sd-list-item__action-menu');
+
+    // if user is trying to click the bottom or top plus button,
+    // or the remove button don't start dragging
+    return addButton !== null || removeButton !== null;
 }

--- a/client/components/UI/List/Item.tsx
+++ b/client/components/UI/List/Item.tsx
@@ -14,6 +14,7 @@ interface IProps {
     draggable?: boolean;
     testId?: string;
     zIndex?: number;
+    flexRow?: boolean;
 
     onClick?(event: React.MouseEvent<HTMLLIElement>): void;
     onMouseEnter?(): void;
@@ -50,6 +51,18 @@ export class Item extends React.PureComponent<IProps> {
             testId,
         } = this.props;
 
+        let styles: React.CSSProperties = {};
+
+        if (this.props.flexRow) {
+            styles.display = 'flex';
+            styles.flexDirection = 'row';
+            styles.justifyContent = 'center';
+        }
+
+        if (this.props.zIndex) {
+            styles.zIndex = this.props.zIndex;
+        }
+
         return (
             <li
                 data-test-id={testId}
@@ -66,9 +79,7 @@ export class Item extends React.PureComponent<IProps> {
                         'sd-list-item--draggable': draggable,
                     }
                 )}
-                style={{
-                    zIndex: this.props.zIndex,
-                }}
+                style={styles}
                 onClick={onClick}
                 onMouseDown={onMouseDown}
                 onMouseUp={onMouseUp}

--- a/client/components/UI/List/Item.tsx
+++ b/client/components/UI/List/Item.tsx
@@ -13,6 +13,7 @@ interface IProps {
     tabIndex?: number;
     draggable?: boolean;
     testId?: string;
+    zIndex?: number;
 
     onClick?(event: React.MouseEvent<HTMLLIElement>): void;
     onMouseEnter?(): void;
@@ -65,6 +66,9 @@ export class Item extends React.PureComponent<IProps> {
                         'sd-list-item--draggable': draggable,
                     }
                 )}
+                style={{
+                    zIndex: this.props.zIndex,
+                }}
                 onClick={onClick}
                 onMouseDown={onMouseDown}
                 onMouseUp={onMouseUp}

--- a/client/interfaces.ts
+++ b/client/interfaces.ts
@@ -1062,6 +1062,7 @@ export interface IProfileSchemaTypeInteger extends IBaseProfileSchemaType<'integ
 export interface IProfileSchemaTypeDict extends IBaseProfileSchemaType<'dict'> {}
 export interface IProfileSchemaTypeDateTime extends IBaseProfileSchemaType<'datetime'> {}
 export interface IProfileSchemaTypeBoolean extends IBaseProfileSchemaType<'boolean'> {}
+export interface IProfileSchemaTypeCustomVocabulary extends IBaseProfileSchemaType<'custom_vocabulary'> {}
 
 export interface IProfileSchemaTypeString extends IBaseProfileSchemaType<'string'> {
     field_type: 'single_line' | 'multi_line' | 'editor_3';
@@ -1337,7 +1338,8 @@ export type IProfileSchemaType = IProfileSchemaTypeList
     | IProfileSchemaTypeInteger
     | IProfileSchemaTypeDict
     | IProfileSchemaTypeDateTime
-    | IProfileSchemaTypeString;
+    | IProfileSchemaTypeString
+    | IProfileSchemaTypeCustomVocabulary;
 
 export type IFormProfileItem = IEventFormProfile
     | IPlanningFormProfile

--- a/e2e/cypress/e2e/events/multilingual_events.cy.ts
+++ b/e2e/cypress/e2e/events/multilingual_events.cy.ts
@@ -1,4 +1,4 @@
-import {setup, login, addItems, waitForPageLoad, SubNavBar, TreeSelect} from '../../support/common';
+import {setup, login, addItems, waitForPageLoad, SubNavBar} from '../../support/common';
 import {EventEditor, ManageContentProfiles} from '../../support/planning';
 
 import {CVs} from '../../fixtures/cvs';
@@ -27,7 +27,7 @@ describe('Planning.Events: multilingual functionality', () => {
 
         // Enable the standard `Language` field
         manageProfiles.openAddFieldMenu(3);
-        manageProfiles.addField('Language');
+        manageProfiles.addField('language');
 
         // Make sure the `multilingual` checkbox is not shown for text fields
         MULTILINGUAL_FIELDS.forEach((field) => {
@@ -122,7 +122,7 @@ describe('Planning.Events: multilingual functionality', () => {
         manageProfiles.selectTab(1);
 
         manageProfiles.openAddFieldMenu(3);
-        manageProfiles.addField('Language');
+        manageProfiles.addField('language');
         manageProfiles.getFooterButton('Save').click();
         manageProfiles.waitTillClosed();
 

--- a/e2e/cypress/e2e/events/multilingual_events.cy.ts
+++ b/e2e/cypress/e2e/events/multilingual_events.cy.ts
@@ -27,7 +27,7 @@ describe('Planning.Events: multilingual functionality', () => {
 
         // Enable the standard `Language` field
         manageProfiles.openAddFieldMenu(3);
-        manageProfiles.addField('language');
+        manageProfiles.addField('Language');
 
         // Make sure the `multilingual` checkbox is not shown for text fields
         MULTILINGUAL_FIELDS.forEach((field) => {
@@ -122,7 +122,7 @@ describe('Planning.Events: multilingual functionality', () => {
         manageProfiles.selectTab(1);
 
         manageProfiles.openAddFieldMenu(3);
-        manageProfiles.addField('language');
+        manageProfiles.addField('Language');
         manageProfiles.getFooterButton('Save').click();
         manageProfiles.waitTillClosed();
 

--- a/e2e/cypress/support/planning/manageContentProfiles.ts
+++ b/e2e/cypress/support/planning/manageContentProfiles.ts
@@ -41,7 +41,8 @@ export class ManageContentProfiles extends Modal {
     }
 
     addField(name: string) {
-        cy.get('[data-test-id="menu"] .suggestion-item')
+        cy.get('[data-test-id="tree-menu-popover"]')
+            .find('button[role="treeItem"]')
             .contains(name)
             .should('exist')
             .click();

--- a/e2e/cypress/support/planning/manageContentProfiles.ts
+++ b/e2e/cypress/support/planning/manageContentProfiles.ts
@@ -76,8 +76,6 @@ export class ManageContentProfiles extends Modal {
     }
 
     getHeaderButton(label: string) {
-        return this.element.find('.side-panel__header')
-            .contains(label);
-        // .should('exist')
+        return this.element.find('.side-panel__header').contains(label);
     }
 }

--- a/e2e/cypress/support/planning/manageContentProfiles.ts
+++ b/e2e/cypress/support/planning/manageContentProfiles.ts
@@ -76,6 +76,8 @@ export class ManageContentProfiles extends Modal {
     }
 
     getHeaderButton(label: string) {
-        return this.element.find('.side-panel__header').contains(label);
+        return this.element.find('.side-panel__header')
+            .contains(label)
+            .should('exist');
     }
 }

--- a/e2e/cypress/support/planning/manageContentProfiles.ts
+++ b/e2e/cypress/support/planning/manageContentProfiles.ts
@@ -41,7 +41,8 @@ export class ManageContentProfiles extends Modal {
     }
 
     addField(name: string) {
-        cy.get(`[data-test-id="menu"] [role="menuitem"]:contains("${name}")`)
+        cy.get('[data-test-id="menu"] .suggestion-item')
+            .contains(name)
             .should('exist')
             .click();
     }
@@ -76,6 +77,6 @@ export class ManageContentProfiles extends Modal {
     getHeaderButton(label: string) {
         return this.element.find('.side-panel__header')
             .contains(label);
-            // .should('exist')
+        // .should('exist')
     }
 }


### PR DESCRIPTION
STT-187

## Front-end checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)
