### PR TITLE
Accreditation should not be automatically filled in - fix

### DIFF
--- a/client/components/fields/editor/base/dateTimeUIFramework.tsx
+++ b/client/components/fields/editor/base/dateTimeUIFramework.tsx
@@ -71,6 +71,7 @@ export class EditorFieldDateTimeUIFramework extends React.PureComponent<IProps> 
                             : {}
                     }
                     required={this.props.schema?.required}
+                    timeRequiresDate
                     onChange={(value) => {
                         const dateTimeString = value.time != null
                             ? new Date(`${value.date} ${value.time}`).toISOString()


### PR DESCRIPTION
SDBELGA-859

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

### Front-end checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [x] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [x] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [x] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [x] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [x] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [x] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [x] This pull request is not adding redux based modals
- [x] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [x] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)

Resolves: #[issue-number]

