### PR TITLE
[SDESK-7676] - Featured stories error when viewing planning items with related events

### DIFF
--- a/client/utils/planning.tsx
+++ b/client/utils/planning.tsx
@@ -1264,7 +1264,7 @@ function getPlanningByDate(
         };
         const primaryEventIds = getRelatedEventIdsForPlanning(plan, 'primary');
 
-        plan.event = primaryEventIds.length > 0 ?
+        plan.event = primaryEventIds.length > 0 && events ?
             events[primaryEventIds[0]] :
             undefined;
         plan.coverages.forEach((coverage) => {


### PR DESCRIPTION
### Purpose
This PR fixes a bug in the `getPlanningByDate` function when opening the Featured Planning modal when planning items have related events. The `events` parameter can be `null` in certain contexts like when calling `getFeaturedPlanningItemsForDate`, which caused an error when attempting to access it.

### What has changed
- Added a null check for the `events` parameter

### Steps to test
1. Create a planning event with a linked event and mark it as a featured item.
2. Open the Featured Stories modal.
3. Verify that it loads without the error and shows featured items as expected.

Resolves - [SDESK-7676](https://sofab.atlassian.net/browse/SDESK-7676)

[SDESK-7676]: https://sofab.atlassian.net/browse/SDESK-7676?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ