### PR TITLE
Drag drop save embedded planning

### DIFF
--- a/client/actions/events/api.ts
+++ b/client/actions/events/api.ts
@@ -562,16 +562,16 @@ function updateLinkedPlanningsForEvent(
     return planningApi.events.getLinkedPlanningItems(eventId).then((currentlyLinked) => {
         const currentLinkedIds = new Set(currentlyLinked.map((item) => item._id));
 
-        const toLink: Array<IPlanningItem> =
-            associatedPlannings.filter(({_id}) => currentLinkedIds.has(_id) !== true);
-
+        const toLink: Array<IPlanningItem> = associatedPlannings
+            .filter(({_id}) => currentLinkedIds.has(_id) !== true);
         const toUnlink: Array<IPlanningItem> = currentlyLinked
             .filter((item) => associatedPlannings.find(({_id}) => _id === item._id) == null);
 
-        return Promise.all(
-            [
-                ...toLink.map((planningItem) => {
-                    const linkType = planningItem._temporary?.link_type;
+        return planningApi.planning.getByIds(associatedPlannings.map(({_id}) => _id), undefined)
+            .then((allPlanningItems) => Promise.all([
+                ...toLink.map((oldPlanning) => {
+                    const planningItem = allPlanningItems.find((x) => x._id === oldPlanning._id);
+                    const linkType = oldPlanning._temporary?.link_type;
 
                     if (linkType == null) {
                         superdeskApi.utilities.logger.error(
@@ -598,12 +598,11 @@ function updateLinkedPlanningsForEvent(
 
                     return planning.update(planningItem, patch);
                 }),
-            ],
-        ).then((updatedPlanningItems) => {
-            planningApi.redux.store.dispatch<any>(planningApis.receivePlannings(updatedPlanningItems));
+            ]).then((updatedPlanningItems) => {
+                planningApi.redux.store.dispatch<any>(planningApis.receivePlannings(updatedPlanningItems));
 
-            return null;
-        });
+                return null;
+            }));
     });
 }
 

--- a/client/components/Events/EventItem.tsx
+++ b/client/components/Events/EventItem.tsx
@@ -198,7 +198,7 @@ class EventItemComponent extends React.Component<IProps, IState> {
                 onMouseEnter={this.onItemHoverOn}
                 refNode={refNode}
                 draggable={!isItemLocked}
-                onDragstart={(dragEvent) => {
+                onDragStart={(dragEvent) => {
                     dragEvent.dataTransfer.setData('application/superdesk.planning.event', JSON.stringify(item));
                     dragEvent.dataTransfer.effectAllowed = 'link';
                 }}

--- a/client/components/Planning/PlanningItem.tsx
+++ b/client/components/Planning/PlanningItem.tsx
@@ -224,7 +224,7 @@ class PlanningItemComponent extends React.Component<IProps, IState> {
                 onMouseEnter={this.onItemHoverOn}
                 refNode={refNode}
                 draggable={!isItemLocked}
-                onDragstart={(dragEvent) => {
+                onDragStart={(dragEvent) => {
                     dragEvent.dataTransfer.setData(
                         'application/superdesk.planning.planning_item',
                         JSON.stringify(item),

--- a/client/components/UI/List/Item.tsx
+++ b/client/components/UI/List/Item.tsx
@@ -23,7 +23,7 @@ interface IProps {
     onMouseUp?(event: React.MouseEvent<HTMLLIElement>): void;
     onFocus?(event: React.FocusEvent<HTMLLIElement>): void;
     onKeyDown?(event: React.KeyboardEvent<HTMLLIElement>): void;
-    onDragstart?: React.DragEventHandler<HTMLElement>;
+    onDragStart?: React.DragEventHandler<HTMLElement>;
 }
 
 export class Item extends React.PureComponent<IProps> {
@@ -47,7 +47,7 @@ export class Item extends React.PureComponent<IProps> {
             refNode,
             tabIndex,
             draggable,
-            onDragstart,
+            onDragStart,
             testId,
         } = this.props;
 
@@ -90,7 +90,7 @@ export class Item extends React.PureComponent<IProps> {
                 ref={refNode}
                 tabIndex={tabIndex}
                 draggable={draggable}
-                onDragStart={onDragstart}
+                onDragStart={onDragStart}
             >
                 {children}
             </li>

--- a/client/components/editor-standalone/profile-fields.ts
+++ b/client/components/editor-standalone/profile-fields.ts
@@ -35,7 +35,7 @@ const unimplementedFields = new Set<string>([
  * A function that handles planning profile field types so they can be used in authoring react.
  * @embeddedOnly defaults to false
  */
-export const getPlanningProfileFields = <T extends 'planning' | 'event'>(
+export const getPlanningProfileFields = (
     options: {
         profile: 'planning' | 'event',
         embeddedOnly?: boolean

--- a/client/utils/planning.tsx
+++ b/client/utils/planning.tsx
@@ -617,19 +617,14 @@ export function addSomeRelatedPlanningsToEventEditor(
         planning._temporary.link_type = link_type;
 
         promises = promises
-            .then(() => editor.item.events.addPlanningItem(planning, {scrollIntoViewAndFocus: false}))
+            .then(() => editor.item.events.addPlanningItem(
+                planning,
+                {scrollIntoViewAndFocus: result.canBeAdded.at(-1) != null},
+            ))
             .then(() => null);
     }
 
-    return promises.then(() => {
-        const lastItem = result.canBeAdded.at(-1);
-
-        if (lastItem != null) {
-            editor.item.events.getRelatedPlanningDomRef(lastItem.planning._id).current.scrollIntoView();
-        }
-
-        return null;
-    });
+    return promises;
 }
 
 interface IGetPlanningActionArgs {


### PR DESCRIPTION
STT-186

## Front-end checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)
