### PR TITLE
update client core

### DIFF
--- a/e2e/cypress/support/common/inputs/coverageUserSelectInput.ts
+++ b/e2e/cypress/support/common/inputs/coverageUserSelectInput.ts
@@ -8,12 +8,12 @@ import {Popup} from '../ui';
 export class CoverageUserSelectInput extends Input {
     type(value) {
         cy.log('Common.SearchableSelectInput.type');
-        const popup = new Popup('.p-dropdown-panel');
+        const popup = new Popup('[data-test-id="tree-select-popover"]');
 
         this.element.click();
         popup.waitTillOpen();
 
-        popup.element.find('input')
+        popup.element.find('[data-test-id="filter-input"]')
             .type(value);
 
         popup.element.find('li')

--- a/e2e/cypress/support/planning/assignments/assignmentEditor.ts
+++ b/e2e/cypress/support/planning/assignments/assignmentEditor.ts
@@ -1,7 +1,7 @@
 import {get} from 'lodash';
 
 import {Modal} from '../../common/ui';
-import {SelectInput, UserSelectInput} from '../../common/inputs';
+import {CoverageUserSelectInput, SelectInput} from '../../common/inputs';
 
 /**
  * Wrapper class for Superdesk's Assignment popup editor
@@ -14,7 +14,7 @@ export class AssignmentEditor extends Modal {
         this.fields = {
             desk: new SelectInput(() => this.element, 'select[name="assigned_to.desk"]'),
             coverage_provider: new SelectInput(() => this.element, 'select[name="assigned_to.coverage_provider"]'),
-            user: new UserSelectInput(() => this.element, '[data-test-id="assigned_to.user"]'),
+            user: new CoverageUserSelectInput(() => this.element, '[data-test-id="assigned_to.user"]'),
         };
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -173,9 +173,9 @@
       "dev": true
     },
     "@sourcefabric/common": {
-      "version": "0.0.63",
-      "resolved": "https://registry.npmjs.org/@sourcefabric/common/-/common-0.0.63.tgz",
-      "integrity": "sha512-YG/hWOt+KToNafaAMYW0/T4QiSLxx5mD4VhWvu3G5NTSFcfASwmiR3hpb7QzUOP6akFiQZ42V2JYhQZMsJNySw==",
+      "version": "0.0.64",
+      "resolved": "https://registry.npmjs.org/@sourcefabric/common/-/common-0.0.64.tgz",
+      "integrity": "sha512-PXRRxt+Y0t1nawZ5jDifOvzoXD3QlwzQXB8Vu3RJx+Drwtwsx11ih7xXETjRb329xG1ZT+qRqvmPd87lyI+zJA==",
       "dev": true,
       "requires": {
         "date-fns": "2.7.0",
@@ -3378,9 +3378,9 @@
       }
     },
     "end-of-stream": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
       "dev": true,
       "requires": {
         "once": "^1.4.0"
@@ -8591,9 +8591,9 @@
       "dev": true
     },
     "postcss": {
-      "version": "8.5.5",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.5.tgz",
-      "integrity": "sha512-d/jtm+rdNT8tpXuHY5MMtcbJFBkhXE6593XVR9UoGCH8jSFGci7jGvMGH5RYd5PBJW+00NZQt6gf7CbagJCrhg==",
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
       "dev": true,
       "requires": {
         "nanoid": "^3.3.11",
@@ -8835,9 +8835,9 @@
       }
     },
     "pump": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
-      "integrity": "sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
       "dev": true,
       "requires": {
         "end-of-stream": "^1.1.0",
@@ -11053,13 +11053,13 @@
       }
     },
     "superdesk-core": {
-      "version": "github:superdesk/superdesk-client-core#6ac2650a5be30e3d56f34802d21ae8ab5907a848",
+      "version": "github:superdesk/superdesk-client-core#3b2a2e1f8ce77bb9a14e7d4b4f8317cba1bbdad0",
       "from": "github:superdesk/superdesk-client-core#develop",
       "dev": true,
       "requires": {
         "@metadata/exif": "github:superdesk/exif#431066d",
         "@popperjs/core": "2.10.2",
-        "@sourcefabric/common": "0.0.63",
+        "@sourcefabric/common": "0.0.64",
         "@sourcefabric/draft-js": "^0.11.5",
         "@superdesk/common": "0.0.17",
         "@types/angular": "~1.6.0",
@@ -11319,6 +11319,21 @@
             "weekstart": "^2.0.0"
           },
           "dependencies": {
+            "@sourcefabric/common": {
+              "version": "0.0.63",
+              "resolved": "https://registry.npmjs.org/@sourcefabric/common/-/common-0.0.63.tgz",
+              "integrity": "sha512-YG/hWOt+KToNafaAMYW0/T4QiSLxx5mD4VhWvu3G5NTSFcfASwmiR3hpb7QzUOP6akFiQZ42V2JYhQZMsJNySw==",
+              "dev": true,
+              "requires": {
+                "date-fns": "2.7.0",
+                "lodash": "4.17.19",
+                "primereact": "^6.0.2",
+                "react": "16.9.0",
+                "react-dom": "16.9.0",
+                "react-sortable-hoc": "^1.11.0",
+                "tippy.js": "^6.3.7"
+              }
+            },
             "date-fns": {
               "version": "2.7.0",
               "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.7.0.tgz",


### PR DESCRIPTION
and fix failing e2e

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

### Front-end checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)

Resolves: #[issue-number]

