### PR TITLE
Fix serving of swagger.yaml in content API docs [stt-107]

### DIFF
--- a/server/planning/content_api/content_api_docs.py
+++ b/server/planning/content_api/content_api_docs.py
@@ -8,7 +8,7 @@
 # AUTHORS and LICENSE files distributed with this source code, or
 # at https://www.sourcefabric.org/superdesk/license
 import os
-from quart import send_file, abort
+from quart import abort, send_from_directory
 from superdesk.core.web import EndpointGroup
 from superdesk.flask import render_template
 from superdesk.core.types import Request
@@ -25,13 +25,8 @@ async def content_api_docs():
 async def api_planning_static_file(args, params, request: Request):
     filename = request.get_view_args("filename")
     base_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "static"))
-    requested_path = os.path.abspath(os.path.join(base_path, filename))
 
-    # Security check: ensure the file stays within base_path
-    if not requested_path.startswith(base_path + os.sep) or not filename.endswith(".yaml"):
-        return abort(403)
-
-    if not os.path.exists(requested_path):
+    try:
+        return await send_from_directory(base_path, filename)
+    except FileNotFoundError:
         return abort(404)
-
-    return await send_file(requested_path)

--- a/server/planning/content_api/content_api_docs.py
+++ b/server/planning/content_api/content_api_docs.py
@@ -21,16 +21,17 @@ async def content_api_docs():
     return await render_template("content_apidocs.html")
 
 
-@content_api_docs_endpoints.endpoint("/planning-static/<path:filename>", auth=False)
-async def planning_static_file(args, params, request: Request):
+@content_api_docs_endpoints.endpoint("/api-planning-static/<path:filename>", auth=False)
+async def api_planning_static_file(args, params, request: Request):
     filename = request.get_view_args("filename")
-    base_path = os.path.abspath(os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "static"))
-    file_path = os.path.join(base_path, filename)
+    base_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "static"))
+    requested_path = os.path.abspath(os.path.join(base_path, filename))
 
-    if not file_path.startswith(base_path):
+    # Security check: ensure the file stays within base_path
+    if not requested_path.startswith(base_path + os.sep) or not filename.endswith(".yaml"):
         return abort(403)
 
-    if not os.path.exists(file_path):
+    if not os.path.exists(requested_path):
         return abort(404)
 
-    return await send_file(file_path)
+    return await send_file(requested_path)

--- a/server/planning/templates/content_apidocs.html
+++ b/server/planning/templates/content_apidocs.html
@@ -18,7 +18,7 @@
     </style>
   </head>
   <body>
-    <redoc spec-url="{{ url_for('content_api_docs.planning_static_file', filename='swagger.yaml') }}"></redoc>
+    <redoc spec-url="{{ url_for('content_api_docs.api_planning_static_file', filename='swagger.yaml') }}"></redoc>
     <script src="https://cdn.jsdelivr.net/npm/redoc@latest/bundles/redoc.standalone.js"> </script>
   </body>
 </html>

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ package_data = {
         "*.mo",
         "data_updates/*.py",
         "data_updates/*.js",
+        "static/*.yaml",
     ]
 }
 


### PR DESCRIPTION
- Renamed static route from `/planning-static` to `/api-planning-static` to match Nginx routing
- Added 'static/*.yaml' to package_data in setup.py to ensure swagger.yaml is included during installation
- Added Security check: ensure the file stays within base_path.