### PR TITLE
As an editor using the Planning Details Widget I want to see all changes saved to the Planning item in real time [STT-127]

### DIFF
--- a/client/components/PlanningDetailsWidget.tsx
+++ b/client/components/PlanningDetailsWidget.tsx
@@ -33,48 +33,47 @@ class PlanningDetailsWidget extends React.Component<IProps, IState> {
     static defaultProps: Partial<IProps>;
     readonly state = {store: null, planning: null};
     private sdPlanningStore: any;
-    private intervalId: NodeJS.Timeout | null = null;
+    private planningId: string | null = null;
+    private unsubscribe: (() => void) | null = null;
 
     constructor(props: IProps) {
         super(props);
-
         this.sdPlanningStore = ng.get('sdPlanningStore');
     }
 
     componentDidMount() {
         const {item} = this.props;
 
-        // Allow the Planning item and store to be loaded concurrently
         getItemPlanningInfo(item).then((planning) => {
+            this.planningId = planning._id;
             this.setState({planning});
         });
 
         this.sdPlanningStore.initWorkspace(WORKSPACE.AUTHORING_WIDGET, (store) => {
-            // Fetch the agendas before saving the store to the state
             store.dispatch(fetchAgendas()).then(() => {
                 this.setState({store});
             });
         });
 
-        this.intervalId = setInterval(() => {
-            this.fetchPlanning(item);
-        }, 10000);
+        const $rootScope = ng.get('$rootScope');
+
+        this.unsubscribe = $rootScope.$on('planning:updated', (_e: any, updatedPlanning: any) => {
+            const updatedPlanningId = updatedPlanning?.item;
+
+            if (!this.planningId || !updatedPlanningId || updatedPlanningId !== this.planningId) {
+                return;
+            }
+
+            getItemPlanningInfo(this.props.item).then((planning) => {
+                this.setState({planning});
+            });
+        });
     }
 
     componentWillUnmount() {
-        if (this.intervalId) {
-            clearInterval(this.intervalId);
+        if (this.unsubscribe) {
+            this.unsubscribe();
         }
-    }
-
-    fetchPlanning(item: IProps['item']) {
-        getItemPlanningInfo(item)
-            .then((planning) => {
-                this.setState({planning});
-            })
-            .catch(() => {
-                // Error ignored
-            });
     }
 
     render() {

--- a/client/components/PlanningDetailsWidget.tsx
+++ b/client/components/PlanningDetailsWidget.tsx
@@ -5,6 +5,7 @@ import {PlanningPreviewContent} from './Planning/PlanningPreviewContent';
 import {modifyForClient} from '../utils/planning';
 import {WORKSPACE} from '../constants';
 import {fetchAgendas} from '../actions';
+import {superdeskApi} from '../superdeskApi';
 
 interface IProps {
     item: {
@@ -39,15 +40,20 @@ class PlanningDetailsWidget extends React.Component<IProps, IState> {
     constructor(props: IProps) {
         super(props);
         this.sdPlanningStore = ng.get('sdPlanningStore');
+        this.loadPlanning = this.loadPlanning.bind(this);
     }
 
-    componentDidMount() {
+    private loadPlanning() {
         const {item} = this.props;
 
         getItemPlanningInfo(item).then((planning) => {
             this.planningId = planning._id;
             this.setState({planning});
         });
+    }
+
+    componentDidMount() {
+        this.loadPlanning();
 
         this.sdPlanningStore.initWorkspace(WORKSPACE.AUTHORING_WIDGET, (store) => {
             store.dispatch(fetchAgendas()).then(() => {
@@ -55,18 +61,14 @@ class PlanningDetailsWidget extends React.Component<IProps, IState> {
             });
         });
 
-        const $rootScope = ng.get('$rootScope');
+        this.unsubscribe = superdeskApi.addWebsocketMessageListener('resource:updated', (event: any) => {
+            const updatedPlanningId = event.detail.extra?._id || event.detail.extra?.item_id;
 
-        this.unsubscribe = $rootScope.$on('planning:updated', (_e: any, updatedPlanning: any) => {
-            const updatedPlanningId = updatedPlanning?.item;
-
-            if (!this.planningId || !updatedPlanningId || updatedPlanningId !== this.planningId) {
+            if (this.planningId === null || updatedPlanningId === null || updatedPlanningId !== this.planningId) {
                 return;
             }
 
-            getItemPlanningInfo(this.props.item).then((planning) => {
-                this.setState({planning});
-            });
+            this.loadPlanning();
         });
     }
 
@@ -78,7 +80,7 @@ class PlanningDetailsWidget extends React.Component<IProps, IState> {
 
     render() {
         // Only render if we have both the planning item and store
-        if (!this.state.planning || !this.state.store) {
+        if (this.state.planning === null || this.state.store === null) {
             return null;
         }
 

--- a/client/components/PlanningDetailsWidget.tsx
+++ b/client/components/PlanningDetailsWidget.tsx
@@ -18,6 +18,13 @@ interface IState {
     planning: any;
 }
 
+interface ResourceUpdatedEventDetail {
+    extra: {
+        _id?: string;
+        item_id?: string;
+    };
+}
+
 export function getItemPlanningInfo(item: {assignment_id: string}) {
     const api = ng.get('api');
 
@@ -61,15 +68,17 @@ class PlanningDetailsWidget extends React.Component<IProps, IState> {
             });
         });
 
-        this.unsubscribe = superdeskApi.addWebsocketMessageListener('resource:updated', (event: any) => {
-            const updatedPlanningId = event.detail.extra?._id || event.detail.extra?.item_id;
+        this.unsubscribe = superdeskApi.addWebsocketMessageListener(
+            'resource:updated',
+            (event: CustomEvent<ResourceUpdatedEventDetail>) => {
+                const updatedPlanningId = event.detail.extra?._id || event.detail.extra?.item_id;
 
-            if (this.planningId === null || updatedPlanningId === null || updatedPlanningId !== this.planningId) {
-                return;
-            }
+                if (this.planningId === null || updatedPlanningId === null || updatedPlanningId !== this.planningId) {
+                    return;
+                }
 
-            this.loadPlanning();
-        });
+                this.loadPlanning();
+            });
     }
 
     componentWillUnmount() {

--- a/client/components/PlanningDetailsWidget.tsx
+++ b/client/components/PlanningDetailsWidget.tsx
@@ -33,6 +33,7 @@ class PlanningDetailsWidget extends React.Component<IProps, IState> {
     static defaultProps: Partial<IProps>;
     readonly state = {store: null, planning: null};
     private sdPlanningStore: any;
+    private intervalId: NodeJS.Timeout | null = null;
 
     constructor(props: IProps) {
         super(props);
@@ -41,7 +42,13 @@ class PlanningDetailsWidget extends React.Component<IProps, IState> {
     }
 
     componentDidMount() {
-        this.loadPlanning();
+        const {item} = this.props;
+
+        // Allow the Planning item and store to be loaded concurrently
+        getItemPlanningInfo(item).then((planning) => {
+            this.setState({planning});
+        });
+
         this.sdPlanningStore.initWorkspace(WORKSPACE.AUTHORING_WIDGET, (store) => {
             // Fetch the agendas before saving the store to the state
             store.dispatch(fetchAgendas()).then(() => {
@@ -49,37 +56,26 @@ class PlanningDetailsWidget extends React.Component<IProps, IState> {
             });
         });
 
-        // Listen to real-time planning updates
-        window.addEventListener('planning:updated', this.onPlanningUpdated as EventListener);
+        this.intervalId = setInterval(() => {
+            this.fetchPlanning(item);
+        }, 10000);
     }
 
     componentWillUnmount() {
-        window.removeEventListener('planning:updated', this.onPlanningUpdated as EventListener);
+        if (this.intervalId) {
+            clearInterval(this.intervalId);
+        }
     }
 
-    private loadPlanning = () => {
-        const {item} = this.props;
-
-        getItemPlanningInfo(item).then((planning) => {
-            this.setState({planning});
-        });
-    };
-
-    private onPlanningUpdated = (event: Event) => {
-        const customEvent = event as CustomEvent;
-        const updatedItem = customEvent.detail?.item;
-
-        const current = this.state.planning;
-
-        if (!updatedItem || !current) {
-            return;
-        }
-
-        // Check if same planning item and different etag
-        if (updatedItem._id === current._id && updatedItem._etag !== current._etag) {
-            this.loadPlanning(); // re-fetch the updated planning
-        }
-    };
+    fetchPlanning(item: IProps['item']) {
+        getItemPlanningInfo(item)
+            .then((planning) => {
+                this.setState({planning});
+            })
+            .catch(() => {
+                // Error ignored
+            });
+    }
 
     render() {
         // Only render if we have both the planning item and store


### PR DESCRIPTION
Issue:
The Planning Details Widget did not reflect real-time updates when a planning item was modified by another user or in a different tab. Updates were only visible after manually refreshing the browser.

Fix:
Added a manual refresh mechanism using setInterval in the componentDidMount lifecycle method. This periodically re-fetches the latest planning item every 10 seconds. The updated planning item is then compared and rendered to ensure users see near real-time updates without needing to reload the page. The interval is cleared on unmount to avoid memory leaks.