### PR TITLE
[SDESK-7721] fix(ingest): Use async signal in Planning, fix history

### DIFF
--- a/server/planning/feed_parsers/events_ml.py
+++ b/server/planning/feed_parsers/events_ml.py
@@ -73,7 +73,7 @@ class EventsMLParser(NewsMLTwoFeedParser):
                 )
                 self.__class__.missing_voc = "continue"
 
-    def get_item_id(self, tree: Element) -> str:
+    async def get_item_id(self, tree: Element) -> str:
         return tree.attrib["guid"]
 
     async def parse(self, tree: Element, provider=None):
@@ -81,7 +81,7 @@ class EventsMLParser(NewsMLTwoFeedParser):
         self.set_missing_voc_policy()
 
         try:
-            guid = self.get_item_id(tree)
+            guid = await self.get_item_id(tree)
 
             item = {
                 GUID_FIELD: guid,

--- a/server/planning/feed_parsers/superdesk_planning_xml.py
+++ b/server/planning/feed_parsers/superdesk_planning_xml.py
@@ -74,7 +74,7 @@ class PlanningMLParser(NewsMLTwoFeedParser):
                 )
                 self.__class__.missing_voc = "continue"
 
-    def get_item_id(self, tree: Element) -> str:
+    async def get_item_id(self, tree: Element) -> str:
         return tree.attrib["guid"]
 
     async def parse(self, tree: Element, provider=None):
@@ -83,7 +83,7 @@ class PlanningMLParser(NewsMLTwoFeedParser):
         planning_service = get_resource_service("planning")
 
         try:
-            guid = self.get_item_id(tree)
+            guid = await self.get_item_id(tree)
             original: Optional[Planning] = planning_service.find_one(req=None, _id=guid)
             item = await self.parse_item(tree, original)
             return [item] if item is not None else []
@@ -91,7 +91,7 @@ class PlanningMLParser(NewsMLTwoFeedParser):
             raise ParserError.parseMessageError(ex, provider)
 
     async def parse_item(self, tree: Element, original: Optional[Planning]) -> Optional[Planning]:
-        guid = (original or {}).get("_id") or self.get_item_id(tree)
+        guid = (original or {}).get("_id") or await self.get_item_id(tree)
         item = {
             GUID_FIELD: guid,
             ITEM_TYPE: CONTENT_TYPE.PLANNING,
@@ -101,7 +101,7 @@ class PlanningMLParser(NewsMLTwoFeedParser):
 
         self.parse_item_meta(tree, item)
         self.parse_content_meta(tree, item)
-        self.parse_news_coverage_set(tree, item, original)
+        await self.parse_news_coverage_set(tree, item, original)
         self.parse_news_coverage_status(tree, item)
 
         await upgrade_rich_text_fields(item, "planning")
@@ -241,7 +241,7 @@ class PlanningMLParser(NewsMLTwoFeedParser):
 
         return None
 
-    def get_coverage_details(self, news_coverage_elt: Element, item: Planning, original: Optional[Planning]):
+    async def get_coverage_details(self, news_coverage_elt: Element, item: Planning, original: Optional[Planning]):
         """Process the Coverage element and optionally return the coverage details
 
         If ``None`` is returned, this coverage is not added to the Planning item
@@ -283,13 +283,13 @@ class PlanningMLParser(NewsMLTwoFeedParser):
 
         return coverage_details
 
-    def parse_news_coverage_set(self, tree: Element, item: Planning, original: Optional[Planning]):
+    async def parse_news_coverage_set(self, tree: Element, item: Planning, original: Optional[Planning]):
         """Parse newsCoverageSet tag"""
 
         item["coverages"] = []
         news_coverage_set = tree.find(self.qname("newsCoverageSet"))
         if news_coverage_set is not None:
             for news_coverage_elt in news_coverage_set.findall(self.qname("newsCoverage")):
-                coverage = self.get_coverage_details(news_coverage_elt, item, original)
+                coverage = await self.get_coverage_details(news_coverage_elt, item, original)
                 if coverage is not None:
                     item["coverages"].append(coverage)

--- a/server/planning/planning/planning.py
+++ b/server/planning/planning/planning.py
@@ -113,7 +113,7 @@ class PlanningService(AsyncBaseService):
         ids = await self.backend.create_in_mongo_async(self.datasource, docs, **kwargs)
         await self.on_created_async(docs)
         for doc in docs:
-            planning_ingested.send(self, item=doc)
+            await planning_ingested.send(doc, None)
         return ids
 
     async def patch_in_mongo(self, id, document, original):
@@ -122,7 +122,7 @@ class PlanningService(AsyncBaseService):
         update_ingest_on_patch(document, original)
         response = await self.backend.update_in_mongo_async(self.datasource, id, document, original)
         await self.on_updated_async(document, original, from_ingest=True)
-        planning_ingested.send(self, item=document, original=original)
+        await planning_ingested.send(document, original)
         return response
 
     def is_new_version(self, new_item, old_item):
@@ -161,7 +161,7 @@ class PlanningService(AsyncBaseService):
     async def on_create_async(self, docs):
         """Set default metadata."""
         planning_type = await PlanningTypesAsyncService().find_one(name="planning")
-        assert planning_type is not None, "Expexted planning_type to not be None"
+        assert planning_type is not None, "Expected planning_type to not be None"
 
         history_service = PlanningHistoryAsyncService()
         generated_planning_items = []
@@ -185,17 +185,10 @@ class PlanningService(AsyncBaseService):
             self.set_planning_schedule(doc)
             # set timestamps
             update_dates_for(doc)
-
-            is_ingested = doc["state"] == "ingested"
-            if is_ingested:
-                await history_service.on_item_created([doc])
-
             update_method: Optional[UPDATE_METHOD] = doc.pop("update_method", None)
             if first_event and update_method is not None:
                 new_plans = await self._add_planning_to_event_series(doc, first_event, update_method)
                 if len(new_plans):
-                    if is_ingested:
-                        await history_service.on_item_created(new_plans)
                     generated_planning_items.extend(new_plans)
 
         if len(generated_planning_items):
@@ -203,6 +196,7 @@ class PlanningService(AsyncBaseService):
 
     async def on_created_async(self, docs):
         session_id = get_auth().get("_id")
+        history_service = PlanningHistoryAsyncService()
         post_planning_with_event = await is_post_planning_with_event_enabled()
         for doc in docs:
             plan_id = str(doc.get(ID_FIELD))
@@ -215,6 +209,8 @@ class PlanningService(AsyncBaseService):
                 session=session_id,
                 event_ids=get_related_event_ids_for_planning(doc, "primary"),  # Event IDs for primary events
             )
+            if doc["state"] == "ingested":
+                await history_service.on_item_created([doc])
             await self._update_event_history(doc)
             planning_created.send(self, item=doc)
 

--- a/server/planning/signals.py
+++ b/server/planning/signals.py
@@ -21,7 +21,12 @@ __all__ = [
 signals = blinker.Namespace()
 
 planning_created = signals.signal("planning:created")
-planning_ingested = signals.signal("planning:ingested")
+
+#: Signal for when a Planning item has been ingested (both created and updated)
+#: param updates: Updated Planning item dict
+#: param original: Original Planning item dict (if updating), else None
+planning_ingested = AsyncSignal[dict, dict | None]("planning:ingested")
+
 assignment_content_create = signals.signal("planning:assignment_content_create")
 
 


### PR DESCRIPTION
### Purpose
Fix issues found with ingesting Planning items.

### What has changed
* Support more async code in planning_xml ingest (required by STT specifics in their repo)
* Update `planning_ingested` signal to async, as it's required by STT handlers
* On ingest Planning, insert history entry **after** the Planning item has been created

Resolves: [SDESK-7721](https://sofab.atlassian.net/browse/SDESK-7721)



[SDESK-7721]: https://sofab.atlassian.net/browse/SDESK-7721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ