### PR TITLE
[STT-47] - Small fix on location item preview

### DIFF
--- a/client/components/GeoLookupInput/LocationItem.tsx
+++ b/client/components/GeoLookupInput/LocationItem.tsx
@@ -8,7 +8,7 @@ import {Item, Column, Row, Border, ActionMenu} from '../UI/List';
 import {Button} from '../UI';
 import {Location} from '../Location';
 
-import {onEventCapture} from '../../utils';
+import {eventUtils, onEventCapture} from '../../utils';
 import {formatLocationToAddress} from '../../utils/locations';
 
 interface IProps {
@@ -41,7 +41,7 @@ export class LocationItem extends React.PureComponent<IProps> {
                             name={locationNameComputed}
                             address={formatLocationToAddress(this.props.location)}
                             multiLine={true}
-                            details={location.details?.[0]}
+                            details={eventUtils.normalizeLocationDetails(location?.details)}
                         />
                         <ActionMenu className="pull-right">
                             {(this.props.readOnly || this.props.onRemoveLocation == null) ? null : (

--- a/client/components/fields/editor/Location.tsx
+++ b/client/components/fields/editor/Location.tsx
@@ -28,7 +28,7 @@ export class EditorFieldLocation extends React.PureComponent<IEditorFieldLocatio
                         {...this.props}
                         field={'location.details'}
                         label={gettext('Location Details')}
-                        value={this.props.item[field]?.location_details ?? ''}
+                        value={this.props.item[field]?.details ?? ''}
                     />
                 </Row>
             </div>


### PR DESCRIPTION
### Purpose
This PR fixes a small display issue where details on the LocationItem card during editing showed the first character of the details alone.

### What has changed
- Passed the details value in the new helper function to normalize it into a string then render it.

### Screenshots

#### Before
![image](https://github.com/user-attachments/assets/6e89a5f5-37fc-452c-bb76-a8bb48d25f15)

#### After
![image](https://github.com/user-attachments/assets/6918b0cc-8773-40ad-8b1e-32208f73789e)


Resolves: #[STT-47]



[STT-47]: https://sofab.atlassian.net/browse/STT-47?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ