### PR TITLE
[SDESK-7723] Fix "add to planning" modal triggering "conflict" warning

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,5 @@
 // styles
+import ReactDOM from 'react-dom';
 import './client/styles/index.scss';
 import planningModule from './client';
 import * as ctrl from './client/controllers';
@@ -73,7 +74,11 @@ window.addEventListener('planning:addToPlanning', (e: CustomEvent) => {
     newElement.className = 'modal__dialog ng-scope';
     rootScope.locals = {data: {item: e.detail}};
 
-    rootScope.resolve = () => newElement.remove();
+    // unmount the component and remove the element when the modal is closed
+    rootScope.resolve = () => {
+        ReactDOM.unmountComponentAtNode(newElement);
+        newElement.remove();
+    };
 
     new ctrl.AddToPlanningController(
         newElement,


### PR DESCRIPTION
### Purpose
Fixes an unexpected conflict that occurred when adding an item to planning. The issue was caused by orphaned React instances left behind after closing the modal, which triggered the autosave feature multiple times and resulted in a "conflict happened" warning when clicking the "Add to coverage" button.

### What has changed
- Make sure that the `addToPlanning` component is properly unmounted when closing the modal

### How to test
Please follow the detailed steps in the ticket's description

Resolves: [SDESK-7723]



[SDESK-7723]: https://sofab.atlassian.net/browse/SDESK-7723?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ