### PR TITLE
[STT-47] - Add additional location details field on Events

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,19 @@
-## Front-end checklist
+### Purpose
+<!--- Explain what this PR accomplishes. Why are we changing this? -->
 
+### What has changed
+<!--- Explain what has changed and how -->
+
+### Steps to test
+<!---
+Try to explain in a few steps how to test and what things to look out for.
+-->
+
+<!-- [For UI changes]
+### Screenshots
+-->
+
+### Front-end checklist
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
 - [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
 - [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
@@ -11,3 +25,6 @@
 - [ ] This pull request is not adding redux based modals
 - [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
 - [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)
+
+Resolves: #[issue-number]
+

--- a/client/api/events.ts
+++ b/client/api/events.ts
@@ -202,8 +202,6 @@ function update(original: IEventItem, updates: Partial<IEventItem>): Promise<Arr
         .then((response) => {
             const events = modifySaveResponseForClient(response);
 
-            events[0].associated_plannings = updates.associated_plannings;
-
             return planningApi.planning.searchGetAll({
                 recurrence_id: events[0].recurrence_id,
                 event_item: events[0].recurrence_id != null ? null : events.map((event) => event._id),
@@ -213,6 +211,7 @@ function update(original: IEventItem, updates: Partial<IEventItem>): Promise<Arr
                 // Make sure to update the Redux Store with the latest Planning items
                 // So that the Editor can set the state with these latest items
                 planningApi.redux.store.dispatch<any>(planningApis.receivePlannings(planningItems));
+                events[0].associated_plannings = planningItems;
 
                 return events;
             });

--- a/client/apps/Assignments/AssignmentPreview.tsx
+++ b/client/apps/Assignments/AssignmentPreview.tsx
@@ -22,6 +22,9 @@ const TABS = {
 };
 
 export class AssignmentPreviewComponent extends React.Component {
+    tools: Array<{icon: string; onClick: any; title: any;}>;
+    tabs: Array<any>;
+
     constructor(props) {
         super(props);
         this.state = {tab: TABS.ASSIGNMENT};
@@ -31,7 +34,7 @@ export class AssignmentPreviewComponent extends React.Component {
         this.onUnlock = this.onUnlock.bind(this);
 
         this.tools = [{
-            icon: 'icon-close-small',
+            icon: 'close-small',
             onClick: props.closePanel,
             title: gettext(TOOLTIPS.close),
         }];
@@ -116,7 +119,6 @@ export class AssignmentPreviewComponent extends React.Component {
                                     gettext('Assignment locked')
                                 }
                                 showUnlock={lockAction !== 'content_edit'}
-                                withLoggedInfo={true}
                                 onUnlock={this.onUnlock}
                             />
                         </div>

--- a/client/components/AbsoluteDate/index.tsx
+++ b/client/components/AbsoluteDate/index.tsx
@@ -27,7 +27,7 @@ export const AbsoluteDate: React.FC<AbsoluteDateProps> = ({
     asTextInput = false,
     toBeConfirmed,
     ...props
-}) => {
+}: AbsoluteDateProps) => {
     let momentDate = moment.utc(date);
     let timeStr = '';
     let spanStr = noDateString;

--- a/client/components/AbsoluteDate/index.tsx
+++ b/client/components/AbsoluteDate/index.tsx
@@ -1,21 +1,26 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import moment from 'moment';
 import {DATE_FORMATS} from '../../constants';
 import {TextInput} from '../UI/Form';
 
-/**
- * Display absolute date in <time> element
- *
- * Usage:
- * <AbsoluteDate date={historyItem._created} />
- *
- * Params:
- * param {object} date - datetime string in utc
- * param {string} noDateString - string to display if the date is not valid
- * param {string} className - The CSS class names to use in the parent time element
- */
-export const AbsoluteDate = ({
+interface AbsoluteDateProps extends React.HTMLAttributes<HTMLElement> {
+    // datetime string in utc
+    date?: string;
+
+    // string to display if the date is not valid
+    noDateString?: string;
+
+    // The CSS class names to use in the parent time element
+    className?: string;
+
+    // show text input instead of time
+    asTextInput?: boolean;
+
+    // show to be confirmed text
+    toBeConfirmed?: boolean;
+}
+
+export const AbsoluteDate: React.FC<AbsoluteDateProps> = ({
     date,
     noDateString = '',
     className,
@@ -51,21 +56,13 @@ export const AbsoluteDate = ({
         }
     }
 
-    return !asTextInput ? (
-        <time className={className} dateTime={timeStr}>
-            <span>{spanStr}</span>
-        </time>
-    ) : (
-        <TextInput className={className} value={spanStr} {...props} />
-    );
-};
+    if (!asTextInput) {
+        return (
+            <time className={className} dateTime={timeStr}>
+                <span>{spanStr}</span>
+            </time>
+        );
+    }
 
-AbsoluteDate.propTypes = {
-    date: PropTypes.string,
-    noDateString: PropTypes.string,
-    className: PropTypes.string,
-    asTextInput: PropTypes.bool,
-    toBeConfirmed: PropTypes.bool,
+    return <TextInput className={className} value={spanStr} {...props} />;
 };
-
-AbsoluteDate.defaultProps = {asTextInput: false};

--- a/client/components/Assignments/AssignmentItem/AssignmentItem_test.tsx
+++ b/client/components/Assignments/AssignmentItem/AssignmentItem_test.tsx
@@ -134,15 +134,6 @@ describe('assignments', () => {
                 );
             });
 
-            it('displays tooltip for priority', () => {
-                const wrapper = getMountedWrapper();
-                const priorityNode = wrapper.find('.priority-label').first();
-
-                expect(priorityNode.prop('data-sd-tooltip')).toBe(
-                    'Priority: {{ name }}'
-                );
-            });
-
             it('ActionMenu executes prop functions', () => {
                 const executeItemAction = (actionLabel) => {
                     const wrapper = getMountedWrapper();

--- a/client/components/Assignments/AssignmentPreviewContainer/AssignmentPreview.tsx
+++ b/client/components/Assignments/AssignmentPreviewContainer/AssignmentPreview.tsx
@@ -41,14 +41,12 @@ export class AssignmentPreview extends React.PureComponent<IProps> {
         } = this.props;
 
         const planning: Partial<ICoveragePlanningDetails> = assignment?.planning ?? {};
-        const contactId = get(assignment, 'assigned_to.contact') ?
-            assignment.assigned_to.contact :
-            get(planning, 'contact_info');
+        const contactId = assignment?.assigned_to?.contact ?? planning?.contact_info;
         const showXMPFiles = planningUtils.showXMPFileUIControl(assignment);
 
         return (
             <div>
-                {contactId == null ? null : (
+                {contactId != null && (
                     <Row label={assignmentUtils.getContactLabel(assignment)}>
                         <ContactsPreviewList
                             contactIds={[contactId]}

--- a/client/components/Assignments/AssignmentPreviewContainer/AssignmentPreviewContainer_test.tsx
+++ b/client/components/Assignments/AssignmentPreviewContainer/AssignmentPreviewContainer_test.tsx
@@ -94,14 +94,7 @@ describe('<AssignmentPreviewContainer />', () => {
             const topTools = wrapper.find('.side-panel__top-tools');
             const audit = wrapper.find('.AssignmentPreview__audit');
 
-            // Renders Content Type icon
-            // Cannot test data-sd-tooltip="Type: text"
-            // Our gettext mock simply returns the string
-            expect(topTools.contains(
-                <span data-sd-tooltip="Type: Text" data-flow="right">
-                    <i className="sd-list-item__inline-icon icon-text" />
-                </span>
-            )).toBe(true);
+            expect(topTools.contains(<i className="sd-list-item__inline-icon icon-text" />)).toBe(true);
 
             // Renders Assignment Priority
             expect(topTools.find('.priority-label--1').exists()).toBe(true);
@@ -116,6 +109,7 @@ describe('<AssignmentPreviewContainer />', () => {
             const menu = new helpers.actionMenu(audit);
 
             expect(menu.isAvailable()).toBe(true);
+
             menu.expectActions([
                 'Start Working',
                 'Reassign',

--- a/client/components/Assignments/AssignmentPreviewContainer/AssignmentPreviewHeader.tsx
+++ b/client/components/Assignments/AssignmentPreviewContainer/AssignmentPreviewHeader.tsx
@@ -6,7 +6,7 @@ import moment from 'moment';
 
 import {assignmentUtils, planningUtils, gettext, stringUtils} from '../../../utils';
 
-import {Item, Column, Row} from '../../UI/List';
+import {Column} from '../../UI/List';
 import {ContentBlock, ContentBlockInner, Tools} from '../../UI/SidePanel';
 import {
     AbsoluteDate,
@@ -15,10 +15,11 @@ import {
     Datetime,
     AuditInformation,
     ItemActionsMenu,
-    Label,
 } from '../../';
 import {UserAvatar} from '../../../components/UserAvatar';
 import {TO_BE_CONFIRMED_FIELD} from '../../../constants';
+import {IconButton, Label, Spacer, Tooltip} from 'superdesk-ui-framework/react';
+import {superdeskApi} from '../../../superdeskApi';
 
 export const AssignmentPreviewHeader = ({
     assignment,
@@ -70,105 +71,109 @@ export const AssignmentPreviewHeader = ({
                 }
             </ContentBlock>
             <Tools className="AssignmentPreview__toolbar" topTools={true}>
-                <div>
-                    <Item noBg={true} noHover={true}>
-                        {
-                            hideAvatar === true ? null : (
-                                <Column border={false}>
-                                    <UserAvatar
-                                        user={assignedUser}
-                                        size="large"
-                                    />
-                                </Column>
-                            )
-                        }
+                <Spacer h gap="4" justifyContent="start" noWrap>
+                    {hideAvatar !== true && (
                         <Column border={false}>
-                            <Row margin={false}>
-                                <span className="sd-list-item__normal">
-                                    {gettext('Desk:')}
-                                </span>
-                                <span className="sd-list-item__strong">
-                                    {assignedDeskName}
-                                </span>
-                            </Row>
-                            <Row margin={false}>
-                                <span className="sd-list-item__text-label sd-list-item__text-label--normal">
-                                    {deskAssignor && (
-                                        <span>
-                                            {gettext('Assigned by {{name}}', {name: deskAssignorName})},
-                                            &nbsp;<Datetime date={assignedDateDesk} />
-                                        </span>
-                                    )}
-                                </span>
-                            </Row>
-                            <Row margin={false}>
-                                <span className="sd-list-item__normal">
-                                    {gettext('Assigned:')}
-                                </span>
-                                <span className="sd-list-item__strong">
-                                    {assignedUserName}
-                                </span>
-                            </Row>
-                            <Row margin={false}>
-                                <span className="sd-list-item__text-label sd-list-item__text-label--normal">
-                                    {userAssignor && (
-                                        <span>
-                                            {gettext('Assigned by {{name}}', {name: userAssignorName})},
-                                            &nbsp;<Datetime date={assignedDateUser} />
-                                        </span>
-                                    )}
-                                </span>
-                            </Row>
-                            {coverageProvider && (
-                                <Row margin={false}>
-                                    <span className="sd-list-item__normal">
-                                        {gettext('Coverage Provider:')}
-                                    </span>
-                                    <span className="sd-list-item__strong">
-                                        {coverageProvider}
-                                    </span>
-                                </Row>
-                            )}
-                            <Row marginTop={true}>
-                                <span className="sd-list-item__normal">
-                                    {gettext('Due:')}
-                                </span>
-                                <AbsoluteDate
-                                    date={moment(planningSchedule).format()}
-                                    noDateString={gettext('\'not scheduled yet\'')}
-                                    toBeConfirmed={get(assignment, `planning.${TO_BE_CONFIRMED_FIELD}`)}
-                                />
-                            </Row>
-                            <Row marginTop={true}>
-                                <span
-                                    data-sd-tooltip={
-                                        gettext('Type: {{type}}', {
-                                            type: stringUtils.firstCharUpperCase(
-                                                get(planning, 'g2_content_type', '').replace('_', ' ')),
-                                        })
-                                    }
-                                    data-flow="right"
-                                >
-                                    <i
-                                        className={classNames('sd-list-item__inline-icon',
-                                            coverageIcon)}
-                                    />
-                                </span>
-                                <PriorityLabel
-                                    item={assignment}
-                                    priorities={priorities}
-                                    tooltipFlow="right"
-                                    inline={true}
-                                />
-                                <StateLabel
-                                    item={assignedTo}
-                                    inline={true}
-                                />
-                                {isAccepted && <Label iconType="highlight" text={gettext('Accepted')} /> }
-                            </Row>
+                            <UserAvatar
+                                user={assignedUser}
+                                size="large"
+                            />
                         </Column>
-                    </Item>
-                </div>
+                    )}
+                    <Spacer v gap="4" noWrap>
+                        <Spacer gap="4" h justifyContent="start" noWrap>
+                            {gettext('Id: {{id}}', {id: assignment._id})}
+                            <IconButton
+                                size="small"
+                                icon="copy"
+                                ariaValue={gettext('Copy assignment Id')}
+                                onClick={() => {
+                                    navigator.clipboard.writeText(assignment._id);
+                                    superdeskApi.ui.notify.success(gettext('Copied to clipboard'));
+                                }}
+                            />
+                        </Spacer>
+                        <Spacer h gap="4" justifyContent="start" noWrap>
+                            <span className="sd-list-item__normal">
+                                {gettext('Desk:')}
+                            </span>
+                            <span className="sd-list-item__strong">
+                                {assignedDeskName}
+                            </span>
+                        </Spacer>
+                        <span className="sd-list-item__text-label sd-list-item__text-label--normal">
+                            {deskAssignor && (
+                                <span>
+                                    {gettext('Assigned by {{name}}', {name: deskAssignorName})},
+                                            &nbsp;<Datetime date={assignedDateDesk} />
+                                </span>
+                            )}
+                        </span>
+                        <Spacer h gap="4" justifyContent="start" noWrap>
+                            <span className="sd-list-item__normal">
+                                {gettext('Assigned:')}
+                            </span>
+                            <span className="sd-list-item__strong">
+                                {assignedUserName}
+                            </span>
+                        </Spacer>
+
+                        <span className="sd-list-item__text-label sd-list-item__text-label--normal">
+                            {userAssignor && (
+                                <span>
+                                    {gettext('Assigned by {{name}}', {name: userAssignorName})} &nbsp;
+                                    <Datetime date={assignedDateUser} />
+                                </span>
+                            )}
+                        </span>
+
+                        {coverageProvider && (
+                            <Spacer h gap="4" justifyContent="start" noWrap>
+                                <span className="sd-list-item__normal">
+                                    {gettext('Coverage Provider:')}
+                                </span>
+                                <span className="sd-list-item__strong">
+                                    {coverageProvider}
+                                </span>
+                            </Spacer>
+                        )}
+                        <Spacer h gap="4" justifyContent="start" noWrap>
+                            <span className="sd-list-item__normal">
+                                {gettext('Due:')}
+                            </span>
+                            <AbsoluteDate
+                                date={moment(planningSchedule).format()}
+                                noDateString={gettext('\'not scheduled yet\'')}
+                                toBeConfirmed={get(assignment, `planning.${TO_BE_CONFIRMED_FIELD}`)}
+                            />
+                        </Spacer>
+                        <Spacer h gap="4" alignItems="start" justifyContent="start" noWrap>
+                            <Tooltip
+                                text={gettext('Type: {{type}}', {
+                                    type: stringUtils.firstCharUpperCase(
+                                        get(planning, 'g2_content_type', '').replace('_', ' ')),
+                                })}
+                                flow="right"
+                            >
+                                <i
+                                    className={classNames('sd-list-item__inline-icon',
+                                        coverageIcon)}
+                                />
+                            </Tooltip>
+                            <PriorityLabel
+                                item={assignment}
+                                priorities={priorities}
+                                tooltipFlow="right"
+                                inline={true}
+                            />
+                            <StateLabel
+                                item={assignedTo}
+                                inline={true}
+                            />
+                            {isAccepted && <Label type="highlight" text={gettext('Accepted')} /> }
+                        </Spacer>
+                    </Spacer>
+                </Spacer>
             </Tools>
         </div>
     );

--- a/client/components/EventsPlanningFilters/PreviewFilter.tsx
+++ b/client/components/EventsPlanningFilters/PreviewFilter.tsx
@@ -37,11 +37,11 @@ export class PreviewFilter extends React.PureComponent<IEventsPlanningContentPan
                     </h3>
                     <SidePanel.Tools
                         tools={[{
-                            icon: 'icon-pencil',
+                            icon: 'pencil',
                             onClick: this.editFilter,
                             title: gettext('Edit'),
                         }, {
-                            icon: 'icon-close-small',
+                            icon: 'close-small',
                             onClick: this.props.onClose,
                             title: gettext('Close'),
                         }]}

--- a/client/components/Label/index.tsx
+++ b/client/components/Label/index.tsx
@@ -34,9 +34,7 @@ export const Label = ({text, iconType, verbose, isHollow, tooltip, onClick, id, 
         </span>
     );
 
-    return onClick ?
-        <a onClick={onClick}>{label}</a> :
-        label;
+    return onClick ? <a onClick={onClick}>{label}</a> : label;
 };
 
 Label.propTypes = {

--- a/client/components/Main/SearchPanel.tsx
+++ b/client/components/Main/SearchPanel.tsx
@@ -104,7 +104,7 @@ export class SearchPanelComponent extends React.Component<IProps, IState> {
                 <Header className="side-panel__header--border-b">
                     <Tools
                         tools={[{
-                            icon: 'icon-close-small',
+                            icon: 'close-small',
                             onClick: this.props.toggleFilterPanel,
                             title: gettext('Close'),
                         }]}

--- a/client/components/PriorityLabel/index.tsx
+++ b/client/components/PriorityLabel/index.tsx
@@ -4,6 +4,7 @@ import classNames from 'classnames';
 import {superdeskApi} from '../../superdeskApi';
 import {getVocabularyItemFieldTranslated} from '../../utils/vocabularies';
 import {getUserInterfaceLanguageFromCV} from '../../utils/users';
+import {Tooltip} from 'superdesk-ui-framework';
 
 interface IProps {
     item: {
@@ -16,9 +17,9 @@ interface IProps {
             name?: {[key: string]: string};
         };
     }>;
-    tooltipFlow: 'up' | 'right' | 'down' | 'left';
+    tooltipFlow: 'top' | 'right' | 'down' | 'left';
     inline: boolean;
-    className: string;
+    className?: string;
 }
 
 export class PriorityLabel extends React.PureComponent<IProps> {
@@ -29,7 +30,7 @@ export class PriorityLabel extends React.PureComponent<IProps> {
             priorities,
             tooltipFlow = 'right',
             inline,
-            className,
+            className = '',
         } = this.props;
 
         if (item.priority == null) {
@@ -57,11 +58,13 @@ export class PriorityLabel extends React.PureComponent<IProps> {
                     {'sd-list-item__inline-icon': inline},
                     className
                 )}
-                data-sd-tooltip={tooltip}
-                data-flow={tooltipFlow}
             >
-                <span className="a11y-only">{tooltip}</span>
-                {priority.qcode}
+                <Tooltip
+                    text={tooltip}
+                    flow={tooltipFlow}
+                >
+                    {priority.qcode}
+                </Tooltip>
             </span>
         );
     }

--- a/client/components/StateLabel/index.tsx
+++ b/client/components/StateLabel/index.tsx
@@ -50,7 +50,7 @@ export const StateLabel = ({
             )}
         >
             {!noState && <div>{getStateLabel(state)}</div>}
-            <div>{withPubStatus && pubState && getStateLabel(pubState)}</div>
+            {withPubStatus && pubState && <div>{getStateLabel(pubState)}</div>}
             {expiredState && (
                 <div>
                     {getStateLabel(expiredState)}

--- a/client/components/UI/SidePanel/Tools.tsx
+++ b/client/components/UI/SidePanel/Tools.tsx
@@ -1,16 +1,26 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import {IconButton} from 'superdesk-ui-framework/react';
 
-import {IconButton} from '../';
+interface ITool {
+    icon: string;
+    onClick: () => void;
+    title: string;
+}
 
+interface IToolsProps {
+    className?: string;
+    tools?: Array<ITool>;
+    children?: React.ReactNode;
+    topTools?: boolean;
+}
 
-/**
- * @ngdoc react
- * @name Tools
- * @description Header tools of a side panel
- */
-export const Tools = ({className, tools, children, topTools}) => (
+export const Tools = ({
+    className,
+    tools = [],
+    children,
+    topTools = false,
+}: IToolsProps) => (
     <div
         className={classNames(
             {
@@ -22,30 +32,13 @@ export const Tools = ({className, tools, children, topTools}) => (
     >
         {tools.map((tool) => (
             <IconButton
+                toolTipFlow="left"
                 key={tool.icon}
                 icon={tool.icon}
                 onClick={tool.onClick}
-                data-sd-tooltip={tool.title}
-                data-flow="left"
-                aria-label={tool.title}
+                ariaValue={tool.title}
             />
         ))}
         {children}
     </div>
 );
-
-Tools.propTypes = {
-    children: PropTypes.node,
-    className: PropTypes.string,
-    tools: PropTypes.arrayOf(PropTypes.shape({
-        icon: PropTypes.string,
-        onClick: PropTypes.func,
-        title: PropTypes.string,
-    })).isRequired,
-    topTools: PropTypes.bool,
-};
-
-Tools.defaultProps = {
-    tools: [],
-    topTools: false,
-};

--- a/client/components/fields/editor/EventRelatedArticles/PreviewArticle.tsx
+++ b/client/components/fields/editor/EventRelatedArticles/PreviewArticle.tsx
@@ -32,15 +32,17 @@ export class PreviewArticle extends React.PureComponent<IProps, IState> {
 
     componentDidMount(): void {
         const {getLabelNameResolver} = superdeskApi.entities.article;
-        const {getCustomFieldVocabularies} = superdeskApi.entities.vocabulary;
 
         getLabelNameResolver().then((getLabel: (fieldId: string) => string) => {
-            const customFieldVocabularies = getCustomFieldVocabularies();
+            const allVocabulariesMap = superdeskApi.entities.vocabulary.getAll();
+            const allVocabulariesArray = allVocabulariesMap.valueSeq().toArray();
+
+            const customVocabularies = allVocabulariesArray;
 
             this.getLabel = getLabel;
 
             this.setState({
-                customFieldVocabularies: customFieldVocabularies,
+                customFieldVocabularies: customVocabularies,
                 loading: false,
             });
         });

--- a/client/components/fields/editor/base/dateTime.tsx
+++ b/client/components/fields/editor/base/dateTime.tsx
@@ -15,6 +15,10 @@ interface IProps extends IEditorFieldProps {
     onToBeConfirmed?(field: string): void;
 }
 
+
+/**
+ * @deprecated use EditorFieldDateTimeUIFramework from client/components/fields/editor/base/dateTimeUIFramework.tsx
+ */
 export class EditorFieldDateTime extends React.PureComponent<IProps> {
     node: HTMLInputElement;
 

--- a/client/components/fields/editor/base/dateTimeUIFramework.tsx
+++ b/client/components/fields/editor/base/dateTimeUIFramework.tsx
@@ -4,6 +4,9 @@ import {IEditorFieldProps} from '../../../../interfaces';
 import {get} from 'lodash';
 import {DateTimePicker} from 'superdesk-ui-framework/react';
 import {appConfig} from 'appConfig';
+import {format} from 'date-fns';
+
+const DATE_ONLY_LENGTH = 10;
 
 interface IProps extends IEditorFieldProps {
     canClear?: boolean;
@@ -26,7 +29,7 @@ export class EditorFieldDateTimeUIFramework extends React.PureComponent<IProps> 
         this.onChange = this.onChange.bind(this);
     }
 
-    onChange(field: string, value: Date) {
+    onChange(field: string, value: string) {
         // `field` is appended with `.date` or `.time` depending on what changed
         // Not all usages of this component requires this, so use `this.props.field` instead
         if (this.props.singleValue === true) {
@@ -44,6 +47,7 @@ export class EditorFieldDateTimeUIFramework extends React.PureComponent<IProps> 
         return (
             <div style={{paddingBlockEnd: 20}}>
                 <DateTimePicker
+                    valueType="object"
                     label={this.props.label}
                     ref={(el) => {
                         this.node = el;
@@ -55,10 +59,24 @@ export class EditorFieldDateTimeUIFramework extends React.PureComponent<IProps> 
                     error={error}
                     disabled={this.props.disabled}
                     dateFormat={appConfig.planning.dateformat}
-                    value={value == undefined ? null : new Date(value)}
+                    value={
+                        value != null
+                            ? {
+                                date: format(new Date(value), 'yyyy-MM-dd'),
+                                // if true, that means value is a date-only ISO string without time part
+                                time: value.length === DATE_ONLY_LENGTH
+                                    ? undefined
+                                    : format(new Date(value), 'HH:mm'),
+                            }
+                            : {}
+                    }
                     required={this.props.schema?.required}
                     onChange={(value) => {
-                        this.onChange(this.props.field, value);
+                        const dateTimeString = value.time != null
+                            ? new Date(`${value.date} ${value.time}`).toISOString()
+                            : value.date;
+
+                        this.onChange(this.props.field, dateTimeString);
                     }}
                 />
             </div>

--- a/client/components/fields/editor/base/dateTimeUIFramework.tsx
+++ b/client/components/fields/editor/base/dateTimeUIFramework.tsx
@@ -1,0 +1,67 @@
+import * as React from 'react';
+
+import {IEditorFieldProps} from '../../../../interfaces';
+import {get} from 'lodash';
+import {DateTimePicker} from 'superdesk-ui-framework/react';
+import {appConfig} from 'appConfig';
+
+interface IProps extends IEditorFieldProps {
+    canClear?: boolean;
+    showToBeConfirmed?: boolean;
+    toBeConfirmed?: boolean;
+    isLocalTimeZoneDifferent?: boolean;
+    remoteTimeZone?: string;
+    singleValue?: boolean;
+    onToBeConfirmed?(field: string): void;
+    allDay?: boolean;
+    hideTime?: boolean;
+}
+
+export class EditorFieldDateTimeUIFramework extends React.PureComponent<IProps> {
+    node: any;
+
+    constructor(props: IProps) {
+        super(props);
+
+        this.onChange = this.onChange.bind(this);
+    }
+
+    onChange(field: string, value: Date) {
+        // `field` is appended with `.date` or `.time` depending on what changed
+        // Not all usages of this component requires this, so use `this.props.field` instead
+        if (this.props.singleValue === true) {
+            this.props.onChange(this.props.field, value);
+        } else {
+            this.props.onChange(field, value);
+        }
+    }
+
+    render() {
+        const field = this.props.field;
+        const value = get(this.props.item, field, this.props.defaultValue); // ISO string usually
+        const error = get(this.props.errors ?? {}, field);
+
+        return (
+            <div style={{paddingBlockEnd: 20}}>
+                <DateTimePicker
+                    label={this.props.label}
+                    ref={(el) => {
+                        this.node = el;
+                    }}
+                    labelHidden={false}
+                    data-test-id={this.props.testId}
+                    readonly={this.props.disabled}
+                    invalid={(error?.length ?? 0) > 0}
+                    error={error}
+                    disabled={this.props.disabled}
+                    dateFormat={appConfig.planning.dateformat}
+                    value={value == undefined ? null : new Date(value)}
+                    required={this.props.schema?.required}
+                    onChange={(value) => {
+                        this.onChange(this.props.field, value);
+                    }}
+                />
+            </div>
+        );
+    }
+}

--- a/client/components/fields/index.tsx
+++ b/client/components/fields/index.tsx
@@ -268,6 +268,7 @@ const PREVIEW_GROUPS: IPreviewGroups = {
             'calendars',
             'place',
             'location',
+            'location_details',
             'event_contact_info',
             'related_items',
         ],

--- a/client/components/fields/preview/index.ts
+++ b/client/components/fields/preview/index.ts
@@ -280,6 +280,13 @@ const multilingualFieldOptions: {[key: string]: IPreviewHocOptions} = {
         props: () => ({label: superdeskApi.localization.gettext('Priority:')}),
         getValue: getPreviewString,
     },
+    location_details: {
+        props: () => ({
+            label: superdeskApi.localization.gettext('Location Details:'),
+            convertNewlineToBreak: true,
+        }),
+        getValue: getPreviewString,
+    },
 };
 
 let FIELD_TO_PREVIEW_COMPONENT: {[key: string]: any} = {};

--- a/client/components/fields/resources/events.ts
+++ b/client/components/fields/resources/events.ts
@@ -14,6 +14,17 @@ import {EditorFieldTreeSelect, IEditorFieldTreeSelectProps} from '../editor/base
 import {EditorFieldDateTimeUIFramework} from '../editor/base/dateTimeUIFramework';
 
 registerEditorField(
+    'location_details',
+    EditorFieldMultilingualText,
+    () => ({
+        label: superdeskApi.localization.gettext('Location Details'),
+        field: 'location_details',
+    }),
+    null,
+    true
+);
+
+registerEditorField(
     'definition_long',
     EditorFieldMultilingualText,
     () => ({

--- a/client/components/fields/resources/events.ts
+++ b/client/components/fields/resources/events.ts
@@ -11,6 +11,7 @@ import {EditorFieldDateTime} from '../editor/base/dateTime';
 import {EditorFieldEventLinks} from '../editor/EventLinks';
 import {EditorFieldEventRelatedItems} from '../editor/EventRelatedArticles/EditorFieldEventRelatedItems';
 import {EditorFieldTreeSelect, IEditorFieldTreeSelectProps} from '../editor/base/treeSelect';
+import {EditorFieldDateTimeUIFramework} from '../editor/base/dateTimeUIFramework';
 
 registerEditorField(
     'definition_long',
@@ -91,7 +92,7 @@ registerEditorField(
 
 registerEditorField(
     'accreditation_deadline',
-    EditorFieldDateTime,
+    EditorFieldDateTimeUIFramework,
     () => ({
         label: superdeskApi.localization.gettext('Accreditation Deadline'),
         field: 'accreditation_deadline',

--- a/client/utils/planning.ts
+++ b/client/utils/planning.ts
@@ -21,7 +21,7 @@ import {
     ICoverageScheduledUpdate,
     IDateTime,
     IItemAction,
-    IPlanningAssignedTo,
+    IAssignmentItem,
 } from '../interfaces';
 const appConfig = config as IPlanningConfig;
 
@@ -1655,8 +1655,8 @@ function getPlanningFiles(planning: IPlanningItem): IPlanningItem['files'] {
     return filesToFetch;
 }
 
-function showXMPFileUIControl(coverage: IPlanningCoverageItem): boolean {
-    return get(coverage, 'planning.g2_content_type') === 'picture' && (
+function showXMPFileUIControl(item: IAssignmentItem | IPlanningCoverageItem): boolean {
+    return get(item, 'planning.g2_content_type') === 'picture' && (
         appConfig.planning_use_xmp_for_pic_assignments ||
         appConfig.planning_use_xmp_for_pic_slugline
     );

--- a/client/validators/index.ts
+++ b/client/validators/index.ts
@@ -7,8 +7,22 @@ import {default as eventValidators} from './events';
 import {default as planningValidators} from './planning';
 import {formProfile, formProfileCustomVocabularies} from './profile';
 import {validateAssignment} from './assignments';
+import {IAssignmentOrPlanningItem, IFormProfileItem} from '../interfaces';
 
 export {eventValidators, formProfile, validateAssignment};
+
+interface IValidateFieldProps {
+    dispatch: () => any;
+    getState: () => any;
+    profileName: string;
+    field: keyof IAssignmentOrPlanningItem;
+    value: any;
+    profile: IFormProfileItem;
+    errors: any;
+    messages: any;
+    diff: any;
+    item: any;
+}
 
 export const validateField = ({
     dispatch,
@@ -21,24 +35,26 @@ export const validateField = ({
     messages,
     diff,
     item,
-}) => {
-    if (get(profile, `schema.${field}.validate_on_post`)) {
+}: IValidateFieldProps) => {
+    if (profile?.schema?.[field]?.validate_on_post) {
         return;
     }
 
-    const funcs = get(validators[profileName], field, []) || [formProfile];
+    const validatorsForField = validators[profileName]?.[field] ?? [formProfile];
 
-    funcs.forEach((func) => func({
-        dispatch,
-        getState,
-        field,
-        value,
-        profile,
-        errors,
-        messages,
-        diff,
-        item,
-    }));
+    validatorsForField.forEach((func) =>
+        func({
+            dispatch,
+            getState,
+            field,
+            value,
+            profile,
+            errors,
+            messages,
+            diff,
+            item,
+        }),
+    );
 };
 
 export const validateItem = ({
@@ -103,8 +119,11 @@ export const validateItem = ({
                 });
         }
 
-        return (fields || Object.keys(
-            ignoreDateValidation ? omit(validators[profileName], 'dates') : validators[profileName])).forEach((key) => (
+        const fieldsToBeValidated = (fields || Object.keys(
+            ignoreDateValidation ? omit(validators[profileName], 'dates') : validators[profileName])
+        );
+
+        fieldsToBeValidated.forEach((key) => (
             validateField({
                 dispatch: dispatch,
                 getState: getState,

--- a/package-lock.json
+++ b/package-lock.json
@@ -11334,14 +11334,14 @@
       }
     },
     "superdesk-ui-framework": {
-      "version": "4.0.24",
-      "resolved": "https://registry.npmjs.org/superdesk-ui-framework/-/superdesk-ui-framework-4.0.24.tgz",
-      "integrity": "sha512-57nJ59Bz3jH63LC1JipiEHeVWXHozoXvq5Bgl50fNPdzE/kYxH6WspZI7sKBtqT2I0GEQNvyIWyE4Eg6vNuncA==",
+      "version": "4.0.35",
+      "resolved": "https://registry.npmjs.org/superdesk-ui-framework/-/superdesk-ui-framework-4.0.35.tgz",
+      "integrity": "sha512-1NUJtQxT5UfXpMuvAok6CeDdfMaRnf/jKwWjDcSxX5HzCfWhnq0PpcPMIxAfR9w06Jaici0R6mLr2lXM0KWqVg==",
       "dev": true,
       "requires": {
         "@popperjs/core": "^2.4.0",
         "@superdesk/common": "0.0.28",
-        "@superdesk/primereact": "^5.0.2-12",
+        "@superdesk/primereact": "^5.0.2-13",
         "@superdesk/react-resizable-panels": "0.0.39",
         "chart.js": "^2.9.3",
         "date-fns": "2.7.0",
@@ -11374,6 +11374,16 @@
           "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
           "dev": true
         },
+        "dom-helpers": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+          "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.8.7",
+            "csstype": "^3.0.2"
+          }
+        },
         "react-sortable-hoc": {
           "version": "1.11.0",
           "resolved": "https://registry.npmjs.org/react-sortable-hoc/-/react-sortable-hoc-1.11.0.tgz",
@@ -11383,6 +11393,18 @@
             "@babel/runtime": "^7.2.0",
             "invariant": "^2.2.4",
             "prop-types": "^15.5.7"
+          }
+        },
+        "react-transition-group": {
+          "version": "4.4.5",
+          "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+          "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.5.5",
+            "dom-helpers": "^5.0.1",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.6.2"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "style-loader": "^2.0.0",
     "superdesk-code-style": "1.5.0",
     "superdesk-core": "github:superdesk/superdesk-client-core#develop",
-    "superdesk-ui-framework": "~4.0.23",
+    "superdesk-ui-framework": "^4.0.35",
     "ts-loader": "^8.4.0",
     "ts-node": "~7.0.1",
     "tslint": "5.11.0",

--- a/server/features/events.feature
+++ b/server/features/events.feature
@@ -46,7 +46,8 @@ Feature: Events
                 },
                 "subject": [{"qcode": "test qcaode", "name": "test name"}],
                 "location": [{"qcode": "test qcaode", "name": "test name"}],
-                "event_contact_info": ["#contacts._id#"]
+                "event_contact_info": ["#contacts._id#"],
+                "accreditation_deadline": "2025-05-05"
             }
         ]
         """
@@ -74,7 +75,8 @@ Feature: Events
                 "definition_long": "long value",
                 "location": [{"qcode": "test qcaode", "name": "test name", "formatted_address": ""}],
                 "firstcreated": "__now__",
-                "versioncreated": "__now__"
+                "versioncreated": "__now__",
+                "accreditation_deadline": "2025-05-05"
             }]}
         """
         When we get "/events?sort=[("dates.start",1)]&source={"query":{"range":{"dates.start":{"lte":"2015-01-01T00:00:00.000Z"}}}}"

--- a/server/planning/content_profiles/profiles/event.py
+++ b/server/planning/content_profiles/profiles/event.py
@@ -31,6 +31,7 @@ class EventSchema(BaseSchema):
     language = LanguageField()
     links = schema.ListField()
     location = schema.StringField()
+    location_details = TextField(field_type="multi_line")
     name = TextField(required=True, field_type="single_line")
     occur_status = schema.DictField()
     occur_status.schema["schema"] = {
@@ -124,10 +125,15 @@ DEFAULT_EVENT_PROFILE = {
             "group": "location",
             "index": 1,
         },
-        "event_contact_info": {
+        "location_details": {
             "enabled": True,
             "group": "location",
             "index": 2,
+        },
+        "event_contact_info": {
+            "enabled": True,
+            "group": "location",
+            "index": 3,
         },
         # Details group
         "anpa_category": {

--- a/server/planning/content_profiles/profiles/event.py
+++ b/server/planning/content_profiles/profiles/event.py
@@ -10,7 +10,7 @@
 
 import superdesk.schema as schema
 
-from .fields import BaseSchema, subjectField, TextField, StringField, LanguageField, DateTimeField
+from .fields import BaseSchema, subjectField, TextField, StringField, LanguageField, DateOptionalTimeField
 
 
 class EventSchema(BaseSchema):
@@ -51,7 +51,7 @@ class EventSchema(BaseSchema):
     registration_details = TextField(field_type="multi_line")
     invitation_details = TextField(field_type="multi_line")
     accreditation_info = TextField(field_type="single_line")
-    accreditation_deadline = DateTimeField()
+    accreditation_deadline = DateOptionalTimeField()
     priority = schema.IntegerField()
     related_items = schema.ListField()
 

--- a/server/planning/content_profiles/profiles/fields.py
+++ b/server/planning/content_profiles/profiles/fields.py
@@ -27,6 +27,17 @@ class DateTimeField(schema.SchemaField):
         self.schema["required"] = required
 
 
+class DateOptionalTimeField(schema.SchemaField):
+    def __repr__(self):
+        return "string"
+
+    def __init__(self, required=False, schema=None):
+        """Initialize"""
+        super().__init__()
+        self.schema["type"] = "string"
+        self.schema["required"] = required
+
+
 class BooleanField(schema.SchemaField):
     """Boolean schema field"""
 

--- a/server/planning/events/events_schema.py
+++ b/server/planning/events/events_schema.py
@@ -76,7 +76,10 @@ events_schema = {
     "registration_details": {"type": "string"},
     "invitation_details": {"type": "string"},
     "accreditation_info": {"type": "string"},
-    "accreditation_deadline": {"type": "datetime"},
+    "accreditation_deadline": {
+        "type": "datetime",
+        "nullable": True,
+    },
     # Reference can be used to hold for example a court case reference number
     "reference": {"type": "string"},
     "anpa_category": {

--- a/server/planning/events/events_schema.py
+++ b/server/planning/events/events_schema.py
@@ -232,6 +232,11 @@ events_schema = {
         },
         "nullable": True,
     },
+    # Additional Location details
+    "location_details": {
+        "type": "string",
+        "nullable": True,
+    },
     "participant": {
         "type": "list",
         "mapping": {"properties": {"qcode": not_analyzed, "name": not_analyzed}},

--- a/server/planning/events/events_schema.py
+++ b/server/planning/events/events_schema.py
@@ -77,8 +77,9 @@ events_schema = {
     "invitation_details": {"type": "string"},
     "accreditation_info": {"type": "string"},
     "accreditation_deadline": {
-        "type": "datetime",
+        "type": "string",
         "nullable": True,
+        "mapping": {"type": "date"},
     },
     # Reference can be used to hold for example a court case reference number
     "reference": {"type": "string"},

--- a/server/planning/validate/planning_validate.py
+++ b/server/planning/validate/planning_validate.py
@@ -141,8 +141,10 @@ class PlanningValidateService(Service):
         return get_resource_service("planning_types").find_one(req=None, name=doc[ITEM_TYPE])
 
     def _get_validator_schema(self, validator, validate_on_post):
-        """Get schema for a given validator, excluding fields with None values,
-        and only include fields that are in enabled_fields."""
+        """
+        Get schema for a given validator, excluding fields with None values,
+        and only include fields that are in enabled_fields.
+        """
 
         enabled_fields = get_enabled_fields(validator)
         return {


### PR DESCRIPTION
### Purpose
This PR adds an additional `location_details` to the Events form and Preview. 

### What has changed
- Add `locations_details` field in Event schema.
- Add `location_details` field in Event form and Preview window.

### Steps to test
1. Open Superdesk and navigate to Planning.
2. Create new Event. Observe Location Details field. Add event and save.
3. Click on Event in the list and observe Location Details on the preview.

Resolves: #[STT-47]



[STT-47]: https://sofab.atlassian.net/browse/STT-47?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ