### PR TITLE
data migration for custom_vocabularies in planning_types

### DIFF
--- a/server/planning/data_updates/00035_20250529-105000_planning_types.py
+++ b/server/planning/data_updates/00035_20250529-105000_planning_types.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8; -*-
+# This file is part of Superdesk.
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+#
+
+from superdesk.commands.data_updates import BaseDataUpdate
+
+
+class DataUpdate(BaseDataUpdate):
+    resource = "planning_types"
+
+    def forwards(self, mongodb_collection, mongodb_database):
+        for resource_type in ["events", "planning"]:
+            profile = mongodb_collection.find_one({"name": resource_type})
+            if not profile or not profile.get("schema") or not profile.get("editor"):
+                continue
+
+            schema = profile["schema"].copy()
+            editor = profile["editor"].copy()
+
+            custom_vocabularies_schema = schema.pop("custom_vocabularies", {})
+            custom_vocabularies_editor = editor.pop("custom_vocabularies", {})
+
+            if (
+                custom_vocabularies_schema
+                and custom_vocabularies_editor
+                and custom_vocabularies_schema.get("vocabularies")
+            ):
+                custom_vocabularies = custom_vocabularies_schema["vocabularies"]
+                mandatory = custom_vocabularies_schema.get("mandatory_in_list") or []
+
+                for field in editor:
+                    if not editor[field]:
+                        continue
+                    if editor[field].get("group") == custom_vocabularies_editor.get("group") and editor[field].get(
+                        "index"
+                    ) > custom_vocabularies_editor.get("index", 0):
+                        editor[field]["index"] += (
+                            len(custom_vocabularies) - 1
+                        )  # add space for new fields - custom vocabularies field
+
+                index = custom_vocabularies_editor.get("index", 0)
+                for scheme in custom_vocabularies:
+                    schema[scheme] = {
+                        "type": "custom_vocabulary",
+                        "required": scheme in mandatory or custom_vocabularies_schema.get("required", False),
+                    }
+                    editor[scheme] = {
+                        "enabled": custom_vocabularies_editor.get("enabled", True),
+                        "group": custom_vocabularies_editor.get("group"),
+                        "index": index,
+                    }
+                    index += 1
+
+            mongodb_collection.update({"name": resource_type}, {"$set": {"schema": schema, "editor": editor}})
+
+    def backwards(self, mongodb_collection, mongodb_database):
+        pass

--- a/server/planning/tests/data_updates/00035_planning_types_test.py
+++ b/server/planning/tests/data_updates/00035_planning_types_test.py
@@ -1,0 +1,38 @@
+import importlib
+
+from planning.tests import TestCase
+
+DataUpdate = importlib.import_module("planning.data_updates.00035_20250529-105000_planning_types").DataUpdate
+
+
+class UpgradeTestCase(TestCase):
+    def test_upgrade(self):
+        self.app.data.insert(
+            "planning_types",
+            [
+                {
+                    "name": "events",
+                    "schema": {"custom_vocabularies": {"vocabularies": ["v1", "v2"], "mandatory_in_list": ["v1"]}},
+                    "editor": {
+                        "other": {"enabled": True, "group": "group2", "index": 0},
+                        "before": {"enabled": True, "group": "group1", "index": 0},
+                        "custom_vocabularies": {"enabled": True, "group": "group1", "index": 1},
+                        "after": {"enabled": True, "group": "group1", "index": 2},
+                    },
+                },
+            ],
+        )
+
+        DataUpdate().forwards(self.app.data.get_mongo_collection(DataUpdate.resource), self.app.data.driver.db)
+
+        profile = self.app.data.find_one("planning_types", req=None, name="events")
+        assert profile is not None
+        assert profile["schema"]["v1"] == {"type": "custom_vocabulary", "required": True}
+        assert profile["schema"]["v2"] == {"type": "custom_vocabulary", "required": False}
+        assert "custom_vocabularies" not in profile["schema"]
+
+        assert profile["editor"]["before"] == {"enabled": True, "group": "group1", "index": 0}
+        assert profile["editor"]["v1"] == {"enabled": True, "group": "group1", "index": 1}
+        assert profile["editor"]["v2"] == {"enabled": True, "group": "group1", "index": 2}
+        assert profile["editor"]["after"] == {"enabled": True, "group": "group1", "index": 3}
+        assert "custom_vocabularies" not in profile["editor"]


### PR DESCRIPTION
STT-184

### Purpose

add migration script to update planning_type schema 

### What has changed

for custom CVs there was single fields in schema/editor, but now
there will be one field per CV

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

### Front-end checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)

Resolves: STT-184

