### PR TITLE
[SDESK-7682] - Error on Add To Event after adding coverage and posting

### DIFF
--- a/client/actions/events/api.ts
+++ b/client/actions/events/api.ts
@@ -588,9 +588,26 @@ function updateLinkedPlanningsForEvent(
                      */
                     return false;
                 } else {
-                    const needToUnlink = associatedPlannings.find(({_id}) => _id === item._id) == null;
+                    /**
+                    * This block ensures we only unlink planning items when it's clearly safe and intentional i.e
+                    * after meeting the following conditions:
+                    * 1. The planning item is not listed in `associatedPlannings`, meaning the user
+                    *    explicitly removed it from the event
+                    * 2. The planning item does not still reference this event in `related_events`
+                    *
+                    * This additional checks prevent accidentally removing links for items just saved with a new ID or the
+                    * unintended side effects in workflows like "Add as Event"
+                    */
 
-                    return needToUnlink;
+                    const wasExplicitlyRemoved = !associatedPlannings.some(
+                        ({ _id }) => _id === item._id
+                    );
+
+                    const isNotStillLinked = !(item.related_events ?? []).some(
+                        (rel) => rel._id === eventId
+                    );
+
+                    return wasExplicitlyRemoved && isNotStillLinked;
                 }
             });
 

--- a/client/actions/events/api.ts
+++ b/client/actions/events/api.ts
@@ -595,12 +595,12 @@ function updateLinkedPlanningsForEvent(
                     *    explicitly removed it from the event
                     * 2. The planning item does not still reference this event in `related_events`
                     *
-                    * This additional checks prevent accidentally removing links for items just saved with a new ID or the
-                    * unintended side effects in workflows like "Add as Event"
+                    * This additional checks prevent accidentally removing links for items just saved with a new
+                    * ID or the unintended side effects in workflows like "Add as Event"
                     */
 
                     const wasExplicitlyRemoved = !associatedPlannings.some(
-                        ({ _id }) => _id === item._id
+                        ({_id}) => _id === item._id
                     );
 
                     const isNotStillLinked = !(item.related_events ?? []).some(


### PR DESCRIPTION
### Purpose
This PR fixes a bug where planning items created and linked via “Add as Event” could become unlinked immediately after saving the event.  
This happened when a user created a planning item, added coverages, posted it, and then later chose “Add as Event.”  
The issue stemmed from recently saved planning items being incorrectly flagged for unlinking.

### What has changed
- Updated the `updateLinkedPlanningsForEvent` logic to prevent unlinking planning items that were just recently created and are already properly linked.
- We now only unlink a planning item if:
  1. It has been explicitly removed and not present in `associatedPlannings`
  2. It is no longer actually linked to the event in its `related_events` field.

### Steps to test
1. Create a planning item, save and close it.
2. Open the three-dot menu and select “Add Coverage.”
3. Add coverages, save, and post the planning item.
4. Again, open the three-dot menu and select “Add as Event.” on the created planning item.
5. Save the event.
6. Verify that the event shows a linked planning item, and the planning item shows a linked event item. Observe the links don't disappear after a while.

Resolves: [SDESK-7682](https://sofab.atlassian.net/browse/SDESK-7682)


[SDESK-7682]: https://sofab.atlassian.net/browse/SDESK-7682?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ