### PR TITLE
[SDESK-7687] - Event schedule date gets stuck

### DIFF
--- a/client/components/fields/editor/EventSchedule.tsx
+++ b/client/components/fields/editor/EventSchedule.tsx
@@ -67,9 +67,6 @@ export class EditorFieldEventSchedule extends React.PureComponent<IProps> {
         if (this.props.item.dates?.all_day === true || changes['dates.all_day'] === true) {
             value = localDateToUtc(value, this.props.item.dates?.tz);
             changes['dates.start'] = value;
-            console.log('[EditorFieldEventSchedule] after UTC conversion', {
-                value: value?.toISOString?.(),
-            });
         }
 
         if (endDate == null) {

--- a/client/components/fields/editor/EventSchedule.tsx
+++ b/client/components/fields/editor/EventSchedule.tsx
@@ -53,20 +53,20 @@ export class EditorFieldEventSchedule extends React.PureComponent<IProps> {
             changes['dates.all_day'] = true;
         }
 
-        if (startDate != null) {
-            value
-                .hour(startDate.hour())
-                .minute(startDate.minute())
-                .second(startDate.second());
-        } else {
-            value.hour(0)
-                .minute(0)
-                .second(0);
-        }
-
         if (this.props.item.dates?.all_day === true || changes['dates.all_day'] === true) {
-            value = localDateToUtc(value, this.props.item.dates?.tz);
+            value = safeLocalDateToUtc(value, this.props.item.dates?.tz);
             changes['dates.start'] = value;
+        } else {
+            if (startDate != null) {
+                value
+                    .hour(startDate.hour())
+                    .minute(startDate.minute())
+                    .second(startDate.second());
+            } else {
+                value.hour(0)
+                    .minute(0)
+                    .second(0);
+            }
         }
 
         if (endDate == null) {
@@ -84,7 +84,7 @@ export class EditorFieldEventSchedule extends React.PureComponent<IProps> {
             const changes = {
                 _startTime: null,
                 _endTime: null,
-                'dates.start': startDate ? localDateToUtc(startDate, this.props.item?.dates?.tz) : null,
+                'dates.start': startDate ? safeLocalDateToUtc(startDate, this.props.item?.dates?.tz) : null,
                 'dates.all_day': true,
                 'dates.no_end_time': true,
                 [TO_BE_CONFIRMED_FIELD]: false,
@@ -119,7 +119,7 @@ export class EditorFieldEventSchedule extends React.PureComponent<IProps> {
 
         if (this.props.item.dates?.all_day === true || changes['dates.all_day'] === true ||
             this.props.item.dates?.no_end_time === true || changes['dates.no_end_time'] === true) {
-            changes['dates.end'] = localDateToUtc(value, this.props.item.dates?.tz);
+            changes['dates.end'] = safeLocalDateToUtc(value, this.props.item.dates?.tz);
         }
 
         if (!startDate) {
@@ -130,7 +130,7 @@ export class EditorFieldEventSchedule extends React.PureComponent<IProps> {
 
         if (this.props.item.dates?.all_day === true || changes['dates.all_day'] === true ||
             this.props.item.dates?.no_end_time === true || changes['dates.no_end_time'] === true) {
-            changes['dates.end'] = localDateToUtc(value, this.props.item.dates?.tz);
+            changes['dates.end'] = safeLocalDateToUtc(value, this.props.item.dates?.tz);
         }
 
         this.props.onChange(changes);
@@ -141,7 +141,7 @@ export class EditorFieldEventSchedule extends React.PureComponent<IProps> {
             const changes = {
                 _endTime: null,
                 'dates.end': this.props.item.dates?.end ?
-                    localDateToUtc(this.props.item.dates.end, this.props.item.dates.tz)
+                    safeLocalDateToUtc(this.props.item.dates.end, this.props.item.dates.tz)
                     : null,
                 'dates.no_end_time': true,
                 [TO_BE_CONFIRMED_FIELD]: false,
@@ -288,4 +288,21 @@ function localDateToUtc(date: moment.MomentInput, tz?: string): moment.Moment {
         moment.tz(date, tz).format('YYYY-MM-DD') :
         moment(date).format('YYYY-MM-DD')
     );
+}
+
+/**
+ * Safely converts a date-time to a UTC date-only moment (00:00:00Z).
+ *
+ * If the input is already at midnight UTC, returns it unchanged to avoid shifting
+ * the date backward in negative timezones. Otherwise, normalizes the date to 00:00 UTC.
+ */
+function safeLocalDateToUtc(date: moment.MomentInput, tz?: string): moment.Moment {
+    const m = moment(date);
+
+    if (m.isUTC() && m.isSame(m.clone().startOf('day'))) {
+        return m;
+    }
+
+    const formattedDate = moment(tz ? moment.tz(date, tz) : m).format('YYYY-MM-DD');
+    return moment.utc(formattedDate);
 }

--- a/client/components/fields/editor/EventSchedule.tsx
+++ b/client/components/fields/editor/EventSchedule.tsx
@@ -53,20 +53,23 @@ export class EditorFieldEventSchedule extends React.PureComponent<IProps> {
             changes['dates.all_day'] = true;
         }
 
-        if (this.props.item.dates?.all_day === true || changes['dates.all_day'] === true) {
-            value = safeLocalDateToUtc(value, this.props.item.dates?.tz);
-            changes['dates.start'] = value;
+        if (startDate != null) {
+            value
+                .hour(startDate.hour())
+                .minute(startDate.minute())
+                .second(startDate.second());
         } else {
-            if (startDate != null) {
-                value
-                    .hour(startDate.hour())
-                    .minute(startDate.minute())
-                    .second(startDate.second());
-            } else {
-                value.hour(0)
-                    .minute(0)
-                    .second(0);
-            }
+            value.hour(0)
+                .minute(0)
+                .second(0);
+        }
+
+        if (this.props.item.dates?.all_day === true || changes['dates.all_day'] === true) {
+            value = localDateToUtc(value, this.props.item.dates?.tz);
+            changes['dates.start'] = value;
+            console.log('[EditorFieldEventSchedule] after UTC conversion', {
+                value: value?.toISOString?.(),
+            });
         }
 
         if (endDate == null) {
@@ -84,7 +87,7 @@ export class EditorFieldEventSchedule extends React.PureComponent<IProps> {
             const changes = {
                 _startTime: null,
                 _endTime: null,
-                'dates.start': startDate ? safeLocalDateToUtc(startDate, this.props.item?.dates?.tz) : null,
+                'dates.start': startDate ? localDateToUtc(startDate, this.props.item?.dates?.tz) : null,
                 'dates.all_day': true,
                 'dates.no_end_time': true,
                 [TO_BE_CONFIRMED_FIELD]: false,
@@ -119,7 +122,7 @@ export class EditorFieldEventSchedule extends React.PureComponent<IProps> {
 
         if (this.props.item.dates?.all_day === true || changes['dates.all_day'] === true ||
             this.props.item.dates?.no_end_time === true || changes['dates.no_end_time'] === true) {
-            changes['dates.end'] = safeLocalDateToUtc(value, this.props.item.dates?.tz);
+            changes['dates.end'] = localDateToUtc(value, this.props.item.dates?.tz);
         }
 
         if (!startDate) {
@@ -130,7 +133,7 @@ export class EditorFieldEventSchedule extends React.PureComponent<IProps> {
 
         if (this.props.item.dates?.all_day === true || changes['dates.all_day'] === true ||
             this.props.item.dates?.no_end_time === true || changes['dates.no_end_time'] === true) {
-            changes['dates.end'] = safeLocalDateToUtc(value, this.props.item.dates?.tz);
+            changes['dates.end'] = localDateToUtc(value, this.props.item.dates?.tz);
         }
 
         this.props.onChange(changes);
@@ -141,7 +144,7 @@ export class EditorFieldEventSchedule extends React.PureComponent<IProps> {
             const changes = {
                 _endTime: null,
                 'dates.end': this.props.item.dates?.end ?
-                    safeLocalDateToUtc(this.props.item.dates.end, this.props.item.dates.tz)
+                    localDateToUtc(this.props.item.dates.end, this.props.item.dates.tz)
                     : null,
                 'dates.no_end_time': true,
                 [TO_BE_CONFIRMED_FIELD]: false,
@@ -288,21 +291,4 @@ function localDateToUtc(date: moment.MomentInput, tz?: string): moment.Moment {
         moment.tz(date, tz).format('YYYY-MM-DD') :
         moment(date).format('YYYY-MM-DD')
     );
-}
-
-/**
- * Safely converts a date-time to a UTC date-only moment (00:00:00Z).
- *
- * If the input is already at midnight UTC, returns it unchanged to avoid shifting
- * the date backward in negative timezones. Otherwise, normalizes the date to 00:00 UTC.
- */
-function safeLocalDateToUtc(date: moment.MomentInput, tz?: string): moment.Moment {
-    const m = moment(date);
-
-    if (m.isUTC() && m.isSame(m.clone().startOf('day'))) {
-        return m;
-    }
-
-    const formattedDate = moment(tz ? moment.tz(date, tz) : m).format('YYYY-MM-DD');
-    return moment.utc(formattedDate);
 }

--- a/client/components/fields/editor/base/dateTime.tsx
+++ b/client/components/fields/editor/base/dateTime.tsx
@@ -54,21 +54,7 @@ export class EditorFieldDateTime extends React.PureComponent<IProps> {
         let momentValue : moment.Moment;
 
         if (value != null) {
-            if (this.props.allDay) {
-                /**
-                 * For all-day events, we shift the UTC value by +12 hours to ensure the date displays
-                 * correctly across different time zones.
-                 *
-                 * Without this adjustment, users in negative time zones (e.g., UTC-4) may see the date
-                 * appear as the *previous* day due to local time rendering of midnight UTC.
-                 *
-                 * This is a visual-only adjustment and does not affect the actual value saved,
-                 * which remains in UTC.
-                 */
-                momentValue = moment.utc(value).add(12, 'hours');
-            } else {
-                momentValue = moment(value);
-            }
+            momentValue = this.props.allDay ? moment.utc(value) : moment(value);
         } else {
             momentValue = undefined;
         }

--- a/client/components/fields/editor/base/dateTime.tsx
+++ b/client/components/fields/editor/base/dateTime.tsx
@@ -55,7 +55,10 @@ export class EditorFieldDateTime extends React.PureComponent<IProps> {
 
         if (value != null) {
             if (this.props.allDay) {
-                momentValue = moment.tz(moment(value).format('YYYY-MM-DD'), this.props.remoteTimeZone || moment.tz.guess());
+                const dateStr = moment(value).format('YYYY-MM-DD');
+                const tz = this.props.remoteTimeZone || moment.tz.guess();
+
+                momentValue = moment.tz(dateStr, tz);
             } else {
                 momentValue = moment(value);
             }

--- a/client/components/fields/editor/base/dateTime.tsx
+++ b/client/components/fields/editor/base/dateTime.tsx
@@ -54,7 +54,11 @@ export class EditorFieldDateTime extends React.PureComponent<IProps> {
         let momentValue : moment.Moment;
 
         if (value != null) {
-            momentValue = this.props.allDay ? moment.utc(value) : moment(value);
+            if (this.props.allDay) {
+                momentValue = moment.tz(moment(value).format('YYYY-MM-DD'), this.props.remoteTimeZone || moment.tz.guess());
+            } else {
+                momentValue = moment(value);
+            }
         } else {
             momentValue = undefined;
         }

--- a/client/components/fields/editor/base/dateTime.tsx
+++ b/client/components/fields/editor/base/dateTime.tsx
@@ -54,7 +54,21 @@ export class EditorFieldDateTime extends React.PureComponent<IProps> {
         let momentValue : moment.Moment;
 
         if (value != null) {
-            momentValue = this.props.allDay ? moment.utc(value) : moment(value);
+            if (this.props.allDay) {
+                /**
+                 * For all-day events, we shift the UTC value by +12 hours to ensure the date displays
+                 * correctly across different time zones.
+                 *
+                 * Without this adjustment, users in negative time zones (e.g., UTC-4) may see the date
+                 * appear as the *previous* day due to local time rendering of midnight UTC.
+                 *
+                 * This is a visual-only adjustment and does not affect the actual value saved,
+                 * which remains in UTC.
+                 */
+                momentValue = moment.utc(value).add(12, 'hours');
+            } else {
+                momentValue = moment(value);
+            }
         } else {
             momentValue = undefined;
         }


### PR DESCRIPTION
### Purpose

Fixes an issue where all-day events would appear as the previous day in negative timezones (e.g., UTC-4) when selected. 

### What has changed

- Added an offset during rendering for all-day events to center the visual display. This is only a rendering offset and value saved remains correct

### Steps to test

1. Set your browser or OS timezone to a negative offset like `America/Toronto`
2. Create an all-day event and select different dates. Observe that the day selected is the day shown in the picker.
3. Switch to a positive timezone like `Africa/Nairobi` and repeat.


Resolves: [#SDESK-7687](https://sofab.atlassian.net/browse/SDESK-7687)

