### PR TITLE
[STT-1276] - Content API planning output: if a coverage has time_to_be_confirmed = true, there should be no scheduled time

### DIFF
--- a/server/planning/content_api/utils.py
+++ b/server/planning/content_api/utils.py
@@ -43,6 +43,18 @@ SYSTEM_FIELDS: set[str] = {
     "planning_schedule",
 }
 
+def adjust_coverage_planning_scheduled_if_tbc(item: dict) -> None:
+    if item.get("type") != "planning" or not item.get("coverages"):
+        return
+
+    for coverage in item["coverages"]:
+        planning = coverage.get("planning")
+        if not planning:
+            continue
+
+        if coverage.get("_time_to_be_confirmed") is True:
+            planning["scheduled"] = planning["scheduled"].strftime("%Y-%m-%d")
+
 
 def convert_capi_item_to_response_instance(item_instance: ResourceModel | dict) -> dict:
     if isinstance(item_instance, ResourceModel):
@@ -62,6 +74,7 @@ def convert_capi_item_to_response_instance(item_instance: ResourceModel | dict) 
                 item.pop(field, None)
 
     convert_event_dates_to_ninjs_3(item)
+    adjust_coverage_planning_scheduled_if_tbc(item)
     return item
 
 

--- a/server/planning/content_api/utils.py
+++ b/server/planning/content_api/utils.py
@@ -48,11 +48,13 @@ def adjust_coverage_planning_scheduled_if_tbc(item: dict) -> None:
         return
 
     for coverage in item["coverages"]:
+        tbc = coverage.pop("_time_to_be_confirmed", None)
+        
         planning = coverage.get("planning")
         if not planning:
             continue
 
-        if coverage.get("_time_to_be_confirmed") is True:
+        if tbc is True:
             planning["scheduled"] = planning["scheduled"].strftime("%Y-%m-%d")
 
 

--- a/server/planning/content_api/utils.py
+++ b/server/planning/content_api/utils.py
@@ -43,13 +43,14 @@ SYSTEM_FIELDS: set[str] = {
     "planning_schedule",
 }
 
+
 def adjust_coverage_planning_scheduled_if_tbc(item: dict) -> None:
     if item.get("type") != "planning" or not item.get("coverages"):
         return
 
     for coverage in item["coverages"]:
         tbc = coverage.pop("_time_to_be_confirmed", None)
-        
+
         planning = coverage.get("planning")
         if not planning:
             continue


### PR DESCRIPTION
### Purpose
This PR removes the `_time_to_be_confirmed` field and formats the `scheduled` field as a date-only string when the flag is true. 

### What has changed
- Removes `_time_to_be_confirmed` from each coverage.
- If `_time_to_be_confirmed` is true, `scheduled` returns as date only. 

### Steps to test
1. Post a planning item with a coverage where time is set as To Be Confirmed.
2. Fetch the planning item from the content api endpoint.
3. Confirm that:
   - `_time_to_be_confirmed` is not present in the response.
   - `planning.scheduled` is displayed as a date only format
4. Updated to a specified coverage time and confirm that in the content api response the `scheduled` field shows the full datetime.


Resolves: #[STT-1276](https://sofab.atlassian.net/browse/STT-1276)



[STT-1276]: https://sofab.atlassian.net/browse/STT-1276?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ