### PR TITLE
Fix coverage fields sorting

### DIFF
--- a/client/components/ContentProfiles/FieldTab/index.tsx
+++ b/client/components/ContentProfiles/FieldTab/index.tsx
@@ -154,32 +154,33 @@ export class FieldTab extends React.Component<IProps, IState> {
     }
 
     updateFieldOrder(fields: Array<IProfileFieldEntry>) {
-        fields.forEach((item, index) => {
-            item.field.index = index;
-        });
-
         this.props.updateFields(fields);
     }
 
-    insertField(itemToAdd: IProfileFieldEntry, groupId: IEditorProfileGroup['_id'] | undefined, index: number) {
+    insertField(
+        fieldToAdd: IProfileFieldEntry,
+        groupId: IEditorProfileGroup['_id'] | undefined,
+        index: number,
+    ) {
         const fields = this.props.groupFields ?
             getEnabledProfileGroupFields(this.props.profile, groupId) :
             getEnabledProfileFields(this.props.profile);
 
-        fields.push({
-            ...itemToAdd,
-            field: {
-                ...itemToAdd.field,
-                enabled: true,
-                group: groupId,
-                index: index,
+        fields.splice(
+            index,
+            0,
+            {
+                ...fieldToAdd,
+                field: {
+                    ...fieldToAdd.field,
+                    enabled: true,
+                    group: groupId,
+                    index: index,
+                },
             },
-        });
+        );
 
         fields.sort((a, b) => a.field.index - b.field.index);
-        fields.forEach((item, index) => {
-            item.field.index = index;
-        });
 
         this.props.updateFields(fields);
     }

--- a/client/components/ContentProfiles/FieldTab/index.tsx
+++ b/client/components/ContentProfiles/FieldTab/index.tsx
@@ -20,6 +20,7 @@ import {
 
 import {FieldList} from './FieldList';
 import {FieldEditor} from './FieldEditor';
+import {arrayInsertAtIndex} from '@sourcefabric/common';
 
 interface IProps {
     profile: IEditorProfile;
@@ -166,9 +167,8 @@ export class FieldTab extends React.Component<IProps, IState> {
             getEnabledProfileGroupFields(this.props.profile, groupId) :
             getEnabledProfileFields(this.props.profile);
 
-        fields.splice(
-            index,
-            0,
+        const withNewField = arrayInsertAtIndex(
+            fields,
             {
                 ...fieldToAdd,
                 field: {
@@ -178,11 +178,13 @@ export class FieldTab extends React.Component<IProps, IState> {
                     index: index,
                 },
             },
+            index,
         );
 
-        fields.sort((a, b) => a.field.index - b.field.index);
 
-        this.props.updateFields(fields);
+        withNewField.sort((a, b) => a.field.index - b.field.index);
+
+        this.props.updateFields(withNewField);
     }
 
     removeField(item: IProfileFieldEntry) {


### PR DESCRIPTION
STT-1183

## Front-end checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)


## Fix:

After moving a field to a new position its new index was being overwritten