### PR TITLE
[SDESK-7681] - Rescheduling of a recurring event yields errors

### DIFF
--- a/client/utils/events.tsx
+++ b/client/utils/events.tsx
@@ -1271,6 +1271,10 @@ function modifyForServer(event: IEventItem, removeNullLinks: boolean = false) {
         event.dates.end = event.dates.end.toISOString();
     }
 
+    if (event.dates?.recurring_rule?.until != null && moment.isMoment(event.dates.recurring_rule.until)) {
+        event.dates.recurring_rule.until = event.dates.recurring_rule.until.toISOString();
+    }
+
     return event;
 }
 


### PR DESCRIPTION
### Purpose
This PR fixes an issue where a normal update to a recurring event (e.g. changing the slugline) fails due to `moment` objects lingering in the `dates.recurring_rule.until` field. This field remains unnormalized after a previous rescheduling action, and is incorrectly treated as a new update—even though no change occurred—because it's still a `moment` object.

### What has changed
- Updated `modifyForServer()` to ensure `dates.recurring_rule.until` is always serialized to an ISO string, regardless of timezone context. This prevents the `getEventDiff()` function from falsely detecting `until` as an update 

### Steps to test
1. Create a recurring event with no time specified.
2. Go to Reschedule and provide a valid date/time. Confirm the event is successfully rescheduled.
3. Then open the same event and perform a minor unrelated update like changing the slugline.
4. Click Save and ensure the update succeeds.
5. Observe that no `dates.recurring_rule.until` field is being unnecessarily sent unless actually changed.

Resolves: [SDESK-7681](https://sofab.atlassian.net/browse/SDESK-7681)

[SDESK-7681]: https://sofab.atlassian.net/browse/SDESK-7681?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ