### PR TITLE
[STT-1278] - Content API outputs: Updating one entity is not reflected in data of the linked entity

### DIFF
--- a/server/planning/content_api/resources/event.py
+++ b/server/planning/content_api/resources/event.py
@@ -17,7 +17,9 @@ from superdesk.core.resources import (
 from superdesk.core.resources.service import AsyncResourceService
 
 from content_api import MONGO_PREFIX, ELASTIC_PREFIX
+from planning.utils import get_related_planning_for_events
 
+from .planning import ContentAPIPlanningService
 from ..types import ContentAPIEventResource
 from ..output_formatters import ContentApiEventFormatter
 
@@ -41,6 +43,11 @@ class ContentAPIEventService(AsyncResourceService[ContentAPIEventResource]):
             await self.update(event_id, formatted_item)
         else:
             await self.create([formatted_item])
+
+        # Check for linked planning items to the event and update them as well
+        related_planning_items = get_related_planning_for_events([event_id])
+        for planning_item in related_planning_items:
+            await ContentAPIPlanningService().publish_async(planning_item, subscribers)
 
 
 content_api_event_resource_config: ResourceConfig = ResourceConfig(

--- a/server/planning/events/events_tests.py
+++ b/server/planning/events/events_tests.py
@@ -703,29 +703,33 @@ class EventPlanningContentAPITestCase(TestCase):
         self.planning_capi_service = ContentAPIPlanningService()
 
     async def test_related_event_planning_details_sync(self):
-        [event_id] = await self.events_service.post_async([
-            {
-                "guid": "test-event-guid",
-                "name": "Original Event Name",
-                "dates": {
-                    "start": datetime.now(),
-                    "end": datetime.now() + timedelta(days=1),
-                },
-            }
-        ])
+        [event_id] = await self.events_service.post_async(
+            [
+                {
+                    "guid": "test-event-guid",
+                    "name": "Original Event Name",
+                    "dates": {
+                        "start": datetime.now(),
+                        "end": datetime.now() + timedelta(days=1),
+                    },
+                }
+            ]
+        )
         event = await self.events_service.find_one_async(req=None, _id=event_id)
         await self.event_capi_service.publish_async(event, None)
-        
-        [planning_id] = await self.planning_service.post_async([
-            {
-                "guid": "test-planning-guid",
-                "slugline": "test slugline",
-                "name": "Test Planning",
-                "planning_date": datetime.now() + timedelta(hours=1),
-                "type": "planning",
-                "related_events": [{"_id": event_id, "link_type": "primary"}],
-            }
-        ])
+
+        [planning_id] = await self.planning_service.post_async(
+            [
+                {
+                    "guid": "test-planning-guid",
+                    "slugline": "test slugline",
+                    "name": "Test Planning",
+                    "planning_date": datetime.now() + timedelta(hours=1),
+                    "type": "planning",
+                    "related_events": [{"_id": event_id, "link_type": "primary"}],
+                }
+            ]
+        )
         planning = await self.planning_service.find_one_async(req=None, _id=planning_id)
         await self.planning_capi_service.publish_async(planning, None)
 
@@ -737,7 +741,7 @@ class EventPlanningContentAPITestCase(TestCase):
         await self.events_service.patch_async(event_id, {"name": updated_name})
         event = await self.events_service.find_one_async(req=None, _id=event_id)
         await self.event_capi_service.publish_async(event, None)
-        
+
         updated_capi_planning = await self.planning_capi_service.find_by_id_raw(planning_id)
         self.assertEqual(len([updated_capi_planning]), 1)
         self.assertEqual(updated_capi_planning["events"][0]["name"], updated_name)

--- a/server/planning/events/events_tests.py
+++ b/server/planning/events/events_tests.py
@@ -22,6 +22,7 @@ from planning.events.events_utils import get_recurring_timeline
 from planning.events.events_reschedule import process_reschedule_event
 from planning.events.events_update_time import process_update_time
 from planning.events.events_update_repetitions import process_update_repetitions
+from planning.content_api.resources import ContentAPIPlanningService, ContentAPIEventService
 
 from .events import is_event_updated
 
@@ -691,3 +692,52 @@ class EventsRelatedPlanningAutoPublish(EventsBaseTestCase):
         planning_item = await planning_service.find_one_async(req=None, _id=new_plannings[0])
         self.assertEqual(len([planning_item]), 1)
         self.assertEqual(planning_item.get("state"), "scheduled")
+
+
+class EventPlanningContentAPITestCase(TestCase):
+    async def asyncSetUp(self):
+        await super().asyncSetUp()
+        self.events_service = get_resource_service("events")
+        self.planning_service = get_resource_service("planning")
+        self.event_capi_service = ContentAPIEventService()
+        self.planning_capi_service = ContentAPIPlanningService()
+
+    async def test_related_event_planning_details_sync(self):
+        [event_id] = await self.events_service.post_async([
+            {
+                "guid": "test-event-guid",
+                "name": "Original Event Name",
+                "dates": {
+                    "start": datetime.now(),
+                    "end": datetime.now() + timedelta(days=1),
+                },
+            }
+        ])
+        event = await self.events_service.find_one_async(req=None, _id=event_id)
+        await self.event_capi_service.publish_async(event, None)
+        
+        [planning_id] = await self.planning_service.post_async([
+            {
+                "guid": "test-planning-guid",
+                "slugline": "test slugline",
+                "name": "Test Planning",
+                "planning_date": datetime.now() + timedelta(hours=1),
+                "type": "planning",
+                "related_events": [{"_id": event_id, "link_type": "primary"}],
+            }
+        ])
+        planning = await self.planning_service.find_one_async(req=None, _id=planning_id)
+        await self.planning_capi_service.publish_async(planning, None)
+
+        content_api_planning = await self.planning_capi_service.find_by_id_raw(planning_id)
+        self.assertEqual(len([content_api_planning]), 1)
+        self.assertEqual(content_api_planning["events"][0]["name"], "Original Event Name")
+
+        updated_name = "Updated Event Name"
+        await self.events_service.patch_async(event_id, {"name": updated_name})
+        event = await self.events_service.find_one_async(req=None, _id=event_id)
+        await self.event_capi_service.publish_async(event, None)
+        
+        updated_capi_planning = await self.planning_capi_service.find_by_id_raw(planning_id)
+        self.assertEqual(len([updated_capi_planning]), 1)
+        self.assertEqual(updated_capi_planning["events"][0]["name"], updated_name)


### PR DESCRIPTION
### Purpose
Ensure that updates to an event's details e.g name gets reflected in the related planning items in the content api. Previously, planning items would only reflect updated event details when manually updated since the event details are fetched again when formatting the item.

### What has changed
- If event has related planning items, re-trigger `publish_async` on each related planning item to refresh their content api entries with the updated event data

### Steps to test
1. Create a planning item linked to an event.
2. Update the event (e.g., change the name).
3. Observe that:
   - The event details are updated on the content api endpoint
   - The related planning item also reflects the changes to the event i.e the name and does not have the old data

Resolves: [STT-1278](https://sofab.atlassian.net/browse/STT-1278)



[STT-1278]: https://sofab.atlassian.net/browse/STT-1278?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ