### PR TITLE
Saving fixes

### DIFF
--- a/client/actions/events/api.ts
+++ b/client/actions/events/api.ts
@@ -9,7 +9,6 @@ import {
     POST_STATE,
     MAIN,
     TO_BE_CONFIRMED_FIELD,
-    TEMP_ID_PREFIX,
 } from '../../constants';
 import * as selectors from '../../selectors';
 import {
@@ -18,9 +17,7 @@ import {
     isExistingItem,
     isValidFileInput,
     isPublishedItemId,
-    isTemporaryId,
     gettext,
-    planningUtils,
 } from '../../utils';
 
 import planningApis from '../planning/api';
@@ -29,7 +26,7 @@ import main from '../main';
 import {eventParamsToSearchParams} from '../../utils/search';
 import {getRelatedEventIdsForPlanning} from '../../utils/planning';
 import {planning} from '../../api/planning';
-import * as actions from '../../actions';
+import {areEmbeddedItemsDirty} from '../../components/editor-standalone/utils';
 
 /**
  * Action dispatcher to load a series of recurring events into the local store.
@@ -646,8 +643,12 @@ const save = (original, updates) => (
                 planningApi.events.create(eventUpdates);
 
             return createOrUpdatePromise.then(([updatedEvent]: Array<IEventItem>) => {
-                if (updatedEvent?._id != null) {
-                    updateLinkedPlanningsForEvent(
+                const haveLinksChanged = updatedEvent?._id ? areEmbeddedItemsDirty(original, updatedEvent) : false;
+
+                if (!haveLinksChanged) {
+                    return [updatedEvent];
+                } else {
+                    return updateLinkedPlanningsForEvent(
                         updatedEvent._id,
                         updates.associated_plannings,
                     ).then((updatedPlannings) => {
@@ -657,8 +658,6 @@ const save = (original, updates) => (
 
                         return [updatedEvent];
                     });
-                } else {
-                    return [updatedEvent];
                 }
             });
         });

--- a/client/actions/events/api.ts
+++ b/client/actions/events/api.ts
@@ -333,10 +333,13 @@ const fetchById = (eventId, {force = false, saveToStore = true, loadPlanning = t
         return promise.then((event) => {
             if (loadPlanning) {
                 return dispatch(self.loadAssociatedPlannings(event))
-                    .then(
-                        () => Promise.resolve(event),
-                        (error) => Promise.reject(error)
-                    );
+                    .then((plannings) => {
+                        return Promise.resolve({
+                            ...event,
+                            associated_plannings: plannings,
+                        });
+                    })
+                    .catch((error) => Promise.reject(error));
             }
 
             return Promise.resolve(event);

--- a/client/actions/events/api.ts
+++ b/client/actions/events/api.ts
@@ -645,18 +645,22 @@ const save = (original, updates) => (
                 planningApi.events.update(originalItem, eventUpdates) :
                 planningApi.events.create(eventUpdates);
 
-            return createOrUpdatePromise.then(([updatedEvent]: Array<IEventItem>) =>
-                updateLinkedPlanningsForEvent(
-                    updatedEvent._id,
-                    updates.associated_plannings,
-                ).then((updatedPlannings) => {
-                    // Update associated events, so if a link has been added/removed etags are updated
-                    // after the change in planning items
-                    updatedEvent.associated_plannings = updatedPlannings;
+            return createOrUpdatePromise.then(([updatedEvent]: Array<IEventItem>) => {
+                if (updatedEvent?._id != null) {
+                    updateLinkedPlanningsForEvent(
+                        updatedEvent._id,
+                        updates.associated_plannings,
+                    ).then((updatedPlannings) => {
+                        // Update associated events, so if a link has been added/removed etags are updated
+                        // after the change in planning items
+                        updatedEvent.associated_plannings = updatedPlannings;
 
+                        return [updatedEvent];
+                    });
+                } else {
                     return [updatedEvent];
-                }),
-            );
+                }
+            });
         });
     }
 );

--- a/client/actions/events/api.ts
+++ b/client/actions/events/api.ts
@@ -558,16 +558,16 @@ function updateLinkedPlanningsForEvent(
      * missing items will be linked, extra items unlinked
      */
     associatedPlannings: Array<IPlanningItem>,
-):Promise<void> {
+):Promise<Array<IPlanningItem>> {
     return planningApi.events.getLinkedPlanningItems(eventId).then((currentlyLinked) => {
         const currentLinkedIds = new Set(currentlyLinked.map((item) => item._id));
-
         const toLink: Array<IPlanningItem> = associatedPlannings
             .filter(({_id}) => currentLinkedIds.has(_id) !== true);
         const toUnlink: Array<IPlanningItem> = currentlyLinked
             .filter((item) => associatedPlannings.find(({_id}) => _id === item._id) == null);
+        const associatedPlanningIds = associatedPlannings.map(({_id}) => _id);
 
-        return planningApi.planning.getByIds(associatedPlannings.map(({_id}) => _id), undefined)
+        return planningApi.planning.getByIds(associatedPlanningIds, undefined)
             .then((allPlanningItems) => Promise.all([
                 ...toLink.map((oldPlanning) => {
                     const planningItem = allPlanningItems.find((x) => x._id === oldPlanning._id);
@@ -601,7 +601,17 @@ function updateLinkedPlanningsForEvent(
             ]).then((updatedPlanningItems) => {
                 planningApi.redux.store.dispatch<any>(planningApis.receivePlannings(updatedPlanningItems));
 
-                return null;
+                if (associatedPlanningIds.length > 0) {
+                    const updatedPlanningIds = updatedPlanningItems.map((x) => x._id);
+
+                    // In cases there's no new links, we still want to return all
+                    // related planning items. Existing link data doesn't change here
+                    // (besides new links and ones to be removed), // but this result is used to update the UI.
+                    return [
+                        ...associatedPlannings.filter((x) => !updatedPlanningIds.includes(x._id)),
+                        ...updatedPlanningItems.filter((x) => associatedPlanningIds.includes(x._id)),
+                    ];
+                }
             }));
     });
 }
@@ -628,75 +638,22 @@ const save = (original, updates) => (
                 EVENTS.UPDATE_METHODS[0].value :
                 eventUpdates.update_method?.value ?? eventUpdates.update_method;
 
-            const [planningsToCreate, planningsToUpdate] = partition(
-                (eventUpdates.associated_plannings ?? []).map((planning) => planningUtils.modifyForServer(planning)),
-                (item) => item._id.startsWith(TEMP_ID_PREFIX),
-            );
-
-            // ensure `associated_plannings` doesn't contain `planningsToCreate`
-            // otherwise it would get created twice - separately and together with event patch
-            eventUpdates.associated_plannings = planningsToUpdate;
-
             const createOrUpdatePromise: Promise<Array<IEventItem>> = originalEvent?._id != null ?
                 planningApi.events.update(originalItem, eventUpdates) :
                 planningApi.events.create(eventUpdates);
 
-            return createOrUpdatePromise.then(([updatedEvent]: Array<IEventItem>) => {
-                if (updates.associated_plannings == null) {
-                    return Promise.resolve([updatedEvent]);
-                }
-
-                let promise = Promise.resolve<void>(null);
-
-                promise = promise.then(
-                    () => Promise.all(
-                        planningsToCreate.map((planning) => {
-                            const linkType = planning._temporary?.link_type;
-
-                            delete planning['_temporary'];
-
-                            if (linkType == null) {
-                                throw new Error('linkType expected but not found');
-                            }
-
-                            for (const relatedEvent of (planning.related_events ?? [])) {
-                                if (relatedEvent._id === originalEvent._id) {
-                                    relatedEvent.link_type = linkType;
-                                }
-                            }
-
-                            return planningApi.planning.create(planning)
-                                .then((saved) => {
-                                    // replace temp ID with newly received permanent ID
-                                    updates.associated_plannings = updates.associated_plannings.map(
-                                        (associated_planning) => {
-                                            if (associated_planning._id === planning._id) {
-                                                return {
-                                                    ...associated_planning,
-                                                    _id: saved._id,
-                                                };
-                                            } else {
-                                                return associated_planning;
-                                            }
-                                        }
-                                    );
-                                });
-                        }),
-                    ).then(() => null)
-                );
-
-                // ensure temp ID replacement takes effect in the editor
-                promise = promise.then(() => {
-                    updatedEvent.associated_plannings = updates.associated_plannings;
-                });
-
-                promise = promise.then(() => updateLinkedPlanningsForEvent(
+            return createOrUpdatePromise.then(([updatedEvent]: Array<IEventItem>) =>
+                updateLinkedPlanningsForEvent(
                     updatedEvent._id,
                     updates.associated_plannings,
-                ));
+                ).then((updatedPlannings) => {
+                    // Update associated events, so if a link has been added/removed etags are updated
+                    // after the change in planning items
+                    updatedEvent.associated_plannings = updatedPlannings;
 
-                return promise.then(() => [updatedEvent]);
-            });
+                    return [updatedEvent];
+                }),
+            );
         });
     }
 );

--- a/client/actions/events/tests/api_test.ts
+++ b/client/actions/events/tests/api_test.ts
@@ -138,13 +138,14 @@ describe('actions.events.api', () => {
         it('returns the Event from the API if force = true', (done) => (
             store.test(done, eventsApi.fetchById('e2', {force: true}))
                 .then((event) => {
-                    expect(event).toEqual(eventUtils.modifyForClient(data.events[1]));
+                    const mockedEventResult = data.events[1];
 
+                    expect(event).toEqual(mockedEventResult);
                     expect(planningApis.events.getById.callCount).toBe(1);
                     expect(planningApis.events.getById.args[0]).toEqual(['e2', {cache: false}]);
 
                     expect(eventsApi.receiveEvents.callCount).toBe(1);
-                    expect(eventsApi.receiveEvents.args[0]).toEqual([[data.events[1]]]);
+                    expect(eventsApi.receiveEvents.args[0]).toEqual([[mockedEventResult]]);
                     expect(eventsApi.loadAssociatedPlannings.callCount).toBe(1);
 
                     done();
@@ -761,7 +762,6 @@ describe('actions.events.api', () => {
                         name: 'New Event',
                         slugline: 'New Slugline',
                         update_method: 'single',
-                        associated_plannings: [],
                     }]);
 
                     done();

--- a/client/actions/tests/main_test.ts
+++ b/client/actions/tests/main_test.ts
@@ -448,6 +448,7 @@ describe('actions.main', () => {
                     expect(main.openPreview.callCount).toBe(1);
                     expect(main.openPreview.args[0]).toEqual([{
                         ...data.events[0],
+                        associated_plannings: [],
                         dates: {
                             ...data.events[0].dates,
                             start: moment(data.events[0].dates.start),
@@ -468,6 +469,7 @@ describe('actions.main', () => {
                     expect(main.openPreview.callCount).toBe(1);
                     expect(main.openPreview.args[0]).toEqual([{
                         ...data.events[0],
+                        associated_plannings: [],
                         dates: {
                             ...data.events[0].dates,
                             start: moment(data.events[0].dates.start),

--- a/client/api/editor/item_planning.ts
+++ b/client/api/editor/item_planning.ts
@@ -99,20 +99,34 @@ export function getPlanningInstance(type: EDITOR_TYPE): IEditorAPI['item']['plan
         const editor = planningApi.editor(type);
         const planning = editor.form.getDiff<IPlanningItem>();
         const events = cloneDeep(planning.related_events || []);
+        const tempEvents = planning._unsaved_related_events ?? [];
         const index = events.findIndex(
             (event) => event._id === original._id
         );
         const isEmpty = events.length < 1;
 
         if (!isEmpty && index < 0) {
-            return;
+            if (tempEvents.find((x) => x._id === original._id) != null) {
+                events.push({
+                    _id: updates._id,
+                    link_type: original.link_type,
+                    recurrence_id: original.recurrence_id,
+                });
+            } else {
+                // This should never happen, but make sure to notify the user in some corruption case
+                superdeskApi.ui.notify.error(
+                    superdeskApi.localization.gettext(
+                        'Could not link event - A corruption occurred, please close the item and try linking again'
+                    ),
+                );
+            }
+        } else {
+            events[isEmpty ? 0 : index] = {
+                _id: updates._id,
+                link_type: original.link_type,
+                recurrence_id: original.recurrence_id
+            };
         }
-
-        events[isEmpty ? 0 : index] = {
-            _id: updates._id,
-            link_type: original.link_type,
-            recurrence_id: original.recurrence_id
-        };
 
         const updateMainField = () => {
             return editor.form.changeField('related_events', events, true, true)

--- a/client/api/editor/item_planning.ts
+++ b/client/api/editor/item_planning.ts
@@ -116,9 +116,11 @@ export function getPlanningInstance(type: EDITOR_TYPE): IEditorAPI['item']['plan
                 // This should never happen, but make sure to notify the user in some corruption case
                 superdeskApi.ui.notify.error(
                     superdeskApi.localization.gettext(
-                        'Could not link event - A corruption occurred, please close the item and try linking again'
+                        'Could not link event - Please close the item and try linking again'
                     ),
                 );
+
+                return;
             }
         } else {
             events[isEmpty ? 0 : index] = {

--- a/client/components/Main/ItemEditor/Editor.tsx
+++ b/client/components/Main/ItemEditor/Editor.tsx
@@ -1,7 +1,14 @@
 import React from 'react';
-import {cloneDeep, isEqual} from 'lodash';
+import {cloneDeep, isEqual, omit} from 'lodash';
 
-import {EDITOR_TYPE, IEditorAPI, IEditorProps, IEditorState, IEventItem, IPlanningItem} from '../../../interfaces';
+import {
+    EDITOR_TYPE,
+    IEditorAPI,
+    IEditorProps,
+    IEditorState,
+    IEventOrPlanningItem,
+    IPlanningItem,
+} from '../../../interfaces';
 import {planningApi, superdeskApi} from '../../../superdeskApi';
 import {ITEM_TYPE, UI} from '../../../constants';
 
@@ -19,7 +26,7 @@ import {ItemManager} from './ItemManager';
 import {AutoSave} from './AutoSave';
 import {EditorHeader} from './EditorHeader';
 import {pickRelatedEventsForPlanning} from './../../../utils/planning';
-import {embeddedItemHasUnsavedChanges} from '../../../components/editor-standalone/save-handling';
+import {areEmbeddedItemsDirty} from '../../../components/editor-standalone/utils';
 
 export class EditorComponent extends React.Component<IEditorProps, IEditorState> {
     autoSave: AutoSave;
@@ -158,8 +165,19 @@ export class EditorComponent extends React.Component<IEditorProps, IEditorState>
             });
     }
 
-    isDirty(initialValues, diff) {
-        return !itemsEqual(diff, initialValues);
+    isDirty(
+        initialValues: Partial<IEventOrPlanningItem>,
+        diff: Partial<IEventOrPlanningItem>,
+        checkRelatedItemsChanges = true,
+    ) {
+        const embeddedItemsAreDirty = checkRelatedItemsChanges ? areEmbeddedItemsDirty(initialValues, diff) : false;
+        const fieldsToOmit = ['associated_plannings', '_unsaved_related_events', 'embedded_planning'];
+
+        if (checkRelatedItemsChanges === false) {
+            fieldsToOmit.push('related_events');
+        }
+
+        return embeddedItemsAreDirty || !itemsEqual(omit(diff, fieldsToOmit), omit(initialValues, fieldsToOmit));
     }
 
     updateTabLabels(nextProps) {
@@ -199,50 +217,52 @@ export class EditorComponent extends React.Component<IEditorProps, IEditorState>
 
         this.autoSave.flushAutosave().then(() => {
             const {openCancelModal, itemId, itemType, addNewsItemToPlanning} = this.props;
-            const {dirty, errorMessages, initialValues} = this.state;
-
+            const {errorMessages, initialValues, diff} = this.state;
             const updateStates = !addNewsItemToPlanning;
 
             this.setState({submitting: true});
 
-            if (!(dirty || embeddedItemHasUnsavedChanges(this.props.itemType))) {
-                this.onCancel();
-                return;
+            const isDirty = this.isDirty(initialValues, diff, false);
+
+            if (isDirty) {
+                const hasErrors = !isEqual(errorMessages, []);
+                const isKilled = isItemKilled(initialValues);
+                const onSave = (isKilled || hasErrors) ? null : (withConfirmation, updateMethod) => (
+                    this.itemManager.save(
+                        withConfirmation,
+                        {name: updateMethod, value: updateMethod},
+                        true,
+                        updateStates,
+                    )
+                );
+                const onSaveAndPost = (!isKilled || hasErrors) ? null : (withConfirmation, updateMethod) => (
+                    this.itemManager.saveAndPost(
+                        withConfirmation,
+                        updateMethod,
+                        true,
+                        updateStates,
+                    )
+                );
+
+                openCancelModal({
+                    itemId: itemId,
+                    itemType: itemType,
+                    onCancel: () => {
+                        if (updateStates) {
+                            this.setState({submitting: false});
+                        }
+                    },
+                    onIgnore: () => {
+                        this.itemManager.unlockAndCancel();
+                    },
+                    onSave: onSave,
+                    onSaveAndPost: onSaveAndPost,
+                });
+            } else {
+                this.itemManager.unlockAndCancel().then(() => {
+                    this.onCancel();
+                });
             }
-
-            const hasErrors = !isEqual(errorMessages, []);
-            const isKilled = isItemKilled(initialValues);
-            const onSave = (isKilled || hasErrors) ? null : (withConfirmation, updateMethod) => (
-                this.itemManager.save(
-                    withConfirmation,
-                    {name: updateMethod, value: updateMethod},
-                    true,
-                    updateStates,
-                )
-            );
-            const onSaveAndPost = (!isKilled || hasErrors) ? null : (withConfirmation, updateMethod) => (
-                this.itemManager.saveAndPost(
-                    withConfirmation,
-                    updateMethod,
-                    true,
-                    updateStates,
-                )
-            );
-
-            openCancelModal({
-                itemId: itemId,
-                itemType: itemType,
-                onCancel: () => {
-                    if (updateStates) {
-                        this.setState({submitting: false});
-                    }
-                },
-                onIgnore: () => {
-                    this.itemManager.unlockAndCancel();
-                },
-                onSave: onSave,
-                onSaveAndPost: onSaveAndPost,
-            });
         });
     }
 
@@ -263,9 +283,7 @@ export class EditorComponent extends React.Component<IEditorProps, IEditorState>
             this.props.onCancel();
         }
 
-        return this.itemManager.unlockAndCancel(
-            embeddedItemHasUnsavedChanges(this.props.itemType) ? 'HANDLE_UNSAVED_CHANGES' : 'DISCARD',
-        );
+        return this.itemManager.unlockAndCancel();
     }
 
     setActiveTab(tab) {

--- a/client/components/Main/ItemEditor/Editor.tsx
+++ b/client/components/Main/ItemEditor/Editor.tsx
@@ -173,7 +173,7 @@ export class EditorComponent extends React.Component<IEditorProps, IEditorState>
         const embeddedItemsAreDirty = checkRelatedItemsChanges ? areEmbeddedItemsDirty(initialValues, diff) : false;
         const fieldsToOmit = ['associated_plannings', '_unsaved_related_events', 'embedded_planning'];
 
-        if (checkRelatedItemsChanges === false) {
+        if (!checkRelatedItemsChanges) {
             fieldsToOmit.push('related_events');
         }
 

--- a/client/components/Main/ItemEditor/ItemManager.ts
+++ b/client/components/Main/ItemEditor/ItemManager.ts
@@ -418,18 +418,14 @@ export class ItemManager {
                     dirty: (() => {
                         // if associated_plannings in autosaveItem is undefined
                         // we treat that as there's been no changes to associated_plannings
-                        if (initialValues.type === 'event' && autosaveItem.associated_plannings === undefined) {
-                            return this.editor.isDirty(
-                                initialValues,
-                                autosaveItem,
-                                false,
-                            );
-                        } else {
-                            return this.editor.isDirty(
-                                initialValues,
-                                autosaveItem,
-                            );
-                        }
+                        const ignoreAssociatedPlannings = initialValues.type === 'event'
+                            && autosaveItem.associated_plannings === undefined;
+
+                        return this.editor.isDirty(
+                            initialValues,
+                            autosaveItem,
+                            ignoreAssociatedPlannings ? false : undefined,
+                        );
                     })(),
                     submitting: false,
                     itemReady: true,

--- a/client/components/Main/ItemEditor/ItemManager.ts
+++ b/client/components/Main/ItemEditor/ItemManager.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {Dispatch} from 'redux';
-import {cloneDeep, get, isEqual, set} from 'lodash';
+import {cloneDeep, get, isEqual, omit, set} from 'lodash';
 
 import {appConfig} from 'appConfig';
 import {
@@ -415,7 +415,22 @@ export class ItemManager {
                 const newState = {
                     initialValues: original,
                     diff: diff,
-                    dirty: this.editor.isDirty(initialValues, autosaveItem),
+                    dirty: (() => {
+                        // if associated_plannings in autosaveItem is undefined
+                        // we treat that as there's been no changes to associated_plannings
+                        if (initialValues.type === 'event' && autosaveItem.associated_plannings === undefined) {
+                            return this.editor.isDirty(
+                                initialValues,
+                                autosaveItem,
+                                false,
+                            );
+                        } else {
+                            return this.editor.isDirty(
+                                initialValues,
+                                autosaveItem,
+                            );
+                        }
+                    })(),
                     submitting: false,
                     itemReady: true,
                     loading: false,

--- a/client/components/editor-standalone/authoring-storage-event-http.ts
+++ b/client/components/editor-standalone/authoring-storage-event-http.ts
@@ -4,7 +4,7 @@ import {superdeskApi} from '../../superdeskApi';
 import {getProfile} from './profile';
 import {omitFields} from './utils';
 import {AutoSaveHttp} from './authoring-autosave';
-import {eventUtils} from '../../utils';
+import {eventUtils, getErrorMessage, gettext, notifyError} from '../../utils';
 
 export const authoringStorageEventItemHttp: IAuthoringStorage<IEventItem> = {
     autosave: new AutoSaveHttp<IEventItem>(
@@ -45,6 +45,11 @@ export const authoringStorageEventItemHttp: IAuthoringStorage<IEventItem> = {
             headers: {
                 'If-Match': original._etag,
             },
+        }).catch((err) => {
+            // Handles date issues like start time should not be after end time
+            superdeskApi.ui.notify.error(getErrorMessage(err, gettext('Could not save event')));
+
+            return original;
         });
     },
     getContentProfile: (item) => {

--- a/client/components/editor-standalone/save-handling.ts
+++ b/client/components/editor-standalone/save-handling.ts
@@ -46,28 +46,29 @@ export const handleEmbeddedItems = async<T extends IEventItem | IPlanningItem>(
     action: IEmbeddedPlanningsActionType,
     itemType: ItemType,
 ): Promise<Array<T>> => {
-    const updatedItems: Array<T> = [];
+    const updatedItems: Array<Promise<T>> = [];
     const itemsExposed = getEmbeddedItemsExposed<T>(editorType, itemType);
 
     for (const exposed of itemsExposed) {
-        if (!exposed.hasUnsavedChanges()) {
-            updatedItems.push(
-                await exposed.getLatestItem(),
-            );
+        const latestItem = exposed.getLatestItem();
+        const areAllChangesSaved = !exposed.hasUnsavedChanges();
+
+        if (areAllChangesSaved) {
+            updatedItems.push(Promise.resolve(latestItem));
             continue;
         }
 
         if (action === 'SAVE') {
-            updatedItems.push(await exposed.save());
+            updatedItems.push(exposed.save());
         } else if (action === 'DISCARD') {
             await exposed.discardUnsavedChanges();
-            updatedItems.push(await exposed.getLatestItem());
+            updatedItems.push(Promise.resolve(latestItem));
         } else {
-            updatedItems.push(await exposed.handleUnsavedChanges());
+            updatedItems.push(exposed.handleUnsavedChanges());
         }
     }
 
-    return updatedItems;
+    return Promise.all(updatedItems);
 };
 
 export const embeddedItemHasUnsavedChanges = (itemType: ItemType) => {

--- a/client/components/editor-standalone/utils.ts
+++ b/client/components/editor-standalone/utils.ts
@@ -1,5 +1,6 @@
-import {IProfileSchemaType, IProfileSchemaTypeString} from 'interfaces';
-import {omit} from 'lodash';
+import {IEventOrPlanningItem, IProfileSchemaType, IProfileSchemaTypeString} from 'interfaces';
+import {isEqual, omit} from 'lodash';
+import {isMoment} from 'moment';
 import {IBaseRestApiResponse} from 'superdesk-api';
 
 export function omitFields<T extends IBaseRestApiResponse>(
@@ -23,4 +24,43 @@ export function omitFields<T extends IBaseRestApiResponse>(
 
 export function isMultiLineField(fieldSchema: IProfileSchemaType) {
     return (fieldSchema as IProfileSchemaTypeString)?.field_type === 'multi_line';
+}
+
+const FIELDS_TO_OMIT_FOR_COMPARISON = ['_links', '_planning_schedule', '_updates_schedule', 'event'];
+
+export function areEmbeddedItemsDirty<T extends Partial<IEventOrPlanningItem>>(original: T, diff: T) {
+    if (diff.type === 'event' && original.type === 'event') { // check both so type narrowing works
+        const origPlans = (original.associated_plannings ?? []);
+        const diffPlans = (diff.associated_plannings ?? []);
+
+        if (origPlans.length !== diffPlans.length) {
+            return true;
+        }
+
+        const plansOriginal = origPlans.map((x) => {
+            const itemCleaned = omit(x, FIELDS_TO_OMIT_FOR_COMPARISON);
+
+            if (isMoment(itemCleaned.planning_date)) {
+                itemCleaned.planning_date = itemCleaned.planning_date.toISOString();
+            }
+
+            return itemCleaned;
+        }).sort((a, b) => a._id.localeCompare(b._id));
+        const plansDiff = diffPlans.map((x) => {
+            const itemCleaned = omit(x, FIELDS_TO_OMIT_FOR_COMPARISON);
+
+            if (isMoment(itemCleaned.planning_date)) {
+                itemCleaned.planning_date = itemCleaned.planning_date.toISOString();
+            }
+
+            return itemCleaned;
+        }).sort((a, b) => a._id.localeCompare(b._id));
+
+        // both arrays are sorted, to make sure order of items doesn't make a difference
+        return !isEqual(plansOriginal, plansDiff);
+    } else if (diff.type === 'planning' && (diff._unsaved_related_events ?? []).length > 0) {
+        return true;
+    } else {
+        return false;
+    }
 }

--- a/client/components/editor-standalone/utils.ts
+++ b/client/components/editor-standalone/utils.ts
@@ -26,7 +26,9 @@ export function isMultiLineField(fieldSchema: IProfileSchemaType) {
     return (fieldSchema as IProfileSchemaTypeString)?.field_type === 'multi_line';
 }
 
-const FIELDS_TO_OMIT_FOR_COMPARISON = ['_links', '_planning_schedule', '_updates_schedule', 'event'];
+function cleanAndSortPlans(plans: Array<Partial<IPlanningItem>>) {
+    return plans.map((x) => x._id).sort((a, b) => a.localeCompare(b));
+}
 
 export function areEmbeddedItemsDirty<T extends Partial<IEventOrPlanningItem>>(original: T, diff: T) {
     if (diff.type === 'event' && original.type === 'event') { // check both so type narrowing works
@@ -37,24 +39,8 @@ export function areEmbeddedItemsDirty<T extends Partial<IEventOrPlanningItem>>(o
             return true;
         }
 
-        const plansOriginal = origPlans.map((x) => {
-            const itemCleaned = omit(x, FIELDS_TO_OMIT_FOR_COMPARISON);
-
-            if (isMoment(itemCleaned.planning_date)) {
-                itemCleaned.planning_date = itemCleaned.planning_date.toISOString();
-            }
-
-            return itemCleaned;
-        }).sort((a, b) => a._id.localeCompare(b._id));
-        const plansDiff = diffPlans.map((x) => {
-            const itemCleaned = omit(x, FIELDS_TO_OMIT_FOR_COMPARISON);
-
-            if (isMoment(itemCleaned.planning_date)) {
-                itemCleaned.planning_date = itemCleaned.planning_date.toISOString();
-            }
-
-            return itemCleaned;
-        }).sort((a, b) => a._id.localeCompare(b._id));
+        const plansOriginal = cleanAndSortPlans(origPlans);
+        const plansDiff = cleanAndSortPlans(diffPlans);
 
         // both arrays are sorted, to make sure order of items doesn't make a difference
         return !isEqual(plansOriginal, plansDiff);

--- a/client/components/fields/editor/AssociatedEvent.tsx
+++ b/client/components/fields/editor/AssociatedEvent.tsx
@@ -134,7 +134,7 @@ export class EditorFieldAssociatedEventComponent extends React.PureComponent<IAs
                         {events.map((event, i) => (
                             <AssociatedEventItem
                                 index={i}
-                                key={event._id}
+                                key={event._etag}
                                 event={event}
                                 planningItem={this.props.item}
                                 updateEventItem={(item, updates, scrollOnChange) =>

--- a/client/components/fields/editor/AssociatedEventItem.tsx
+++ b/client/components/fields/editor/AssociatedEventItem.tsx
@@ -122,6 +122,9 @@ export class AssociatedEventItem extends React.PureComponent<IProps> {
                                             .then((unlocked) => {
                                                 this.update(unlocked);
 
+                                                // remove the temporary event so user doesn't see it in the work queue
+                                                planningApi.autosave.delete(item);
+
                                                 return unlocked;
                                             })
                                     );

--- a/client/components/fields/editor/EventRelatedPlannings/EventRelatedPlannings.tsx
+++ b/client/components/fields/editor/EventRelatedPlannings/EventRelatedPlannings.tsx
@@ -97,7 +97,7 @@ export class EditorFieldEventRelatedPlanningsComponent extends React.PureCompone
 
                             return (
                                 <RelatedPlanningItem
-                                    // Reload if _etag has changed so saving doesn't crash
+                                    // Reload if _etag has changed so autosave and saving doesn't crash
                                     key={plan._etag}
                                     ref={(ref) => {
                                         this.relatedItemRefs[index] = ref;

--- a/client/components/fields/editor/EventRelatedPlannings/EventRelatedPlannings.tsx
+++ b/client/components/fields/editor/EventRelatedPlannings/EventRelatedPlannings.tsx
@@ -97,10 +97,11 @@ export class EditorFieldEventRelatedPlanningsComponent extends React.PureCompone
 
                             return (
                                 <RelatedPlanningItem
+                                    // Reload if _etag has changed so saving doesn't crash
+                                    key={plan._etag}
                                     ref={(ref) => {
                                         this.relatedItemRefs[index] = ref;
                                     }}
-                                    key={plan._id}
                                     index={index}
                                     event={this.props.item}
                                     item={plan}

--- a/client/interfaces.ts
+++ b/client/interfaces.ts
@@ -1922,7 +1922,7 @@ export type IEditorAction = 'read' | 'create' | 'edit';
 
 export interface IEditorState {
     tab: number;
-    diff: DeepPartial<IEventOrPlanningItem>;
+    diff: Partial<IEventOrPlanningItem>;
     errors: {[key: string]: string};
     errorMessages: Array<string>;
     dirty: boolean;
@@ -1931,7 +1931,7 @@ export interface IEditorState {
     partialSave: boolean;
     itemReady: boolean;
     loading: boolean;
-    initialValues: DeepPartial<IEventOrPlanningItem>;
+    initialValues: Partial<IEventOrPlanningItem>;
     mainLanguage?: IVocabularyItem['qcode'];
     showAllLanguages: boolean;
 

--- a/client/utils/testData.ts
+++ b/client/utils/testData.ts
@@ -704,6 +704,7 @@ export const events: Array<IEventItem> = [
             tz: 'Australia/Sydney',
         },
         planning_ids: [],
+        associated_plannings: undefined,
     },
     {
         _id: 'e3',
@@ -714,6 +715,7 @@ export const events: Array<IEventItem> = [
             end: '2015-10-15T15:01:11+0000',
             tz: 'Australia/Sydney',
         },
+        associated_plannings: undefined,
     },
 ];
 


### PR DESCRIPTION
## Front-end checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)
