### PR TITLE
Fix: Add to Planning not working [STT-1237]

### DIFF
--- a/client/components/AddToPlanningModal/index.tsx
+++ b/client/components/AddToPlanningModal/index.tsx
@@ -58,28 +58,36 @@ export class AddToPlanningComponent extends React.Component {
                 show={true}
                 onHide={actionInProgress ? null : handleCancel}
                 fill={true}
-                size="x-large"
-                contentPadding="none"
-                headerTemplate={(
+            >
+                <Modal.Header>
                     <h3 className="modal__heading">
                         {gettext('Select an existing Planning Item or create a new one')}
                     </h3>
-                )}
-                footerTemplate={(
+                    {actionInProgress ? null : (
+                        <a className="icn-btn" onClick={handleCancel}>
+                            <i className="icon-close-small" />
+                        </a>
+                    )}
+                </Modal.Header>
+
+                <Modal.Body noPadding fullHeight noScroll>
+                    <div className="planning-app__modal AddToPlanning">
+                        <AddToPlanningApp
+                            addNewsItemToPlanning={newsItem}
+                            popupContainer={() => this.dom.popupContainer}
+                            onCancel={handleCancel}
+                        />
+                    </div>
+                </Modal.Body>
+
+                <Modal.Footer>
                     <Button
                         text={gettext('Ignore')}
                         disabled={actionInProgress}
                         onClick={handleCancel}
                     />
-                )}
-            >
-                <div className="planning-app__modal AddToPlanning">
-                    <AddToPlanningApp
-                        addNewsItemToPlanning={newsItem}
-                        popupContainer={() => this.dom.popupContainer}
-                        onCancel={handleCancel}
-                    />
-                </div>
+                </Modal.Footer>
+                <div ref={(node) => this.dom.popupContainer = node} />
             </Modal>
         );
     }

--- a/client/components/AddToPlanningModal/index.tsx
+++ b/client/components/AddToPlanningModal/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 
-import {Modal} from 'superdesk-ui-framework/react';
+import {Modal} from '../index';
 import {Button} from '../UI';
 import {AddToPlanningApp} from '../../apps';
 
@@ -55,8 +55,9 @@ export class AddToPlanningComponent extends React.Component {
 
         return (
             <Modal
-                visible={true}
+                show={true}
                 onHide={actionInProgress ? null : handleCancel}
+                fill={true}
                 size="x-large"
                 contentPadding="none"
                 headerTemplate={(

--- a/client/utils/index.ts
+++ b/client/utils/index.ts
@@ -707,7 +707,7 @@ export const getSearchDateRange = (
     startOfWeek: number,
     viewInterval?: JUMP_INTERVAL,
 ): IDateRange => {
-    const dates = currentSearch.advancedSearch.dates ?? {};
+    const dates = currentSearch.advancedSearch?.dates ?? {};
     const dateRange = {startDate: null, endDate: null};
     const jumpUnit = viewInterval ? INTERVAL_UNIT_MAPPING[viewInterval] : 'month';
 


### PR DESCRIPTION
### Purpose
Modal from `superdesk-ui-framework/react` is not working correctly in the Planning application. It fails to render as expected due to compatibility issues with the app's layout and modal handling system.

### What has changed

- Replaced usage of Modal from `superdesk-ui-framework/react` with the custom Modal component defined in the Planning app (../index).

### Front-end checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [x] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [x] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [x] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [x] This pull request is not adding redux based modals
- [x] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [x] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)

Resolves: #[STT-1237]



[STT-1237]: https://sofab.atlassian.net/browse/STT-1237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ