### PR TITLE
Accreditation should not be automatically filled in

### DIFF
--- a/client/components/fields/editor/base/dateTimeUIFramework.tsx
+++ b/client/components/fields/editor/base/dateTimeUIFramework.tsx
@@ -4,6 +4,7 @@ import {IEditorFieldProps} from '../../../../interfaces';
 import {get} from 'lodash';
 import {DateTimePicker} from 'superdesk-ui-framework/react';
 import {appConfig} from 'appConfig';
+import {format} from 'date-fns';
 
 interface IProps extends IEditorFieldProps {
     canClear?: boolean;
@@ -44,6 +45,7 @@ export class EditorFieldDateTimeUIFramework extends React.PureComponent<IProps> 
         return (
             <div style={{paddingBlockEnd: 20}}>
                 <DateTimePicker
+                    valueType="object"
                     label={this.props.label}
                     ref={(el) => {
                         this.node = el;
@@ -55,10 +57,17 @@ export class EditorFieldDateTimeUIFramework extends React.PureComponent<IProps> 
                     error={error}
                     disabled={this.props.disabled}
                     dateFormat={appConfig.planning.dateformat}
-                    value={value == undefined ? null : new Date(value)}
+                    value={
+                        value == undefined
+                            ? null
+                            : {
+                                date: format(new Date(value), 'yyyy-MM-dd'),
+                                time: format(new Date(value), 'HH:mm'),
+                            }
+                    }
                     required={this.props.schema?.required}
                     onChange={(value) => {
-                        this.onChange(this.props.field, value);
+                        this.onChange(this.props.field, new Date(`${value.date} ${value.time}`));
                     }}
                 />
             </div>

--- a/client/components/fields/editor/base/dateTimeUIFramework.tsx
+++ b/client/components/fields/editor/base/dateTimeUIFramework.tsx
@@ -6,6 +6,8 @@ import {DateTimePicker} from 'superdesk-ui-framework/react';
 import {appConfig} from 'appConfig';
 import {format} from 'date-fns';
 
+const DATE_ONLY_LENGTH = 10;
+
 interface IProps extends IEditorFieldProps {
     canClear?: boolean;
     showToBeConfirmed?: boolean;
@@ -27,7 +29,7 @@ export class EditorFieldDateTimeUIFramework extends React.PureComponent<IProps> 
         this.onChange = this.onChange.bind(this);
     }
 
-    onChange(field: string, value: Date) {
+    onChange(field: string, value: string) {
         // `field` is appended with `.date` or `.time` depending on what changed
         // Not all usages of this component requires this, so use `this.props.field` instead
         if (this.props.singleValue === true) {
@@ -58,16 +60,23 @@ export class EditorFieldDateTimeUIFramework extends React.PureComponent<IProps> 
                     disabled={this.props.disabled}
                     dateFormat={appConfig.planning.dateformat}
                     value={
-                        value == undefined
-                            ? null
-                            : {
+                        value != null
+                            ? {
                                 date: format(new Date(value), 'yyyy-MM-dd'),
-                                time: format(new Date(value), 'HH:mm'),
+                                // if true, that means value is a date-only ISO string without time part
+                                time: value.length === DATE_ONLY_LENGTH
+                                    ? undefined
+                                    : format(new Date(value), 'HH:mm'),
                             }
+                            : {}
                     }
                     required={this.props.schema?.required}
                     onChange={(value) => {
-                        this.onChange(this.props.field, new Date(`${value.date} ${value.time}`));
+                        const dateTimeString = value.time != null
+                            ? new Date(`${value.date} ${value.time}`).toISOString()
+                            : value.date;
+
+                        this.onChange(this.props.field, dateTimeString);
                     }}
                 />
             </div>


### PR DESCRIPTION
SDBELGA-859

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

### Front-end checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [x] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [x] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [x] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [x] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [x] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [x] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [x] This pull request is not adding redux based modals
- [x] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [x] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)

Resolves: #[issue-number]

