### PR TITLE
implement debounce in text fields

### DIFF
--- a/client/components/UI/Form/ExpandableTextArea.tsx
+++ b/client/components/UI/Form/ExpandableTextArea.tsx
@@ -219,5 +219,5 @@ ExpandableTextArea.defaultProps = {
     nativeOnChange: false,
     readOnly: false,
     initialFocus: false,
-    autoHeightTimeout: 50,
+    autoHeightTimeout: 100,
 };

--- a/client/components/UI/Form/TextArea.tsx
+++ b/client/components/UI/Form/TextArea.tsx
@@ -138,7 +138,7 @@ TextArea.propTypes = {
 TextArea.defaultProps = {
     readOnly: false,
     autoHeight: true,
-    autoHeightTimeout: 50,
+    autoHeightTimeout: 200,
     nativeOnChange: false,
     paddingRight60: false,
     multiLine: true,

--- a/client/components/fields/editor/base/dynamicTextTypeField.tsx
+++ b/client/components/fields/editor/base/dynamicTextTypeField.tsx
@@ -6,6 +6,7 @@ import {EditorFieldText} from './text';
 import {EditorFieldTextArea} from './textArea';
 import {EditorFieldExpandableTextArea} from './expandableTextArea';
 import {EditorFieldTextEditor3} from './textEditor3';
+import {CHANGE_DELAY} from '../../../../constants';
 
 export function getTextFieldComponent(schema?: IProfileSchemaTypeString) {
     switch (schema?.field_type) {
@@ -32,6 +33,8 @@ export class EditorFieldDynamicTextType extends React.PureComponent<IProps> {
     render() {
         const Component = getTextFieldComponent(this.props.schema);
         const {refNode, ...props} = this.props;
+
+        props.debounce = CHANGE_DELAY;
 
         // TODO: Support min/max length, required etc from props.schema
 

--- a/client/components/fields/editor/base/expandableTextArea.tsx
+++ b/client/components/fields/editor/base/expandableTextArea.tsx
@@ -24,7 +24,7 @@ export class EditorFieldExpandableTextArea extends React.PureComponent<IProps, I
 
         this.node = React.createRef();
 
-        this.state = {value: get(props.item, props.field, props.defaultValue) ?? ''};
+        this.state = {value: get(props.item, props.field, props.defaultValue || '')};
 
         this.onChange = this.onChange.bind(this);
         this.propsOnChange = debounce(

--- a/client/components/fields/editor/base/expandableTextArea.tsx
+++ b/client/components/fields/editor/base/expandableTextArea.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {get} from 'lodash';
+import {debounce, get} from 'lodash';
 
 import {IEditorFieldProps, IProfileSchemaTypeString} from '../../../../interfaces';
 
@@ -12,13 +12,26 @@ interface IProps extends IEditorFieldProps {
     noPadding?: boolean;
 }
 
-export class EditorFieldExpandableTextArea extends React.PureComponent<IProps> {
+interface IState {
+    value: string;
+}
+
+export class EditorFieldExpandableTextArea extends React.PureComponent<IProps, IState> {
     node: React.RefObject<HTMLDivElement>;
 
     constructor(props) {
         super(props);
 
         this.node = React.createRef();
+
+        this.state = {value: get(props.item, props.field, props.defaultValue) ?? ''};
+
+        this.onChange = this.onChange.bind(this);
+        this.propsOnChange = debounce(
+            this.propsOnChange.bind(this),
+            props.debounce ?? 0,
+            {maxWait: 1000},
+        );
     }
 
     focus() {
@@ -27,9 +40,19 @@ export class EditorFieldExpandableTextArea extends React.PureComponent<IProps> {
         }
     }
 
+    onChange(field: string, value: string) {
+        this.setState({value}, () => {
+            this.propsOnChange(this.state.value);
+        });
+    }
+
+    propsOnChange(value: string) {
+        this.props.onChange(this.props.field, value);
+    }
+
     render() {
         const field = this.props.field;
-        const value = get(this.props.item, field, this.props.defaultValue);
+        const value = this.state.value;
         const error = get(this.props.errors ?? {}, field);
 
         return (
@@ -46,6 +69,7 @@ export class EditorFieldExpandableTextArea extends React.PureComponent<IProps> {
                     maxLength={this.props.maxLength ?? this.props.schema?.maxlength}
                     invalid={this.props.invalid ?? (error != null && this.props.showErrors)}
                     noMargin={true}
+                    onChange={this.onChange}
                 />
             </Row>
         );

--- a/client/components/fields/editor/base/text.tsx
+++ b/client/components/fields/editor/base/text.tsx
@@ -44,7 +44,7 @@ export class EditorFieldText extends React.Component<IEditorFieldTextProps, ISta
         this.state = {
             key: uniqueId(),
             suggestions: [],
-            value: get(props.item, props.field, props.defaultValue) ?? '',
+            value: get(props.item, props.field, props.defaultValue || ''),
         };
     }
 

--- a/client/components/fields/editor/base/text.tsx
+++ b/client/components/fields/editor/base/text.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {get, uniqueId} from 'lodash';
+import {debounce, get, uniqueId} from 'lodash';
 import {IRestApiResponse} from 'superdesk-api';
 import {appConfig} from 'appConfig';
 
@@ -17,10 +17,12 @@ export interface IEditorFieldTextProps extends IEditorFieldProps {
     schema?: IProfileSchemaTypeString;
     noPadding: boolean;
     language?: string;
+    debounce?: number;
 }
 
 interface IState {
     key: string;
+    value: string;
     suggestions: string[];
 }
 
@@ -31,19 +33,19 @@ export class EditorFieldText extends React.Component<IEditorFieldTextProps, ISta
         super(props);
 
         this.onChange = this.onChange.bind(this);
+        this.propsOnChange = debounce(
+            this.propsOnChange.bind(this),
+            props.debounce ?? 0,
+            {maxWait: 1000},
+        );
         this.searchSuggestions = this.searchSuggestions.bind(this);
         this.node = React.createRef();
 
         this.state = {
             key: uniqueId(),
             suggestions: [],
+            value: get(props.item, props.field, props.defaultValue) ?? '',
         };
-    }
-
-    componentDidUpdate(prevProps: Readonly<IEditorFieldTextProps>, prevState: Readonly<IState>, snapshot?: any) {
-        if (get(prevProps.item, prevProps.field) !== get(this.props.item, this.props.field)) {
-            this.onPropValueChanged();
-        }
     }
 
     componentDidMount(): void {
@@ -56,22 +58,14 @@ export class EditorFieldText extends React.Component<IEditorFieldTextProps, ISta
         }
     }
 
-    onPropValueChanged() {
-        // If the value on the provided item has changed
-        // Check this new value against the value in the `input` element directly
-        // If these two differ, then force a re-mount/render of the `input` element
-        // Using the React `key` attribute
-
-        const node = this.getInputElement();
-        const propValue = get(this.props.item, this.props.field);
-
-        if (node != null && node.value !== propValue) {
-            this.setState({key: uniqueId()});
-        }
+    onChange(value: string) {
+        this.setState({value}, () => {
+            this.propsOnChange(this.state.value);
+        });
     }
 
-    onChange(newValue) {
-        this.props.onChange(this.props.field, newValue);
+    propsOnChange(value: string) {
+        this.props.onChange(this.props.field, value);
     }
 
     getInputElement(): HTMLInputElement | undefined {
@@ -99,8 +93,6 @@ export class EditorFieldText extends React.Component<IEditorFieldTextProps, ISta
     }
 
     searchSuggestions(searchString: string, callback: (result: Array<any>) => void) {
-        const currentValue = this.props.item[this.props.field];
-
         callback(this.state.suggestions.filter(
             (name) => name.toLowerCase().includes(searchString.toLowerCase()),
         ));
@@ -111,7 +103,7 @@ export class EditorFieldText extends React.Component<IEditorFieldTextProps, ISta
 
     render() {
         const field = this.props.field;
-        const value = get(this.props.item, field, this.props.defaultValue);
+        const value = this.state.value;
         const error = get(this.props.errors ?? {}, field);
 
         return (

--- a/client/components/fields/editor/base/textArea.tsx
+++ b/client/components/fields/editor/base/textArea.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {get} from 'lodash';
+import {debounce, get} from 'lodash';
 
 import {IEditorFieldProps, IProfileSchemaTypeString} from '../../../../interfaces';
 
@@ -15,13 +15,26 @@ interface IProps extends IEditorFieldProps {
     noPadding?: boolean;
 }
 
-export class EditorFieldTextArea extends React.PureComponent<IProps> {
+interface IState {
+    value: string;
+}
+
+export class EditorFieldTextArea extends React.PureComponent<IProps, IState> {
     node: React.RefObject<HTMLDivElement>;
 
     constructor(props) {
         super(props);
 
         this.node = React.createRef();
+
+        this.state = {value: get(props.item, props.field, props.defaultValue) ?? ''};
+
+        this.onChange = this.onChange.bind(this);
+        this.propsOnChange = debounce(
+            this.propsOnChange.bind(this),
+            props.debounce ?? 0,
+            {maxWait: 1000},
+        );
     }
 
     focus() {
@@ -30,9 +43,19 @@ export class EditorFieldTextArea extends React.PureComponent<IProps> {
         }
     }
 
+    onChange(field: string, value: string) {
+        this.setState({value}, () => {
+            this.propsOnChange(this.state.value);
+        });
+    }
+
+    propsOnChange(value: string) {
+        this.props.onChange(this.props.field, value);
+    }
+
     render() {
         const field = this.props.field;
-        const value = get(this.props.item, field, this.props.defaultValue);
+        const value = this.state.value;
         const error = get(this.props.errors ?? {}, field);
 
         return (
@@ -49,6 +72,7 @@ export class EditorFieldTextArea extends React.PureComponent<IProps> {
                     maxLength={this.props.maxLength ?? this.props.schema?.maxlength}
                     invalid={this.props.invalid ?? (error != null && this.props.showErrors)}
                     noMargin={true}
+                    onChange={this.onChange}
                 />
             </Row>
         );

--- a/client/components/fields/editor/base/textArea.tsx
+++ b/client/components/fields/editor/base/textArea.tsx
@@ -27,7 +27,7 @@ export class EditorFieldTextArea extends React.PureComponent<IProps, IState> {
 
         this.node = React.createRef();
 
-        this.state = {value: get(props.item, props.field, props.defaultValue) ?? ''};
+        this.state = {value: get(props.item, props.field, props.defaultValue || '')};
 
         this.onChange = this.onChange.bind(this);
         this.propsOnChange = debounce(

--- a/client/constants/index.ts
+++ b/client/constants/index.ts
@@ -95,6 +95,9 @@ export const TEMP_ID_PREFIX = 'tempId-';
 // The delay in ms for use with single and double click detection
 export const CLICK_DELAY = 250;
 
+// The delay in ms for use with input changes
+export const CHANGE_DELAY = 500;
+
 export const USER_ACTIONS = {
     RECEIVE_USER_PREFERENCES: 'RECEIVE_USER_PREFERENCES',
 };

--- a/client/interfaces.ts
+++ b/client/interfaces.ts
@@ -1583,6 +1583,7 @@ export interface IEditorFieldProps {
     showErrors?: boolean;
     editorType?: EDITOR_TYPE;
     profile?: IPlanningContentProfile;
+    debounce?: number;
 
     onChange(field: string | {[key: string]: any}, value: any): void;
     popupContainer?(): HTMLElement;

--- a/e2e/cypress/support/common/inputs/input.ts
+++ b/e2e/cypress/support/common/inputs/input.ts
@@ -37,10 +37,10 @@ export class Input {
      * @param {string} value - The value to type into the input field
      */
     type(value) {
+        this.clear();
         cy.log('Common.Input.type');
-        this.element
-            .clear()
-            .type(value);
+        this.element.type(value);
+        cy.wait(250); // Wait for any potential debounce
     }
 
     /**
@@ -56,6 +56,7 @@ export class Input {
     clear() {
         cy.log('Common.Input.clear');
         this.element.clear();
+        cy.wait(250); // Wait for any potential debounce
     }
 
     expectError(message) {

--- a/e2e/cypress/support/planning/advancedSearch.ts
+++ b/e2e/cypress/support/planning/advancedSearch.ts
@@ -208,6 +208,7 @@ export class AdvancedSearch {
                     throw new Error(`Field "${name}" not registered with e2e search helper`);
                 } else if (value?.length || isBoolean(value)) {
                     field.type(value);
+                    cy.wait(100); // Wait for any potential debounce
                 } else {
                     field.clear();
                 }

--- a/e2e/server/core-requirements.txt
+++ b/e2e/server/core-requirements.txt
@@ -1,3 +1,3 @@
 gunicorn==22.0.0
 honcho==1.0.1
-git+https://github.com/superdesk/superdesk-core.git@develop#egg=superdesk-core
+git+https://github.com/superdesk/superdesk-core.git@release/2.9#egg=superdesk-core


### PR DESCRIPTION
handle field value via local state and debounce redux state updates.

SDCP-954

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

### Front-end checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)

Resolves: #[issue-number]

