### PR TITLE
Fix: keywords are not showing in the preview[SDBELGA-932]

### DIFF
--- a/client/components/fields/editor/EventRelatedArticles/PreviewArticle.tsx
+++ b/client/components/fields/editor/EventRelatedArticles/PreviewArticle.tsx
@@ -32,15 +32,17 @@ export class PreviewArticle extends React.PureComponent<IProps, IState> {
 
     componentDidMount(): void {
         const {getLabelNameResolver} = superdeskApi.entities.article;
-        const {getCustomFieldVocabularies} = superdeskApi.entities.vocabulary;
 
         getLabelNameResolver().then((getLabel: (fieldId: string) => string) => {
-            const customFieldVocabularies = getCustomFieldVocabularies();
+            const allVocabulariesMap = superdeskApi.entities.vocabulary.getAll();
+            const allVocabulariesArray = allVocabulariesMap.valueSeq().toArray();
+
+            const customVocabularies = allVocabulariesArray;
 
             this.getLabel = getLabel;
 
             this.setState({
-                customFieldVocabularies: customFieldVocabularies,
+                customFieldVocabularies: customVocabularies,
                 loading: false,
             });
         });


### PR DESCRIPTION
Fixes issue where keywords were not displaying in the article preview. 
Previously, the logic relied only on custom vocabularies, but belga_keywords are not present in that list. Now, using getAll() to fetch all vocabularies and matching schemes accordingly to ensure keywords render correctly.