### PR TITLE
[SDESK-7723] Fix add to planning item remaining locked

### DIFF
--- a/client/components/ModalsContainer.tsx
+++ b/client/components/ModalsContainer.tsx
@@ -57,20 +57,25 @@ Modals.propTypes = {
     modalType: PropTypes.string,
     modalProps: PropTypes.object,
     handleHide: PropTypes.func.isRequired,
+    onModalHide: PropTypes.func,
 };
 
 const mapStateToProps = (state) => ({
     modalType: modalType(state),
     modalProps: modalProps(state),
 });
-const mapDispatchToProps = (dispatch) => ({
+
+const mapDispatchToProps = (dispatch, ownProps) => ({
     handleHide: (itemType) => {
         dispatch(modalActions.hideModal());
-        if (itemType === ITEM_TYPE.EVENT) {
-            dispatch(multiSelect.deSelectEvents(null, true));
-        } else {
-            dispatch(multiSelect.deSelectPlannings(null, true));
-        }
+
+        const action = itemType === ITEM_TYPE.EVENT
+            ? multiSelect.deSelectEvents
+            : multiSelect.deSelectPlannings;
+
+        dispatch(action(null, true));
+
+        ownProps?.onModalHide?.();
     },
 });
 

--- a/client/controllers/AddToPlanningController.tsx
+++ b/client/controllers/AddToPlanningController.tsx
@@ -107,7 +107,7 @@ export class AddToPlanningController {
 
         ReactDOM.render(
             <Provider store={this.store}>
-                <ModalsContainer />
+                <ModalsContainer onModalHide={this.unlockAddToPlanningItem} />
             </Provider>,
             this.$element
         );
@@ -170,17 +170,23 @@ export class AddToPlanningController {
             }, 1000);
         }
 
-        // Only unlock the item if it was locked when launching this modal
-        if ((this.newsItem?.lock_session ?? null) !== null
-            && (this.newsItem.lock_action ?? 'edit') === 'add_to_planning'
-        ) {
-            this.lock.unlock(this.newsItem);
-        }
+        this.unlockAddToPlanningItem();
 
         if (this.rendered) {
             ReactDOM.unmountComponentAtNode(this.$element.get(0));
         }
     }
+
+    /**
+     * Unlocks the item if it was locked when launching this modal
+     */
+    unlockAddToPlanningItem = () => {
+        const {lock_session, lock_action} = this.newsItem || {};
+
+        if (lock_session && lock_action === 'add_to_planning') {
+            this.lock.unlock(this.newsItem);
+        }
+    };
 
     onItemUnlock(_e, data) {
         if (this.store &&

--- a/client/controllers/AddToPlanningController.tsx
+++ b/client/controllers/AddToPlanningController.tsx
@@ -5,9 +5,9 @@ import ReactDOM from 'react-dom';
 import {Provider} from 'react-redux';
 import {ModalsContainer} from '../components';
 import {planning} from '../actions';
-import {get, isEmpty, isNumber, noop} from 'lodash';
+import {isEmpty, isNumber, noop} from 'lodash';
 import {registerNotifications, getErrorMessage, isExistingItem} from '../utils';
-import {WORKSPACE, MODALS} from '../constants';
+import {WORKSPACE, MODALS, PLANNING} from '../constants';
 import {GET_LABEL_MAP} from 'superdesk-core/scripts/apps/workspace/content/constants';
 import {IArticle, IContentProfile} from 'superdesk-api';
 import {authoringReactViewEnabled} from 'appConfig';
@@ -20,6 +20,8 @@ const DEFAULT_PLANNING_SCHEMA = {
     slugline: {required: true},
     urgency: {required: true},
 };
+
+const ADD_TO_PLANNING_LOCK = PLANNING.ITEM_ACTIONS.ADD_TO_PLANNING.lock_action;
 
 export class AddToPlanningController {
     $scope: any;
@@ -178,19 +180,19 @@ export class AddToPlanningController {
     }
 
     /**
-     * Unlocks the item if it was locked when launching this modal
+     * Unlocks item locked due to `add_to_planning` action
      */
     unlockAddToPlanningItem = () => {
         const {lock_session, lock_action} = this.newsItem || {};
 
-        if (lock_session && lock_action === 'add_to_planning') {
+        if (lock_session && lock_action === ADD_TO_PLANNING_LOCK) {
             this.lock.unlock(this.newsItem);
         }
     };
 
     onItemUnlock(_e, data) {
         if (this.store &&
-            data.item === this.newsItem._id &&
+            data.item === this.newsItem?._id &&
             data.lock_session !== this.session.sessionId
         ) {
             this.store.dispatch(actions.hideModal());
@@ -292,7 +294,7 @@ export class AddToPlanningController {
 
                 if (!this.lock.isLockedInCurrentSession(newsItem)) {
                     newsItem._editable = true;
-                    return this.lock.lock(newsItem, false, 'add_to_planning')
+                    return this.lock.lock(newsItem, false, ADD_TO_PLANNING_LOCK)
                         .then(
                             (lockedItem) => Promise.resolve(lockedItem),
                             (error) => {

--- a/index.ts
+++ b/index.ts
@@ -69,19 +69,15 @@ window.addEventListener('planning:fulfilassignment', (event: CustomEvent) => {
 window.addEventListener('planning:addToPlanning', (e: CustomEvent) => {
     const newElement = document.createElement('div');
     const rootScope = ng.get('$rootScope');
-    const timeout = ng.get('$timeout');
 
     document.body.appendChild(newElement);
     newElement.className = 'modal__dialog ng-scope';
     rootScope.locals = {data: {item: e.detail}};
 
-    // clean up: unmount the React component and remove the DOM element after the modal closes.
-    // delay is added to ensure any pending actions complete before removal.
+    // unmount the component and remove the element when the modal is closed
     rootScope.resolve = () => {
-        timeout(() => {
-            ReactDOM.unmountComponentAtNode(newElement);
-            newElement.remove();
-        }, 500);
+        ReactDOM.unmountComponentAtNode(newElement);
+        newElement.remove();
     };
 
     new ctrl.AddToPlanningController(
@@ -94,7 +90,7 @@ window.addEventListener('planning:addToPlanning', (e: CustomEvent) => {
         ng.get('lock'),
         ng.get('session'),
         ng.get('userList'),
-        timeout,
+        ng.get('$timeout'),
         ng.get('superdeskFlags'),
     );
 });

--- a/index.ts
+++ b/index.ts
@@ -68,16 +68,20 @@ window.addEventListener('planning:fulfilassignment', (event: CustomEvent) => {
 
 window.addEventListener('planning:addToPlanning', (e: CustomEvent) => {
     const newElement = document.createElement('div');
-    document.body.appendChild(newElement);
     const rootScope = ng.get('$rootScope');
+    const timeout = ng.get('$timeout');
 
+    document.body.appendChild(newElement);
     newElement.className = 'modal__dialog ng-scope';
     rootScope.locals = {data: {item: e.detail}};
 
-    // unmount the component and remove the element when the modal is closed
+    // clean up: unmount the React component and remove the DOM element after the modal closes.
+    // delay is added to ensure any pending actions complete before removal.
     rootScope.resolve = () => {
-        ReactDOM.unmountComponentAtNode(newElement);
-        newElement.remove();
+        timeout(() => {
+            ReactDOM.unmountComponentAtNode(newElement);
+            newElement.remove();
+        }, 500);
     };
 
     new ctrl.AddToPlanningController(
@@ -90,7 +94,7 @@ window.addEventListener('planning:addToPlanning', (e: CustomEvent) => {
         ng.get('lock'),
         ng.get('session'),
         ng.get('userList'),
-        ng.get('$timeout'),
+        timeout,
         ng.get('superdeskFlags'),
     );
 });


### PR DESCRIPTION
### Purpose
To fix the issue of the add to planning item remaining locked after closing the modal or after adding the item to coverage. In this PR we make to unlock the item if it was locked by the "Add to planning" modal in the first place.

### What has changed
- Refactored the `AddToPlanningController` to move unlock logic into a dedicated method and ensure it is called when the modal is closed
- Updated `ModalsContainer` to support an (optional) `onModalHide` callback 
- Adjusted event handling in `index.ts` to delay DOM cleanup to avoid race conditions with certain actions 
  
### Steps to test
Please follow the steps in the ticket comment https://sofab.atlassian.net/browse/SDESK-7723?focusedCommentId=141132

### Front-end checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)

Resolves: [SDESK-7723]

Thanks for checking!



[SDESK-7723]: https://sofab.atlassian.net/browse/SDESK-7723?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ