### PR TITLE
Add custom vocabularies support in coverages

### DIFF
--- a/client/components/ContentProfiles/CoverageProfileModal.tsx
+++ b/client/components/ContentProfiles/CoverageProfileModal.tsx
@@ -167,6 +167,7 @@ export class CoverageProfilesModal extends React.Component<IProps, IState> {
 
         fields.forEach((item, index) => {
             profileCloned.editor[item.name] = {...item.field};
+            profileCloned.schema[item.name] = {...item.schema};
             profileCloned.editor[item.name].index = index;
         });
 

--- a/client/components/ContentProfiles/FieldTab/AddFieldsMenu.tsx
+++ b/client/components/ContentProfiles/FieldTab/AddFieldsMenu.tsx
@@ -19,6 +19,7 @@ export default class AddFieldsMenu extends React.PureComponent<IProps, any> {
 
         return (
             <TreeMenu
+                key={options.length}
                 data-test-id="menu"
                 getId={(field) => field.name}
                 optionTemplate={(item) => item.schema?.type === 'custom_vocabulary' ? (

--- a/client/components/ContentProfiles/FieldTab/index.tsx
+++ b/client/components/ContentProfiles/FieldTab/index.tsx
@@ -201,6 +201,12 @@ export class FieldTab extends React.Component<IProps, IState> {
 
                 this.props.updateFields([{
                     ...item,
+
+                    // If field is custom_vocabulary, schema should also be removed, on field remove
+                    // otherwise if required is set to true UI issues will occur.
+                    // We check for schema.type === 'custom_vocabulary' because some field names might have ids
+                    // of a custom vocabulary, while registered as static fields
+                    schema: item.schema.type === 'custom_vocabulary' ? undefined : item.schema,
                     field: {
                         ...item.field,
                         enabled: false,

--- a/client/components/fields/editor/CustomCV.tsx
+++ b/client/components/fields/editor/CustomCV.tsx
@@ -36,10 +36,15 @@ export class EditorFieldCV extends React.PureComponent<IEditorFieldProps> {
                     value={(item.subject ?? []).filter((x) => x.scheme === cv._id)}
                     label={gettext(cv.display_name)}
                     required={this.props.schema.required}
+
+                    // map to specific properties so backend schema check doesn't fail
                     getOptions={() => superdeskApi.utilities.arrayToTree(
                             cv.items.map((cvItem) => ({
-                                ...cvItem,
+                                name: cvItem.name,
+                                qcode: cvItem.qcode,
                                 scheme: cv._id,
+                                parent: cvItem.parent,
+                                service: cvItem.service,
                             })) as Array<ISubject>,
                             ({qcode}) => qcode.toString(),
                             ({parent}) => parent?.toString(),
@@ -57,6 +62,7 @@ export class EditorFieldCV extends React.PureComponent<IEditorFieldProps> {
                     onChange={(vals) => {
                         const restOfItems = (item.subject ?? []).filter((x) => x.scheme !== cv._id);
 
+                        debugger;
                         onChange(
                             'subject',
                             [...restOfItems, ...vals],

--- a/client/components/fields/editor/CustomCV.tsx
+++ b/client/components/fields/editor/CustomCV.tsx
@@ -62,7 +62,6 @@ export class EditorFieldCV extends React.PureComponent<IEditorFieldProps> {
                     onChange={(vals) => {
                         const restOfItems = (item.subject ?? []).filter((x) => x.scheme !== cv._id);
 
-                        debugger;
                         onChange(
                             'subject',
                             [...restOfItems, ...vals],

--- a/client/extension_bridge.ts
+++ b/client/extension_bridge.ts
@@ -39,6 +39,7 @@ import {EditorFieldEventRecurringRules} from './components/fields/editor/EventRe
 import {IEventScheduleFieldProps} from './components/fields/editor/EventSchedule.interface';
 import {EditorFieldEventSchedule} from './components/fields/editor/EventSchedule';
 import {EditorFieldCV} from './components/fields/editor/CustomCV';
+import {COVERAGE_VOCABULARIES} from './utils/contentProfiles';
 import {isCustomVocabulary} from './helpers';
 import {appConfig} from 'appConfig';
 
@@ -91,6 +92,7 @@ interface IExtensionBridge {
             ): string;
             isContentLinkToCoverageAllowed(item: IArticle): boolean;
             isCustomVocabulary(vocabulary: IVocabulary): boolean;
+            COVERAGE_VOCABULARIES: Array<string>;
         };
 
         components: {
@@ -147,6 +149,7 @@ export const extensionBridge: IExtensionBridge = {
             getVocabularyItemFieldTranslated: getVocabularyItemFieldTranslated,
             isContentLinkToCoverageAllowed: isContentLinkToCoverageAllowed,
             isCustomVocabulary: isCustomVocabulary,
+            COVERAGE_VOCABULARIES: COVERAGE_VOCABULARIES,
         },
         components: {
             EditorFieldVocabulary,

--- a/client/planning-extension/src/extension.ts
+++ b/client/planning-extension/src/extension.ts
@@ -114,8 +114,6 @@ function onSendBefore(superdesk: ISuperdesk, items: Array<IArticle>, desk: IDesk
     return Promise.resolve();
 }
 
-const COVERAGE_VOCABULARIES = ['news_coverage_status', 'g2_content_type'];
-
 const extension: IExtension = {
     activate: (superdesk: ISuperdesk) => {
         const extensionConfig: IPlanningExtensionConfigurationOptions = superdesk.getExtensionConfig();
@@ -278,7 +276,10 @@ const extension: IExtension = {
         const vocabularies = superdesk.entities.vocabulary
             .getAll()
             .toArray()
-            .filter((x) => !COVERAGE_VOCABULARIES.includes(x._id) && extensionBridge.ui.utils.isCustomVocabulary(x));
+            .filter((x) =>
+                !extensionBridge.ui.utils.COVERAGE_VOCABULARIES.includes(x._id)
+                && extensionBridge.ui.utils.isCustomVocabulary(x),
+            );
 
         vocabularies.forEach((vocab) => {
             registerEditorField(

--- a/client/planning-extension/src/extension_bridge.ts
+++ b/client/planning-extension/src/extension_bridge.ts
@@ -74,6 +74,7 @@ interface IExtensionBridge {
             ): string;
             isContentLinkToCoverageAllowed(item: IArticle): boolean;
             isCustomVocabulary(vocabulary: IVocabulary): boolean;
+            COVERAGE_VOCABULARIES: Array<string>;
         };
         components: {
             EditorFieldVocabulary: React.ComponentType<IEditorFieldVocabularyProps>;

--- a/client/utils/contentProfiles.ts
+++ b/client/utils/contentProfiles.ts
@@ -82,17 +82,6 @@ export function getUnusedProfileFields(
     profile: IEditorProfile,
     includeGroupCheck: boolean = true
 ): Array<IProfileFieldEntry> {
-    // Temporary FIXME: Will be removed once we add support for CVs as fields in coverage profiles
-    if (profile.name === 'coverage') {
-        const fieldsFromProfile = getProfileFields(profile);
-
-        return orderBy(
-            fieldsFromProfile
-                .filter((field) => (includeGroupCheck && field.field.group == null) || !field.field.enabled),
-            superdeskApi.helpers.nameof<IProfileFieldEntry>('name')
-        );
-    }
-
     const customVocabularies = planningApi.vocabularies.getCustomVocabularies();
     const vocabularyIds = customVocabularies.map((x) => x._id);
     const vocabularyFields: Array<IProfileFieldEntry> = customVocabularies

--- a/client/utils/contentProfiles.ts
+++ b/client/utils/contentProfiles.ts
@@ -78,6 +78,8 @@ export function getGroupFieldsSorted(
     return fields;
 }
 
+export const COVERAGE_VOCABULARIES = ['news_coverage_status', 'g2_content_type'];
+
 export function getUnusedProfileFields(
     profile: IEditorProfile,
     includeGroupCheck: boolean = true
@@ -105,10 +107,13 @@ export function getUnusedProfileFields(
             && vocabularyIds.includes(fieldEntry.name)
             && fieldEntry.field.enabled
     );
-    const unusedVocabularies = vocabularyFields.filter((field) =>
-        field.schema?.type === 'custom_vocabulary'
-        && !usedVocabularies.some((usedFieldEntry) => usedFieldEntry.name === field.name)
-    );
+    const unusedVocabularies = vocabularyFields.filter((field) => {
+        const isCustomVocabulary = field.schema?.type === 'custom_vocabulary';
+        const isUnused = !usedVocabularies.some((usedFieldEntry) => usedFieldEntry.name === field.name);
+        const isCoverageVocabulary = COVERAGE_VOCABULARIES.includes(field.name);
+
+        return isCustomVocabulary && isUnused && !isCoverageVocabulary;
+    });
 
     return orderBy(
         fieldsFromProfile

--- a/client/validators/index.ts
+++ b/client/validators/index.ts
@@ -7,6 +7,8 @@ import {default as eventValidators} from './events';
 import {default as planningValidators} from './planning';
 import {formProfile} from './profile';
 import {validateAssignment} from './assignments';
+import {getFieldNameTranslated} from '../utils/contentProfiles';
+import {vocabularies} from '../api/vocabularies';
 
 export {eventValidators, formProfile, validateAssignment};
 
@@ -52,7 +54,6 @@ export const validateItem = ({
 }) => (
     (dispatch, getState) => {
         const profiles = formProfiles ? formProfiles : selectors.forms.profiles(getState());
-
         const getValue = (key) => (
             key !== 'dates' ? get(diff, key) : {
                 ...get(diff, key),
@@ -60,49 +61,58 @@ export const validateItem = ({
                 _endTime: diff._endTime,
             }
         );
+        const profile = profiles[profileName];
 
-        const profile = get(profiles, profileName);
+        /*
+        * Custom fields validation
+        */
+        if (profile.schema) {
+            const vocabularyLabels = new Map(vocabularies.getCustomVocabularies().map((x) => [x._id, x.display_name]));
 
-        if (get(profile, 'schema')) {
-            // validate custom fields
-            Object.keys(profile.schema)
-                .filter((key) => (
-                    !validators[profileName][key] &&
-                    profile.schema[key] != null)
-                )
-                .forEach((key) => {
-                    const schema = profile.schema[key];
+            Object.keys(profile.schema).filter((fieldId) => {
+                const hasNoDefinedValidator = !validators[profileName][fieldId] && profile.schema[fieldId] != null;
 
-                    switch (true) {
-                    case schema.required:
-                        if (
-                            ((
-                                schema.type !== 'integer' &&
-                                isEmpty(diff[key])
-                            ) ||
-                            (
-                                schema.type === 'integer' &&
-                                diff[key] == null
-                            )) &&
-                            isEmpty(getSubject(diff, key)) &&
-                            fieldsToValidate == null ||
-                            (
-                                Array.isArray(fieldsToValidate) &&
-                                fieldsToValidate.includes(key)
-                            )
-                        ) {
-                            errors[key] = gettext('This field is required');
-                            messages.push(gettext('{{ key }} is a required field', {key: key.toUpperCase()}));
-                        } else if (errors[key]) {
-                            errors[key] = null;
-                        }
-                        break;
+                return hasNoDefinedValidator;
+            })
+                .forEach((fieldId) => {
+                    const fieldSchema = profile.schema[fieldId];
+                    const isNotIntegerAndEmpty = fieldSchema.type !== 'integer' && isEmpty(diff[fieldId]);
+                    const isIntegerAndEmpty = fieldSchema.type === 'integer' && diff[fieldId] == null;
+                    const isValidSubject = isEmpty(getSubject(diff, fieldId)) && fieldsToValidate == null || (
+                        Array.isArray(fieldsToValidate) &&
+                        fieldsToValidate.includes(fieldId)
+                    );
+
+                    if (
+                        fieldSchema.required
+                        && (isNotIntegerAndEmpty || isIntegerAndEmpty)
+                        && isValidSubject
+                    ) {
+                        errors[fieldId] = gettext('This field is required');
+
+                        // Pass a field label matching field label in the editor UI
+                        const fieldLabel = (() => {
+                            if (fieldSchema?.type === 'custom_vocabulary') {
+                                return vocabularyLabels.get(fieldId);
+                            }
+
+                            return getFieldNameTranslated(fieldId);
+                        })();
+
+                        messages.push(gettext('{{ key }} is a required field', {key: fieldLabel}));
+                    } else if (errors[fieldId]) {
+                        errors[fieldId] = null;
                     }
                 });
         }
 
-        return (fields || Object.keys(
-            ignoreDateValidation ? omit(validators[profileName], 'dates') : validators[profileName])).forEach((key) => (
+        const fieldsCleaned = fields || Object.keys(
+            ignoreDateValidation
+                ? omit(validators[profileName], 'dates')
+                : validators[profileName],
+        );
+
+        fieldsCleaned.forEach((key) => {
             validateField({
                 dispatch: dispatch,
                 getState: getState,
@@ -113,8 +123,8 @@ export const validateItem = ({
                 errors: errors,
                 messages: messages,
                 diff: diff,
-            })
-        ));
+            });
+        });
     }
 );
 
@@ -182,7 +192,7 @@ export const validators = {
     },
 };
 
-function getSubject(item, scheme) {
-    return get(item, 'subject', [])
+export function getSubject(item, scheme) {
+    return (item?.subject ?? [])
         .filter((subject) => scheme != null ? subject.scheme === scheme : isEmpty(subject.scheme));
 }

--- a/client/validators/index.ts
+++ b/client/validators/index.ts
@@ -66,10 +66,10 @@ export const validateItem = ({
         /*
         * Custom fields validation
         */
-        if (profile.schema) {
+        if (profile?.schema) {
             const vocabularyLabels = new Map(vocabularies.getCustomVocabularies().map((x) => [x._id, x.display_name]));
 
-            Object.keys(profile.schema).filter((fieldId) => {
+            Object.keys(profile?.schema ?? []).filter((fieldId) => {
                 const hasNoDefinedValidator = !validators[profileName][fieldId] && profile.schema[fieldId] != null;
 
                 return hasNoDefinedValidator;

--- a/client/validators/planning.ts
+++ b/client/validators/planning.ts
@@ -5,10 +5,11 @@ import {WORKSPACE, WORKFLOW_STATE, PRIVILEGES} from '../constants';
 import * as selectors from '../selectors';
 import {gettext, getItemInArrayById} from '../utils';
 
-import {validateField, validators} from './index';
+import {getSubject, validateField, validators} from './index';
 import {IPlanningCoverageItem} from 'interfaces';
 import {planningApi} from '../superdeskApi';
 import {getCoverageFields} from '../api/editor/item_planning';
+import {vocabularies} from '../api/vocabularies';
 
 const validatePlanningScheduleDate = ({getState, field, value, errors, messages, diff, item}) => {
     // Only validate the schedule if it has changed
@@ -67,7 +68,7 @@ interface IValidateCoverages {
 export const validateCoverages = ({
     dispatch,
     getState,
-    value,
+    value: coverages,
     errors,
     messages,
     diff,
@@ -82,19 +83,20 @@ export const validateCoverages = ({
         }
     };
 
-    if (Array.isArray(value) === false) {
+    if (Array.isArray(coverages) === false) {
         handleErrors();
         return;
     }
 
-    value.forEach((coverage, index) => {
+    coverages.forEach((coverage, index) => {
         const originalCoverage = getItemInArrayById(
             get(item, 'coverages') || [],
             get(coverage, 'coverage_id'),
             'coverage_id'
         );
-
         const coverageProfile = getCoverageFields(coverage.planning.g2_content_type).profile;
+
+        validateCoverageVocabularyFields(coverageProfile, errors, messages, diff.coverages[index]);
 
         Object.entries(validators.coverage).forEach(([key, val]) => {
             const coverageErrors = {};
@@ -129,6 +131,29 @@ export const validateCoverages = ({
     });
 
     handleErrors();
+};
+
+export const validateCoverageVocabularyFields = (coverageProfile, errors, messages, diff) => {
+    const vocabularyLabels = new Map(vocabularies.getCustomVocabularies().map((x) => [x._id, x.display_name]));
+
+    Object.keys(coverageProfile.schema).filter((fieldId) => {
+        const hasNoDefinedValidator = !validators['coverage'][fieldId];
+        const isCustomVocabulary = coverageProfile.schema[fieldId].type === 'custom_vocabulary';
+
+        return hasNoDefinedValidator && isCustomVocabulary;
+    })
+        .forEach((fieldId) => {
+            const subjectIsInvalid = coverageProfile.schema[fieldId].required
+                ? isEmpty(getSubject(diff, fieldId))
+                : false;
+
+            if (subjectIsInvalid) {
+                errors[fieldId] = gettext('This field is required');
+                messages.push(gettext('{{ key }} is a required field', {key: vocabularyLabels.get(fieldId)}));
+            } else {
+                errors[fieldId] = null;
+            }
+        });
 };
 
 const validateCoverageScheduleDate = ({

--- a/client/validators/planning.ts
+++ b/client/validators/planning.ts
@@ -6,7 +6,7 @@ import * as selectors from '../selectors';
 import {gettext, getItemInArrayById} from '../utils';
 
 import {getSubject, validateField, validators} from './index';
-import {IPlanningCoverageItem} from 'interfaces';
+import {ICoverageContentProfile, IPlanningCoverageItem} from 'interfaces';
 import {planningApi} from '../superdeskApi';
 import {getCoverageFields} from '../api/editor/item_planning';
 import {vocabularies} from '../api/vocabularies';
@@ -74,7 +74,7 @@ export const validateCoverages = ({
     diff,
     item,
 }: IValidateCoverages) => {
-    const error = {};
+    const error: Dictionary<string, string> = {};
     const handleErrors = () => {
         if (!isEqual(error, {})) {
             errors.coverages = error;
@@ -133,7 +133,12 @@ export const validateCoverages = ({
     handleErrors();
 };
 
-export const validateCoverageVocabularyFields = (coverageProfile, errors, messages, diff) => {
+export const validateCoverageVocabularyFields = (
+    coverageProfile: ICoverageContentProfile,
+    errors: Dictionary<string, string>,
+    messages: Array<string>,
+    diff: IPlanningCoverageItem,
+): void => {
     const vocabularyLabels = new Map(vocabularies.getCustomVocabularies().map((x) => [x._id, x.display_name]));
 
     Object.keys(coverageProfile.schema).filter((fieldId) => {

--- a/server/planning/content_profiles/profiles/coverage.py
+++ b/server/planning/content_profiles/profiles/coverage.py
@@ -10,7 +10,7 @@
 
 import superdesk.schema as schema
 
-from .fields import BaseSchema, DateTimeField, BooleanField, TextField
+from .fields import subjectField, BaseSchema, DateTimeField, BooleanField, TextField
 
 
 class CoverageSchema(BaseSchema):
@@ -27,6 +27,7 @@ class CoverageSchema(BaseSchema):
     news_coverage_status = schema.ListField()
     scheduled = DateTimeField(required=True)
     slugline = schema.StringField()
+    subject = subjectField
     xmp_file = schema.DictField()
     no_content_linking = BooleanField()
     scheduled_updates = schema.ListField()
@@ -72,6 +73,7 @@ DEFAULT_COVERAGE_PROFILE = {
             "enabled": True,
             "index": 9,
         },
+        "subject": {"enabled": False},
         # Fields disabled by default
         "contact_info": {"enabled": False},
         "language": {"enabled": False},

--- a/server/planning/planning/planning_schema.py
+++ b/server/planning/planning/planning_schema.py
@@ -15,6 +15,7 @@ from eve.utils import config
 
 from superdesk.resource import Resource, not_analyzed, string_with_analyzer
 from superdesk.metadata.item import metadata_schema, ITEM_TYPE
+from planning.content_profiles.profiles.fields import subjectField
 
 from planning.common import (
     WORKFLOW_STATE_SCHEMA,
@@ -131,7 +132,7 @@ coverage_schema = {
         "schema": {"no_content_linking": {"type": "boolean", "default": False}},
     },
     TO_BE_CONFIRMED_FIELD: TO_BE_CONFIRMED_FIELD_SCHEMA,
-    "subject": {"type": "list"},
+    "subject": {"type": "list", "schema": subjectField.schema["schema"]},
     "scheduled_updates": {
         "type": "list",
         "schema": {

--- a/server/planning/planning/planning_schema.py
+++ b/server/planning/planning/planning_schema.py
@@ -131,6 +131,7 @@ coverage_schema = {
         "schema": {"no_content_linking": {"type": "boolean", "default": False}},
     },
     TO_BE_CONFIRMED_FIELD: TO_BE_CONFIRMED_FIELD_SCHEMA,
+    "subject": {"type": "list"},
     "scheduled_updates": {
         "type": "list",
         "schema": {


### PR DESCRIPTION
STT-134

## Front-end checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)
