### PR TITLE
Respect vocabulary config

### DIFF
--- a/client/components/ContentProfiles/CoverageProfileModal.tsx
+++ b/client/components/ContentProfiles/CoverageProfileModal.tsx
@@ -33,6 +33,8 @@ interface IProps {
 }
 
 export class CoverageProfilesModal extends React.Component<IProps, IState> {
+    availableCoverageTypes: Array<{value: ICoverageType; label: string; icon: string}>;
+
     constructor(props) {
         super(props);
 
@@ -41,12 +43,26 @@ export class CoverageProfilesModal extends React.Component<IProps, IState> {
         const newlyCreatedProfile = allProfiles.find((x) => x.content_type === 'text');
         const defaultProfile = newlyCreatedProfile ? newlyCreatedProfile : omit(oldProfile(state), '_id');
 
+        this.availableCoverageTypes = (contentTypes(planningApi.redux.store.getState()))
+            .map((item) => ({
+                value: item.qcode as ICoverageType,
+                label: getVocabularyItemFieldTranslated(
+                    item,
+                    superdeskApi.helpers.nameof<typeof item>('name'),
+                    planningApi.contentProfiles.getDefaultLanguage(defaultProfile)
+                ),
+
+                // remove 'icon-' string because RadioButtonGroup icon prop for each option expects just icon name
+                // function not changed because it's originally used in other places
+                icon: planningUtils.getCoverageIcon(item['content item type'] || item.qcode).replace('icon-', ''),
+            }));
+
         this.state = {
             saving: false,
             dirty: false,
             profile: defaultProfile,
             originalProfile: defaultProfile,
-            selectedType: 'text',
+            selectedType: this.availableCoverageTypes?.[0]?.value ?? 'text',
             allProfiles: allProfiles,
         };
 
@@ -189,20 +205,6 @@ export class CoverageProfilesModal extends React.Component<IProps, IState> {
 
     render() {
         const {gettext} = superdeskApi.localization;
-        const coverageContentTypes: Array<{value: string; label: string; icon: string}> =
-            (contentTypes(planningApi.redux.store.getState()))
-                .map((item) => ({
-                    value: item.qcode,
-                    label: getVocabularyItemFieldTranslated(
-                        item,
-                        superdeskApi.helpers.nameof<typeof item>('name'),
-                        planningApi.contentProfiles.getDefaultLanguage(this.state.originalProfile)
-                    ),
-
-                    // remove 'icon-' string because RadioButtonGroup icon prop for each option expects just icon name
-                    // function not changed because it's originally used in other places
-                    icon: planningUtils.getCoverageIcon(item['content item type'] || item.qcode).replace('icon-', ''),
-                }));
 
         return (
             <Modal
@@ -242,7 +244,7 @@ export class CoverageProfilesModal extends React.Component<IProps, IState> {
                             onChange={(nextType: ICoverageType) => {
                                 this.switchProfileType(nextType);
                             }}
-                            options={coverageContentTypes}
+                            options={this.availableCoverageTypes}
                             group={{
                                 orientation: 'vertical',
                             }}


### PR DESCRIPTION
## Front-end checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)
