### PR TITLE
Planning: Coverage status update in the UI broken

### DIFF
--- a/client/components/Coverages/CoverageIcons.tsx
+++ b/client/components/Coverages/CoverageIcons.tsx
@@ -49,6 +49,7 @@ export function getAvatarForCoverage(
     noIcon: boolean = false,
 ): Omit<IPropsAvatar, 'size'> | Omit<IPropsAvatarPlaceholder, 'size'> {
     const user = users.find((u) => u._id === coverage.assigned_to?.user);
+    const statusDotColor = planningUtils.getNewsCoverageStatusDotColor(coverage);
 
     const icon: {name: string; color: string} | undefined =
         noIcon === true || coverage.planning?.g2_content_type == null ? undefined : {
@@ -66,16 +67,16 @@ export function getAvatarForCoverage(
         };
 
     if (user == null) {
-        const placeholder: Omit<IPropsAvatarPlaceholder, 'size'> = {
-            kind: 'user-icon',
+        const placeholder: Omit<IPropsAvatar, 'size'> = {
+            initials: null,
+            imageUrl: null,
+            displayName: 'Unassigned',
             icon: icon,
-            tooltip: gettext('Unassigned'),
+            statusDot: statusDotColor != null ? {color: statusDotColor} : null,
         };
 
         return placeholder;
     } else {
-        const statusDotColor = planningUtils.getNewsCoverageStatusDotColor(coverage);
-
         const avatar: Omit<IPropsAvatar, 'size'> = {
             initials: getUserInitials(user.display_name),
             imageUrl: user.picture_url,


### PR DESCRIPTION
SDESK-7638

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

### Front-end checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [x] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [x] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [x] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [x] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [x] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [x] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [x] This pull request is not adding redux based modals
- [x] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [x] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)

Resolves: #[issue-number]

