### PR TITLE
fix start/end time handling

### DIFF
--- a/client/components/Main/ItemEditor/ItemManager.ts
+++ b/client/components/Main/ItemEditor/ItemManager.ts
@@ -251,7 +251,7 @@ export class ItemManager {
             formProfiles: nextProps.formProfiles,
             errors: errors,
             messages: errorMessages,
-            ignoreDateValidation: !isTemporaryId(nextProps.itemId),
+            ignoreDateValidation: false,
         }));
 
         newState.errors = errors;

--- a/client/components/fields/editor/EventSchedule.tsx
+++ b/client/components/fields/editor/EventSchedule.tsx
@@ -79,16 +79,14 @@ export class EditorFieldEventSchedule extends React.PureComponent<IProps> {
     changeStartTime(value?: moment.Moment) {
         const startDate = this.props.item?.dates?.start;
         const endDate = this.props.item?.dates?.end;
-        const isAllDay = this.props.item.dates?.all_day === true;
 
         if (!value) {
             const changes = {
                 _startTime: null,
                 _endTime: null,
                 'dates.start': startDate ? localDateToUtc(startDate, this.props.item?.dates?.tz) : null,
-                'dates.end': endDate ? localDateToUtc(endDate, this.props.item?.dates?.tz) : null,
                 'dates.all_day': true,
-                'dates.no_end_time': false,
+                'dates.no_end_time': true,
                 [TO_BE_CONFIRMED_FIELD]: false,
             };
 
@@ -100,9 +98,12 @@ export class EditorFieldEventSchedule extends React.PureComponent<IProps> {
         const changes = {
             'dates.start': newStartDate,
             'dates.all_day': false,
-            'dates.no_end_time': isAllDay, // If event was all day there won't be any end time now
             [TO_BE_CONFIRMED_FIELD]: false,
         };
+
+        if (this.props.item.dates?.no_end_time == null) {
+            changes['dates.no_end_time'] = true;
+        }
 
         changes['_startTime'] = newStartDate;
         this.props.onChange(changes);
@@ -137,14 +138,12 @@ export class EditorFieldEventSchedule extends React.PureComponent<IProps> {
 
     changeEndTime(value?: moment.Moment) {
         if (!value) {
-            const hasStartTime = this.props.item._startTime != null;
             const changes = {
                 _endTime: null,
                 'dates.end': this.props.item.dates?.end ?
                     localDateToUtc(this.props.item.dates.end, this.props.item.dates.tz)
                     : null,
-                'dates.all_day': !hasStartTime,
-                'dates.no_end_time': hasStartTime,
+                'dates.no_end_time': true,
                 [TO_BE_CONFIRMED_FIELD]: false,
             };
 
@@ -160,7 +159,6 @@ export class EditorFieldEventSchedule extends React.PureComponent<IProps> {
         const changes = {
             _endTime: newEndDate,
             'dates.end': newEndDate,
-            'dates.all_day': false,
             'dates.no_end_time': false,
             [TO_BE_CONFIRMED_FIELD]: false,
         };
@@ -243,24 +241,28 @@ export class EditorFieldEventSchedule extends React.PureComponent<IProps> {
                     toBeConfirmed={this.props.item[TO_BE_CONFIRMED_FIELD] === true}
                     isLocalTimeZoneDifferent={isLocalTimeZoneDifferent}
                     remoteTimeZone={this.props.item.dates?.tz}
-                    allDay={this.props.item.dates?.no_end_time || this.props.item.dates?.all_day}
+                    allDay={this.props.item.dates?.no_end_time ?? this.props.item.dates?.all_day}
                 />
                 <Row
                     flex={true}
                     noPadding={true}
                 >
-                    {this.props.showTimeZone && this.props.item._startTime && (
-                        <TimeZoneInput
-                            testId={`${this.props.testId}_timezone`}
-                            field="dates.tz"
-                            label={gettext('Timezone')}
-                            onChange={this.changeTimezone}
-                            halfWidth={this.props.showAllDay}
-                            value={this.props.item.dates?.tz}
-                            marginLeftAuto={this.props.showAllDay}
-                            noPadding={true}
-                        />
-                    )}
+                    {
+                        this.props.showTimeZone &&
+                        this.props.item._startTime &&
+                        this.props.item.dates?.all_day !== true && (
+                            <TimeZoneInput
+                                testId={`${this.props.testId}_timezone`}
+                                field="dates.tz"
+                                label={gettext('Timezone')}
+                                onChange={this.changeTimezone}
+                                halfWidth={this.props.showAllDay}
+                                value={this.props.item.dates?.tz}
+                                marginLeftAuto={this.props.showAllDay}
+                                noPadding={true}
+                            />
+                        )
+                    }
                 </Row>
             </React.Fragment>
         );

--- a/client/validators/events.ts
+++ b/client/validators/events.ts
@@ -20,9 +20,14 @@ const validateRequiredDates = ({value, errors, messages, diff}) => {
         messages.push(gettext('END DATE is a required field'));
     }
 
-    if (!get(value, 'tz')) {
+    if (value.tz === undefined) {
         set(errors, 'tz', gettext('This field is required'));
         messages.push(gettext('TIMEZONE is a required field'));
+    }
+
+    if (value.all_day === true && value.no_end_time === false) {
+        set(errors, '_startTime', gettext('This field is required'));
+        messages.push(gettext('START TIME is required when END TIME is set'));
     }
 
     if (!get(diff, TO_BE_CONFIRMED_FIELD)) {

--- a/client/validators/tests/events_test.ts
+++ b/client/validators/tests/events_test.ts
@@ -89,7 +89,7 @@ describe('eventValidators', () => {
         });
 
         it('fails if timezone is not defined', () => {
-            event.dates.tz = null;
+            event.dates.tz = undefined;
             testValidate(eventValidators.validateDates, 'dates',
                 {
                     dates: {tz: 'This field is required'},

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -54,7 +54,7 @@ services:
             - ELASTICSEARCH_INDEX=superdesk_e2e
             - CELERY_BROKER_URL=redis://redis:6379/1
             - REDIS_URL=redis://redis:6379/1
-            - DEFAULT_TIMEZONE=Europe/Prague
+            - DEFAULT_TIMEZONE=Australia/Sydney
             - SECRET_KEY=e2e
 
 networks:

--- a/server/planning/events/events_schema.py
+++ b/server/planning/events/events_schema.py
@@ -124,8 +124,8 @@ events_schema = {
                 "nullable": True,
             },
             "end_tz": {"type": "string"},
-            "all_day": {"type": "boolean"},
-            "no_end_time": {"type": "boolean"},
+            "all_day": {"type": "boolean", "nullable": True},
+            "no_end_time": {"type": "boolean", "nullable": True},
             "duration": {"type": "string"},
             "confirmation": {"type": "string"},
             "recurring_date": {


### PR DESCRIPTION
validate if there is only end time on save,
but allow that when editing.

STT-163

## Front-end checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)
