### PR TITLE
Fix multiline field

### DIFF
--- a/client/components/editor-standalone/field-definitions/text-field-config.ts
+++ b/client/components/editor-standalone/field-definitions/text-field-config.ts
@@ -18,7 +18,7 @@ export function getTextFieldConfig(
                 editorFormat: [],
                 minLength: undefined,
                 maxLength: undefined,
-                cleanPastedHtml: false,
+                cleanPastedHtml: true,
                 singleLine: true,
                 ...basicOptions,
             };
@@ -27,7 +27,7 @@ export function getTextFieldConfig(
                 editorFormat: options.formattingOptions ?? [],
                 minLength: options.minLength ?? undefined,
                 maxLength: options.maxLength ?? undefined,
-                cleanPastedHtml: true,
+                cleanPastedHtml: false,
                 singleLine: false,
                 ...basicOptions,
             };
@@ -36,7 +36,7 @@ export function getTextFieldConfig(
                 editorFormat: [],
                 minLength: options.minLength ?? undefined,
                 maxLength: options.maxLength ?? undefined,
-                cleanPastedHtml: false,
+                cleanPastedHtml: true,
                 singleLine: false,
                 expandable: options.expandable ? {
                     enabled: true,

--- a/client/components/editor-standalone/profile-fields.ts
+++ b/client/components/editor-standalone/profile-fields.ts
@@ -4,6 +4,7 @@ import {planningApi, superdeskApi} from '../../superdeskApi';
 import {getEditorFormGroupsFromProfile} from '../../utils/contentProfiles';
 import {IProfileSchemaTypeString} from 'interfaces';
 import {RICH_FORMATTING_OPTION} from 'superdesk-api';
+import {isMultiLineField} from './utils';
 
 interface IBaseField<T> {
     type: T;
@@ -133,10 +134,7 @@ export const getPlanningProfileFields = (
                 maxlength: castedSchema.maxlength,
                 minlength: castedSchema.minlength,
             });
-        } else if (
-            TEXT_FIELDS_WITH_EDITOR_TYPE_CONFIG.has(fieldId)
-            && (fieldSchema as IProfileSchemaTypeString).field_type === 'multi_line'
-        ) {
+        } else if (TEXT_FIELDS_WITH_EDITOR_TYPE_CONFIG.has(fieldId) && isMultiLineField(fieldSchema)) {
             const castedSchema = fieldSchema as IProfileSchemaTypeString;
 
             convertedFields.push({

--- a/client/components/editor-standalone/storage-adapter.ts
+++ b/client/components/editor-standalone/storage-adapter.ts
@@ -8,6 +8,7 @@ import {
 import {planningApi, superdeskApi} from '../../superdeskApi';
 import {getFieldDefinitions} from './field-definitions/index';
 import {IFieldDefinition, IFieldStorageAdapter} from './field-definitions/interfaces';
+import {isMultiLineField} from './utils';
 
 export function getStorageAdapter<T extends IPlanningItem | IEventItem>(
     profile: 'event' | 'planning',
@@ -25,15 +26,11 @@ export function getStorageAdapter<T extends IPlanningItem | IEventItem>(
             } else if (fieldType === 'editor3') {
                 const editor3Config = config as IEditor3Config;
                 const rawState = (value as IEditor3ValueStorage).rawContentState;
-                const isMultiLineField = (
-                    itemProfile.schema[fieldId] as IProfileSchemaTypeString
-                )?.field_type === 'multi_line';
-
                 const computed = computeEditor3Output(
                     rawState,
                     editor3Config,
                     item.language ?? 'en',
-                    isMultiLineField,
+                    isMultiLineField(itemProfile.schema[fieldId]),
                 );
 
                 return {
@@ -58,11 +55,7 @@ export function getStorageAdapter<T extends IPlanningItem | IEventItem>(
             if (fieldStorageAdapter != null) {
                 return fieldStorageAdapter.retrieveStoredValue(item, fieldId);
             } else if (fieldType === 'editor3') {
-                const isMultiLineField = (
-                    itemProfile.schema[fieldId] as IProfileSchemaTypeString
-                )?.field_type === 'multi_line';
-
-                if (isMultiLineField) {
+                if (isMultiLineField(itemProfile.schema[fieldId])) {
                     return {rawContentState: convertToRaw(ContentState.createFromText(value ?? ''))};
                 }
 

--- a/client/components/editor-standalone/storage-adapter.ts
+++ b/client/components/editor-standalone/storage-adapter.ts
@@ -1,11 +1,11 @@
-import {IEventItem} from 'interfaces';
-import {convertToRaw} from 'draft-js';
+import {IEventItem, IProfileSchemaTypeString} from 'interfaces';
+import {ContentState, convertToRaw} from 'draft-js';
 import {
     IEditor3Config,
     IEditor3ValueStorage,
     IStorageAdapter,
 } from 'superdesk-api';
-import {superdeskApi} from '../../superdeskApi';
+import {planningApi, superdeskApi} from '../../superdeskApi';
 import {getFieldDefinitions} from './field-definitions/index';
 import {IFieldDefinition, IFieldStorageAdapter} from './field-definitions/interfaces';
 
@@ -18,17 +18,22 @@ export function getStorageAdapter<T extends IPlanningItem | IEventItem>(
             const {computeEditor3Output} = superdeskApi.helpers;
             const fieldDefinitions = getFieldDefinitions(profile);
             const fieldStorageAdapter = getFieldStorageAdapter(fieldDefinitions[fieldId]);
+            const itemProfile = planningApi.contentProfiles.get(profile);
 
             if (fieldStorageAdapter != null) {
                 return fieldStorageAdapter.storeValue(item, value);
             } else if (fieldType === 'editor3') {
                 const editor3Config = config as IEditor3Config;
                 const rawState = (value as IEditor3ValueStorage).rawContentState;
+                const isMultiLineField = (
+                    itemProfile.schema[fieldId] as IProfileSchemaTypeString
+                )?.field_type === 'multi_line';
 
                 const computed = computeEditor3Output(
                     rawState,
                     editor3Config,
                     item.language ?? 'en',
+                    isMultiLineField,
                 );
 
                 return {
@@ -48,14 +53,20 @@ export function getStorageAdapter<T extends IPlanningItem | IEventItem>(
             const fieldDefinitions = getFieldDefinitions(profile);
             const value = (item as {[key: string]: any})[fieldId] ?? undefined;
             const fieldStorageAdapter = getFieldStorageAdapter(fieldDefinitions[fieldId]);
+            const itemProfile = planningApi.contentProfiles.get(profile);
 
             if (fieldStorageAdapter != null) {
                 return fieldStorageAdapter.retrieveStoredValue(item, fieldId);
             } else if (fieldType === 'editor3') {
-                const returnValue: IEditor3ValueStorage
-                    = {rawContentState: convertToRaw(getContentStateFromHtml(value ?? ''))};
+                const isMultiLineField = (
+                    itemProfile.schema[fieldId] as IProfileSchemaTypeString
+                )?.field_type === 'multi_line';
 
-                return returnValue;
+                if (isMultiLineField) {
+                    return {rawContentState: convertToRaw(ContentState.createFromText(value ?? ''))};
+                }
+
+                return {rawContentState: convertToRaw(getContentStateFromHtml(value ?? ''))};
             } else {
                 return value;
             }

--- a/client/components/editor-standalone/storage-adapter.ts
+++ b/client/components/editor-standalone/storage-adapter.ts
@@ -1,4 +1,4 @@
-import {IEventItem, IProfileSchemaTypeString} from 'interfaces';
+import {IEventItem} from 'interfaces';
 import {ContentState, convertToRaw} from 'draft-js';
 import {
     IEditor3Config,

--- a/client/components/editor-standalone/utils.ts
+++ b/client/components/editor-standalone/utils.ts
@@ -1,3 +1,4 @@
+import {IProfileSchemaType, IProfileSchemaType, IProfileSchemaTypeString} from 'interfaces';
 import {omit} from 'lodash';
 import {IBaseRestApiResponse} from 'superdesk-api';
 
@@ -18,4 +19,8 @@ export function omitFields<T extends IBaseRestApiResponse>(
     }
 
     return {...omit(item, baseApiFields)};
+}
+
+export function isMultiLineField(fieldSchema: IProfileSchemaType) {
+    return (fieldSchema as IProfileSchemaTypeString)?.field_type === 'multi_line';
 }

--- a/client/components/editor-standalone/utils.ts
+++ b/client/components/editor-standalone/utils.ts
@@ -1,4 +1,4 @@
-import {IProfileSchemaType, IProfileSchemaType, IProfileSchemaTypeString} from 'interfaces';
+import {IProfileSchemaType, IProfileSchemaTypeString} from 'interfaces';
 import {omit} from 'lodash';
 import {IBaseRestApiResponse} from 'superdesk-api';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11253,7 +11253,7 @@
       }
     },
     "superdesk-core": {
-      "version": "github:superdesk/superdesk-client-core#20226b6acb83bf46c7cdd862d8753e342708e941",
+      "version": "github:superdesk/superdesk-client-core#92b73db366948afe5bbee797c71af9bd6cba5ecd",
       "from": "github:superdesk/superdesk-client-core#develop",
       "dev": true,
       "requires": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11253,7 +11253,7 @@
       }
     },
     "superdesk-core": {
-      "version": "github:superdesk/superdesk-client-core#92b73db366948afe5bbee797c71af9bd6cba5ecd",
+      "version": "github:superdesk/superdesk-client-core#d19172ee173d3b8e65e984a18a38b1a4a5892666",
       "from": "github:superdesk/superdesk-client-core#develop",
       "dev": true,
       "requires": {


### PR DESCRIPTION
STT-156
## Front-end checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)
