### PR TITLE
Respect no time config

### DIFF
--- a/client/components/editor-standalone/field-definitions/planning-date.ts
+++ b/client/components/editor-standalone/field-definitions/planning-date.ts
@@ -17,7 +17,10 @@ export const getPlanningDate = (): IFieldDefinition => {
             const field: IAuthoringFieldV2 = {
                 id: id,
                 name: gettext('Planning Date'),
+
+                // time picker must not be displayed for all day events
                 fieldType: appConfig.planning.all_day ? 'date' : 'datetime-v2',
+
                 fieldConfig: {
                     ...config,
                     required: required,

--- a/client/components/editor-standalone/field-definitions/planning-date.ts
+++ b/client/components/editor-standalone/field-definitions/planning-date.ts
@@ -1,3 +1,4 @@
+import {appConfig} from 'superdesk-core/scripts/appConfig';
 import {superdeskApi} from '../../../superdeskApi';
 import {IFieldDefinition} from './interfaces';
 import {IAuthoringFieldV2, IDateTimeFieldConfig} from 'superdesk-api';
@@ -16,7 +17,7 @@ export const getPlanningDate = (): IFieldDefinition => {
             const field: IAuthoringFieldV2 = {
                 id: id,
                 name: gettext('Planning Date'),
-                fieldType: 'datetime-v2',
+                fieldType: appConfig.planning.all_day ? 'date' : 'datetime-v2',
                 fieldConfig: {
                     ...config,
                     required: required,
@@ -42,10 +43,19 @@ export const getPlanningDate = (): IFieldDefinition => {
                     return val;
                 }
             },
-            storeValue: (item, operationalValue: Date) => {
+            storeValue: (item, operationalValue: Date | string) => {
+                if (operationalValue == null) {
+                    return {...item, planning_date: null};
+                }
+
+                // If field type is date, operational value is ISO string date
+                const dateValue = operationalValue instanceof Date
+                    ? operationalValue
+                    : new Date(operationalValue);
+
                 return {
                     ...item,
-                    planning_date: operationalValue == null ? null : operationalValue.toISOString(),
+                    planning_date: dateValue.toISOString(),
                 };
             },
         },

--- a/client/components/editor-standalone/field-definitions/planning-date.ts
+++ b/client/components/editor-standalone/field-definitions/planning-date.ts
@@ -18,7 +18,7 @@ export const getPlanningDate = (): IFieldDefinition => {
                 id: id,
                 name: gettext('Planning Date'),
 
-                // time picker must not be displayed for all day events
+                // time picker must not be displayed for all day planning
                 fieldType: appConfig.planning.all_day ? 'date' : 'datetime-v2',
 
                 fieldConfig: {

--- a/client/globals.d.ts
+++ b/client/globals.d.ts
@@ -186,6 +186,8 @@ declare module 'superdesk-api' {
             autosave_timeout?: number;
             default_create_planning_series_with_event_series?: boolean;
             event_related_item_search_provider_name?: string;
+
+            // Controls whether date only input is rendered in the editor
             all_day?: boolean;
         };
 

--- a/client/globals.d.ts
+++ b/client/globals.d.ts
@@ -187,7 +187,7 @@ declare module 'superdesk-api' {
             default_create_planning_series_with_event_series?: boolean;
             event_related_item_search_provider_name?: string;
 
-            // Controls whether date only input is rendered in the editor
+            // Controls whether planning should have date only
             all_day?: boolean;
         };
 


### PR DESCRIPTION
STT-1187

## Front-end checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)
