### PR TITLE
[SDESK-7591] Fix missing await call on cursor count

### DIFF
--- a/server/planning/commands/export_scheduled_filters.py
+++ b/server/planning/commands/export_scheduled_filters.py
@@ -143,7 +143,7 @@ class ExportScheduledFilters:
             search_filter["_id"], projections=["_id"], args={"start_of_week": start_of_week}
         )
 
-        if not items.count():
+        if not await items.count():
             search_filter_id = search_filter["_id"]
             logger.info(f"No items found for filter {search_filter_id}")
             return


### PR DESCRIPTION
### Purpose
Similarly to https://github.com/superdesk/superdesk-core/pull/2965 this fixes another error found on logs from `sd-async` instance. 

[SDESK-7591]



[SDESK-7591]: https://sofab.atlassian.net/browse/SDESK-7591?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ