### PR TITLE
[SDESK-7497] Fix remaining behave tests

### DIFF
--- a/server/features/assignments_link.feature
+++ b/server/features/assignments_link.feature
@@ -1134,7 +1134,7 @@ Feature: Assignment link
         """
         {
         "_items": [
-          {"state": "pending", "content_type": "text",
+          {"state": "success", "content_type": "text",
           "subscriber_id": "#wire#", "item_id": "123", "item_version": 2,
           "ingest_provider": "__none__",
           "destination": {

--- a/server/features/assignments_revert.feature
+++ b/server/features/assignments_revert.feature
@@ -7,6 +7,16 @@ Feature: Assignment Revert
     """
     [{"_id": "desk123", "name": "Politic Desk"}]
     """
+    When we post to "planning" with success
+    """
+    [{
+        "guid": "plan1",
+        "headline": "test headline",
+        "slugline": "test slugline",
+        "state": "scheduled",
+        "planning_date": "2016-01-02"
+    }]
+    """
     Given "assignments"
     """
     [{

--- a/server/features/content_rewrite.feature
+++ b/server/features/content_rewrite.feature
@@ -103,7 +103,7 @@ Feature: Rewrite content
         """
         {
         "_items": [
-          {"state": "pending", "content_type": "text",
+          {"state": "success", "content_type": "text",
           "subscriber_id": "#wire#", "item_id": "#archive._id#", "item_version": 2,
           "ingest_provider": "__none__",
           "destination": {

--- a/server/features/environment.py
+++ b/server/features/environment.py
@@ -14,6 +14,7 @@ import logging
 from os import path
 from copy import copy
 
+from superdesk import get_resource_service
 from apps.prepopulate.app_populate import AppPopulateCommand
 from superdesk.tests.environment import (
     setup_before_all,
@@ -40,6 +41,14 @@ def before_all(context):
         "INSTALLED_APPS": INSTALLED_APPS,
         "ELASTICSEARCH_FORCE_REFRESH": True,
         "MODULES": TEST_MODULES,
+        "PLANNING_USE_XMP_FOR_PIC_ASSIGNMENTS": False,
+        "PLANNING_USE_XMP_FOR_PIC_SLUGLINE": False,
+        "PLANNING_XMP_SLUGLINE_MAPPING": "",
+        "PLANNING_XMP_ASSIGNMENT_MAPPING": "",
+        "PLANNING_LINK_UPDATES_TO_COVERAGES": False,
+        "PLANNING_ALLOW_SCHEDULED_UPDATES": True,
+        "PLANNING_AUTO_ASSIGN_TO_WORKFLOW": False,
+        "ASSIGNMENT_MANUAL_REASSIGNMENT_ONLY": False,
     }
 
     LOG_CONFIG_FILE = env("LOG_CONFIG_FILE", "../e2e/server/logging_config.yml")
@@ -75,25 +84,38 @@ async def before_feature_async(context, feature):
 
 
 async def before_scenario_async(context, scenario):
+    await setup_before_scenario(context, scenario)
+
     # Update app config based on scenario tags
     current_app = context.app
     if "link_updates" in scenario.tags:
         current_app.config["PLANNING_LINK_UPDATES_TO_COVERAGES"] = True
-    else:
-        current_app.config["PLANNING_LINK_UPDATES_TO_COVERAGES"] = False
+    _update_signals_for_link_coverage_updates_setting(current_app)
 
     if "no_scheduled_updates" in scenario.tags:
         current_app.config["PLANNING_ALLOW_SCHEDULED_UPDATES"] = False
-    else:
-        current_app.config["PLANNING_ALLOW_SCHEDULED_UPDATES"] = True
 
     if "skipped" in scenario.tags:
         scenario.mark_skipped()
-
-    await setup_before_scenario(context, scenario)
 
     if "planning_cvs" in scenario.tags:
         async with context.app.app_context():
             cmd = AppPopulateCommand()
             filename = path.join(path.abspath(path.dirname("features/steps/fixtures/")), "vocabularies.json")
             await cmd.run(filename)
+
+
+def _update_signals_for_link_coverage_updates_setting(app):
+    # Update signals based on ``PLANNING_LINK_UPDATES_TO_COVERAGES`` config
+    # As these signals are connected on ``planning.init_app`` which happens on before_feature stage
+    assignments_publish_service = get_resource_service("assignments")
+    app.on_inserted_archive_rewrite -= assignments_publish_service.create_delivery_for_content_update
+    app.on_deleted_resource_archive_rewrite -= (
+        assignments_publish_service.unlink_assignment_on_delete_archive_rewrite
+    )
+
+    if app.config.get("PLANNING_LINK_UPDATES_TO_COVERAGES"):
+        app.on_inserted_archive_rewrite += assignments_publish_service.create_delivery_for_content_update
+        app.on_deleted_resource_archive_rewrite += (
+            assignments_publish_service.unlink_assignment_on_delete_archive_rewrite
+        )

--- a/server/features/planning.feature
+++ b/server/features/planning.feature
@@ -517,24 +517,6 @@ Feature: Planning
     @notification
     @vocabulary
     Scenario: Cancel specific coverage
-        Given "vocabularies"
-        """
-        [{
-          "_id": "newscoveragestatus",
-          "display_name": "News Coverage Status",
-          "type": "manageable",
-          "unique_field": "qcode",
-          "items": [
-              {"is_active": true, "qcode": "ncostat:int", "name": "coverage intended", "label": "Planned"},
-              {"is_active": true, "qcode": "ncostat:notdec", "name": "coverage not decided yet",
-                  "label": "On merit"},
-              {"is_active": true, "qcode": "ncostat:notint", "name": "coverage not intended",
-                  "label": "Not planned"},
-              {"is_active": true, "qcode": "ncostat:onreq", "name": "coverage upon request",
-                  "label": "On request"}
-          ]
-        }]
-        """
         When we post to "planning" with success
         """
         [{
@@ -628,24 +610,6 @@ Feature: Planning
         Given "users"
         """
         [{"_id": "507f191e810c19729de871eb", "name":"testfoo", "email":"foo@122d.com", "username":"johnfoo"}]
-        """
-        Given "vocabularies"
-        """
-        [{
-          "_id": "newscoveragestatus",
-          "display_name": "News Coverage Status",
-          "type": "manageable",
-          "unique_field": "qcode",
-          "items": [
-              {"is_active": true, "qcode": "ncostat:int", "name": "coverage intended", "label": "Planned"},
-              {"is_active": true, "qcode": "ncostat:notdec", "name": "coverage not decided yet",
-                  "label": "On merit"},
-              {"is_active": true, "qcode": "ncostat:notint", "name": "coverage not intended",
-                  "label": "Not planned"},
-              {"is_active": true, "qcode": "ncostat:onreq", "name": "coverage upon request",
-                  "label": "On request"}
-          ]
-        }]
         """
         When we post to "/planning"
         """
@@ -1535,56 +1499,59 @@ Feature: Planning
         [{"_id": "desk_123", "name": "Politic Desk",
          "members": [{"user": "#CONTEXT_USER_ID#"}]}]
         """
-        Given "assignments"
-        """
-        [{
-          "_id": "aaaaaaaaaaaaaaaaaaaaaaaa",
-          "planning_item": "123",
-          "planning": {
-              "ednote": "test coverage, I want 250 words",
-              "headline": "test headline",
-              "slugline": "test slugline",
-              "g2_content_type" : "text",
-              "scheduled": "2029-11-21T14:00:00.000Z"
-          },
-          "assigned_to": {
-              "desk": "desk_123",
-              "user": "#CONTEXT_USER_ID#",
-              "state": "assigned"
-          }
-        }]
-        """
         When we post to "planning" with success
         """
         [{
-          "guid": "123",
-          "headline": "test headline",
-          "slugline": "test slugline",
-          "state": "scheduled",
-          "pubstatus": "usable",
-          "internal_note": "Thanks for all the ",
-          "coverages": [
-              {
-                  "coverage_id": "cov_123",
-                  "planning": {
-                      "ednote": "test coverage, 250 words",
-                      "headline": "test headline",
-                      "slugline": "test slugline",
-                      "scheduled": "2029-11-21T14:00:00.000Z",
-                      "g2_content_type": "text",
-                      "internal_note": "Harmless"
-                  },
-                  "assigned_to": {
+            "guid": "123",
+            "headline": "test headline",
+            "slugline": "test slugline",
+            "state": "scheduled",
+            "pubstatus": "usable",
+            "internal_note": "Thanks for all the ",
+            "coverages": [
+                {
+                    "planning": {
+                        "ednote": "test coverage, 250 words",
+                        "headline": "test headline",
+                        "slugline": "test slugline",
+                        "scheduled": "2029-11-21T14:00:00.000Z",
+                        "g2_content_type": "text",
+                        "internal_note": "Harmless"
+                    },
+                    "assigned_to": {
                         "desk": "#desks._id#",
                         "user": "#CONTEXT_USER_ID#",
-                        "assignment_id": "aaaaaaaaaaaaaaaaaaaaaaaa",
                         "state": "assigned"
-                  },
-                  "workflow_status": "active"
-              }
-          ],
-          "planning_date": "2016-01-02"
+                    },
+                    "workflow_status": "active"
+                }
+            ],
+            "planning_date": "2016-01-02"
         }]
+        """
+        Then we store coverage id in "firstcoverage" from coverage 0
+        Then we store assignment id in "firstassignment" from coverage 0
+        When we reset notifications
+        When we get "/assignments/#firstassignment#"
+        Then we get existing resource
+        """
+        {
+            "planning_item": "123",
+            "coverage_item": "#firstcoverage#",
+            "planning": {
+                "ednote": "test coverage, 250 words",
+                "headline": "test headline",
+                "slugline": "test slugline",
+                "scheduled": "2029-11-21T14:00:00+0000",
+                "g2_content_type": "text",
+                "internal_note": "Harmless"
+            },
+            "assigned_to": {
+                "desk": "desk_123",
+                "user": "#CONTEXT_USER_ID#",
+                "state": "assigned"
+            }
+        }
         """
         When we patch "/planning/#planning._id#"
         """
@@ -1592,7 +1559,7 @@ Feature: Planning
           "internal_note": "Thanks for all the fish",
           "coverages": [
               {
-                  "coverage_id": "cov_123",
+                  "coverage_id": "#firstcoverage#",
                   "planning": {
                       "ednote": "test coverage, 250 words",
                       "headline": "test headline",
@@ -1604,7 +1571,7 @@ Feature: Planning
                   "assigned_to": {
                         "desk": "#desks._id#",
                         "user": "#CONTEXT_USER_ID#",
-                        "assignment_id": "aaaaaaaaaaaaaaaaaaaaaaaa",
+                        "assignment_id": "#firstassignment#",
                         "state": "assigned"
                   },
                   "workflow_status": "active"
@@ -3335,24 +3302,6 @@ Feature: Planning
         Given "desks"
         """
         [{"_id": "desk_123", "name": "Politic Desk"}]
-        """
-        Given "vocabularies"
-        """
-        [{
-          "_id": "newscoveragestatus",
-          "display_name": "News Coverage Status",
-          "type": "manageable",
-          "unique_field": "qcode",
-          "items": [
-              {"is_active": true, "qcode": "ncostat:int", "name": "coverage intended", "label": "Planned"},
-              {"is_active": true, "qcode": "ncostat:notdec", "name": "coverage not decided yet",
-                  "label": "On merit"},
-              {"is_active": true, "qcode": "ncostat:notint", "name": "coverage not intended",
-                  "label": "Not planned"},
-              {"is_active": true, "qcode": "ncostat:onreq", "name": "coverage upon request",
-                  "label": "On request"}
-          ]
-        }]
         """
         Given empty "planning"
         When we post to "planning"

--- a/server/features/planning_cancel.feature
+++ b/server/features/planning_cancel.feature
@@ -161,24 +161,6 @@ Feature: Cancel all coverage
     @notification
     @vocabulary
     Scenario: Posted planning gets updated on cancel all coverage
-      Given "vocabularies"
-      """
-      [{
-          "_id": "newscoveragestatus",
-          "display_name": "News Coverage Status",
-          "type": "manageable",
-          "unique_field": "qcode",
-          "items": [
-              {"is_active": true, "qcode": "ncostat:int", "name": "coverage intended", "label": "Planned"},
-              {"is_active": true, "qcode": "ncostat:notdec", "name": "coverage not decided yet",
-                  "label": "On merit"},
-              {"is_active": true, "qcode": "ncostat:notint", "name": "coverage not intended",
-                  "label": "Not planned"},
-              {"is_active": true, "qcode": "ncostat:onreq", "name": "coverage upon request",
-                  "label": "On request"}
-          ]
-      }]
-      """
       When we post to "planning" with success
       """
       [{
@@ -264,39 +246,6 @@ Feature: Cancel all coverage
     @notification
     @vocabulary
     Scenario: Associated event remains unchanged
-      Given "vocabularies"
-      """
-      [{
-          "_id": "newscoveragestatus",
-          "display_name": "News Coverage Status",
-          "type": "manageable",
-          "unique_field": "qcode",
-          "items": [
-              {"is_active": true, "qcode": "ncostat:int", "name": "coverage intended", "label": "Planned"},
-              {"is_active": true, "qcode": "ncostat:notdec", "name": "coverage not decided yet",
-                  "label": "On merit"},
-              {"is_active": true, "qcode": "ncostat:notint", "name": "coverage not intended",
-                  "label": "Not planned"},
-              {"is_active": true, "qcode": "ncostat:onreq", "name": "coverage upon request",
-                  "label": "On request"}
-          ]
-      },
-      {
-          "_id": "eventoccurstatus",
-          "display_name": "Event Occurence Status",
-          "type": "manageable",
-          "unique_field": "qcode",
-          "items": [
-              {"is_active": true, "qcode": "eocstat:eos0", "name": "Unplanned event"},
-              {"is_active": true, "qcode": "eocstat:eos1", "name": "Planned, occurence planned only"},
-              {"is_active": true, "qcode": "eocstat:eos2", "name": "Planned, occurence highly uncertain"},
-              {"is_active": true, "qcode": "eocstat:eos3", "name": "Planned, May occur"},
-              {"is_active": true, "qcode": "eocstat:eos4", "name": "Planned, occurence highly likely"},
-              {"is_active": true, "qcode": "eocstat:eos5", "name": "Planned, occurs certainly"},
-              {"is_active": true, "qcode": "eocstat:eos6", "name": "Planned, then cancelled"}
-          ]
-        }]
-      """
       Given "contacts"
       """
         [{"first_name": "Albert", "last_name": "Foo"}]
@@ -404,24 +353,6 @@ Feature: Cancel all coverage
     @notification
     @vocabulary
     Scenario: Changes coverage status on cancel all coverage
-      Given "vocabularies"
-      """
-      [{
-          "_id": "newscoveragestatus",
-          "display_name": "News Coverage Status",
-          "type": "manageable",
-          "unique_field": "qcode",
-          "items": [
-              {"is_active": true, "qcode": "ncostat:int", "name": "coverage intended", "label": "Planned"},
-              {"is_active": true, "qcode": "ncostat:notdec", "name": "coverage not decided yet",
-                  "label": "On merit"},
-              {"is_active": true, "qcode": "ncostat:notint", "name": "coverage not intended",
-                  "label": "Not planned"},
-              {"is_active": true, "qcode": "ncostat:onreq", "name": "coverage upon request",
-                  "label": "On request"}
-          ]
-      }]
-      """
       When we post to "planning" with success
       """
       [{
@@ -848,25 +779,7 @@ Feature: Cancel all coverage
     @notification
     @vocabulary
     Scenario: Reason field is required field for cancel all coverage action
-      Given "vocabularies"
-      """
-      [{
-          "_id": "newscoveragestatus",
-          "display_name": "News Coverage Status",
-          "type": "manageable",
-          "unique_field": "qcode",
-          "items": [
-              {"is_active": true, "qcode": "ncostat:int", "name": "coverage intended", "label": "Planned"},
-              {"is_active": true, "qcode": "ncostat:notdec", "name": "coverage not decided yet",
-                  "label": "On merit"},
-              {"is_active": true, "qcode": "ncostat:notint", "name": "coverage not intended",
-                  "label": "Not planned"},
-              {"is_active": true, "qcode": "ncostat:onreq", "name": "coverage upon request",
-                  "label": "On request"}
-          ]
-      }]
-      """
-        And "planning_types"
+      Given "planning_types"
         """
         [
             {

--- a/server/features/planning_featured_post.feature
+++ b/server/features/planning_featured_post.feature
@@ -55,15 +55,19 @@ Feature: Post Featured Planning
             "items": ["#planning._id#"]
         }]
         """
+        Then we get OK response
         When we post to "/products" with success
         """
-        { "name": "prod-1", "codes": "abc", "product_type": "both" }
+        {"name": "prod-1", "codes": "abc", "product_type": "both"}
         """
 
         And we post to "/subscribers" with success
         """
         {
-        "name": "Featured Planning Subscriber", "media_type": "media", "subscriber_type": "digital", "products": ["#products._id#"], "is_active": true,
+        "name": "Featured Planning Subscriber", "media_type": "media", "subscriber_type": "digital",
+        "products": ["#products._id#"],
+        "is_active": true,
+        "email": "test@test.com",
         "codes": "abc",
         "destinations": [{
             "name": "planning_featured",

--- a/server/features/planning_recurring.feature
+++ b/server/features/planning_recurring.feature
@@ -282,14 +282,14 @@ Feature: Recurring Events & Planning
                             "slugline": "test text slugline v3",
                             "scheduled": "2024-11-22T17:00:00+0000",
                             "g2_content_type": "text",
-                            "news_coverage_status": {"qcode": "ncostat:int"}
+                            "news_coverage_status": "ncostat:int"
                         },
                         {
                             "coverage_id": "#PIC_COVERAGE_2_ID#",
                             "slugline": "test pic slugline v3",
                             "scheduled": "2024-11-22T18:00:00+0000",
                             "g2_content_type": "picture",
-                            "news_coverage_status": {"qcode": "ncostat:int"}
+                            "news_coverage_status": "ncostat:int"
                         }
                     ]
                 }
@@ -603,14 +603,14 @@ Feature: Recurring Events & Planning
                             "slugline": "test text slugline v3",
                             "scheduled": "2024-11-22T17:00:00+0000",
                             "g2_content_type": "text",
-                            "news_coverage_status": {"qcode": "ncostat:int"}
+                            "news_coverage_status": "ncostat:int"
                         },
                         {
                             "coverage_id": "#PIC_COVERAGE_3_ID#",
                             "slugline": "test pic slugline v3",
                             "scheduled": "2024-11-22T18:00:00+0000",
                             "g2_content_type": "picture",
-                            "news_coverage_status": {"qcode": "ncostat:int"}
+                            "news_coverage_status": "ncostat:int"
                         },
                         {
                             "coverage_id": "6834696421f83fc293588ae9",

--- a/server/features/planning_validate.feature
+++ b/server/features/planning_validate.feature
@@ -56,16 +56,6 @@ Feature: Planning Validate
             }
         }]
         """
-        Given the "vocabularies"
-        """
-        [{
-            "_id": "event_calendars",
-            "display_name": "Event Calendars",
-            "type": "manageable",
-            "unique_field": "qcode",
-            "items": [{"is_active": true, "name": "Calendar 1", "qcode": "cal1"}]
-        }]
-        """
 
     @auth
     @vocabulary
@@ -105,7 +95,7 @@ Feature: Planning Validate
         """
         {
             "slugline": "Test slugger",
-            "calendars": [{"qcode": "cal1", "name": "Calendar 1"}],
+            "calendars": [{"qcode": "sport", "name": "Sport"}],
             "dates": {
                 "start": "2029-11-21T01:00:00.000Z",
                 "end": "2029-11-21T04:00:00.000Z",
@@ -149,7 +139,7 @@ Feature: Planning Validate
         """
         {
             "slugline": "Test slugger",
-            "calendars": [{"qcode": "cal1", "name": "Calendar 1"}],
+            "calendars": [{"qcode": "sport", "name": "Sport"}],
             "dates": {
                 "start": "2029-11-21T01:00:00.000Z",
                 "end": "2029-11-21T04:00:00.000Z",
@@ -205,7 +195,7 @@ Feature: Planning Validate
         """
         {
             "slugline": "Test slugger",
-            "calendars": [{"qcode": "cal1", "name": "Calendar 1"}],
+            "calendars": [{"qcode": "sport", "name": "Sport"}],
             "update_method": "all",
             "dates": {
                 "start": "2029-11-21T01:00:00.000Z",

--- a/server/features/publish.feature
+++ b/server/features/publish.feature
@@ -81,8 +81,7 @@ Feature: Publish
         Then we get list with 1 items
         Then we store "PUBLISHQUEUE" with first item
         When we transmit items
-        # TODO-ASYNC: Modify ``MockPublishExchangeFactory`` to support file transmitters
-#        Then versioned file exists "/tmp/123-#PUBLISHQUEUE.item_version#-1.txt"
+        Then versioned file exists "/tmp/123-#PUBLISHQUEUE.item_version#-1.txt"
         When we get "published_planning?where={\"item_id\": \"#PUBLISHQUEUE.item_id#\", \"version\": #PUBLISHQUEUE.item_version#}"
         Then we get list with 1 items
         """
@@ -185,8 +184,7 @@ Feature: Publish
             {"_items": [{"state": "success"}]}
         """
         Then we store "PUBLISHQUEUE" with first item
-        # TODO-ASYNC: Modify ``MockPublishExchangeFactory`` to support file transmitters
-#        Then versioned file exists "/tmp/123-#PUBLISHQUEUE.item_version#-1.txt"
+        Then versioned file exists "/tmp/124-#PUBLISHQUEUE.item_version#-1.txt"
 
     @auth
     Scenario: Post non existing event
@@ -321,8 +319,7 @@ Feature: Publish
         Then we store "PUBLISHQUEUE" with first item
 
         When we transmit items
-        # TODO-ASYNC: Modify ``MockPublishExchangeFactory`` to support file transmitters
-#        Then versioned file exists "/tmp/123-#PUBLISHQUEUE.item_version#-1.txt"
+        Then versioned file exists "/tmp/126-#PUBLISHQUEUE.item_version#-1.txt"
 
     @auth
     Scenario: Patch state of ingested event (SDNTB-568 regression test)

--- a/server/features/search_combined.feature
+++ b/server/features/search_combined.feature
@@ -120,6 +120,8 @@ Feature: Search Events and Planning
 
     @auth
     Scenario: Users can only see their events without the planning_global_filters privilege
+        Given empty "events"
+        And empty "planning"
         Given "events"
         """
         [{

--- a/server/features/search_events.feature
+++ b/server/features/search_events.feature
@@ -315,6 +315,7 @@ Feature: Event Search
 
     @auth
     Scenario: Users can only see their events without the planning_global_filters privilege
+        Given empty "events"
         Given "events"
         """
         [{

--- a/server/features/search_planning.feature
+++ b/server/features/search_planning.feature
@@ -642,6 +642,7 @@ Feature: Planning Search
 
     @auth
     Scenario: Users can only see their planning items without the planning_global_filters privilege
+        Given empty "planning"
         Given "planning"
         """
         [{

--- a/server/features/steps/steps.py
+++ b/server/features/steps/steps.py
@@ -432,7 +432,7 @@ def then_set_assignment_manual_reassignment_only(context):
 def then_set_use_xmp_for_pic_assignments(context):
     ABS_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), "../"))
     BEHAVE_TESTS_FIXTURES_PATH = ABS_PATH + "/steps/fixtures"
-    context.app.settings["BEHAVE_TESTS_FIXTURES_PATH"] = BEHAVE_TESTS_FIXTURES_PATH
+    context.app.config["BEHAVE_TESTS_FIXTURES_PATH"] = BEHAVE_TESTS_FIXTURES_PATH
     context.app.config["PLANNING_USE_XMP_FOR_PIC_ASSIGNMENTS"] = True
 
 
@@ -440,7 +440,7 @@ def then_set_use_xmp_for_pic_assignments(context):
 def then_set_xmp_assignment_mapping(context):
     ABS_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), "../"))
     BEHAVE_TESTS_FIXTURES_PATH = ABS_PATH + "/steps/fixtures"
-    context.app.settings["BEHAVE_TESTS_FIXTURES_PATH"] = BEHAVE_TESTS_FIXTURES_PATH
+    context.app.config["BEHAVE_TESTS_FIXTURES_PATH"] = BEHAVE_TESTS_FIXTURES_PATH
     context.app.config["PLANNING_USE_XMP_FOR_PIC_ASSIGNMENTS"] = True
     context.app.config["PLANNING_XMP_ASSIGNMENT_MAPPING"] = {
         "xpath": "//x:xmpmeta/rdf:RDF/rdf:Description",
@@ -457,7 +457,7 @@ def then_set_xmp_assignment_mapping(context):
 def then_set_xmp_slugline_mapping(context):
     ABS_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), "../"))
     BEHAVE_TESTS_FIXTURES_PATH = ABS_PATH + "/steps/fixtures"
-    context.app.settings["BEHAVE_TESTS_FIXTURES_PATH"] = BEHAVE_TESTS_FIXTURES_PATH
+    context.app.config["BEHAVE_TESTS_FIXTURES_PATH"] = BEHAVE_TESTS_FIXTURES_PATH
     context.app.config["PLANNING_USE_XMP_FOR_PIC_SLUGLINE"] = True
     context.app.config["PLANNING_XMP_SLUGLINE_MAPPING"] = {
         "xpath": "//x:xmpmeta/rdf:RDF/rdf:Description/dc:title/rdf:Alt/rdf:li",
@@ -474,7 +474,7 @@ def then_set_xmp_slugline_mapping(context):
 def then_set_use_xmp_for_pic_slugline(context):
     ABS_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), "../"))
     BEHAVE_TESTS_FIXTURES_PATH = ABS_PATH + "/steps/fixtures"
-    context.app.settings["BEHAVE_TESTS_FIXTURES_PATH"] = BEHAVE_TESTS_FIXTURES_PATH
+    context.app.config["BEHAVE_TESTS_FIXTURES_PATH"] = BEHAVE_TESTS_FIXTURES_PATH
     context.app.config["PLANNING_USE_XMP_FOR_PIC_SLUGLINE"] = True
 
 

--- a/server/planning/assignments/assignments.py
+++ b/server/planning/assignments/assignments.py
@@ -1028,7 +1028,7 @@ class AssignmentsService(AsyncBaseService):
             user_id = assignment_update_data.get("item_user_id")
             if assignment.get(LOCK_SESSION) and user_id:
                 lock_service = get_component(LockService)
-                lock_service.unlock(assignment, user_id, get_auth()["_id"], "assignments")
+                await lock_service.unlock(assignment, user_id, get_auth()["_id"], "assignments")
 
     async def on_events_updated(self, updates: dict[str, Any], original: EventResourceModel):
         """Send assignment notifications if any relevant Event metadata has changed"""
@@ -1194,13 +1194,13 @@ class AssignmentsService(AsyncBaseService):
             or await get_resource_service("archive").count_async({"assignment_id": assignment[ID_FIELD]}) <= 1
         ):
             lock_service = get_component(LockService)
-            lock_service.lock(assignment, user_id, get_auth()["_id"], "content_edit", "assignments")
+            await lock_service.lock(assignment, user_id, get_auth()["_id"], "content_edit", "assignments")
 
     async def sync_assignment_unlock(self, item, user_id):
         assignment = await self._get_assignment_from_archive_item({}, item)
         if assignment and assignment.get(LOCK_USER) and assignment.get(LOCK_ACTION) == "content_edit":
             lock_service = get_component(LockService)
-            lock_service.unlock(assignment, user_id, get_auth()["_id"], "assignments")
+            await lock_service.unlock(assignment, user_id, get_auth()["_id"], "assignments")
 
     def can_edit(self, item, user_id):
         # Check privileges

--- a/server/planning/assignments/assignments_complete.py
+++ b/server/planning/assignments/assignments_complete.py
@@ -121,7 +121,7 @@ class AssignmentsCompleteService(AsyncBaseService):
         item = await self.backend.update_async(self.datasource, id, updates, original)
 
         # publish the planning item
-        assignments_service.publish_planning(original["planning_item"])
+        await assignments_service.publish_planning(original["planning_item"])
 
         # Save history if user initiates complete
         assignments_history_service = AssignmentsHistoryAsyncService()

--- a/server/planning/assignments/assignments_revert.py
+++ b/server/planning/assignments/assignments_revert.py
@@ -76,7 +76,7 @@ class AssignmentsRevertService(AsyncBaseService):
         )
 
         # publish the planning item
-        get_resource_service("assignments").publish_planning(original.get("planning_item"))
+        await get_resource_service("assignments").publish_planning(original.get("planning_item"))
 
         # External (slack/browser pop-up) notifications
         assignments_service = get_resource_service("assignments")

--- a/server/planning/events/events_post.py
+++ b/server/planning/events/events_post.py
@@ -140,7 +140,7 @@ class EventsPostService(AsyncBaseService):
         # First we want to validate that all events can be posted
         for event in posted_events:
             self.validate_post_state(post_to_state)
-            # self.validate_item(event)
+            await self.validate_item(event)
 
         # Next we perform the actual post
         updated_event = None

--- a/server/planning/planning/planning_duplicate.py
+++ b/server/planning/planning/planning_duplicate.py
@@ -13,6 +13,7 @@ from copy import deepcopy
 from typing import Any
 
 from superdesk.core import get_app_config
+from superdesk import get_resource_service
 from superdesk.resource_fields import ID_FIELD
 from superdesk.metadata.utils import generate_guid
 from superdesk.metadata.item import GUID_NEWSML
@@ -25,15 +26,14 @@ from planning.common import (
     get_coverage_status_from_cv,
     get_config_planning_duplicate_retain_assignee_details,
 )
-from planning.planning import PlanningAsyncService, PlanningHistoryAsyncService
-from planning.types.planning import PlanningResourceModel
+from planning.planning import PlanningHistoryAsyncService
 from planning.utils import get_related_event_links_for_planning, get_related_event_items_for_planning
 
 
 logger = logging.getLogger(__name__)
 
 
-def duplicate_planning_item(original: dict[str, Any]) -> PlanningResourceModel:
+def duplicate_planning_item(original: dict[str, Any]) -> dict:
     new_plan = deepcopy(original)
     related_events = get_related_event_links_for_planning(original)
 
@@ -97,7 +97,7 @@ def duplicate_planning_item(original: dict[str, Any]) -> PlanningResourceModel:
         if not get_config_planning_duplicate_retain_assignee_details():
             cov.pop("assigned_to", None)
 
-    return PlanningResourceModel(**new_plan)
+    return new_plan
 
 
 async def process_planning_item_duplicate(parent_plan: dict[str, Any]) -> dict[str, Any]:
@@ -107,18 +107,17 @@ async def process_planning_item_duplicate(parent_plan: dict[str, Any]) -> dict[s
     :param original: The original planning item.
     :return: List of new planning item guid.
     """
-    planning_service = PlanningAsyncService()
+    planning_service = get_resource_service("planning")
     history_service = PlanningHistoryAsyncService()
 
     parent_id = parent_plan[ID_FIELD]
     new_plan = duplicate_planning_item(parent_plan)
-    new_plan_dict = new_plan.to_dict()
 
-    await planning_service.on_create([new_plan])
-    await planning_service.create([new_plan])
+    await planning_service.on_create_async([new_plan])
+    await planning_service.create_async([new_plan])
 
-    await history_service.on_duplicate(parent_plan, new_plan_dict)
-    await history_service.on_duplicate_from(new_plan_dict, parent_id)
-    await planning_service.on_duplicated(new_plan_dict, parent_id)
+    await history_service.on_duplicate(parent_plan, new_plan)
+    await history_service.on_duplicate_from(new_plan, parent_id)
+    await planning_service.on_duplicated(new_plan, parent_id)
 
-    return new_plan_dict
+    return new_plan

--- a/server/planning/planning/planning_featured_async_service.py
+++ b/server/planning/planning/planning_featured_async_service.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from typing import Any
 from copy import deepcopy
 
@@ -12,12 +11,8 @@ from planning.common import (
 from planning.planning.planning_service import PlanningAsyncService
 from planning.types import PlanningFeaturedResourceModel
 from superdesk import get_resource_service, logger
-from superdesk.core import get_app_config
-from superdesk.core.types import SearchRequest
 from superdesk.errors import SuperdeskApiError
-from superdesk.utc import utc_to_local, utcnow
-
-ID_DATE_FORMAT = "%Y%m%d"
+from superdesk.utc import utcnow
 
 
 class PlanningFeaturedAsyncService(BasePlanningAsyncService[PlanningFeaturedResourceModel]):
@@ -27,16 +22,11 @@ class PlanningFeaturedAsyncService(BasePlanningAsyncService[PlanningFeaturedReso
         await super().on_create(docs)
 
         for doc in docs:
-            date = utc_to_local(doc.tz or get_app_config("DEFAULT_TIMEZONE"), doc.date)
-            _id = date.strftime(ID_DATE_FORMAT)
-
-            search_request = SearchRequest(where={"_id": _id})
-            items = await super().find(search_request)
+            items = await super().find({"_id": doc.id})
             if await items.count() > 0:
                 raise SuperdeskApiError.badRequestError(message="Featured story already exists for this date.")
 
             await self.validate_featured_attrribute(doc.items)
-            doc.id = _id
             await self.post_featured_planning(doc)
 
     async def on_created(self, docs: list[PlanningFeaturedResourceModel]):
@@ -50,11 +40,11 @@ class PlanningFeaturedAsyncService(BasePlanningAsyncService[PlanningFeaturedReso
         # Find all planning items in the list
         added_featured = [item_id for item_id in updates.get("items") or [] if item_id not in original.items or []]
         await self.validate_featured_attrribute(added_featured)
-        await self.post_featured_planning(PlanningFeaturedResourceModel(**updates), original)
+        await self.post_featured_planning(original.clone_with(updates), original)
 
     async def on_updated(self, updates: dict[str, Any], original: PlanningFeaturedResourceModel):
         await super().on_updated(updates, original)
-        await self.enqueue_published_item(PlanningFeaturedResourceModel(**updates), original)
+        await self.enqueue_published_item(original.clone_with(updates), original)
 
     async def post_featured_planning(
         self, updates: PlanningFeaturedResourceModel, original: PlanningFeaturedResourceModel | None = None
@@ -105,7 +95,3 @@ class PlanningFeaturedAsyncService(BasePlanningAsyncService[PlanningFeaturedReso
                 raise SuperdeskApiError.badRequestError(
                     message="Not all planning items are posted. Aborting post action."
                 )
-
-    def get_id_for_date(self, date: datetime) -> str:
-        local_date = utc_to_local(get_app_config("DEFAULT_TIMEZONE"), date)
-        return local_date.strftime(ID_DATE_FORMAT)

--- a/server/planning/planning/planning_spike.py
+++ b/server/planning/planning/planning_spike.py
@@ -8,6 +8,7 @@ from superdesk.errors import SuperdeskApiError
 from apps.auth import get_user, get_user_id
 from apps.archive.common import get_auth
 
+from planning import signals
 from planning.assignments import AssignmentsAsyncService
 from planning.common import (
     ITEM_EXPIRY,
@@ -18,9 +19,7 @@ from planning.common import (
     remove_autosave_on_spike,
     remove_lock_information,
 )
-from planning.events import EventsAsyncService
 from planning.item_lock import LOCK_USER
-from planning.planning import PlanningAsyncService
 from planning.planning.planning_utils import delete_assignments_for_coverages
 from planning.planning_notifications import PlanningNotifications
 from planning.utils import get_related_event_ids_for_planning, get_first_related_event_id_for_planning
@@ -42,7 +41,7 @@ def post_update_planning_item_actions(updates: dict[str, Any], original: dict[st
 
 async def post_planning_item_spike_actions(updates: dict[str, Any], original: dict[str, Any]):
     post_update_planning_item_actions(updates, original)
-    events_service = EventsAsyncService()
+    events_service = get_resource_service("events")
 
     # Delete assignments in workflow
     assignments_to_delete = []
@@ -55,7 +54,7 @@ async def post_planning_item_spike_actions(updates: dict[str, Any], original: di
     first_event_id = get_first_related_event_id_for_planning(original, "primary")
 
     if first_event_id:
-        event = await events_service.find_by_id_raw(first_event_id)
+        event = await events_service.find_one_async(req=None, _id=first_event_id)
         notify_user_on_failed_assignment_deletes = not event or event.get("state") != WORKFLOW_STATE.SPIKED
 
     await delete_assignments_for_coverages(assignments_to_delete, notify_user_on_failed_assignment_deletes)
@@ -126,7 +125,8 @@ async def process_spike_planning_item(updates: dict[str, Any], original: dict[st
     await remove_autosave_on_spike(original)
 
     planning_item_id = original[ID_FIELD]
-    await planning_service.system_update_async(planning_item_id, updates, original)
+    await planning_service.update_async(planning_item_id, updates, original)
+    await signals.planning_spiked.send(updates, original)
     spiked_planning_item = await planning_service.find_one_async(req=None, _id=planning_item_id)
     assert spiked_planning_item is not None, "Expected spiked_planning to be a dict, got None"
 
@@ -157,12 +157,12 @@ async def process_unspike_planning_item(updates: dict[str, Any], original: dict[
     :param original: The original planning document.
     :return: The updated planning document.
     """
-    planning_service = PlanningAsyncService()
-    events_service = EventsAsyncService()
+    planning_service = get_resource_service("planning")
+    events_service = get_resource_service("events")
 
     first_event_id = get_first_related_event_id_for_planning(original, "primary")
     if first_event_id:
-        event = await events_service.find_by_id_raw(first_event_id)
+        event = await events_service.find_one_async(req=None, _id=first_event_id)
         if event and event.get("state") == WORKFLOW_STATE.SPIKED:
             raise SuperdeskApiError.badRequestError(message="Unspike failed. Associated event is spiked.")
 
@@ -172,8 +172,9 @@ async def process_unspike_planning_item(updates: dict[str, Any], original: dict[
     remove_lock_information(updates)
 
     planning_item_id = original[ID_FIELD]
-    await planning_service.system_update(planning_item_id, updates)
-    unspiked_planning_item = await planning_service.find_by_id_raw(planning_item_id)
+    await planning_service.update_async(planning_item_id, updates, original)
+    await signals.planning_unspiked.send(updates, original)
+    unspiked_planning_item = await planning_service.find_one_async(req=None, _id=planning_item_id)
     assert unspiked_planning_item is not None, "Expected unspiked_planning to be a dict, got None"
 
     push_notification(

--- a/server/planning/planning/views.py
+++ b/server/planning/planning/views.py
@@ -65,6 +65,7 @@ async def duplicate_planning_item(args: PlanningArgs, params: None, request: Req
 
     duplicated_planning_item = await process_planning_item_duplicate(original)
 
+    duplicated_planning_item["_status"] = "OK"
     return Response(duplicated_planning_item)
 
 

--- a/server/planning/planning_notifications.py
+++ b/server/planning/planning_notifications.py
@@ -382,7 +382,7 @@ async def _send_user_email(user_id, contact_id, source, meta_message, data):
             name = get_assginment_name(data.get("assignment"))
             attachments.append(Attachment(filename=name, content_type="text/calendar", data=ics))
 
-    send_email(
+    await send_email(
         subject=data["subject"],
         sender=admins[0],
         recipients=[email_address],

--- a/server/planning/search/planning_search.py
+++ b/server/planning/search/planning_search.py
@@ -121,12 +121,17 @@ class PlanningSearchService(AsyncBaseService):
         """Run the query against events and planning indexes"""
         query = self._get_query(req)
         types = self._get_types(req)
-        indexes = self.get_indexes_for_search(types)
-        projection = self.get_projection(req)
+        fields = self._get_projected_fields(req)
 
-        elastic = EventResourceModel.get_service().elastic
-        hits = await elastic.search(fix_query(query), indexes, projection)
-        cursor = self.elastic_async._parse_hits_async(hits, types[0])
+        params = {}
+        if fields:
+            # If projections are provided, make sure `type` is always included
+            if "type" not in fields:
+                fields += ",type"
+
+            params["_source"] = fields
+
+        cursor = await self.elastic_async.search(query, types, params)
 
         await self._format_docs(cursor)
 

--- a/server/planning/types/planning_featured.py
+++ b/server/planning/types/planning_featured.py
@@ -40,7 +40,6 @@ class PlanningFeaturedResourceModel(BasePlanningModel):
         elif isinstance(values["date"], str):
             values["date"] = parse_date(values["date"])
 
-        # print(values)
         date = utc_to_local(values["tz"], values["date"])
         values["_id"] = date.strftime(ID_DATE_FORMAT)
         return values

--- a/server/planning/types/planning_featured.py
+++ b/server/planning/types/planning_featured.py
@@ -1,14 +1,21 @@
 from datetime import datetime
-from pydantic import Field
-from typing import Annotated
+from pydantic import Field, model_validator
+from typing import Annotated, Union
 
-from .base import BasePlanningModel
-from superdesk.utc import utcnow
+from eve_elastic.elastic import parse_date
+
+from superdesk.utc import utcnow, utc_to_local
+from superdesk.core import get_config
 from superdesk.core.resources import fields
 from superdesk.core.resources.validators import validate_data_relation_async
 
+from .base import BasePlanningModel
+
+ID_DATE_FORMAT = "%Y%m%d"
+
 
 class PlanningFeaturedResourceModel(BasePlanningModel):
+    id: Annotated[str, Field(alias="_id")]
     date: datetime = Field(default_factory=utcnow)
     items: list[str] = Field(default_factory=list)
     tz: str | None = None
@@ -20,3 +27,20 @@ class PlanningFeaturedResourceModel(BasePlanningModel):
     item_type: str = Field(
         alias="type", default="planning_featured", description="Item type used by superdesk publishing"
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def set_id(
+        cls, values: Union[dict, "PlanningFeaturedResourceModel"]
+    ) -> Union[dict, "PlanningFeaturedResourceModel"]:
+        values.setdefault("tz", get_config(str, "DEFAULT_TIMEZONE"))
+
+        if not values.get("date"):
+            values["date"] = utcnow()
+        elif isinstance(values["date"], str):
+            values["date"] = parse_date(values["date"])
+
+        # print(values)
+        date = utc_to_local(values["tz"], values["date"])
+        values["_id"] = date.strftime(ID_DATE_FORMAT)
+        return values


### PR DESCRIPTION
### Purpose
To get all the behave tests passing

### What has changed
* Fix Assignment locks (missing `await` prefix)
* Fix Assignment publish Planning (missing `await` prefix)
* Fix Event publish validation (validation statement was commented out from early on in project)
* Fix remaining Planning actions (use Eve services, use `update_async` instead of `patch_async`, make sure to call signals)
* Fix sending email notifications (missing `await` prefix)
* Fix FeaturedPlanning ID generation (was being done on the service, I moved it onto the Model itself)
* Fix base PlanningSearch (migrated to use our async eve elastic service as previous version of newer elastic client was failing on projections).
