### PR TITLE
[SDESK-7685] - Fix date differences in create planning item from event

### DIFF
--- a/client/actions/agenda.ts
+++ b/client/actions/agenda.ts
@@ -1,6 +1,6 @@
 import * as selectors from '../selectors';
 import {cloneDeep, pick, get, sortBy, findIndex} from 'lodash';
-import {Moment} from 'moment';
+import moment, {Moment} from 'moment-timezone';
 
 import {IEventItem, IPlanningItem, IAgenda, IPlanningRelatedEventLink} from '../interfaces';
 import {planningApi} from '../superdeskApi';

--- a/client/actions/agenda.ts
+++ b/client/actions/agenda.ts
@@ -219,7 +219,7 @@ const addEventToCurrentAgenda = (
                         if (!event._sortDate && event.dates?.start) {
                             event._sortDate = eventUtils.normalizeSortDate(event);
                         }
-                        return dispatch(createPlanningFromEvent(event, planningDate, updatesAgendas))
+                        return dispatch(createPlanningFromEvent(event, planningDate, updatesAgendas));
                     })
                 )
                     .then((data) => data.forEach((p) => plannings.push(p)))

--- a/client/actions/agenda.ts
+++ b/client/actions/agenda.ts
@@ -6,7 +6,7 @@ import {IEventItem, IPlanningItem, IAgenda, IPlanningRelatedEventLink} from '../
 import {planningApi} from '../superdeskApi';
 
 import {AGENDA, MODALS, EVENTS} from '../constants';
-import {getErrorMessage, gettext, planningUtils} from '../utils';
+import {getErrorMessage, gettext, planningUtils, timeUtils} from '../utils';
 import {planning, showModal, main} from './index';
 import {convertStringFields} from '../utils/strings';
 import planningApis from '../actions/planning/api';
@@ -254,11 +254,24 @@ export function convertEventToPlanningItem(event: IEventItem): Partial<IPlanning
         eventLink.recurrence_id = event.recurrence_id;
     }
 
+    const isAllDay = event.dates?.all_day === true;
+    const timeZone = event.dates?.tz || timeUtils.localTimeZone();
+    const eventStart = event.dates?.start;
+    let planningDate: moment.MomentInput;
+
+    if (eventStart) {
+        const baseStart = moment.tz(eventStart, timeZone);
+
+        planningDate = isAllDay ? baseStart.startOf('day').utc() : baseStart.utc();
+    } else {
+        planningDate = event._sortDate;
+    }
+
     let newPlanningItem: Partial<IPlanningItem> = {
         ...defaultValues,
         type: 'planning',
         related_events: [eventLink],
-        planning_date: event._sortDate || event.dates?.start,
+        planning_date: planningDate,
         all_day: appConfig.planning.all_day === true,
         place: event.place || defaultPlace,
         subject: event.subject,

--- a/client/actions/agenda.ts
+++ b/client/actions/agenda.ts
@@ -1,12 +1,12 @@
 import * as selectors from '../selectors';
 import {cloneDeep, pick, get, sortBy, findIndex} from 'lodash';
-import moment, {Moment} from 'moment-timezone';
+import {Moment} from 'moment';
 
 import {IEventItem, IPlanningItem, IAgenda, IPlanningRelatedEventLink} from '../interfaces';
 import {planningApi} from '../superdeskApi';
 
 import {AGENDA, MODALS, EVENTS} from '../constants';
-import {getErrorMessage, gettext, planningUtils, timeUtils} from '../utils';
+import {getErrorMessage, gettext, planningUtils} from '../utils';
 import {planning, showModal, main} from './index';
 import {convertStringFields} from '../utils/strings';
 import planningApis from '../actions/planning/api';
@@ -254,24 +254,11 @@ export function convertEventToPlanningItem(event: IEventItem): Partial<IPlanning
         eventLink.recurrence_id = event.recurrence_id;
     }
 
-    const isAllDay = event.dates?.all_day === true;
-    const timeZone = event.dates?.tz || timeUtils.localTimeZone();
-    const eventStart = event.dates?.start;
-    let planningDate: moment.MomentInput;
-
-    if (eventStart) {
-        const baseStart = moment.tz(eventStart, timeZone);
-
-        planningDate = isAllDay ? baseStart.startOf('day').utc() : baseStart.utc();
-    } else {
-        planningDate = event._sortDate;
-    }
-
     let newPlanningItem: Partial<IPlanningItem> = {
         ...defaultValues,
         type: 'planning',
         related_events: [eventLink],
-        planning_date: planningDate,
+        planning_date: event.dates?.start || event._sortDate,
         all_day: appConfig.planning.all_day === true,
         place: event.place || defaultPlace,
         subject: event.subject,

--- a/client/actions/agenda.ts
+++ b/client/actions/agenda.ts
@@ -6,7 +6,7 @@ import {IEventItem, IPlanningItem, IAgenda, IPlanningRelatedEventLink} from '../
 import {planningApi} from '../superdeskApi';
 
 import {AGENDA, MODALS, EVENTS} from '../constants';
-import {getErrorMessage, gettext, planningUtils} from '../utils';
+import {getErrorMessage, gettext, planningUtils, eventUtils} from '../utils';
 import {planning, showModal, main} from './index';
 import {convertStringFields} from '../utils/strings';
 import planningApis from '../actions/planning/api';
@@ -215,9 +215,12 @@ const addEventToCurrentAgenda = (
 
             promise = promise.then(() => (
                 Promise.all(
-                    eventsChunk.map((event) => (
-                        dispatch(createPlanningFromEvent(event, planningDate, updatesAgendas))
-                    ))
+                    eventsChunk.map((event, idx) => {
+                        if (!event._sortDate && event.dates?.start) {
+                            event._sortDate = eventUtils.normalizeSortDate(event);
+                        }
+                        return dispatch(createPlanningFromEvent(event, planningDate, updatesAgendas))
+                    })
                 )
                     .then((data) => data.forEach((p) => plannings.push(p)))
                     .then(() => {
@@ -258,7 +261,7 @@ export function convertEventToPlanningItem(event: IEventItem): Partial<IPlanning
         ...defaultValues,
         type: 'planning',
         related_events: [eventLink],
-        planning_date: event.dates?.start || event._sortDate,
+        planning_date: event._sortDate || event.dates?.start,
         all_day: appConfig.planning.all_day === true,
         place: event.place || defaultPlace,
         subject: event.subject,

--- a/client/actions/tests/agenda_test.ts
+++ b/client/actions/tests/agenda_test.ts
@@ -1,5 +1,5 @@
 import sinon from 'sinon';
-import moment from "moment";
+import moment from 'moment';
 import * as actions from '../agenda';
 import {createTestStore, registerNotifications} from '../../utils';
 import {cloneDeep} from 'lodash';
@@ -340,7 +340,10 @@ describe('agenda', () => {
                                 related_events: [{
                                     _id: events[0]._id,
                                 }],
-                                planning_date: moment.tz(events[0].dates.start, events[0].dates.tz).utc().toISOString(),
+                                planning_date: moment
+                                    .tz(events[0].dates.start, events[0].dates.tz)
+                                    .utc()
+                                    .toISOString(),
                                 all_day: false,
                                 slugline: events[0].slugline,
                                 name: events[0].name,

--- a/client/actions/tests/agenda_test.ts
+++ b/client/actions/tests/agenda_test.ts
@@ -1,4 +1,5 @@
 import sinon from 'sinon';
+import moment from "moment";
 import * as actions from '../agenda';
 import {createTestStore, registerNotifications} from '../../utils';
 import {cloneDeep} from 'lodash';
@@ -69,7 +70,7 @@ describe('agenda', () => {
                 slugline: 'Slugger',
                 subject: '123',
                 anpa_category: 'abc',
-                dates: {start: '2016-10-15T13:01:11'},
+                dates: {start: '2016-10-15T13:01:11', tz: 'Australia/Sydney'},
                 internal_note: 'internal note',
             }];
 
@@ -339,7 +340,7 @@ describe('agenda', () => {
                                 related_events: [{
                                     _id: events[0]._id,
                                 }],
-                                planning_date: events[0].dates.start,
+                                planning_date: moment.tz(events[0].dates.start, events[0].dates.tz).utc().toISOString(),
                                 all_day: false,
                                 slugline: events[0].slugline,
                                 name: events[0].name,

--- a/client/utils/events.tsx
+++ b/client/utils/events.tsx
@@ -1614,7 +1614,6 @@ const self = {
     getEventDiff,
     convertCoverageToEventEmbedded,
     addSomeEventsAsRelatedToPlanningEditor,
-    getLocalStartDate,
     normalizeSortDate,
 };
 

--- a/client/utils/events.tsx
+++ b/client/utils/events.tsx
@@ -1151,6 +1151,12 @@ function getLocalEndDate(event: IEventItem): moment.Moment {
     return moment(event.dates.end);
 }
 
+function normalizeSortDate(event: IEventItem) {
+    const localStart = getLocalStartDate(event);
+    
+    return localStart.toISOString();
+}
+
 function modifyForClient(event: IEventItem): IEventItem; // overload
 
 // eslint-disable-next-line no-redeclare
@@ -1608,6 +1614,8 @@ const self = {
     getEventDiff,
     convertCoverageToEventEmbedded,
     addSomeEventsAsRelatedToPlanningEditor,
+    getLocalStartDate,
+    normalizeSortDate,
 };
 
 export default self;

--- a/client/utils/events.tsx
+++ b/client/utils/events.tsx
@@ -1153,7 +1153,7 @@ function getLocalEndDate(event: IEventItem): moment.Moment {
 
 function normalizeSortDate(event: IEventItem) {
     const localStart = getLocalStartDate(event);
-    
+
     return localStart.toISOString();
 }
 


### PR DESCRIPTION
### Purpose

This PR ensures that planning items created from an event—whether via the dropdown menu or the top "Create Planning" action—consistently reflect the same `planning_date`. The focus is to avoid drift or mismatch in values between the two creation paths.

### What Has Changed

* Prioritizes `event.dates.start` as the single, consistent source of truth for `planning_date`
* Falls back to `event._sortDate` only if `start` is unavailable

### Steps to Test

1. Create an event (all-day or with a specific time)
2. Use either the 3-dot menu → *Create Planning Item* **or** the top bar *Create Planning* button
3. Confirm that the resulting `planning_date` is the same in both flows

Resolves - [[SDESK-7685](https://sofab.atlassian.net/browse/SDESK-7685)]


[SDESK-7685]: https://sofab.atlassian.net/browse/SDESK-7685?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ