### PR TITLE
scheme not required

### DIFF
--- a/client/components/UI/Form/SelectMetaTermsInput/index.tsx
+++ b/client/components/UI/Form/SelectMetaTermsInput/index.tsx
@@ -44,9 +44,13 @@ export class SelectMetaTermsInput extends React.Component {
         const {value, field, onChange} = this.props;
 
         if (term.scheme || term.qcode) {
+            const updatedValue = value.filter(({scheme, qcode}) =>
+                !((term.scheme ?? null) === scheme && term.qcode === qcode),
+            );
+
             onChange(
                 field,
-                value.filter(({scheme, qcode}) => !(term.scheme === scheme && term.qcode === qcode))
+                updatedValue,
             );
         } else {
             // Delete by index
@@ -158,7 +162,10 @@ export class SelectMetaTermsInput extends React.Component {
                         onCancel={this.toggleOpenSelectPopup}
                         target="sd-line-input__plus-btn"
                         onChange={(opt) => {
-                            this.onChange(opt);
+                            this.onChange({
+                                ...opt,
+                                scheme: opt.scheme ?? null,
+                            });
                             this.toggleOpenSelectPopup();
                         }}
                         labelKey={labelKey}

--- a/client/validators/index.ts
+++ b/client/validators/index.ts
@@ -78,10 +78,9 @@ export const validateItem = ({
                     const fieldSchema = profile.schema[fieldId];
                     const isNotIntegerAndEmpty = fieldSchema.type !== 'integer' && isEmpty(diff[fieldId]);
                     const isIntegerAndEmpty = fieldSchema.type === 'integer' && diff[fieldId] == null;
-                    const isValidSubject = isEmpty(getVocabularyItemsForScheme(diff, fieldId)) && fieldsToValidate == null || (
-                        Array.isArray(fieldsToValidate) &&
-                        fieldsToValidate.includes(fieldId)
-                    );
+                    const isValidSubject = isEmpty(getVocabularyItemsForScheme(diff, fieldId))
+                        && fieldsToValidate == null
+                        || (Array.isArray(fieldsToValidate) && fieldsToValidate.includes(fieldId));
 
                     if (
                         fieldSchema.required

--- a/server/planning/content_profiles/profiles/fields.py
+++ b/server/planning/content_profiles/profiles/fields.py
@@ -118,7 +118,7 @@ subjectField = schema.ListField(
             "qcode": {},
             "scheme": {
                 "type": "string",
-                "required": True,
+                "required": False,
                 "nullable": True,
             },
             "service": {"nullable": True},

--- a/server/planning/content_profiles/profiles/fields.py
+++ b/server/planning/content_profiles/profiles/fields.py
@@ -118,7 +118,7 @@ subjectField = schema.ListField(
             "qcode": {},
             "scheme": {
                 "type": "string",
-                "required": False,
+                "required": True,
                 "nullable": True,
             },
             "service": {"nullable": True},


### PR DESCRIPTION
SDESK-7640

### Purpose
With the introduction of custom vocabularies, subject schema had to be changed, since entries for all cv fields are stored in subject field. When getting them from the backend we diff based on `scheme` - this is where vocabulary ID is stored for each cv field. Except for subject itself - `scheme` for it is null, we just store vocabulary items without it there. 

### What has changed
Make `scheme` not required, due to `subject` field failing to save.

### Steps to test
Add `subject` field to any coverage type profile. Make a planning/event item, add a coverage, add a couple items in subject, save the item. Saving should work, and UI should not be getting stuck with endless loading. 

<!-- [For UI changes]
### Screenshots
-->

### Front-end checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)

Resolves: SDESK-7640

