### PR TITLE
[SDESK-7697] - Saving prompt intiated even with no new changes

### DIFF
--- a/client/utils/index.ts
+++ b/client/utils/index.ts
@@ -880,12 +880,14 @@ export const itemsEqual = (nextItem, currentItem) => {
 
     get(lhs, 'coverages', []).forEach(
         (coverage) => {
+            delete coverage.planning._scheduledTime;
             formatDate(coverage, 'planning.scheduled');
         }
     );
 
     get(rhs, 'coverages', []).forEach(
         (coverage) => {
+            delete coverage.planning._scheduledTime;
             formatDate(coverage, 'planning.scheduled');
         }
     );


### PR DESCRIPTION
### Purpose
Fixes a false-positive dirty state in the Planning Editor caused by the `_scheduledTime` field. Despite having the same datetime value in the intialValues and in the diff, moment internals caused `_.isEqual` to falsely detect differences, triggering the "Save changes?" prompt even when no real changes were made on the editor.

This also led to the Save and Save & Post and other buttons being incorrectly enabled — as if the form was dirty — when in reality, no user modifications had occurred yet.

### What has changed
- Remove `_scheduledTime` from the coverages before performing the deep equality check on the cloned copies. Original data remains untouched but now prevents the false positive.

### Steps to test
1. Create a planning item with no coverage and save. Reopen it but make no changes. Click close. No prompt should be triggered.
2. Create a planning item with at least one coverage and save. Reopen it but make no changes. Click close. No prompt should be triggered.
3. In both cases above, also confirm that Save and Save & Post buttons remain disabled unless an actual edit is made.
4. Make real edits (e.g., slugline or description) and confirm that the dirty state triggers as expected.


Resolves: [SDESK-7697](https://sofab.atlassian.net/browse/SDESK-7697)



[SDESK-7697]: https://sofab.atlassian.net/browse/SDESK-7697?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ