### PR TITLE
Fix available coverage types

### DIFF
--- a/client/components/ContentProfiles/CoverageProfileModal.tsx
+++ b/client/components/ContentProfiles/CoverageProfileModal.tsx
@@ -8,13 +8,15 @@ import {
     IEditorProfile,
 } from '../../interfaces';
 import {superdeskApi, planningApi} from '../../superdeskApi';
-import {getErrorMessage} from '../../utils';
+import {getErrorMessage, planningUtils} from '../../utils';
+import {contentTypes} from '../../selectors/general';
 import {Button, Modal, RadioButtonGroup, Spacer} from 'superdesk-ui-framework/react';
+import {getLanguages} from '../../selectors/vocabs';
+import {getVocabularyItemFieldTranslated} from '../../utils/vocabularies';
 import {FieldTab} from './FieldTab';
 import './style.scss';
-import {getLanguages} from '../../selectors/vocabs';
-import {validateAndNotifyForRequiredFields} from './utils';
 import {COVERAGE_SYSTEM_REQUIRED_FIELDS} from '../../api/utils/constants';
+import {validateAndNotifyForRequiredFields} from './utils';
 import {updateCoverageProfiles} from '../../actions/coverages';
 import {coverageProfiles, oldProfile} from '../../selectors/coverageProfiles';
 
@@ -31,18 +33,6 @@ interface IState {
 interface IProps {
     closeModal(): void;
 }
-
-const allCoverageTypesObject: {[key in ICoverageType]: 1} = {
-    text: 1,
-    picture: 1,
-    video: 1,
-    audio: 1,
-    infographics: 1,
-    liveBlog: 1,
-    liveVideo: 1,
-};
-
-export const ALL_COVERAGE_TYPES: Array<ICoverageType> = Object.keys(allCoverageTypesObject) as Array<ICoverageType>;
 
 export class CoverageProfilesModal extends React.Component<IProps, IState> {
     constructor(props) {
@@ -202,37 +192,16 @@ export class CoverageProfilesModal extends React.Component<IProps, IState> {
 
     render() {
         const {gettext} = superdeskApi.localization;
-        const {selectedType} = this.state;
-        const propsMap: Record<ICoverageType, {label: string; icon: string;}> = {
-            text: {
-                label: gettext('Text'),
-                icon: 'text',
-            },
-            picture: {
-                label: gettext('Picture'),
-                icon: 'picture',
-            },
-            video: {
-                label: gettext('Video'),
-                icon: 'video'
-            },
-            audio: {
-                label: gettext('Audio'),
-                icon: 'audio'
-            },
-            infographics: {
-                label: gettext('Infographics'),
-                icon: 'file',
-            },
-            liveBlog: {
-                label: gettext('Live Blog'),
-                icon: 'video',
-            },
-            liveVideo: {
-                label: gettext('Live Video'),
-                icon: 'post',
-            },
-        };
+        const coverageContentTypes: Array<{value: string; label: string; icon: string}> =
+            (contentTypes(planningApi.redux.store.getState()))
+                .map((item) => ({
+                    value: item.qcode,
+                    label: getVocabularyItemFieldTranslated(item, superdeskApi.helpers.nameof('name'), 'en'),
+
+                    // remove 'icon-' string because RadioButtonGroup icon prop for each option expects just icon name
+                    // function not changed because it's originally used in other places
+                    icon: planningUtils.getCoverageIcon(item['content item type'] || item.qcode).replace('icon-', ''),
+                }));
 
         return (
             <Modal
@@ -272,11 +241,7 @@ export class CoverageProfilesModal extends React.Component<IProps, IState> {
                             onChange={(nextType: ICoverageType) => {
                                 this.switchProfileType(nextType);
                             }}
-                            options={ALL_COVERAGE_TYPES.map((type) => ({
-                                label: propsMap[type].label,
-                                icon: propsMap[type].icon,
-                                value: type,
-                            }))}
+                            options={coverageContentTypes}
                             group={{
                                 orientation: 'vertical',
                             }}

--- a/client/components/ContentProfiles/CoverageProfileModal.tsx
+++ b/client/components/ContentProfiles/CoverageProfileModal.tsx
@@ -195,7 +195,7 @@ export class CoverageProfilesModal extends React.Component<IProps, IState> {
                     value: item.qcode,
                     label: getVocabularyItemFieldTranslated(
                         item,
-                        superdeskApi.helpers.nameof('name'),
+                        superdeskApi.helpers.nameof<typeof item>('name'),
                         planningApi.contentProfiles.getDefaultLanguage(this.state.originalProfile)
                     ),
 

--- a/client/components/ContentProfiles/CoverageProfileModal.tsx
+++ b/client/components/ContentProfiles/CoverageProfileModal.tsx
@@ -11,7 +11,6 @@ import {superdeskApi, planningApi} from '../../superdeskApi';
 import {getErrorMessage, planningUtils} from '../../utils';
 import {contentTypes} from '../../selectors/general';
 import {Button, Modal, RadioButtonGroup, Spacer} from 'superdesk-ui-framework/react';
-import {getLanguages} from '../../selectors/vocabs';
 import {getVocabularyItemFieldTranslated} from '../../utils/vocabularies';
 import {FieldTab} from './FieldTab';
 import './style.scss';
@@ -23,7 +22,6 @@ import {coverageProfiles, oldProfile} from '../../selectors/coverageProfiles';
 interface IState {
     saving: boolean;
     dirty: boolean;
-    languages: Array<IG2ContentType>;
     originalProfile: Partial<ICoverageContentProfile>;
     profile: Partial<ICoverageContentProfile> & IEditorProfile;
     selectedType: ICoverageType;
@@ -48,7 +46,6 @@ export class CoverageProfilesModal extends React.Component<IProps, IState> {
             dirty: false,
             profile: defaultProfile,
             originalProfile: defaultProfile,
-            languages: getLanguages(state),
             selectedType: 'text',
             allProfiles: allProfiles,
         };
@@ -196,7 +193,11 @@ export class CoverageProfilesModal extends React.Component<IProps, IState> {
             (contentTypes(planningApi.redux.store.getState()))
                 .map((item) => ({
                     value: item.qcode,
-                    label: getVocabularyItemFieldTranslated(item, superdeskApi.helpers.nameof('name'), 'en'),
+                    label: getVocabularyItemFieldTranslated(
+                        item,
+                        superdeskApi.helpers.nameof('name'),
+                        planningApi.contentProfiles.getDefaultLanguage(this.state.originalProfile)
+                    ),
 
                     // remove 'icon-' string because RadioButtonGroup icon prop for each option expects just icon name
                     // function not changed because it's originally used in other places

--- a/client/components/Coverages/CoverageAddAdvancedModal.tsx
+++ b/client/components/Coverages/CoverageAddAdvancedModal.tsx
@@ -87,6 +87,12 @@ class CoverageAddAdvancedModalComponent extends React.Component<IProps, IState> 
         const {value, contentTypes, users, desks, newsCoverageStatus} = this.props;
         const coverages = [];
         const savedCoverages = value
+
+            // if there was a savedCoverage but later the coverage type got removed/disabled from
+            // g2_content_type vocabulary do not try to render it
+            .filter((coverage) =>
+                contentTypes.find((type) => type.qcode === coverage.planning.g2_content_type) != null,
+            )
             .map((coverage) => {
                 const contentType = contentTypes.find(
                     (type) => type.qcode === coverage.planning.g2_content_type

--- a/client/interfaces.ts
+++ b/client/interfaces.ts
@@ -2360,7 +2360,9 @@ export interface IPlanningAPI {
             getFields(profile: IPlanningContentProfile): Array<keyof IEventOrPlanningItem>;
             getConfig(contentType: string): IProfileMultilingualDetails;
         };
-        getDefaultLanguage(profile: IPlanningContentProfile): IVocabularyItem['qcode'];
+        getDefaultLanguage(
+            profile: IPlanningContentProfile | Partial<ICoverageContentProfile>,
+        ): IVocabularyItem['qcode'];
         getDefaultValues(profile: IPlanningContentProfile): DeepPartial<IEventOrPlanningItem | IPlanningCoverageItem>;
         patch(
             original: IPlanningContentProfile,

--- a/client/selectors/general.ts
+++ b/client/selectors/general.ts
@@ -1,7 +1,7 @@
 import {get, keyBy} from 'lodash';
 import {createSelector} from 'reselect';
 
-import {IAgenda, IPlanningAppState} from '../interfaces';
+import {IAgenda, IG2ContentType, IPlanningAppState} from '../interfaces';
 import {getEnabledAgendas, getDisabledAgendas, getItemInArrayById} from '../utils';
 import {ITEM_TYPE, COVERAGES, ASSIGNMENTS} from '../constants/index';
 
@@ -14,7 +14,7 @@ export const newsCoverageStatus = (state) => get(state, 'vocabularies.newscovera
 export const regions = (state) => get(state, 'vocabularies.regions', []);
 export const countries = (state) => get(state, 'vocabularies.countries', []);
 
-export const contentTypes = (state) => get(state, 'vocabularies.g2_content_type', []);
+export const contentTypes = (state: any): Array<IG2ContentType> => state?.vocabularies.g2_content_type ?? [];
 export const preferredVocabularies = (state) => get(state, 'session.userPreferences.cvs:preferred_items.value');
 
 export const currentDeskId = (state) => get(state, 'workspace.currentDeskId', null);

--- a/client/services/PlanningStoreService.ts
+++ b/client/services/PlanningStoreService.ts
@@ -299,7 +299,7 @@ export class PlanningStoreService {
             .then((voc) => {
                 this.store.dispatch({
                     type: 'RECEIVE_VOCABULARIES',
-                    payload: voc._items,
+                    payload: voc,
                 });
             });
     }


### PR DESCRIPTION
STT-1184

## Front-end checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)
