### PR TITLE
Add to Planning not working

### DIFF
--- a/client/components/AddToPlanningModal/index.tsx
+++ b/client/components/AddToPlanningModal/index.tsx
@@ -9,8 +9,16 @@ import {AddToPlanningApp} from '../../apps';
 import * as selectors from '../../selectors';
 import {gettext} from '../../utils';
 import {KEYCODES} from '../../constants';
+import {IArticle} from 'superdesk-api';
 
-export class AddToPlanningComponent extends React.Component {
+interface IProps {
+    handleHide(): void,
+    modalProps: {newsItem: IArticle, $scope: ng.IScope},
+    currentWorkspace?: string,
+    actionInProgress?: boolean,
+}
+
+export class AddToPlanningComponent extends React.Component<IProps> {
     constructor(props) {
         super(props);
 
@@ -83,16 +91,6 @@ export class AddToPlanningComponent extends React.Component {
         );
     }
 }
-
-AddToPlanningComponent.propTypes = {
-    handleHide: PropTypes.func.isRequired,
-    modalProps: PropTypes.shape({
-        newsItem: PropTypes.object,
-        $scope: PropTypes.object,
-    }),
-    currentWorkspace: PropTypes.string,
-    actionInProgress: PropTypes.bool,
-};
 
 const mapStateToProps = (state) => ({
     currentWorkspace: selectors.general.currentWorkspace(state),

--- a/client/controllers/AddToPlanningController.tsx
+++ b/client/controllers/AddToPlanningController.tsx
@@ -109,7 +109,7 @@ export class AddToPlanningController {
             <Provider store={this.store}>
                 <ModalsContainer />
             </Provider>,
-            this.$element.get(0)
+            this.$element
         );
 
         this.rendered = true;

--- a/index.ts
+++ b/index.ts
@@ -67,6 +67,7 @@ window.addEventListener('planning:fulfilassignment', (event: CustomEvent) => {
 
 window.addEventListener('planning:addToPlanning', (e: CustomEvent) => {
     const newElement = document.createElement('div');
+    document.body.appendChild(newElement);
     const jQueryElement = window.$(newElement);
     const rootScope = ng.get('$rootScope');
 
@@ -76,7 +77,7 @@ window.addEventListener('planning:addToPlanning', (e: CustomEvent) => {
     rootScope.resolve = () => newElement.remove();
 
     new ctrl.AddToPlanningController(
-        jQueryElement,
+        newElement,
         rootScope,
         ng.get('sdPlanningStore'),
         ng.get('notify'),


### PR DESCRIPTION
STT-1237

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

### Front-end checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [x] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [x] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [x] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [x] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [x] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [x] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [x] This pull request is not adding redux based modals
- [x] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [x] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)

Resolves: #[issue-number]

