### PR TITLE
Subject validation

### DIFF
--- a/client/interfaces.ts
+++ b/client/interfaces.ts
@@ -650,7 +650,7 @@ export interface IPlanningCoverageItem {
     versioncreated: string;
     add_coverage_to_workflow: boolean;
     profile?: string; // coverage profile id
-
+    subject?: Array<IVocabularyItem>;
     planning: ICoveragePlanningDetails;
 
     news_coverage_status: IPlanningNewsCoverageStatus;

--- a/client/validators/index.ts
+++ b/client/validators/index.ts
@@ -78,7 +78,7 @@ export const validateItem = ({
                     const fieldSchema = profile.schema[fieldId];
                     const isNotIntegerAndEmpty = fieldSchema.type !== 'integer' && isEmpty(diff[fieldId]);
                     const isIntegerAndEmpty = fieldSchema.type === 'integer' && diff[fieldId] == null;
-                    const isValidSubject = isEmpty(getSubject(diff, fieldId)) && fieldsToValidate == null || (
+                    const isValidSubject = isEmpty(getVocabularyItemsForScheme(diff, fieldId)) && fieldsToValidate == null || (
                         Array.isArray(fieldsToValidate) &&
                         fieldsToValidate.includes(fieldId)
                     );
@@ -192,7 +192,7 @@ export const validators = {
     },
 };
 
-export function getSubject(item, scheme) {
+export function getVocabularyItemsForScheme(item, scheme) {
     return (item?.subject ?? [])
         .filter((subject) => scheme != null ? subject.scheme === scheme : isEmpty(subject.scheme));
 }

--- a/client/validators/planning.ts
+++ b/client/validators/planning.ts
@@ -5,7 +5,7 @@ import {WORKSPACE, WORKFLOW_STATE, PRIVILEGES} from '../constants';
 import * as selectors from '../selectors';
 import {gettext, getItemInArrayById} from '../utils';
 
-import {getSubject, validateField, validators} from './index';
+import {getVocabularyItemsForScheme, validateField, validators} from './index';
 import {ICoverageContentProfile, IPlanningCoverageItem} from 'interfaces';
 import {planningApi} from '../superdeskApi';
 import {getCoverageFields} from '../api/editor/item_planning';
@@ -98,6 +98,17 @@ export const validateCoverages = ({
 
         validateCoverageVocabularyFields(coverageProfile, errors, messages, diff.coverages[index]);
 
+        const isValidSubject = coverageProfile.schema['subject'].required
+            ? !isEmpty((diff.coverages[index].subject ?? []).filter((x) => x.scheme == null))
+            : true;
+
+        if (!isValidSubject) {
+            set(error, `${index}.subject`, gettext('Field is required'));
+            messages.push(gettext('Subject is a required field'));
+        } else {
+            delete error?.[index]?.['subject'];
+        }
+
         Object.entries(validators.coverage).forEach(([key, val]) => {
             const coverageErrors = {};
             const keyName = ['news_coverage_status', 'scheduled_updates'].includes(key) ? key : `planning.${key}`;
@@ -124,7 +135,7 @@ export const validateCoverages = ({
                 diff: diff,
             });
 
-            if (get(coverageErrors, key)) {
+            if (coverageErrors?.[key] !== null) {
                 set(error, `${index}.${keyName}`, coverageErrors[key]);
             }
         });
@@ -148,11 +159,11 @@ export const validateCoverageVocabularyFields = (
         return hasNoDefinedValidator && isCustomVocabulary;
     })
         .forEach((fieldId) => {
-            const subjectIsInvalid = coverageProfile.schema[fieldId].required
-                ? isEmpty(getSubject(diff, fieldId))
+            const isInvalid = coverageProfile.schema[fieldId].required
+                ? isEmpty(getVocabularyItemsForScheme(diff, fieldId))
                 : false;
 
-            if (subjectIsInvalid) {
+            if (isInvalid) {
                 errors[fieldId] = gettext('This field is required');
                 messages.push(gettext('{{ key }} is a required field', {key: vocabularyLabels.get(fieldId)}));
             } else {


### PR DESCRIPTION
STT-134

## Front-end checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)
