### PR TITLE
Fix item load and lock

### DIFF
--- a/client/components/Main/ItemEditor/Editor.tsx
+++ b/client/components/Main/ItemEditor/Editor.tsx
@@ -200,6 +200,7 @@ export class EditorComponent extends React.Component<IEditorProps, IEditorState>
         this.autoSave.flushAutosave().then(() => {
             const {openCancelModal, itemId, itemType, addNewsItemToPlanning} = this.props;
             const {dirty, errorMessages, initialValues} = this.state;
+
             const updateStates = !addNewsItemToPlanning;
 
             this.setState({submitting: true});

--- a/client/components/Main/ItemEditor/ItemManager.ts
+++ b/client/components/Main/ItemEditor/ItemManager.ts
@@ -142,7 +142,7 @@ export class ItemManager {
         editor.events.onEditorMounted(this, this.autoSave);
 
         if (this.props.itemId && this.props.itemType && this.props.itemAction) {
-            this.onItemIDChanged(this.props);
+            this.onItemIDChanged();
         }
     }
 
@@ -155,7 +155,7 @@ export class ItemManager {
         return this.autoSave.flushAutosave()
             .then(() => (
                 this.dispatch<any>(actions.main.openEditorAction(
-                    this.state.initialValues,
+                    this.state.initialValues as IEventOrPlanningItem,
                     'edit',
                     false,
                     true
@@ -188,7 +188,7 @@ export class ItemManager {
         } else if (actionChanged) {
             this.onItemActionChanged(prevProps);
         } else if (idChanged) {
-            this.onItemIDChanged(prevProps);
+            this.onItemIDChanged();
         } else if (!this.state.loading &&
             !isTemporaryId(currentId) &&
             !itemsEqual(prevProps.item, this.props.item) &&
@@ -205,10 +205,10 @@ export class ItemManager {
             promise = this.autoSave.remove();
         }
 
-        return promise.then(() => this.onItemIDChanged(prevProps));
+        return promise.then(() => this.onItemIDChanged());
     }
 
-    onItemIDChanged(prevProps: IEditorProps) {
+    onItemIDChanged() {
         return this.setState({
             itemReady: false,
             tab: UI.EDITOR.CONTENT_TAB_INDEX,

--- a/client/components/Main/ItemEditor/ItemManager.ts
+++ b/client/components/Main/ItemEditor/ItemManager.ts
@@ -18,6 +18,7 @@ import {
     eventUtils,
     isTemporaryId,
     itemsEqual,
+    lockUtils,
     planningUtils,
     removeAutosaveFields,
     shouldUnLockItem,
@@ -356,10 +357,23 @@ export class ItemManager {
             promise = this.dispatch<any>(
                 actions.main.fetchById(nextProps.itemId, nextProps.itemType, true)
             )
-                .then((original) => {
+                .then((original: IEventOrPlanningItem) => {
                     initialValues = cloneDeep(original);
 
-                    return planningApi.locks.lockItem(original);
+                    const allLockedItems = selectors.locks
+                        .getLockedItems((planningApi.redux.store.getState() as any));
+                    const isItemLocked = lockUtils.isItemLockedInThisSession(
+                        original,
+                        this.props.session,
+                        allLockedItems,
+                    );
+
+                    // if the item is already locked in this session don't lock it again
+                    if (isItemLocked) {
+                        return Promise.resolve(original);
+                    } else {
+                        return planningApi.locks.lockItem(original, 'edit');
+                    }
                 });
         } else {
             // Fetch the latest item from the API to view in read-only mode

--- a/client/components/Main/ItemEditor/tests/ItemManager_test.ts
+++ b/client/components/Main/ItemEditor/tests/ItemManager_test.ts
@@ -246,9 +246,6 @@ describe('components.Main.ItemManager', () => {
             updateProps(nextProps);
             manager.componentWillMount();
             expect(manager.onItemIDChanged.callCount).toBe(1);
-            expect(manager.onItemIDChanged.args[0]).toEqual([
-                jasmine.objectContaining(nextProps),
-            ]);
         });
 
         it('on mount open for editing', () => {
@@ -262,9 +259,6 @@ describe('components.Main.ItemManager', () => {
             updateProps(nextProps);
             manager.componentWillMount();
             expect(manager.onItemIDChanged.callCount).toBe(1);
-            expect(manager.onItemIDChanged.args[0]).toEqual([
-                jasmine.objectContaining(nextProps),
-            ]);
         });
 
         it('on mount open for read only', () => {
@@ -278,9 +272,6 @@ describe('components.Main.ItemManager', () => {
             updateProps(nextProps);
             manager.componentWillMount();
             expect(manager.onItemIDChanged.callCount).toBe(1);
-            expect(manager.onItemIDChanged.args[0]).toEqual([
-                jasmine.objectContaining(nextProps),
-            ]);
         });
     });
 
@@ -341,11 +332,6 @@ describe('components.Main.ItemManager', () => {
             });
 
             expect(manager.onItemIDChanged.callCount).toBe(1);
-            expect(manager.onItemIDChanged.args[0]).toEqual([jasmine.objectContaining({
-                itemId: 'e1',
-                itemType: 'event',
-                itemAction: 'edit',
-            })]);
         });
 
         it('calls on action changed', () => {
@@ -527,8 +513,6 @@ describe('components.Main.ItemManager', () => {
         });
 
         it('edit existing item', (done) => {
-            const prevProps = cloneDeep(editor.props);
-
             updateProps({
                 itemId: 'e1',
                 itemType: 'event',
@@ -536,7 +520,7 @@ describe('components.Main.ItemManager', () => {
                 initialValues: testData.events[0],
             });
 
-            manager.onItemIDChanged(prevProps);
+            manager.onItemIDChanged();
             expectState(states.loading);
 
             waitFor(() => manager.loadItem.callCount > 0)
@@ -550,7 +534,7 @@ describe('components.Main.ItemManager', () => {
                     expect(main.fetchById.args[0]).toEqual(['e1', 'event', true]);
 
                     expect(planningApi.locks.lockItem.callCount).toBe(1);
-                    expect(planningApi.locks.lockItem.args[0]).toEqual([testData.events[0]]);
+                    expect(planningApi.locks.lockItem.args[0]).toEqual([testData.events[0], 'edit']);
 
                     expect(editor.autoSave.createOrLoadAutosave.callCount).toBe(1);
                     expect(editor.autoSave.createOrLoadAutosave.args[0]).toEqual([
@@ -822,7 +806,7 @@ describe('components.Main.ItemManager', () => {
                     expect(main.fetchById.args[0]).toEqual(['e1', 'event', true]);
 
                     expect(planningApi.locks.lockItem.callCount).toBe(1);
-                    expect(planningApi.locks.lockItem.args[0]).toEqual([testData.events[0]]);
+                    expect(planningApi.locks.lockItem.args[0]).toEqual([testData.events[0], 'edit']);
 
                     expect(editor.autoSave.createOrLoadAutosave.callCount).toBe(1);
                     expect(editor.autoSave.createOrLoadAutosave.args[0]).toEqual([

--- a/client/interfaces.ts
+++ b/client/interfaces.ts
@@ -2068,6 +2068,7 @@ export interface IWebsocketMessageData {
         item: IEventOrPlanningItem['_id'];
         etag: IEventOrPlanningItem['_etag'];
         from_ingest: boolean;
+        event_ids?: Array<string>;
         user?: IEventOrPlanningItem['lock_user'];
         lock_session?: IEventOrPlanningItem['lock_session'];
         recurrence_id?: IEventItem['recurrence_id'];
@@ -2077,6 +2078,7 @@ export interface IWebsocketMessageData {
         item: IEventOrPlanningItem['_id'];
         etag: IEventOrPlanningItem['_etag'];
         user: IEventOrPlanningItem['lock_user'];
+        event_ids?: Array<string>;
         lock_session: IEventOrPlanningItem['lock_session'];
         lock_action: IEventOrPlanningItem['lock_action'];
         lock_time: IEventOrPlanningItem['lock_time'];

--- a/client/interfaces.ts
+++ b/client/interfaces.ts
@@ -1969,6 +1969,7 @@ export interface IEditorProps {
     currentWorkspace: string;
     editorType: EDITOR_TYPE;
     groups: Array<IEditorFormGroup>;
+    initialValues?: IEventOrPlanningItem;
 
     minimize(): void;
     openCancelModal(modalProps: {

--- a/client/planning-extension/src/authoring-react-fields/event-dates/editor.tsx
+++ b/client/planning-extension/src/authoring-react-fields/event-dates/editor.tsx
@@ -26,11 +26,7 @@ export class Editor extends React.PureComponent<IProps> {
                 <EditorFieldEventSchedule
                     required={true}
                     profile={profile}
-                    disabled={
-                        extensionBridge.ui.utils.planning_event_link_method === 'many_secondary'
-                            ? true
-                            : !extensionBridge.ui.utils.isTemporaryId(this.props.item.id)
-                    }
+                    disabled={false}
                     onChange={(changes: {[fieldPath: string]: any}) => {
                         const valueCopy = cloneDeep(this.props.value);
 


### PR DESCRIPTION
STT-189

## Front-end checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)
