### PR TITLE
[STT-1238] fix: Publish Planning to ContentAPI fails when linked to an Event

### DIFF
--- a/server/planning/content_api/types/planning.py
+++ b/server/planning/content_api/types/planning.py
@@ -6,7 +6,7 @@ from planning.types import (
     PlanningCoverage,
     CoverageProvider,
     DeliveryResourceModel,
-    PLANNING_EVENT_LINK_METHOD,
+    LinkType,
 )
 from planning.types.common import SlugLineField, CoverageAssignedTo
 from .common import MatchingProduct
@@ -22,7 +22,7 @@ class RelatedEvent(Dataclass):
     uri: fields.Keyword
     name: str
     literal: fields.Keyword
-    rel: PLANNING_EVENT_LINK_METHOD
+    rel: LinkType
 
 
 class CoverageContactInfo(Dataclass):

--- a/server/planning/types/__init__.py
+++ b/server/planning/types/__init__.py
@@ -36,6 +36,7 @@ from .enums import (
     SearchScheduleFrequency,
     SearchWeekDay,
     SearchDateRange,
+    LinkType,
 )
 from .agendas import AgendasResourceModel
 from .planning_types import PlanningTypesResourceModel


### PR DESCRIPTION
### Purpose
Publishing a Planning item to the ContentAPI fails if it is linked to an Event, due to a Pydantic validation issue.

### What has changed
* Fix the Pydantic model so that it includes the correct type for event relation

Resolves: [STT-1238](https://sofab.atlassian.net/browse/STT-1238)



[STT-1238]: https://sofab.atlassian.net/browse/STT-1238?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ