### PR TITLE
Fix: As an editor using the Planning Details Widget I want to see all changes saved to the Planning item in real time [STT-127]

### DIFF
--- a/client/components/PlanningDetailsWidget.tsx
+++ b/client/components/PlanningDetailsWidget.tsx
@@ -41,20 +41,45 @@ class PlanningDetailsWidget extends React.Component<IProps, IState> {
     }
 
     componentDidMount() {
-        const {item} = this.props;
-
-        // Allow the Planning item and store to be loaded concurrently
-        getItemPlanningInfo(item).then((planning) => {
-            this.setState({planning});
-        });
-
+        this.loadPlanning();
         this.sdPlanningStore.initWorkspace(WORKSPACE.AUTHORING_WIDGET, (store) => {
             // Fetch the agendas before saving the store to the state
             store.dispatch(fetchAgendas()).then(() => {
                 this.setState({store});
             });
         });
+
+        // Listen to real-time planning updates
+        window.addEventListener('planning:updated', this.onPlanningUpdated as EventListener);
     }
+
+    componentWillUnmount() {
+        window.removeEventListener('planning:updated', this.onPlanningUpdated as EventListener);
+    }
+
+    private loadPlanning = () => {
+        const {item} = this.props;
+
+        getItemPlanningInfo(item).then((planning) => {
+            this.setState({planning});
+        });
+    };
+
+    private onPlanningUpdated = (event: Event) => {
+        const customEvent = event as CustomEvent;
+        const updatedItem = customEvent.detail?.item;
+
+        const current = this.state.planning;
+
+        if (!updatedItem || !current) {
+            return;
+        }
+
+        // Check if same planning item and different etag
+        if (updatedItem._id === current._id && updatedItem._etag !== current._etag) {
+            this.loadPlanning(); // re-fetch the updated planning
+        }
+    };
 
     render() {
         // Only render if we have both the planning item and store

--- a/client/planning-extension/src/planning-details-widget.tsx
+++ b/client/planning-extension/src/planning-details-widget.tsx
@@ -13,6 +13,7 @@ export const PLANNING_DETAILS_WIDGET_LABEL = gettext('Planning Details');
 interface IState {
     loading: boolean;
     planningId: string | null;
+    planningEtag: string | null;
 }
 
 export class PlanningDetailsWidget extends React.PureComponent<IArticleSideWidgetComponentType, IState> {
@@ -22,6 +23,7 @@ export class PlanningDetailsWidget extends React.PureComponent<IArticleSideWidge
         this.state = {
             loading: props.article.assignment_id != null,
             planningId: null,
+            planningEtag: null,
         };
     }
 
@@ -43,6 +45,7 @@ export class PlanningDetailsWidget extends React.PureComponent<IArticleSideWidge
             .then((planning) => {
                 this.setState({
                     planningId: planning._id,
+                    planningEtag: planning._etag,
                     loading: false,
                 });
             })
@@ -61,15 +64,18 @@ export class PlanningDetailsWidget extends React.PureComponent<IArticleSideWidge
 
     private onPlanningUpdated = (event: Event) => {
         const customEvent = event as CustomEvent;
-        const updatedId = customEvent?.detail?.item;
-        const {planningId} = this.state;
+        const updatedPlanningItem = customEvent?.detail?.item;
 
-        if (planningId && updatedId === planningId) {
-            const {assignment_id} = this.props.article;
+        if (!updatedPlanningItem) return;
 
-            if (assignment_id) {
-                this.fetchPlanningInfo(assignment_id);
-            }
+        const {assignment_id} = this.props.article;
+        const {planningId, planningEtag} = this.state;
+
+        if (!assignment_id || !planningId) return;
+
+        // Only respond to changes of the currently loaded planning item
+        if (updatedPlanningItem._id === planningId && updatedPlanningItem._etag !== planningEtag) {
+            this.fetchPlanningInfo(assignment_id); // Re-fetch planning info
         }
     };
 


### PR DESCRIPTION
Issue:
The Planning Details Widget did not reflect real-time updates when a planning item was modified by another user. 

Fix:
Added a listener for the planning:updated event and implemented a check using _etag. When the _etag of the incoming planning item differs from the current one, the widget triggers a re-fetch to display the latest content. So that real-time updates are visible.