### PR TITLE
fix content profiles not returning custom CVs

### DIFF
--- a/server/features/content_profiles_event.feature
+++ b/server/features/content_profiles_event.feature
@@ -308,3 +308,43 @@ Feature: Event Content Profiles
         }
     }]}
     """
+
+    @auth
+    Scenario: Add custom CV
+    Given "vocabularies"
+    """
+    [
+        {"_id": "custom", "field_type": null, "type": "manageable", "service": {"all": 1}}
+    ]
+    """
+
+    When we post to "planning_types"
+    """
+    [{
+        "_id": "with_custom_field",
+        "name": "event",
+        "editor": {
+            "custom": {"enabled": true}
+        },
+        "schema": {
+            "custom": {"required": true, "type": "list"}
+        }
+    }]
+    """
+    Then we get OK response
+
+    When we get "/planning_types/with_custom_field"
+    Then we get existing resource
+    """
+    {
+        "_id": "with_custom_field",
+        "name": "event",
+        "editor": {
+            "custom": {"enabled": true}
+        },
+        "schema": {
+            "custom": {"required": true, "type": "list"}
+        }
+    }
+    """
+ 

--- a/server/planning/content_profiles/service.py
+++ b/server/planning/content_profiles/service.py
@@ -91,6 +91,10 @@ class PlanningTypesService(superdesk.Service):
                     # no need to copy any schema
                     if updated_planning_type[config_type][field]:
                         updated_planning_type[config_type][field].update(planning_type[config_type].get(field) or {})
+                for field, options in planning_type[config_type].items():
+                    if field not in updated_planning_type[config_type]:
+                        updated_planning_type[config_type][field] = options
+
         else:
             updated_planning_type["editor"].update(planning_type.get("editor", {}))
             updated_planning_type["schema"].update(planning_type.get("schema", {}))


### PR DESCRIPTION
## Front-end checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)
