### PR TITLE
[SDESK-7569] - Migrate usage of PlanningTypes to the Pydantic based async resource

### DIFF
--- a/server/planning/commands/populate_planning_types_test.py
+++ b/server/planning/commands/populate_planning_types_test.py
@@ -11,8 +11,8 @@
 import os
 import json
 
+from planning.content_profiles.planning_types_async_service import PlanningTypesAsyncService
 from planning.tests import TestCase
-from superdesk import get_resource_service
 from apps.prepopulate.app_populate import AppPopulateCommand
 
 
@@ -50,14 +50,15 @@ class AppPopulatePlanningTypesTest(TestCase):
     async def test_populate_types(self):
         cmd = AppPopulateCommand()
         async with self.app.app_context():
-            service = get_resource_service("planning_types")
-            cmd.run(self.filename)
+            service = PlanningTypesAsyncService()
+            await cmd.run(self.filename)
 
             for item in self.json_data:
-                data = service.find_one(_id=item["_id"], req=None)
-                self.assertEqual(data["_id"], item["_id"])
-                self.assertEqual(data["editor"]["definition_long"], item["editor"]["definition_long"])
-                self.assertDictEqual(data["schema"]["definition_long"], item["schema"]["definition_long"])
+                data = await service.find_one(_id=item["_id"])
+                self.assertIsNotNone(data)
+                self.assertEqual(data.id, item["_id"])
+                self.assertEqual(data.editor["definition_long"], item["editor"]["definition_long"])
+                self.assertDictEqual(data.schema["definition_long"], item["schema"]["definition_long"])
 
     def tearDown(self):
         os.remove(self.filename)

--- a/server/planning/common.py
+++ b/server/planning/common.py
@@ -619,6 +619,7 @@ def is_valid_event_planning_reason(updates, original):
     item_type = original.get(ITEM_TYPE)
 
     # get the validator based on the item_type and lock_action
+    # TODO-ASYNC[PlanningTypesAsyncService] - Update to use PlanningTypesAsyncService when function is updated to async and everywhere else it is called
     validator = (
         get_resource_service("planning_types").find_one(req=None, name="{}_{}".format(item_type, lock_action)) or {}
     )

--- a/server/planning/common.py
+++ b/server/planning/common.py
@@ -32,6 +32,7 @@ from superdesk.etree import parse_html
 import json
 from bson import ObjectId
 
+from planning.content_profiles.planning_types_async_service import PlanningTypesAsyncService
 from planning.types import Planning, Coverage, Event, EventAutosaveResourceModel, PlanningAutosaveResourceModel
 
 ITEM_STATE = "state"
@@ -595,7 +596,7 @@ def planning_link_updates_to_coverage():
     return get_app_config("PLANNING_LINK_UPDATES_TO_COVERAGES", False)
 
 
-def is_valid_event_planning_reason(updates, original):
+async def is_valid_event_planning_reason(updates, original):
     """Custom validation for reason field.
 
     This method is called from item action endpoints to validate the reason is required or not.
@@ -619,15 +620,13 @@ def is_valid_event_planning_reason(updates, original):
     item_type = original.get(ITEM_TYPE)
 
     # get the validator based on the item_type and lock_action
-    # TODO-ASYNC[PlanningTypesAsyncService] - Update to use PlanningTypesAsyncService when function is updated to async and everywhere else it is called
-    validator = (
-        get_resource_service("planning_types").find_one(req=None, name="{}_{}".format(item_type, lock_action)) or {}
-    )
+    planning_type = await PlanningTypesAsyncService().find_one(name=f"{item_type}_{lock_action}")
+    validator = planning_type.to_dict() if planning_type is not None else {}
 
     if not validator.get("schema"):
         return True
 
-    reason_mapping = validator.get("schema").get("reason") or {}
+    reason_mapping = validator.get("schema", {}).get("reason") or {}
     if reason_mapping.get("required") and not updates.get("reason"):
         return False
     return True

--- a/server/planning/content_profiles/utils.py
+++ b/server/planning/content_profiles/utils.py
@@ -14,6 +14,7 @@ from planning.types import ContentProfile
 
 
 def get_planning_schema(resource: str) -> ContentProfile:
+    # TODO-ASYNC[PlanningTypesAsyncService] - Update to use PlanningTypesAsyncService when function is updated to async and everywhere else it is also called
     return get_resource_service("planning_types").find_one(req=None, name=resource)
 
 

--- a/server/planning/content_profiles/utils.py
+++ b/server/planning/content_profiles/utils.py
@@ -14,7 +14,7 @@ from planning.types import ContentProfile
 
 
 def get_planning_schema(resource: str) -> ContentProfile:
-    # TODO-ASYNC[PlanningTypesAsyncService] - Update to use PlanningTypesAsyncService when function is updated to async and everywhere else it is also called
+    # TODO-ASYNC[PlanningTypesAsyncService] - Update to use PlanningTypesAsyncService when function is updated to async and everywhere else it is called
     return get_resource_service("planning_types").find_one(req=None, name=resource)
 
 

--- a/server/planning/events/events.py
+++ b/server/planning/events/events.py
@@ -239,7 +239,11 @@ class EventsService(AsyncBaseService):
             # Now, get associated planning items with the same recurrence
             return itertools.chain(
                 all_items,
-                await (await get_resource_service("planning").find_async(where={"recurrence_id": item.get("recurrence_id")})).to_list(),
+                await (
+                    await get_resource_service("planning").find_async(
+                        where={"recurrence_id": item.get("recurrence_id")}
+                    )
+                ).to_list(),
             )
         else:
             # Get associated planning items

--- a/server/planning/events/events_cancel.py
+++ b/server/planning/events/events_cancel.py
@@ -151,7 +151,7 @@ async def process_cancel_event(updates: dict[str, Any], original: dict[str, Any]
     ACTION = "cancel"
 
     # Perform pre update event actions
-    pre_update_event_actions(updates, original, ACTION)
+    await pre_update_event_actions(updates, original, ACTION)
 
     # Determin update method
     update_method = get_update_method(updates, original)

--- a/server/planning/events/events_postpone.py
+++ b/server/planning/events/events_postpone.py
@@ -94,7 +94,7 @@ async def process_postpone_event(updates: dict[str, Any], original: dict[str, An
     ACTION = "postpone"
 
     # Perform pre update event actions
-    pre_update_event_actions(updates, original, ACTION)
+    await pre_update_event_actions(updates, original, ACTION)
 
     # Determin update method
     update_method = get_update_method(updates, original)

--- a/server/planning/events/events_reschedule.py
+++ b/server/planning/events/events_reschedule.py
@@ -354,7 +354,7 @@ async def process_reschedule_event(
     ACTION = "reschedule"
 
     # Perform pre update event actions
-    pre_update_event_actions(updates, original, ACTION, require_lock)
+    await pre_update_event_actions(updates, original, ACTION, require_lock)
 
     # Determin update method
     update_method = get_update_method(updates, original)

--- a/server/planning/events/events_spike.py
+++ b/server/planning/events/events_spike.py
@@ -252,7 +252,7 @@ async def process_spike_event(updates: dict[str, Any], original: dict[str, Any])
     ACTION = "spiked"
 
     # Perform pre update event actions
-    pre_update_event_actions(updates, original, ACTION)
+    await pre_update_event_actions(updates, original, ACTION)
 
     # Determine update method
     update_method = get_update_method(updates, original)
@@ -302,7 +302,7 @@ async def process_unspike_event(updates: dict[str, Any], original: dict[str, Any
     ACTION = "unspiked"
 
     # Perform pre update event actions
-    pre_update_event_actions(updates, original, ACTION)
+    await pre_update_event_actions(updates, original, ACTION)
 
     # Determine update method
     update_method = get_update_method(updates, original)

--- a/server/planning/events/events_update_repetitions.py
+++ b/server/planning/events/events_update_repetitions.py
@@ -227,7 +227,7 @@ async def process_update_repetitions(
     ACTION = "update_repetitions"
 
     # Perform pre update event actions
-    pre_update_event_actions(updates, original, ACTION, require_lock)
+    await pre_update_event_actions(updates, original, ACTION, require_lock)
 
     await update_event_repetitions(updates, original)
 

--- a/server/planning/events/events_update_time.py
+++ b/server/planning/events/events_update_time.py
@@ -105,7 +105,7 @@ async def process_update_time(
     ACTION = "update_time"
 
     # Perform pre update event actions
-    pre_update_event_actions(updates, original, ACTION, require_lock)
+    await pre_update_event_actions(updates, original, ACTION, require_lock)
 
     # Determine update method
     update_method = get_update_method(updates, original)

--- a/server/planning/events/events_utils.py
+++ b/server/planning/events/events_utils.py
@@ -244,7 +244,7 @@ async def get_recurring_timeline(
     return historic, past, future
 
 
-def pre_update_event_actions(
+async def pre_update_event_actions(
     updates: dict[str, Any], original: dict[str, Any], ACTION: str = "", require_lock: bool = True
 ):
     # Set version_creator and update ingested state
@@ -254,7 +254,7 @@ def pre_update_event_actions(
         set_ingested_event_state(updates, original)
 
     # Perform additional validation for event action
-    validate_event_action(updates, original, ACTION, require_lock)
+    await validate_event_action(updates, original, ACTION, require_lock)
 
 
 def get_update_method(updates: dict[str, Any], original: dict[str, Any]) -> str:
@@ -268,7 +268,7 @@ def get_update_method(updates: dict[str, Any], original: dict[str, Any]) -> str:
     return update_method
 
 
-def validate_event_action(
+async def validate_event_action(
     updates: dict[str, Any],
     original: dict[str, Any],
     ACTION: str = "",
@@ -283,7 +283,7 @@ def validate_event_action(
     if not original:
         raise SuperdeskApiError.notFoundError()
 
-    if not is_valid_event_planning_reason(updates, original):
+    if not await is_valid_event_planning_reason(updates, original):
         raise SuperdeskApiError.badRequestError(message="Reason is required field.")
 
     if original.get("state") == WORKFLOW_STATE.CANCELLED:

--- a/server/planning/feed_parsers/events_ml.py
+++ b/server/planning/feed_parsers/events_ml.py
@@ -144,6 +144,7 @@ class EventsMLParser(NewsMLTwoFeedParser):
             pass
 
     def get_default_event_duration(self):
+        # TODO-ASYNC[PlanningTypesAsyncService] - Update to use PlanningTypesAsyncService when class is updated to async
         profile = get_resource_service("planning_types").find_one(req=None, name="event") or {}
         return ((profile.get("editor") or {}).get("dates") or {}).get("default_duration_on_change", 1)
 

--- a/server/planning/planning/planning.py
+++ b/server/planning/planning/planning.py
@@ -10,7 +10,7 @@
 
 """Superdesk Planning"""
 
-from typing import Dict, Any, Optional, List
+from typing import Dict, Any, Optional, List, cast
 from typing_extensions import assert_never
 from copy import deepcopy
 import logging
@@ -178,7 +178,7 @@ class PlanningService(AsyncBaseService):
             await self.validate_planning(doc)
             set_original_creator(doc)
 
-            first_event = await self._set_planning_event_info(doc, ContentProfile(**planning_type.to_dict()))
+            first_event = await self._set_planning_event_info(doc, cast(ContentProfile, planning_type.to_dict()))
             await self._set_coverage(doc)
             self.set_planning_schedule(doc)
             # set timestamps

--- a/server/planning/planning/planning.py
+++ b/server/planning/planning/planning.py
@@ -11,7 +11,6 @@
 """Superdesk Planning"""
 
 from typing import Dict, Any, Optional, List
-from superdesk.core.types import SearchRequest
 from typing_extensions import assert_never
 from copy import deepcopy
 import logging

--- a/server/planning/planning/planning.py
+++ b/server/planning/planning/planning.py
@@ -11,6 +11,7 @@
 """Superdesk Planning"""
 
 from typing import Dict, Any, Optional, List
+from superdesk.core.types import SearchRequest
 from typing_extensions import assert_never
 from copy import deepcopy
 import logging
@@ -47,6 +48,7 @@ from planning.types import (
 )
 from planning.planning.planning_history_async_service import PlanningHistoryAsyncService
 from planning.assignments.assignments_history_async import AssignmentsHistoryAsyncService
+from planning.content_profiles.planning_types_async_service import PlanningTypesAsyncService
 from planning.common import (
     get_coverage_status_from_cv,
     WORKFLOW_STATE,
@@ -157,7 +159,9 @@ class PlanningService(AsyncBaseService):
 
     async def on_create_async(self, docs):
         """Set default metadata."""
-        planning_type = get_resource_service("planning_types").find_one(req=None, name="planning")
+        planning_type = await PlanningTypesAsyncService().find_one(name="planning")
+        assert planning_type is not None, "Expexted planning_type to not be None"
+
         history_service = PlanningHistoryAsyncService()
         generated_planning_items = []
         for doc in docs:
@@ -175,7 +179,7 @@ class PlanningService(AsyncBaseService):
             await self.validate_planning(doc)
             set_original_creator(doc)
 
-            first_event = await self._set_planning_event_info(doc, planning_type)
+            first_event = await self._set_planning_event_info(doc, ContentProfile(**planning_type.to_dict()))
             await self._set_coverage(doc)
             self.set_planning_schedule(doc)
             # set timestamps

--- a/server/planning/planning/planning_cancel.py
+++ b/server/planning/planning/planning_cancel.py
@@ -53,7 +53,7 @@ class PlanningCancelResource(PlanningResource):
 
 class PlanningCancelService(AsyncBaseService):
     async def on_update_async(self, updates, original):
-        if not is_valid_event_planning_reason(updates, original):
+        if not await is_valid_event_planning_reason(updates, original):
             raise SuperdeskApiError.badRequestError(message="Reason is required field.")
 
     async def update_async(self, id, updates, original):

--- a/server/planning/planning/planning_service.py
+++ b/server/planning/planning/planning_service.py
@@ -51,6 +51,7 @@ from planning.types import (
     ContentProfile,
     UpdateMethods,
     EventResourceModel,
+    PlanningTypesResourceModel,
 )
 from planning.utils import (
     get_related_event_links_for_planning,
@@ -441,7 +442,7 @@ class PlanningAsyncService(BasePlanningAsyncService[PlanningResourceModel]):
             if doc.agendas:
                 doc.agendas = unique_items_in_order(doc.agendas)
 
-            first_event = await self._populate_planning_from_event(doc, ContentProfile(**planning_type.to_dict()))
+            first_event = await self._populate_planning_from_event(doc, planning_type)
             await self._handle_coverages(doc)
             self.set_planning_schedule(doc)
 
@@ -1054,7 +1055,7 @@ class PlanningAsyncService(BasePlanningAsyncService[PlanningResourceModel]):
 
     @staticmethod
     async def _populate_planning_from_event(
-        planning: PlanningResourceModel, planning_type: ContentProfile
+        planning: PlanningResourceModel, planning_type: ContentProfile | PlanningTypesResourceModel
     ) -> EventResourceModel | None:
         """
         Populate planning document information based on a linked event. Retrieves a primary linked event

--- a/server/planning/planning/planning_service.py
+++ b/server/planning/planning/planning_service.py
@@ -45,6 +45,7 @@ from planning.common import (
 from planning.core.service import BasePlanningAsyncService
 from planning.assignments.assignments_history_async import AssignmentsHistoryAsyncService
 from planning.planning.planning_history_async_service import PlanningHistoryAsyncService
+from planning.content_profiles.planning_types_async_service import PlanningTypesAsyncService
 from planning.types import (
     PlanningResourceModel,
     ContentProfile,
@@ -423,7 +424,9 @@ class PlanningAsyncService(BasePlanningAsyncService[PlanningResourceModel]):
         """
         Set default metadata.
         """
-        planning_type = get_resource_service("planning_types").find_one(req=None, name="planning")
+        planning_type = await PlanningTypesAsyncService().find_one(name="planning")
+        assert planning_type is not None, "Expexted planning_type to not be None"
+
         history_service = PlanningHistoryAsyncService()
         generated_planning_items = []
 
@@ -438,7 +441,7 @@ class PlanningAsyncService(BasePlanningAsyncService[PlanningResourceModel]):
             if doc.agendas:
                 doc.agendas = unique_items_in_order(doc.agendas)
 
-            first_event = await self._populate_planning_from_event(doc, planning_type)
+            first_event = await self._populate_planning_from_event(doc, ContentProfile(**planning_type.to_dict()))
             await self._handle_coverages(doc)
             self.set_planning_schedule(doc)
 

--- a/server/planning/planning/planning_service.py
+++ b/server/planning/planning/planning_service.py
@@ -442,7 +442,7 @@ class PlanningAsyncService(BasePlanningAsyncService[PlanningResourceModel]):
             if doc.agendas:
                 doc.agendas = unique_items_in_order(doc.agendas)
 
-            first_event = await self._populate_planning_from_event(doc, planning_type)
+            first_event = await self._populate_planning_from_event(doc, cast(ContentProfile, planning_type.to_dict()))
             await self._handle_coverages(doc)
             self.set_planning_schedule(doc)
 
@@ -1055,7 +1055,7 @@ class PlanningAsyncService(BasePlanningAsyncService[PlanningResourceModel]):
 
     @staticmethod
     async def _populate_planning_from_event(
-        planning: PlanningResourceModel, planning_type: ContentProfile | PlanningTypesResourceModel
+        planning: PlanningResourceModel, planning_type: ContentProfile
     ) -> EventResourceModel | None:
         """
         Populate planning document information based on a linked event. Retrieves a primary linked event


### PR DESCRIPTION
### Purpose
This PR migrate usage of the PlanningTypes resource service to the Pydantic based async resource

- Migrated use of PlanningTypes resource service into using the new async pydantic ones


Solves: [SDESK-7569](https://sofab.atlassian.net/browse/SDESK-7569)

[SDESK-7569]: https://sofab.atlassian.net/browse/SDESK-7569?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ