### PR TITLE
[SDESK-7497] Fix Event Cancel & Reschedule endpoints

### DIFF
--- a/server/features/environment.py
+++ b/server/features/environment.py
@@ -15,9 +15,10 @@ from os import path
 from copy import copy
 
 from apps.prepopulate.app_populate import AppPopulateCommand
+from superdesk.core import AsyncSignal
 from superdesk.tests.environment import (
     setup_before_all,
-    before_feature,
+    before_feature_async as setup_before_feature_async,
     before_scenario_async as setup_before_scenario,
     before_step,
     after_scenario,
@@ -26,6 +27,7 @@ from superdesk.default_settings import MODULES as CORE_MODULES
 
 from app import get_app
 from settings import INSTALLED_APPS, env, MODULES
+from planning import signals as planning_signals
 
 
 logger = logging.getLogger(__name__)
@@ -63,6 +65,15 @@ def before_scenario(context, scenario):
     run_async_task(before_scenario_async(context, scenario))
 
 
+def before_feature(context, feature):
+    run_async_task(before_feature_async(context, feature))
+
+
+async def before_feature_async(context, feature):
+    clear_signals()
+    await setup_before_feature_async(context, feature)
+
+
 async def before_scenario_async(context, scenario):
     # Update app config based on scenario tags
     current_app = context.app
@@ -86,3 +97,9 @@ async def before_scenario_async(context, scenario):
             cmd = AppPopulateCommand()
             filename = path.join(path.abspath(path.dirname("features/steps/fixtures/")), "vocabularies.json")
             await cmd.run(filename)
+
+
+def clear_signals():
+    signal_instances = [getattr(planning_signals, attr_name) for attr_name in dir(planning_signals) if isinstance(getattr(planning_signals, attr_name), AsyncSignal)]
+    for signal_instance in signal_instances:
+        signal_instance.clear_listeners()

--- a/server/features/events_cancel.feature
+++ b/server/features/events_cancel.feature
@@ -522,22 +522,22 @@ Feature: Events Cancel
         When we perform cancel on events "event1"
         Then we get error 400
         """
-        {"_issues": {"validator exception": "403: The event must be locked"}, "_status": "ERR"}
+        {"_message": "The event must be locked", "_status": "ERR"}
         """
         When we perform cancel on events "event2"
         Then we get error 400
         """
-        {"_issues": {"validator exception": "403: The event is locked by you in another session"}, "_status": "ERR"}
+        {"_message": "The event is locked by you in another session", "_status": "ERR"}
         """
         When we perform cancel on events "event3"
         Then we get error 400
         """
-        {"_issues": {"validator exception": "403: The event is locked by another user"}, "_status": "ERR"}
+        {"_message": "The event is locked by another user", "_status": "ERR"}
         """
         When we perform cancel on events "event4"
         Then we get error 400
         """
-        {"_issues": {"validator exception": "403: The lock must be for the `cancel` action"}, "_status": "ERR"}
+        {"_message": "The lock must be for the `cancel` action", "_status": "ERR"}
         """
 
     @auth
@@ -566,7 +566,7 @@ Feature: Events Cancel
         When we perform cancel on events "event1"
         Then we get error 400
         """
-        {"_issues": {"validator exception": "400: Event not in valid state for cancellation"}, "_status": "ERR"}
+        {"_message": "Event not in valid state for cancellation", "_status": "ERR"}
         """
         When we patch "/events/#events._id#"
         """
@@ -576,7 +576,7 @@ Feature: Events Cancel
         When we perform cancel on events "event1"
         Then we get error 400
         """
-        {"_issues": {"validator exception": "400: Event not in valid state for cancellation"}, "_status": "ERR"}
+        {"_message": "Event not in valid state for cancellation", "_status": "ERR"}
         """
         When we patch "/events/#events._id#"
         """
@@ -586,7 +586,7 @@ Feature: Events Cancel
         When we perform cancel on events "event1"
         Then we get error 400
         """
-        {"_issues": {"validator exception": "403: Aborted. Event is already cancelled"}, "_status": "ERR"}
+        {"_message": "Aborted. Event is already cancelled", "_status": "ERR"}
         """
 
     @auth

--- a/server/features/events_reschedule.feature
+++ b/server/features/events_reschedule.feature
@@ -1024,7 +1024,7 @@ Feature: Events Reschedule
                         "workflow_status_reason": "Postponed this event!",
                         "headline": "test headline",
                         "slugline": "test slugline",
-                        "scheduled": "2025-11-21T14:00:00+0000",
+                        "scheduled": "2025-11-21T14:00:00+00:00",
                         "g2_content_type": "text"
                     },
                     "news_coverage_status": { "qcode": "ncostat:int" }
@@ -1229,7 +1229,7 @@ Feature: Events Reschedule
         """
         Then we get error 400
         """
-        {"_issues": {"validator exception": "403: The event must be locked"}, "_status": "ERR"}
+        {"_message": "The event must be locked", "_status": "ERR"}
         """
         When we perform reschedule on events "event2"
         """
@@ -1243,7 +1243,7 @@ Feature: Events Reschedule
         """
         Then we get error 400
         """
-        {"_issues": {"validator exception": "403: The event is locked by you in another session"}, "_status": "ERR"}
+        {"_message": "The event is locked by you in another session", "_status": "ERR"}
         """
         When we perform reschedule on events "event3"
         """
@@ -1257,7 +1257,7 @@ Feature: Events Reschedule
         """
         Then we get error 400
         """
-        {"_issues": {"validator exception": "403: The event is locked by another user"}, "_status": "ERR"}
+        {"_message": "The event is locked by another user", "_status": "ERR"}
         """
         When we perform reschedule on events "event4"
         """
@@ -1271,7 +1271,7 @@ Feature: Events Reschedule
         """
         Then we get error 400
         """
-        {"_issues": {"validator exception": "403: The lock must be for the `reschedule` action"}, "_status": "ERR"}
+        {"_message": "The lock must be for the `reschedule` action", "_status": "ERR"}
         """
 
     @auth
@@ -1502,7 +1502,7 @@ Feature: Events Reschedule
         """
         Then we get error 400
         """
-        {"_status": "ERR", "_issues": {"validator exception": "400: Event duration is greater than 7 days."}}
+        {"_status": "ERR", "_message": "Event duration is greater than 7 days."}
         """
 
     @auth

--- a/server/planning/common.py
+++ b/server/planning/common.py
@@ -448,7 +448,13 @@ async def enqueue_planning_item(id):
         )
 
         if not publish_response.routed:
-            raise SuperdeskApiError.badRequestError(message=gettext("Failed to publish the item"))
+            if not len(publish_response.matched_products) and not len(publish_response.matched_api_products):
+                error_message = gettext("Item didn't match any Products")
+            elif not len(publish_response.subscribers) and not len(publish_response.content_api_subscribers):
+                error_message = gettext("Item not published to any Subscribers")
+            else:
+                error_message = gettext("Failed to route item")
+            logger.warning(error_message, extra=publish_response.to_dict())
     else:
         logger.error("Failed to retrieve planning item from planning versions with id: {}".format(id))
 

--- a/server/planning/events/__init__.py
+++ b/server/planning/events/__init__.py
@@ -91,7 +91,7 @@ def init_app(app):
     signals.event_postponed.connect(events_history_async_service.on_postpone)
     signals.event_cancel.connect(events_history_async_service.on_cancel)
     signals.event_reschedule.connect(events_history_async_service.on_reschedule)
-    signals.event_reschedule.connect(events_history_async_service.on_reschedule)
+    signals.event_rescheduled.connect(events_history_async_service.on_reschedule)
 
     app.on_updated_events += events_history_service.on_item_updated
 

--- a/server/planning/events/events.py
+++ b/server/planning/events/events.py
@@ -458,7 +458,9 @@ class EventsService(AsyncBaseService):
         event_duration = end - start
 
         if event_duration.days > max_duration:
-            raise SuperdeskApiError(message="Event duration is greater than {} days.".format(max_duration))
+            raise SuperdeskApiError.badRequestError(
+                message="Event duration is greater than {} days.".format(max_duration)
+            )
 
     @staticmethod
     def _validate_template(updates, original):

--- a/server/planning/events/events_cancel.py
+++ b/server/planning/events/events_cancel.py
@@ -170,7 +170,7 @@ async def process_cancel_event(updates: dict[str, Any], original: dict[str, Any]
 
     # Update the original event in the database
     event_id = original[ID_FIELD]
-    await events_service.patch_async(event_id, updates)
+    await events_service.update_async(event_id, updates, original)
     await signals.event_cancel.send(updates, original)
     canceled_event = await events_service.find_one_async(req=None, _id=event_id)
     assert canceled_event is not None, "Expected canceled_event to be a dict, got None"

--- a/server/planning/events/events_reschedule.py
+++ b/server/planning/events/events_reschedule.py
@@ -115,7 +115,7 @@ async def duplicate_event(updates: dict[str, Any], original: dict[str, Any]):
     set_original_creator(new_event)
     set_planning_schedule(new_event)
 
-    await events_service.post_async([new_event])
+    await events_service.create_async([new_event])
     await events_history_service.on_reschedule_from(new_event)
     return new_event
 
@@ -309,7 +309,7 @@ async def reschedule_recurring_event(updates: dict[str, Any], original: dict[str
 
     # Now iterate over the new events and create them
     if new_events:
-        await events_service.post_async(new_events)
+        await events_service.create_async(new_events)
         await app.on_inserted_events.call_async(new_events)
 
     for event in deleted_events.values():
@@ -323,14 +323,14 @@ async def reschedule_recurring_event(updates: dict[str, Any], original: dict[str
                 # all Planning items
                 new_updates = {"skip_on_update": True, "reason": reason}
                 mark_event_rescheduled(new_updates, reason)
-                await events_service.patch_async(event[ID_FIELD], new_updates)
+                await events_service.update_async(event[ID_FIELD], new_updates, event)
 
             if len(event_plans) > 0:
                 await reschedule_event_plannings(original, reason, event_plans)
         else:
             # This event has no Planning items, therefor we can safely
             # delete this event
-            await events_service.delete_action(lookup={"_id": event[ID_FIELD]})
+            await events_service.delete_action_async(lookup={"_id": event[ID_FIELD]})
             await app.on_deleted_item_events.call_async(event)
 
             if is_original:
@@ -368,7 +368,8 @@ async def process_reschedule_event(
 
     # Update the original event in the database
     event_id = original[ID_FIELD]
-    await events_service.patch_async(event_id, updates)
+    await events_service.update_async(event_id, updates, original)
+    await signals.event_rescheduled.send(updates, original)
     rescheduled_event = await events_service.find_one_async(req=None, _id=event_id)
     assert rescheduled_event is not None, "Expected rescheduled_event to be a dict, got None"
 

--- a/server/planning/events/events_tests.py
+++ b/server/planning/events/events_tests.py
@@ -231,7 +231,7 @@ class EventLocationFormatAddress(EventsBaseTestCase):
 
 class EventPlanningSchedule(EventsBaseTestCase):
     async def _get_all_events_raw(self) -> list[dict[str, Any]]:
-        events_cursor = await self.events_service.find_async({})
+        events_cursor = await self.events_service.get_async(req=None, lookup=None)
         return await events_cursor.to_list()
 
     def assertPlanningSchedule(self, events, event_count):
@@ -286,7 +286,7 @@ class EventPlanningSchedule(EventsBaseTestCase):
         # reschedule recurring event before posting
         schedule = deepcopy(events[0].get("dates"))
         schedule["start"] = datetime(2099, 11, 21, 12, 00, 00, tzinfo=pytz.UTC) + timedelta(days=5)
-        schedule["end"] = datetime(2099, 11, 21, 12, 00, 00, tzinfo=pytz.UTC) + timedelta(days=5)
+        schedule["end"] = datetime(2099, 11, 21, 14, 00, 00, tzinfo=pytz.UTC) + timedelta(days=5)
 
         res = await process_reschedule_event({"dates": schedule}, events[0], False)
         self.assertEqual(res["dates"]["start"], schedule["start"])

--- a/server/planning/events/events_utils.py
+++ b/server/planning/events/events_utils.py
@@ -300,7 +300,7 @@ async def validate_event_action(
         raise SuperdeskApiError.badRequestError(message="Reason is required field.")
 
     if original.get("state") == WORKFLOW_STATE.CANCELLED:
-        raise SuperdeskApiError.forbiddenError(message="Aborted. Event is already cancelled")
+        raise SuperdeskApiError.badRequestError(message="Aborted. Event is already cancelled")
 
     if require_lock:
         user_id = get_user_id()
@@ -311,13 +311,13 @@ async def validate_event_action(
         lock_action = original.get(LOCK_ACTION, None)
 
         if not lock_user:
-            raise SuperdeskApiError.forbiddenError(message="The event must be locked")
+            raise SuperdeskApiError.badRequestError(message="The event must be locked")
         elif str(lock_user) != str(user_id):
-            raise SuperdeskApiError.forbiddenError(message="The event is locked by another user")
+            raise SuperdeskApiError.badRequestError(message="The event is locked by another user")
         elif str(lock_session) != str(session_id):
-            raise SuperdeskApiError.forbiddenError(message="The event is locked by you in another session")
+            raise SuperdeskApiError.badRequestError(message="The event is locked by you in another session")
         elif str(lock_action) != ACTION:
-            raise SuperdeskApiError.forbiddenError(
+            raise SuperdeskApiError.badRequestError(
                 message="The lock must be for the `{}` action".format(ACTION.lower().replace("_", " "))
             )
 

--- a/server/planning/events/views.py
+++ b/server/planning/events/views.py
@@ -1,8 +1,8 @@
 from pydantic import BaseModel
+from eve_elastic.elastic import parse_date
 
 from planning.events.events_cancel import process_cancel_event
 from planning.events.events_reschedule import process_reschedule_event
-from planning.events.events_service import EventsAsyncService
 from planning.events.events_update_repetitions import process_update_repetitions
 from planning.events.events_update_time import process_update_time
 from planning.events.events_spike import process_spike_event, process_unspike_event
@@ -128,6 +128,12 @@ async def reschedule_event(args: EventsArgs, params: None, request: Request) -> 
         await request.abort(404, "Event not found")
 
     updates = await get_json_or_400_async(request)
+
+    # Make sure date-time strings are converted to datetime instances
+    # Using Eve-Elastic's ``parse_date`` because it handles many different date/time formats
+    updates["dates"]["start"] = parse_date(updates["dates"]["start"])
+    updates["dates"]["end"] = parse_date(updates["dates"]["end"])
+
     rescheduled_event = await process_reschedule_event(updates, original)
 
     return Response(rescheduled_event)

--- a/server/planning/signals.py
+++ b/server/planning/signals.py
@@ -67,6 +67,7 @@ event_cancel = AsyncSignal[dict, dict]("events:cancel")
 
 #: Signal for when an Event is rescheduled
 event_reschedule = AsyncSignal[dict, dict]("events:reschedule")
+event_rescheduled = AsyncSignal[dict, dict]("events:rescheduled")
 
 #: Signal for when an Assignment is updated
 assignments_updated = AsyncSignal[dict, dict]("assignments:updated")

--- a/server/planning/tests/output_formatters/file_providers_test.py
+++ b/server/planning/tests/output_formatters/file_providers_test.py
@@ -57,6 +57,7 @@ class FileProvidersTestCase(TestCase):
             TransmitterFileEntry(
                 media="event_file",
                 mimetype="text/csv",
+                resource="events_files",
             )
         ],
         "type": "event",
@@ -68,6 +69,7 @@ class FileProvidersTestCase(TestCase):
             TransmitterFileEntry(
                 media="plan_file",
                 mimetype="text/csv",
+                resource="planning_files",
             )
         ],
         "type": "planning",
@@ -116,11 +118,10 @@ class FileProvidersTestCase(TestCase):
     @mock.patch("superdesk.publish.transmitters.http_push.get_app_config", return_value=(5, 30))
     @mock.patch("superdesk.publish.transmitters.http_push.requests.Session.send", return_value=CreatedResponse)
     @mock.patch("requests.get", return_value=NotFoundResponse)
-    def test_push_event_files(self, get_mock, send_mock, mock_config, get_mock_app):
-        # app_mock = get_mock_app()
+    async def test_push_event_files(self, get_mock, send_mock, mock_config, get_mock_app):
         dest = {"config": {"assets_url": "http://example.com", "secret_token": "foo"}}
         service = HTTPPushService()
-        service._copy_published_media_files(self.event_item, dest)
+        await service._copy_published_media_files(self.event_item, dest)
         get_mock_app().media.get.assert_called_with("event_file", resource="events_files")
         get_mock.assert_called_with("http://example.com/event_file", timeout=(5, 30))
         send_mock.assert_called_once_with(mock.ANY, timeout=(5, 30))
@@ -140,14 +141,11 @@ class FileProvidersTestCase(TestCase):
     @mock.patch("superdesk.publish.transmitters.http_push.get_app_config", return_value=(5, 30))
     @mock.patch("superdesk.publish.transmitters.http_push.requests.Session.send", return_value=CreatedResponse)
     @mock.patch("requests.get", return_value=NotFoundResponse)
-    def test_push_planning_files(self, get_mock, send_mock, mock_config, get_mock_app):
-        # app_mock.config = {}
-        # app_mock.media.get.return_value = TestPlanningMedia(b"bin")
+    async def test_push_planning_files(self, get_mock, send_mock, mock_config, get_mock_app):
         app_mock = get_mock_app()
-        # mock_app.media = MockMedia()
         dest = {"config": {"assets_url": "http://example.com", "secret_token": "foo"}}
         service = HTTPPushService()
-        service._copy_published_media_files(self.plan_item, dest)
+        await service._copy_published_media_files(self.plan_item, dest)
         app_mock.media.get.assert_called_with("plan_file", resource="planning_files")
         get_mock.assert_called_with("http://example.com/plan_file", timeout=(5, 30))
         send_mock.assert_called_once_with(mock.ANY, timeout=(5, 30))

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -20,6 +20,6 @@ black~=23.0
 behave==1.2.6
 aioresponses
 
-superdesk-core @ git+https://github.com/superdesk/superdesk-core.git@async
-
 -e .
+# Install in editable state so we get feature fixtures
+-e git+https://github.com/superdesk/superdesk-core.git@async#egg=superdesk-core


### PR DESCRIPTION
### Purpose
To continue fixing behave tests and any bugs found. This focus was on Event Cancel & Reschedule actions.

### What has changed
* Don't raise an exception on publish `routed == False` (keeping to existing functionality of < v3.0, we can revisit this later with front-end improvements to publishing)
* Fix dev requirements.txt, we need to install superdesk-core in editable state to include feature fixtures. We need to revisit the superdesk-core setup.py and use newer standards (and support installs like `superdesk-core[tests]`)
* Fix `file_providers` output formatter unit tests
* Fix Event Cancel & Reschedule endpoints (various issues, from invalid date/time instances to using `create_async` and `update_async` instead of `post_async` and `patch_async` which have side-affects, such as creating more Events or automatically posting the Event)
* Clear AsyncSignals before running behave tests (as old service was keeping a reference to previous MongoDB connection which was closed).