### PR TITLE
fix(slack): Remove deprected `as_user` argument

### DIFF
--- a/server/planning/planning_notifications.py
+++ b/server/planning/planning_notifications.py
@@ -402,7 +402,6 @@ def _send_to_slack_user(sc, user_id, message):
         if im.get("ok", False):
             sent = sc.api_call(
                 "chat.postMessage",
-                as_user=False,
                 channel=im.get("channel", {}).get("id"),
                 text=message,
                 link_names=True,


### PR DESCRIPTION
### Purpose
The `as_user` param is marked as deprecated in their SDK when using newer permission system. Remove this param when sending message directly to a user (still works when sending to a channel).

Error message from logs:
```
Traceback (most recent call last):
  File "celery/app/trace.py", line 453, in trace_task
    R = retval = fun(*args, **kwargs)
  File "superdesk/celery_app.py", line 91, in __call__
    return super().__call__(*args, **kwargs)
  File "celery/app/trace.py", line 736, in __protected_call__
    return self.run(*args, **kwargs)
  File "planning/planning_notifications.py", line 190, in _notify_slack
    _send_to_slack_user(sc, target_user, message)
  File "planning/planning_notifications.py", line 412, in _send_to_slack_user
    raise Exception("Failure response from slack post message call {}".format(sent))
Exception: Failure response from slack post message call 
{
    "ok": false,
    "error": "invalid_arguments",
    "deprecated_argument": "as_user",
    "headers": {
        "x-slack-failure": "invalid_arguments",
        "x-accepted-oauth-scopes": "chat:write:bot",
        "x-oauth-scopes": "app_mentions:read,channels:history,channels:join,channels:manage,channels:read,chat:write.customize,chat:write.public,chat:write,files:read,files:write,groups:history,groups:read,groups:write,im:history,im:read,im:write,links:read,links:write,mpim:history,mpim:read,mpim:write,pins:read,pins:write,reactions:read,reactions:write,reminders:read,reminders:write,team:read,usergroups:read,usergroups:write,users:read,users:write,users.profile:read",
        "access-control-expose-headers": "x-slack-req-id, retry-after",
        "access-control-allow-headers": "slack-route, x-slack-version-ts, x-b3-traceid, x-b3-spanid, x-b3-parentspanid, x-b3-sampled, x-b3-flags",
        "x-slack-backend": "r",
    }
}

```