### PR TITLE
Fix planning autosave returning not temp IDs after temp ID has been sent

### DIFF
--- a/server/planning/types/autosave.py
+++ b/server/planning/types/autosave.py
@@ -1,5 +1,7 @@
 from .event import EventResourceModel
-from .planning import PlanningResourceModel
+from .planning import PlanningResourceModel, PlanningCoverage
+from pydantic import model_validator
+from typing import Any
 
 
 class EventAutosaveResourceModel(EventResourceModel):
@@ -7,4 +9,12 @@ class EventAutosaveResourceModel(EventResourceModel):
 
 
 class PlanningAutosaveResourceModel(PlanningResourceModel):
-    pass
+    @model_validator(mode="before")
+    @classmethod
+    def parse_dict(cls, values) -> dict[str, Any]:
+        # Only parse coverages, don't modify IDs, otherwise on frontend
+        # we can't know if the item is temporary
+        for coverage in values.get("coverages", []):
+            PlanningCoverage.parse_dict(coverage)
+
+        return values


### PR DESCRIPTION
SDESK-7628

## Front-end checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)
