### PR TITLE
Stt fixes

### DIFF
--- a/client/actions/events/notifications.ts
+++ b/client/actions/events/notifications.ts
@@ -92,7 +92,7 @@ const onEventLocked = (_e, data) => (
                         payload: {event: evtInStore},
                     });
 
-                    // reload the initialvalues of the editor if different session has made changes
+                    // reload the initialValues of the editor if different session has made changes
                     if (data.lock_session !== sessionId) {
                         dispatch(main.reloadEditor(eventInStore, 'read'));
                     }

--- a/client/actions/events/ui.ts
+++ b/client/actions/events/ui.ts
@@ -766,7 +766,6 @@ export const convertPlanningToEvent = (plan, getState) => {
         calendars: [],
         place: plan.place,
         occur_status: unplannedStatus,
-        _planning_item: plan._id,
         language: plan.language,
     };
 

--- a/client/actions/events/ui.ts
+++ b/client/actions/events/ui.ts
@@ -737,7 +737,7 @@ const receiveEventHistory = (eventHistoryItems) => ({
     payload: eventHistoryItems,
 });
 
-export const convertPlanningToEvent = (plan, getState) => {
+export const convertPlanningToEvent = (plan, getState, associatePlanning = true) => {
     const state = getState();
     const defaultDurationOnChange = selectors.forms.defaultEventDuration(state);
     const occurStatuses = selectors.vocabs.eventOccurStatuses(state);
@@ -768,6 +768,10 @@ export const convertPlanningToEvent = (plan, getState) => {
         occur_status: unplannedStatus,
         language: plan.language,
     };
+
+    if (associatePlanning) {
+        newEvent._planning_item = plan._id;
+    }
 
     if (plan.languages != null) {
         newEvent.languages = plan.languages;

--- a/client/actions/main.ts
+++ b/client/actions/main.ts
@@ -704,14 +704,18 @@ const openIgnoreCancelSaveModal = ({
             itemId
         ) || {};
 
-        if (itemId && isItemSameAsAutosave(
-            {
-                _id: itemId,
-                type: itemType,
-            },
-            autosaveData,
-            selectors.events.storedEvents(getState()),
-            selectors.planning.storedPlannings(getState()))) {
+        if (
+            itemId
+            && isItemSameAsAutosave(
+                {
+                    _id: itemId,
+                    type: itemType,
+                },
+                autosaveData,
+                selectors.events.storedEvents(getState()),
+                selectors.planning.storedPlannings(getState()),
+            )
+        ) {
             return onIgnore();
         }
 
@@ -1195,7 +1199,7 @@ const openFromLockActions = () => (
                 PLANNING.ITEM_ACTIONS,
                 EVENTS.ITEM_ACTIONS)).filter((a) => a.lock_action == sessionLastLock.action);
 
-            if (action) {
+            if (action.length > 0) {
                 /* get the item we're operating on */
                 dispatch(self.fetchById(sessionLastLock.item_id, sessionLastLock.item_type)).then((item) => {
                     actionUtils.getActionDispatches({

--- a/client/api/editor/item_planning.ts
+++ b/client/api/editor/item_planning.ts
@@ -102,13 +102,13 @@ export function getPlanningInstance(type: EDITOR_TYPE): IEditorAPI['item']['plan
         const index = events.findIndex(
             (event) => event._id === original._id
         );
-        const isFirstRelatedEvent = events.length < 1;
+        const isEmpty = events.length < 1;
 
-        if (!isFirstRelatedEvent && index < 0) {
+        if (!isEmpty && index < 0) {
             return;
         }
 
-        events[isFirstRelatedEvent ? 0 : index] = {
+        events[isEmpty ? 0 : index] = {
             _id: updates._id,
             link_type: original.link_type,
             recurrence_id: original.recurrence_id

--- a/client/api/editor/item_planning.ts
+++ b/client/api/editor/item_planning.ts
@@ -102,19 +102,20 @@ export function getPlanningInstance(type: EDITOR_TYPE): IEditorAPI['item']['plan
         const index = events.findIndex(
             (event) => event._id === original._id
         );
+        const isFirstRelatedEvent = events.length < 1;
 
-        if (index < 0) {
+        if (!isFirstRelatedEvent && index < 0) {
             return;
         }
 
-        events[index] = {
+        events[isFirstRelatedEvent ? 0 : index] = {
             _id: updates._id,
             link_type: original.link_type,
             recurrence_id: original.recurrence_id
         };
 
         const updateMainField = () => {
-            editor.form.changeField('related_events', events)
+            return editor.form.changeField('related_events', events, true, true)
                 .then(() => {
                     if (scrollOnChange) {
                         getRelatedEventsDomRef(original._id).current?.scrollIntoView();
@@ -126,12 +127,14 @@ export function getPlanningInstance(type: EDITOR_TYPE): IEditorAPI['item']['plan
         // we must also remove it from _unsaved_related_events
         // otherwise trying to save the same item twice would happen
         if (isTemporaryId(original._id) && !isTemporaryId(updates._id)) {
-            editor.form.changeField(
+            return editor.form.changeField(
                 superdeskApi.helpers.nameof<IPlanningItem>('_unsaved_related_events'),
-                planning._unsaved_related_events.filter((x) => x._id != original._id)
+                planning._unsaved_related_events.filter((x) => x._id != original._id),
+                true,
+                true
             ).then(updateMainField);
         } else {
-            updateMainField();
+            return updateMainField();
         }
     }
 
@@ -163,7 +166,7 @@ export function getPlanningInstance(type: EDITOR_TYPE): IEditorAPI['item']['plan
             .then(() => {
                 const lastEvent = events[events.length - 1];
 
-                getRelatedEventsDomRef(lastEvent?._id).current?.toggleBoxRef.current.scrollIntoView();
+                getRelatedEventsDomRef(lastEvent?._id)?.current?.scrollIntoView();
             });
     }
 

--- a/client/api/locks.ts
+++ b/client/api/locks.ts
@@ -277,7 +277,7 @@ function unlockItem<T extends IAssignmentOrPlanningItem>(item: T, reloadLocksIfN
                 item: unlockedItem._id,
                 type: unlockedItem.type,
                 event_ids: unlockedItem.type === 'planning' ?
-                    getRelatedEventIdsForPlanning(unlockedItem, 'primary') :
+                    getRelatedEventIdsForPlanning(unlockedItem) :
                     [],
                 recurrence_id: unlockedItem.type !== 'assignment' ? unlockedItem.recurrence_id : undefined,
                 etag: unlockedItem._etag,

--- a/client/api/locks.ts
+++ b/client/api/locks.ts
@@ -12,7 +12,7 @@ import {EVENTS, LOCKS, PLANNING, WORKSPACE, ASSIGNMENTS} from '../constants';
 
 import featuredPlanning from '../actions/planning/featuredPlanning';
 import {lockUtils, getErrorMessage, eventUtils, planningUtils, isExistingItem} from '../utils';
-import {getRelatedEventIdsForPlanning, getRelatedEventLinksForPlanning} from '../utils/planning';
+import {getRelatedEventIdsForPlanning} from '../utils/planning';
 import {currentWorkspace as getCurrentWorkspace} from '../selectors/general';
 import {getLockedItems} from '../selectors/locks';
 
@@ -150,7 +150,7 @@ function lockItem<T extends IAssignmentOrPlanningItem>(item: T, action?: string)
                 item: lockedItem._id,
                 type: lockedItem.type,
                 event_ids: lockedItem.type === 'planning' ?
-                    getRelatedEventIdsForPlanning(lockedItem, 'primary') :
+                    getRelatedEventIdsForPlanning(lockedItem) :
                     [],
                 recurrence_id: lockedItem.type !== 'assignment' ? lockedItem.recurrence_id : undefined,
                 etag: lockedItem._etag,
@@ -178,7 +178,8 @@ function lockItem<T extends IAssignmentOrPlanningItem>(item: T, action?: string)
             }
 
             return lockedItem;
-        }, (error) => {
+        })
+        .catch((error) => {
             const {gettext} = superdeskApi.localization;
             const {notify} = superdeskApi.ui;
 
@@ -313,6 +314,42 @@ function unlockItem<T extends IAssignmentOrPlanningItem>(item: T, reloadLocksIfN
         });
 }
 
+function unlockEmbeddedEvent(itemId: string): Promise<IEventItem> {
+    const {dispatch} = planningApi.redux.store;
+    const endpoint = `events/${itemId}/unlock`;
+
+    return superdeskApi.dataApi.create<IEventItem>(endpoint, {})
+        .then((unlockedItem) => {
+            eventUtils.modifyForClient(unlockedItem);
+
+            locks.setItemAsUnlocked({
+                item: unlockedItem._id,
+                type: unlockedItem.type,
+                event_ids: [],
+                recurrence_id: unlockedItem.recurrence_id,
+                etag: unlockedItem._etag,
+                from_ingest: false,
+                user: unlockedItem.lock_user,
+                lock_session: unlockedItem.lock_session,
+            });
+
+            dispatch({
+                type: EVENTS.ACTIONS.UNLOCK_EVENT,
+                payload: {event: unlockedItem},
+            });
+
+            return unlockedItem;
+        })
+        .catch((error) => {
+            const {gettext} = superdeskApi.localization;
+            const {notify} = superdeskApi.ui;
+
+            notify.error(getErrorMessage(error, gettext('Failed to unlock item')));
+
+            return Promise.reject(error);
+        });
+}
+
 function unlockItemById<T extends IAssignmentOrPlanningItem>(itemId: T['_id'], itemType: T['type']): Promise<T> {
     return getItemById(itemId, itemType).then((item) => unlockItem(item));
 }
@@ -350,5 +387,6 @@ export const locks: IPlanningAPI['locks'] = {
     unlockItemById: unlockItemById,
     unlockThenLockItem: unlockThenLockItem,
     lockFeaturedPlanning: lockFeaturedPlanning,
+    unlockEmbeddedEvent: unlockEmbeddedEvent,
     unlockFeaturedPlanning: unlockFeaturedPlanning,
 };

--- a/client/components/Events/EventMetadata/RelatedEventListItem.tsx
+++ b/client/components/Events/EventMetadata/RelatedEventListItem.tsx
@@ -10,6 +10,7 @@ import * as selectors from '../../../selectors';
 import * as List from '../../UI/List';
 import {ItemIcon} from '../../ItemIcon';
 import {StateLabel} from '../../StateLabel';
+import {stringUtils} from '../../../utils';
 
 interface IProps {
     item: DeepPartial<IEventItem>;
@@ -68,7 +69,9 @@ class RelatedEventListItemComponent extends React.PureComponent<IProps> {
                 >
                     <List.Row>
                         <span className="sd-overflow-ellipsis sd-list-item--element-grow">
-                            <span className="sd-list-item__text-strong">{this.props.item.name}</span>
+                            <span className="sd-list-item__text-strong">
+                                {stringUtils.convertHtmlToPlainText(this.props.item.name)}
+                            </span>
                         </span>
                     </List.Row>
                     <List.Row>

--- a/client/components/Main/ItemEditor/Editor.tsx
+++ b/client/components/Main/ItemEditor/Editor.tsx
@@ -238,9 +238,7 @@ export class EditorComponent extends React.Component<IEditorProps, IEditorState>
                     }
                 },
                 onIgnore: () => {
-                    this.itemManager.unlockAndCancel(
-                        embeddedItemHasUnsavedChanges(this.props.itemType) ? 'HANDLE_UNSAVED_CHANGES' : 'DISCARD',
-                    );
+                    this.itemManager.unlockAndCancel();
                 },
                 onSave: onSave,
                 onSaveAndPost: onSaveAndPost,

--- a/client/components/Main/ItemEditor/ItemManager.ts
+++ b/client/components/Main/ItemEditor/ItemManager.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {Dispatch} from 'redux';
-import {cloneDeep, get, isEqual, partition, set} from 'lodash';
+import {cloneDeep, get, isEqual, set} from 'lodash';
 
 import {appConfig} from 'appConfig';
 import {
@@ -18,7 +18,6 @@ import {
     eventUtils,
     isTemporaryId,
     itemsEqual,
-    lockUtils,
     planningUtils,
     removeAutosaveFields,
     shouldUnLockItem,
@@ -30,10 +29,8 @@ import {EditorComponent} from './Editor';
 import {AutoSave} from './AutoSave';
 import {EditorGroup} from '../../Editor/EditorGroup';
 import * as selectors from '../../../selectors';
-import {
-    handleEmbeddedItems,
-    IEmbeddedPlanningsActionType,
-} from '../../../components/editor-standalone/save-handling';
+import {handleEmbeddedItems} from '../../../components/editor-standalone/save-handling';
+
 
 export class ItemManager {
     editor: EditorComponent;
@@ -360,20 +357,7 @@ export class ItemManager {
                 .then((original: IEventOrPlanningItem) => {
                     initialValues = cloneDeep(original);
 
-                    const allLockedItems = selectors.locks
-                        .getLockedItems((planningApi.redux.store.getState() as any));
-                    const isItemLocked = lockUtils.isItemLockedInThisSession(
-                        original,
-                        this.props.session,
-                        allLockedItems,
-                    );
-
-                    // if the item is already locked in this session don't lock it again
-                    if (isItemLocked) {
-                        return Promise.resolve(original);
-                    } else {
-                        return planningApi.locks.lockItem(original, 'edit');
-                    }
+                    return planningApi.locks.lockItem(original, 'edit');
                 });
         } else {
             // Fetch the latest item from the API to view in read-only mode
@@ -688,7 +672,7 @@ export class ItemManager {
                 ])
             );
 
-        return promise.then(([embeddedItems]) => {
+        return promise.then(() => {
             if (this.props.addNewsItemToPlanning) {
                 return this._saveFromAuthoring({post, unpost});
             }
@@ -715,42 +699,20 @@ export class ItemManager {
                 updates.update_method = updateMethod;
 
                 if (Object.keys(planningUpdateMethods).length > 0) {
-                        updates.associated_plannings?.forEach((planningItem) => {
-                            if (planningUpdateMethods[planningItem._id] != null) {
-                                planningItem.update_method = planningUpdateMethods[planningItem._id];
-                            }
-                        });
+                    updates.associated_plannings?.forEach((planningItem) => {
+                        if (planningUpdateMethods[planningItem._id] != null) {
+                            planningItem.update_method = planningUpdateMethods[planningItem._id];
+                        }
+                    });
                 }
             }
 
-            if (
-                updates.type === 'planning'
-                && (
-                    (updates.related_events ?? []).length > 0
-                    || ((updates as IPlanningItem)._unsaved_related_events ?? []).length > 0
-                )
-            ) {
-                const [_withNewEvents, withExistingEvents] = partition(
-                    ((updates as IPlanningItem).related_events ?? []) as Array<IPlanningRelatedEventLink>,
-                    (x) => !isTemporaryId(x._id),
-                );
-
-                const updatedLinks = eventUtils.addRelatedEvents(
-                    withExistingEvents,
-                    embeddedItems as Array<IEventItem>,
-                );
-
-                (updates as IPlanningItem).related_events = updatedLinks.next;
-            }
-
             return this.autoSave.flushAutosave()
-                .then(() => (
-                    this.dispatch<any>(actions.main.save(
-                        isTemporary ? {} : this.state.initialValues,
-                        updates,
-                        withConfirmation
-                    ))
-                ))
+                .then(() => this.dispatch<any>(actions.main.save(
+                    isTemporary ? {} : this.state.initialValues,
+                    updates,
+                    withConfirmation
+                )))
                 .then((updatedItem) => {
                     if (!updatedItem) {
                         // This occurs during an 'Ignore/Cancel/Save' from ModalEditor
@@ -771,24 +733,27 @@ export class ItemManager {
                         }
                     } else if (closeAfter) {
                         return this.editor.onCancel(updateStates);
-                    } else {
-                        const newState: Partial<IEditorState> = {
-                            initialValues: updatedItem,
-                            diff: cloneDeep(updatedItem),
-                            dirty: false,
-                            submitting: false,
-                            submitFailed: false,
-                            errors: {},
-                            errorMessages: [],
-                            itemReady: true,
-                            loading: false,
-                        };
-
-                        this.editorApi.events.onItemUpdated(newState);
-
-                        return this.setState(newState, null, true);
                     }
-                }, (error) => {
+
+                    planningApi.locks.reloadSoftLocksForRelatedEvents(updatedItem);
+
+                    const newState: Partial<IEditorState> = {
+                        initialValues: updatedItem,
+                        diff: cloneDeep(updatedItem),
+                        dirty: false,
+                        submitting: false,
+                        submitFailed: false,
+                        errors: {},
+                        errorMessages: [],
+                        itemReady: true,
+                        loading: false,
+                    };
+
+                    this.editorApi.events.onItemUpdated(newState);
+
+                    return this.setState(newState, null, true);
+                })
+                .catch((error) => {
                     if (get(error, 'status') === 412) {
                         // If etag error, then notify user and change editor to read-only
                         this.dispatch<any>(
@@ -802,6 +767,10 @@ export class ItemManager {
                 });
         }).catch((error) => {
             this.setState({submitting: false});
+
+            if (error === 'validation errors were found') {
+                return;
+            }
 
             throw error;
         });
@@ -879,10 +848,10 @@ export class ItemManager {
             ));
     }
 
-    unlockAndCancel(embeddedEditorAction: IEmbeddedPlanningsActionType) {
+    unlockAndCancel() {
         return handleEmbeddedItems(
             this.props.editorType,
-            embeddedEditorAction,
+            'DISCARD',
             this.props.itemType,
         ).then(() => {
             const {session, currentWorkspace} = this.props;
@@ -891,6 +860,13 @@ export class ItemManager {
 
             if (shouldUnLockItem(initialValues, session, currentWorkspace, this.props.lockedItems)) {
                 promises.push(planningApi.locks.unlockItem(this.props.item));
+
+                if (this.autoSave.autosaveItem.type == 'planning') {
+                    (this.autoSave.autosaveItem.related_events ?? []).forEach((x) => {
+                        // remove soft lock that was added on load in AssociatedEvent.tsx
+                        promises.push(planningApi.locks.unlockEmbeddedEvent(x._id));
+                    });
+                }
             }
 
             // If event was created by a planning item, unlock the planning item

--- a/client/components/Main/ItemEditor/ItemManager.ts
+++ b/client/components/Main/ItemEditor/ItemManager.ts
@@ -735,7 +735,9 @@ export class ItemManager {
                         return this.editor.onCancel(updateStates);
                     }
 
-                    planningApi.locks.reloadSoftLocksForRelatedEvents(updatedItem);
+                    if (updatedItem.type == 'planning') {
+                        planningApi.locks.reloadSoftLocksForRelatedEvents(updatedItem);
+                    }
 
                     const newState: Partial<IEditorState> = {
                         initialValues: updatedItem,

--- a/client/components/RelatedPlannings/PlanningMetaData/RelatedPlanningListItem.tsx
+++ b/client/components/RelatedPlannings/PlanningMetaData/RelatedPlanningListItem.tsx
@@ -5,7 +5,7 @@ import {IPlanningItem, IG2ContentType, ILockedItems, IAgenda} from '../../../int
 import {IDesk, IUser} from 'superdesk-api';
 import {superdeskApi} from '../../../superdeskApi';
 
-import {lockUtils, getItemWorkflowStateLabel} from '../../../utils';
+import {lockUtils, getItemWorkflowStateLabel, stringUtils} from '../../../utils';
 import * as selectors from '../../../selectors';
 
 import {Label} from 'superdesk-ui-framework/react';
@@ -84,7 +84,11 @@ class RelatedPlanningListItemComponent extends React.PureComponent<IProps> {
                         )}
                         {itemDescription.length === 0 ? null : (
                             <span className="sd-overflow-ellipsis sd-list-item--element-grow">
-                                {this.props.item.name || this.props.item.description_text}
+                                {/* Description_text may contain HTML and we
+                                do not want to display that in this header */}
+                                {stringUtils.convertHtmlToPlainText(
+                                    this.props.item.name || this.props.item.description_text,
+                                )}
                             </span>
                         )}
                     </List.Row>

--- a/client/components/editor-standalone/authoring-storage-in-memory.ts
+++ b/client/components/editor-standalone/authoring-storage-in-memory.ts
@@ -69,6 +69,8 @@ export function getAuthoringStorageInMemory<T extends IEventOrPlanningItem>(
                     }
                 })
                 .catch(() => {
+                    // If there's no autosaved item an error is returned from the backend,
+                    // so process it here and return the original item
                     return {...item} as unknown as T;
                 });
         },

--- a/client/components/editor-standalone/authoring-storage-in-memory.ts
+++ b/client/components/editor-standalone/authoring-storage-in-memory.ts
@@ -67,6 +67,9 @@ export function getAuthoringStorageInMemory<T extends IEventOrPlanningItem>(
                     } else {
                         return {...x} as unknown as T;
                     }
+                })
+                .catch(() => {
+                    return {...item} as unknown as T;
                 });
         },
 

--- a/client/components/editor-standalone/authoring-storage-in-memory.ts
+++ b/client/components/editor-standalone/authoring-storage-in-memory.ts
@@ -79,12 +79,15 @@ export function getAuthoringStorageInMemory<T extends IEventOrPlanningItem>(
         saveEntity: (current, original) => {
             return onSave(current, original);
         },
+
         getContentProfile: () => {
             return Promise.resolve(getProfile(profile, item.language ?? 'en'));
         },
+
         closeAuthoring: (_current, original, hasUnsavedChanges, _cancelAutosave, doClose) => {
             return Promise.resolve();
         },
+
         getUserPreferences: () => ng.get('preferencesService').get()
     };
 

--- a/client/components/editor-standalone/field-definitions/text-field-config.ts
+++ b/client/components/editor-standalone/field-definitions/text-field-config.ts
@@ -6,8 +6,7 @@ export function getTextFieldConfig(
     options: (IBaseFieldDefinition<'base'> | IEditor3Definition | IMultiLineDefinition) & {label: string},
 ): IAuthoringFieldV2 {
     const editor3Config: IEditor3Config = (() => {
-        const basicOptions = {cleanPastedHtml: true,
-            singleLine: false,
+        const basicOptions = {
             disallowedCharacters: [],
             showStatistics: true,
             width: 100,
@@ -20,6 +19,7 @@ export function getTextFieldConfig(
                 minLength: undefined,
                 maxLength: undefined,
                 cleanPastedHtml: false,
+                singleLine: true,
                 ...basicOptions,
             };
         } else if (fieldType === 'editor3') {
@@ -28,6 +28,7 @@ export function getTextFieldConfig(
                 minLength: options.minLength ?? undefined,
                 maxLength: options.maxLength ?? undefined,
                 cleanPastedHtml: true,
+                singleLine: false,
                 ...basicOptions,
             };
         } else if (fieldType === 'multi_line') {
@@ -36,6 +37,7 @@ export function getTextFieldConfig(
                 minLength: options.minLength ?? undefined,
                 maxLength: options.maxLength ?? undefined,
                 cleanPastedHtml: false,
+                singleLine: true,
                 expandable: {
                     enabled: options.expandable,
                     defaultValue: false,

--- a/client/components/editor-standalone/field-definitions/text-field-config.ts
+++ b/client/components/editor-standalone/field-definitions/text-field-config.ts
@@ -38,11 +38,11 @@ export function getTextFieldConfig(
                 maxLength: options.maxLength ?? undefined,
                 cleanPastedHtml: false,
                 singleLine: true,
-                expandable: {
-                    enabled: options.expandable,
+                expandable: options.expandable ? {
+                    enabled: true,
                     defaultValue: false,
                     numberOfRowsWhenCollapsed: 4,
-                },
+                } : undefined,
                 ...basicOptions,
             };
         }

--- a/client/components/editor-standalone/save-handling.ts
+++ b/client/components/editor-standalone/save-handling.ts
@@ -45,7 +45,7 @@ export const handleEmbeddedItems = async<T extends IEventItem | IPlanningItem>(
     editorType: EDITOR_TYPE,
     action: IEmbeddedPlanningsActionType,
     itemType: ItemType,
-) => {
+): Promise<Array<T>> => {
     const updatedItems: Array<T> = [];
     const itemsExposed = getEmbeddedItemsExposed<T>(editorType, itemType);
 

--- a/client/components/editor-standalone/save-handling.ts
+++ b/client/components/editor-standalone/save-handling.ts
@@ -1,5 +1,5 @@
 import {notNullOrUndefined} from '@sourcefabric/common';
-import {EDITOR_TYPE} from '../../interfaces';
+import {EDITOR_TYPE, IEventItem, IPlanningItem} from '../../interfaces';
 import {IExposedFromAuthoring} from 'superdesk-api';
 import {planningApi} from '../../superdeskApi';
 import {RelatedPlanningItem} from '../../components/fields/editor/EventRelatedPlannings/RelatedPlanningItem';
@@ -46,23 +46,28 @@ export const handleEmbeddedItems = async<T extends IEventItem | IPlanningItem>(
     action: IEmbeddedPlanningsActionType,
     itemType: ItemType,
 ): Promise<Array<T>> => {
-    const updatedItems: Array<T> = [];
+    const updatedItems: Array<Promise<T>> = [];
+    const itemsExposed = getEmbeddedItemsExposed<T>(editorType, itemType);
 
-    for (const exposed of getEmbeddedItemsExposed<T>(editorType, itemType)) {
+    for (const exposed of itemsExposed) {
         if (!exposed.hasUnsavedChanges()) {
-            updatedItems.push(exposed.getLatestItem());
+            updatedItems.push(
+                Promise.resolve(exposed.getLatestItem())
+            );
+            continue;
         }
 
         if (action === 'SAVE') {
-            updatedItems.push(await exposed.save());
+            updatedItems.push(exposed.save());
         } else if (action === 'DISCARD') {
             await exposed.discardUnsavedChanges();
+            updatedItems.push(Promise.resolve(exposed.getLatestItem()));
         } else {
-            updatedItems.push(await exposed.handleUnsavedChanges());
+            updatedItems.push(exposed.handleUnsavedChanges());
         }
     }
 
-    return updatedItems;
+    return await Promise.all(updatedItems);
 };
 
 export const embeddedItemHasUnsavedChanges = (itemType: ItemType) => {

--- a/client/components/editor-standalone/save-handling.ts
+++ b/client/components/editor-standalone/save-handling.ts
@@ -45,29 +45,29 @@ export const handleEmbeddedItems = async<T extends IEventItem | IPlanningItem>(
     editorType: EDITOR_TYPE,
     action: IEmbeddedPlanningsActionType,
     itemType: ItemType,
-): Promise<Array<T>> => {
-    const updatedItems: Array<Promise<T>> = [];
+) => {
+    const updatedItems: Array<T> = [];
     const itemsExposed = getEmbeddedItemsExposed<T>(editorType, itemType);
 
     for (const exposed of itemsExposed) {
         if (!exposed.hasUnsavedChanges()) {
             updatedItems.push(
-                Promise.resolve(exposed.getLatestItem())
+                await exposed.getLatestItem(),
             );
             continue;
         }
 
         if (action === 'SAVE') {
-            updatedItems.push(exposed.save());
+            updatedItems.push(await exposed.save());
         } else if (action === 'DISCARD') {
             await exposed.discardUnsavedChanges();
-            updatedItems.push(Promise.resolve(exposed.getLatestItem()));
+            updatedItems.push(await exposed.getLatestItem());
         } else {
-            updatedItems.push(exposed.handleUnsavedChanges());
+            updatedItems.push(await exposed.handleUnsavedChanges());
         }
     }
 
-    return await Promise.all(updatedItems);
+    return updatedItems;
 };
 
 export const embeddedItemHasUnsavedChanges = (itemType: ItemType) => {

--- a/client/components/fields/editor/AssociatedEvent.tsx
+++ b/client/components/fields/editor/AssociatedEvent.tsx
@@ -56,7 +56,7 @@ export class EditorFieldAssociatedEventComponent extends React.PureComponent<IAs
     private addNewRelatedEvent() {
         const newEvent = {
             _id: generateTempId(),
-            ...convertPlanningToEvent(this.props.item, planningApi.redux.store.getState)
+            ...convertPlanningToEvent(this.props.item, planningApi.redux.store.getState, false)
         };
 
         return autosave.save(undefined, newEvent).then((autosavedEvent) => {

--- a/client/components/fields/editor/AssociatedEvent.tsx
+++ b/client/components/fields/editor/AssociatedEvent.tsx
@@ -18,11 +18,10 @@ export class EditorFieldAssociatedEventComponent extends React.PureComponent<IAs
         this.relatedItemRefs = {};
         this.getCurrentValue = this.getCurrentValue.bind(this);
         this.addRelatedEvent = this.addRelatedEvent.bind(this);
-        this.removeRelatedEvent = this.removeRelatedEvent.bind(this);
         this.relatedItemExists = this.relatedItemExists.bind(this);
         this.addNewRelatedEvent = this.addNewRelatedEvent.bind(this);
+        this.lockRelatedItemsOnFrontEnd = this.lockRelatedItemsOnFrontEnd.bind(this);
     }
-
 
     private getCurrentValue(): Array<IPlanningRelatedEventLink> {
         const {field, item} = this.props;
@@ -47,13 +46,6 @@ export class EditorFieldAssociatedEventComponent extends React.PureComponent<IAs
         });
     }
 
-    private removeRelatedEvent(id: IEventItem['_id']) {
-        this.props.onChange(
-            this.props.field,
-            this.getCurrentValue().filter((item) => item._id !== id),
-        );
-    }
-
     private relatedItemExists(id: IEventItem['_id']) {
         const {field, item} = this.props;
         const relatedEvents = item[field] ?? [];
@@ -67,9 +59,28 @@ export class EditorFieldAssociatedEventComponent extends React.PureComponent<IAs
             ...convertPlanningToEvent(this.props.item, planningApi.redux.store.getState)
         };
 
-        return autosave.save(undefined, newEvent).then(() => {
-            this.addRelatedEvent(newEvent as IEventItem);
+        return autosave.save(undefined, newEvent).then((autosavedEvent) => {
+            this.addRelatedEvent(autosavedEvent as IEventItem);
+
+            return autosavedEvent;
         });
+    }
+
+    private lockRelatedItemsOnFrontEnd() {
+        planningApi.locks.setItemAsLocked({
+            ...this.props.item,
+            event_ids: this.props.events.map((x) => x._id),
+            etag: this.props.item._etag,
+            item: this.props.item._id,
+            user: this.props.item.lock_user,
+            lock_action: this.props.item.lock_action,
+            lock_session: this.props.item.lock_session,
+            lock_time: this.props.item.lock_time,
+        });
+    }
+
+    componentDidMount(): void {
+        this.lockRelatedItemsOnFrontEnd();
     }
 
     render() {
@@ -102,7 +113,14 @@ export class EditorFieldAssociatedEventComponent extends React.PureComponent<IAs
                             shape="round"
                             size="small"
                             iconOnly={true}
-                            onClick={this.addNewRelatedEvent}
+                            onClick={() => {
+                                this.addNewRelatedEvent()
+                                    .then(() => {
+                                        setTimeout(() => {
+                                            this.lockRelatedItemsOnFrontEnd();
+                                        }, 100);
+                                    });
+                            }}
                         />
                     )}
                 </Spacer>
@@ -110,12 +128,23 @@ export class EditorFieldAssociatedEventComponent extends React.PureComponent<IAs
                     <Spacer gap="8" v>
                         {events.map((event, i) => (
                             <AssociatedEventItem
-                                isTemporary={isTemporaryId(event._id)}
                                 index={i}
                                 key={event._id}
                                 event={event}
-                                updateEventItem={this.props.updateEventItem}
-                                unlinkEvent={this.props.unlinkEvent}
+                                planningItem={this.props.item}
+                                updateEventItem={(item, updates, scrollOnChange) =>
+                                    this.props.updateEventItem(item as IEventItem, updates, scrollOnChange)
+                                        .then(() => {
+                                            setTimeout(() => {
+                                                this.lockRelatedItemsOnFrontEnd();
+                                            }, 100);
+                                        })
+                                }
+                                unlinkEvent={(item) => {
+                                    this.props.unlinkEvent(item);
+
+                                    planningApi.locks.unlockEmbeddedEvent(item._id);
+                                }}
                                 disabled={this.props.disabled}
                                 ref={(ref) => {
                                     this.relatedItemRefs[i] = ref;
@@ -138,6 +167,10 @@ export class EditorFieldAssociatedEventComponent extends React.PureComponent<IAs
                                 const eventItem: IEventItem = JSON.parse(data);
 
                                 this.addRelatedEvent(eventItem);
+
+                                setTimeout(() => {
+                                    this.lockRelatedItemsOnFrontEnd();
+                                }, 100);
                             }
                         }}
                         multiple={true}

--- a/client/components/fields/editor/AssociatedEvent.tsx
+++ b/client/components/fields/editor/AssociatedEvent.tsx
@@ -138,11 +138,13 @@ export class EditorFieldAssociatedEventComponent extends React.PureComponent<IAs
                                 event={event}
                                 planningItem={this.props.item}
                                 updateEventItem={(item, updates, scrollOnChange) =>
-                                    this.props.updateEventItem(item as IEventItem, updates, scrollOnChange).then(() => {
-                                        setTimeout(() => {
-                                            this.lockRelatedItemsOnFrontEnd();
-                                        }, 100);
-                                    })
+                                    this.props.updateEventItem(item as IEventItem, updates, scrollOnChange)
+                                        .then(() => {
+                                            // Wait for redux store to update
+                                            setTimeout(() => {
+                                                this.lockRelatedItemsOnFrontEnd();
+                                            }, 100);
+                                        })
                                 }
                                 unlinkEvent={(item) => {
                                     this.props.unlinkEvent(item);

--- a/client/components/fields/editor/AssociatedEvent.tsx
+++ b/client/components/fields/editor/AssociatedEvent.tsx
@@ -138,7 +138,11 @@ export class EditorFieldAssociatedEventComponent extends React.PureComponent<IAs
                                 event={event}
                                 planningItem={this.props.item}
                                 updateEventItem={(item, updates, scrollOnChange) =>
-                                    this.props.updateEventItem(item as IEventItem, updates, scrollOnChange)
+                                    this.props.updateEventItem(item as IEventItem, updates, scrollOnChange).then(() => {
+                                        setTimeout(() => {
+                                            this.lockRelatedItemsOnFrontEnd();
+                                        }, 100);
+                                    })
                                 }
                                 unlinkEvent={(item) => {
                                     this.props.unlinkEvent(item);

--- a/client/components/fields/editor/AssociatedEvent.tsx
+++ b/client/components/fields/editor/AssociatedEvent.tsx
@@ -8,6 +8,7 @@ import {Spacer, Button} from 'superdesk-ui-framework/react';
 import {generateTempId, isTemporaryId} from '../../../utils';
 import {convertPlanningToEvent} from '../../../actions/events/ui';
 import {autosave} from '../../../api/autosave';
+import {isEqual} from 'lodash';
 
 export class EditorFieldAssociatedEventComponent extends React.PureComponent<IAssociatedEventFieldProps> {
     public relatedItemRefs: {[id: string]: AssociatedEventItem};
@@ -83,6 +84,15 @@ export class EditorFieldAssociatedEventComponent extends React.PureComponent<IAs
         this.lockRelatedItemsOnFrontEnd();
     }
 
+    componentDidUpdate(prevProps: Readonly<IAssociatedEventFieldProps>): void {
+        const prevEventIds = prevProps.events.map((x) => x._id);
+        const currentEventIds = this.props.events.map((x) => x._id);
+
+        if (isEqual(prevEventIds, currentEventIds) === false) {
+            this.lockRelatedItemsOnFrontEnd();
+        }
+    }
+
     render() {
         const {gettext} = superdeskApi.localization;
         const {DropZone} = superdeskApi.components;
@@ -114,12 +124,7 @@ export class EditorFieldAssociatedEventComponent extends React.PureComponent<IAs
                             size="small"
                             iconOnly={true}
                             onClick={() => {
-                                this.addNewRelatedEvent()
-                                    .then(() => {
-                                        setTimeout(() => {
-                                            this.lockRelatedItemsOnFrontEnd();
-                                        }, 100);
-                                    });
+                                this.addNewRelatedEvent();
                             }}
                         />
                     )}
@@ -134,11 +139,6 @@ export class EditorFieldAssociatedEventComponent extends React.PureComponent<IAs
                                 planningItem={this.props.item}
                                 updateEventItem={(item, updates, scrollOnChange) =>
                                     this.props.updateEventItem(item as IEventItem, updates, scrollOnChange)
-                                        .then(() => {
-                                            setTimeout(() => {
-                                                this.lockRelatedItemsOnFrontEnd();
-                                            }, 100);
-                                        })
                                 }
                                 unlinkEvent={(item) => {
                                     this.props.unlinkEvent(item);
@@ -167,10 +167,6 @@ export class EditorFieldAssociatedEventComponent extends React.PureComponent<IAs
                                 const eventItem: IEventItem = JSON.parse(data);
 
                                 this.addRelatedEvent(eventItem);
-
-                                setTimeout(() => {
-                                    this.lockRelatedItemsOnFrontEnd();
-                                }, 100);
                             }
                         }}
                         multiple={true}

--- a/client/components/fields/editor/AssociatedEventItem.tsx
+++ b/client/components/fields/editor/AssociatedEventItem.tsx
@@ -1,6 +1,6 @@
 import React, {createRef} from 'react';
 import {IAuthoringReact} from 'superdesk-api';
-import {superdeskApi} from '../../../superdeskApi';
+import {planningApi, superdeskApi} from '../../../superdeskApi';
 import {authoringStorageEventItemHttp} from '../../../components/editor-standalone/authoring-storage-event-http';
 import {EventEditorStandalone} from '../../../components/editor-standalone/event-editor-standalone';
 import {RelatedEventListItem} from '../../../components/Events/EventMetadata/RelatedEventListItem';
@@ -13,19 +13,27 @@ import {omit} from 'lodash';
 import {IPlanningRelatedEventLink} from 'interfaces';
 
 interface IPropsSavedEvent {
-    isTemporary: false;
     unlinkEvent(item: DeepPartial<IEventItem>): void;
-    updateEventItem(item: IPlanningRelatedEventLink, updates: IEventItem, scrollOnChange: boolean): void;
+    updateEventItem(
+        item: IPlanningRelatedEventLink,
+        updates: IEventItem,
+        scrollOnChange: boolean,
+    ): Promise<void>;
     event: IEventItem;
+    planningItem: IPlanningItem;
     index: number;
     disabled?: boolean;
 }
 
 interface IPropsTemporaryEvent {
-    isTemporary: true;
     unlinkEvent(item: DeepPartial<IPlanningRelatedEventLink>): void;
-    updateEventItem(item: IPlanningRelatedEventLink, updates: IEventItem, scrollOnChange: boolean): void;
+    updateEventItem(
+        item: IPlanningRelatedEventLink,
+        updates: IEventItem,
+        scrollOnChange: boolean,
+    ): Promise<void>;
     event: IPlanningRelatedEventLink;
+    planningItem: IPlanningItem;
     index: number;
     disabled?: boolean;
 }
@@ -85,9 +93,11 @@ export class AssociatedEventItem extends React.PureComponent<IProps> {
                     toggleBoxRef={this.toggleBoxRef}
                     getToggleButtonLabel={(isOpen) => isOpen ? gettext('Show less') : gettext('Show more')}
                     alwaysRenderChildren
+                    key={event._id}
                     header={(
-                        this.props.isTemporary ?
-                            renderRelatedEvent(event as IEventItem) : (
+                        isTemporaryId(event._id)
+                            ? renderRelatedEvent(event as IEventItem)
+                            : (
                                 <WithLiveResources resources={[{ids: [event._id], resource: 'events'}]}>
                                     {(res) => renderRelatedEvent(res[0]._items[0] as IEventItem)}
                                 </WithLiveResources>
@@ -97,7 +107,7 @@ export class AssociatedEventItem extends React.PureComponent<IProps> {
                     <EventEditorStandalone
                         editorRef={this.authoringRef}
                         itemId={event._id}
-                        authoringStorage={this.props.isTemporary
+                        authoringStorage={isTemporaryId(event._id)
                             ? getAuthoringStorageInMemory(
                                 'event',
                                 event as IEventItem,
@@ -107,11 +117,22 @@ export class AssociatedEventItem extends React.PureComponent<IProps> {
                                         ['_endTime', '_startTime', '_created', '_etag', '_links', '_updated']
                                     );
 
-                                    return eventsApi.events.create(itemClean).then(([createdEvent]) => {
-                                        this.update(createdEvent);
+                                    // Sometimes UI is clicked too fast, and since we don't have a perfect flow
+                                    // the users could end up creating a new event with the same ID twice
+                                    if (!isTemporaryId(itemClean._id)) {
+                                        this.update(itemClean as IEventItem);
 
-                                        return createdEvent;
-                                    });
+                                        return Promise.resolve(itemClean as IEventItem);
+                                    }
+
+                                    return eventsApi.events.create(itemClean).then(([created]) =>
+                                        planningApi.locks.unlockEmbeddedEvent(created._id)
+                                            .then((unlocked) => {
+                                                this.update(unlocked);
+
+                                                return unlocked;
+                                            })
+                                    );
                                 },
                             )
                             : authoringStorageEventItemHttp

--- a/client/components/fields/editor/AssociatedEventItem.tsx
+++ b/client/components/fields/editor/AssociatedEventItem.tsx
@@ -117,14 +117,6 @@ export class AssociatedEventItem extends React.PureComponent<IProps> {
                                         ['_endTime', '_startTime', '_created', '_etag', '_links', '_updated']
                                     );
 
-                                    // Sometimes UI is clicked too fast, and since we don't have a perfect flow
-                                    // the users could end up creating a new event with the same ID twice
-                                    if (!isTemporaryId(itemClean._id)) {
-                                        this.update(itemClean as IEventItem);
-
-                                        return Promise.resolve(itemClean as IEventItem);
-                                    }
-
                                     return eventsApi.events.create(itemClean).then(([created]) =>
                                         planningApi.locks.unlockEmbeddedEvent(created._id)
                                             .then((unlocked) => {

--- a/client/components/fields/editor/AssociatedEventWrapper.tsx
+++ b/client/components/fields/editor/AssociatedEventWrapper.tsx
@@ -6,7 +6,7 @@ export interface IAssociatedEventFieldProps extends IEditorFieldProps {
     events?: Array<IEventItem>;
     tabEnabled?: boolean; // defaults to true
     unlinkEvent(item: DeepPartial<IEventItem>): void;
-    updateEventItem(item: IEventItem, updates: IEventItem, scrollOnChange: boolean): void;
+    updateEventItem(item: IEventItem, updates: IEventItem, scrollOnChange: boolean): Promise<void>;
 }
 
 export class EditorFieldAssociatedEvents extends React.PureComponent<IAssociatedEventFieldProps> {

--- a/client/components/fields/headline.tsx
+++ b/client/components/fields/headline.tsx
@@ -1,9 +1,13 @@
 import PropTypes from 'prop-types';
 import {getTranslatedValue} from '.';
 import {IFieldsProps} from '../../interfaces';
+import {stringUtils} from '../../utils';
 
-export const headline = ({item, language}: IFieldsProps) => getTranslatedValue(
-    language, item, 'headline') || item.headline || null;
+export const headline = ({item, language}: IFieldsProps) => item.headline != null
+    ? stringUtils.convertHtmlToPlainText(
+        getTranslatedValue(language, item, 'headline') || item.headline,
+    )
+    : null;
 
 headline.propTypes = {
     item: PropTypes.shape({

--- a/client/components/fields/name.tsx
+++ b/client/components/fields/name.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {getTranslatedValue} from '.';
 import {IFieldsProps} from '../../interfaces';
+import {stringUtils} from '../../utils';
 
 export const name = ({item, language}: IFieldsProps) => {
     if (item.name == null) {
@@ -9,7 +10,7 @@ export const name = ({item, language}: IFieldsProps) => {
 
     return (
         <span className="sd-list-item__name">
-            {getTranslatedValue(language, item, 'name') ?? item.name}
+            {stringUtils.convertHtmlToPlainText(getTranslatedValue(language, item, 'name') ?? item.name)}
         </span>
     );
 };

--- a/client/components/fields/slugline.tsx
+++ b/client/components/fields/slugline.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {get} from 'lodash';
 import {getTranslatedValue} from '.';
 import {IFieldsProps} from '../../interfaces';
+import {stringUtils} from '../../utils';
 
 export const slugline = ({item, language}: IFieldsProps) => {
     if (!get(item, 'slugline', '')) {
@@ -9,7 +10,10 @@ export const slugline = ({item, language}: IFieldsProps) => {
     }
 
     return (
-        <span className="sd-list-item__slugline">{getTranslatedValue(language, item, 'slugline') ||
-    item.slugline}</span>
+        <span className="sd-list-item__slugline">
+            {stringUtils.convertHtmlToPlainText(
+                getTranslatedValue(language, item, 'slugline') || item.slugline,
+            )}
+        </span>
     );
 };

--- a/client/interfaces.ts
+++ b/client/interfaces.ts
@@ -2196,7 +2196,7 @@ export interface IEditorAPI {
                 bookmarks: Array<IEditorBookmark>;
                 groups: Array<IEditorFormGroup>;
             };
-            updateEventItem(item: IEventItem, updates: IEventItem, scrollOnChange: boolean): void;
+            updateEventItem(item: IEventItem, updates: IEventItem, scrollOnChange: boolean): Promise<void>;
             unlinkEvent(item: DeepPartial<IEventItem>): void;
             getRelatedEventsDomRef(eventId: IEventItem['_id']): React.RefObject<any>;
             getCoverageFields(
@@ -2366,6 +2366,7 @@ export interface IPlanningAPI {
         updateProfilesInStore(): Promise<void>;
     };
     locks: {
+        unlockEmbeddedEvent(itemId: string): Promise<IEventItem>;
         loadLockedItems(types?: Array<'events_and_planning' | 'featured_planning' | 'assignments'>): Promise<void>;
         setItemAsLocked(data: IWebsocketMessageData['ITEM_LOCKED']): void;
         setItemAsUnlocked(data: IWebsocketMessageData['ITEM_UNLOCKED']): void;

--- a/client/reducers/locks.ts
+++ b/client/reducers/locks.ts
@@ -16,7 +16,8 @@ function removeLock(state: ILockedItems, data: IWebsocketMessageData['ITEM_UNLOC
         delete state.recurring[data.recurrence_id];
     } else if ((data.event_ids?.length ?? 0) > 0) {
         // For now, only support 1 primary event link for locks
-        delete state.event[data.event_ids[0]];
+
+        data.event_ids.forEach((x) => delete state.event[x]);
     }
 
     // Always try and delete a lock direclty on the supplied item
@@ -43,8 +44,9 @@ function addLock(state: ILockedItems, data: IWebsocketMessageData['ITEM_LOCKED']
     } else if ((data.event_ids?.length ?? 0) > 0) {
         state[data.type][data.item] = lockData;
 
-        // For now, only support 1 primary event link for locks
-        state.event[data.event_ids[0]] = lockData;
+        data.event_ids.forEach((x) => {
+            state.event[x] = lockData;
+        });
     } else {
         state[data.type][data.item] = lockData;
     }
@@ -84,7 +86,7 @@ export default createReducer(initialLockState, {
             }
         }
 
-        for (const relatedEventId of getRelatedEventIdsForPlanning(planning, 'primary')) {
+        for (const relatedEventId of getRelatedEventIdsForPlanning(planning)) {
             // lock related planning unless event itself is locked
             // if event itself is locked, locking a related planning item would drop event's lock
             if (nextEventLocks[relatedEventId]?.item_type !== 'event') {


### PR DESCRIPTION
STT-189

## Front-end checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)
