### PR TITLE
[SDESK-7701] - Planning date "to_be_confrimed" stuck even after change

### DIFF
--- a/client/components/fields/editor/PlanningDateTime.tsx
+++ b/client/components/fields/editor/PlanningDateTime.tsx
@@ -5,6 +5,7 @@ import {IEditorFieldProps, IPlanningItem} from '../../../interfaces';
 import {EditorFieldDateTime} from './base/dateTime';
 import {appConfig} from 'appConfig';
 import moment from 'moment';
+import {TO_BE_CONFIRMED_FIELD} from '../../../constants';
 
 interface IProps extends IEditorFieldProps {
     item: IPlanningItem;
@@ -26,10 +27,16 @@ export class EditorFieldPlanningDateTime extends React.PureComponent<IProps> {
         if (typeof fieldOrValues === 'string') {
             const updateValue = value?.isValid() ? this.formatValue(value) : null;
 
-            this.props.onChange({
+            const updatedFields: any = {
                 [fieldOrValues]: updateValue,
                 all_day: this.allDay,
-            });
+            };
+
+            if (updateValue !== null) {
+                updatedFields._time_to_be_confirmed = false;
+            }
+
+            this.props.onChange(updatedFields);
         } else {
             this.props.onChange(fieldOrValues);
         }
@@ -56,6 +63,9 @@ export class EditorFieldPlanningDateTime extends React.PureComponent<IProps> {
                 label={label ?? gettext('Planning Date')}
                 showToBeConfirmed={true}
                 toBeConfirmed={this.props.item?._time_to_be_confirmed == true}
+                onToBeConfirmed={() => {
+                    this.props.onChange({[TO_BE_CONFIRMED_FIELD]: true});
+                }}
                 singleValue={true}
                 allDay={this.allDay}
                 hideTime={this.allDay}


### PR DESCRIPTION
### Purpose
Fixes a bug where switching from "To Be Confirmed" to a specific time in the Planning Editor would still display "TCB"  in both the editor and the preview. This happened because the `_time_to_be_confirmed` flag was not being unset when a valid time was selected.

### What has changed
- Updated `EditorFieldPlanningDateTime` to set `_time_to_be_confirmed` to false when a valid time is picked 
- Also added `onToBeConfirmed` handler

### Steps to test
1. Create a new Planning item.
2. In the date-time picker, click "To Be Confirmed" and save. Confirm the preview and the editor shows "TCB"
3. Edit the Planning item and pick an actual time, then save. Confirm the preview and the editor now show the selected time.

Resolves: [SDESK-7701](https://sofab.atlassian.net/browse/SDESK-7701)



[SDESK-7701]: https://sofab.atlassian.net/browse/SDESK-7701?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ