### PR TITLE
[SDESK-7675] - Event freezes and gets locked when saving after adding a related planning

### DIFF
--- a/client/reducers/locks.ts
+++ b/client/reducers/locks.ts
@@ -85,6 +85,17 @@ export default createReducer(initialLockState, {
         }
 
         for (const relatedEventId of getRelatedEventIdsForPlanning(planning, 'primary')) {
+            const currentLock = nextEventLocks[relatedEventId];
+
+            // If planning lock is empty, don't overwrite existing event lock
+            if (
+                planning.lock_user == null &&
+                planning.lock_session == null &&
+                planning.lock_action == null
+            ) {
+                continue;
+            }
+
             nextEventLocks[relatedEventId] = {
                 action: planning.lock_action,
                 item_id: planning._id,


### PR DESCRIPTION
### Purpose
Fixes a bug where dragging a planning item into an event and saving could make the event form read-only — even if the event was already properly locked for editing. This was noted to be caused by the event lock being overwritten with an "empty" planning lock.

### What has changed
- Updated the `RELOAD_SOFT_LOCKS_FOR_RELATED_EVENTS` logic to skip writing a new lock on related events if the planning item has no active lock.
- Before, after drag and drop, the system would update related event locks using the planning lock information. If the planning item had no active lock (i.e., `lock_user`, `lock_session`, and `lock_action` were all null), this would overwrite a valid event lock with a "blank" planning lock.
- As a result, when checking if the event was editable, the lock appeared invalid or missing, causing `isItemReadOnly` to return `true` and making the form uneditable.

### Steps to test
1. Open an event in split view.
2. From the planning list, drag a planning item and drop it into the event's "Related Planning Items" area and save.
3. Verify that the event form remains editable.

Resolves: [SDESK-7675](https://sofab.atlassian.net/browse/SDESK-7675)

[SDESK-7675]: https://sofab.atlassian.net/browse/SDESK-7675?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ