### PR TITLE
add support for custom CVs in search panel

### DIFF
--- a/client/api/events.ts
+++ b/client/api/events.ts
@@ -29,6 +29,15 @@ function convertEventParams(params: ISearchParams): Partial<ISearchAPIParams> {
         calendars: cvsToString(params.calendars),
         no_calendar_assigned: params.no_calendar_assigned,
         priority: arrayToString(params.priority),
+        invitation_details: params.invitation_details,
+        accreditation_details: params.accreditation_details,
+        registration_details: params.registration_details,
+        internal_note: params.internal_note,
+        accreditation_info: params.accreditation_info,
+        definition_short: params.definition_short,
+        definition_long: params.definition_long,
+        registration: params.registration,
+        description_text: params.description_text,
     };
 }
 

--- a/client/api/planning.ts
+++ b/client/api/planning.ts
@@ -41,6 +41,8 @@ export function convertPlanningParams(params: ISearchParams): Partial<ISearchAPI
         coverage_user_id: params.coverage_user_id,
         coverage_assignment_status: params.coverage_assignment_status,
         priority: arrayToString(params.priority),
+        description_text: params.description_text,
+        headline: params.headline,
     };
 }
 

--- a/client/api/search.ts
+++ b/client/api/search.ts
@@ -8,10 +8,14 @@ import planningApi from '../actions/planning/api';
 import eventsApi from '../actions/events/api';
 import {partition} from 'lodash';
 
-export function cvsToString(items?: Array<{[key: string]: any}>, field: string = 'qcode'): string {
+export function cvsToString(
+    items?: Array<{[key: string]: any}>,
+    field: string = 'qcode',
+    includeScheme: boolean = false,
+): string {
     return arrayToString(
         (items ?? [])
-            .map((item) => item[field])
+            .map((item) => includeScheme && item.scheme ? item.scheme + ':' + item[field] : item[field])
     );
 }
 
@@ -26,7 +30,7 @@ export function convertCommonParams(params: ISearchParams): Partial<ISearchAPIPa
         name: params.name,
         full_text: params.full_text,
         anpa_category: cvsToString(params.anpa_category),
-        subject: cvsToString(params.subject),
+        subject: cvsToString(params.subject, 'qcode', true),
         state: cvsToString(params.state),
         posted: params.posted,
         language: params.language,
@@ -53,6 +57,7 @@ export function convertCommonParams(params: ISearchParams): Partial<ISearchAPIPa
         sort_field: params.sort_field,
         tz_offset: params.date_filter ? getTimeZoneOffset() : null,
         time_zone: timeUtils.localTimeZone(),
+        ednote: params.ednote,
     };
 }
 

--- a/client/components/AdvancedSearch/index.tsx
+++ b/client/components/AdvancedSearch/index.tsx
@@ -99,6 +99,7 @@ export class AdvancedSearch extends React.PureComponent<IProps> {
                 popupContainer: this.props.popupContainer,
                 language: getUserInterfaceLanguageFromCV(),
                 item: this.props.params,
+                schema: {},
             },
             {
                 start_date: {

--- a/client/components/fields/editor/CustomCV.tsx
+++ b/client/components/fields/editor/CustomCV.tsx
@@ -29,7 +29,7 @@ export class EditorFieldCV extends React.PureComponent<IEditorFieldProps> {
             <Row
                 key={cv._id}
                 id={`form-row-${cv.display_name}`}
-                data-test-id={testId?.length ? `${testId}.${cv._id}` : cv._id}
+                testId={testId?.length ? testId : cv._id}
             >
                 <TreeSelect
                     selectBranchWithChildren={

--- a/client/components/fields/resources/events.ts
+++ b/client/components/fields/resources/events.ts
@@ -69,6 +69,17 @@ registerEditorField(
 );
 
 registerEditorField(
+    'registration',
+    EditorFieldMultilingualText,
+    () => ({
+        label: superdeskApi.localization.gettext('Registration'),
+        field: 'registration',
+    }),
+    null,
+    false,
+);
+
+registerEditorField(
     'invitation_details',
     EditorFieldMultilingualText,
     () => ({

--- a/client/interfaces.ts
+++ b/client/interfaces.ts
@@ -966,6 +966,8 @@ export interface ICommonAdvancedSearchParams {
         name?: string;
     }>;
     priority?: Array<number>;
+    internal_note?: string;
+    ednote?: string;
 }
 
 export interface ICommonSearchParams<T extends IEventOrPlanningItem> {
@@ -998,8 +1000,14 @@ export interface IEventSearchParams extends ICommonSearchParams<IEventItem> {
     advancedSearch?: ICommonAdvancedSearchParams & {
         location?: IEventLocation;
         reference?: string;
+        invitation_details?: string;
+        accreditation_details?: string;
+        registration_details?: string;
+        accreditation_info?: string;
+        definition_short?: string;
+        definition_long?: string;
+        registration?: string;
     };
-
 }
 
 export interface IPlanningSearchParams extends ICommonSearchParams<IPlanningItem> {
@@ -1015,6 +1023,8 @@ export interface IPlanningSearchParams extends ICommonSearchParams<IPlanningItem
         g2_content_type?: IG2ContentType;
         noCoverage?: boolean;
         urgency?: IUrgency;
+        description_text?: string;
+        headline?: string;
     };
 }
 
@@ -1389,6 +1399,7 @@ export interface IFormAutosave {
 }
 
 export interface ISearchParams {
+    ednote: any;
     // Common Params
     item_ids?: Array<string>;
     name?: string;
@@ -1430,6 +1441,14 @@ export interface ISearchParams {
     location?: IEventLocation;
     calendars?: Array<ICalendar>;
     no_calendar_assigned?: boolean;
+    invitation_details?: string;
+    accreditation_details?: string;
+    registration_details?: string;
+    internal_note?: string;
+    accreditation_info?: string;
+    definition_short?: string;
+    definition_long?: string;
+    registration?: string;
 
     // Planning Params
     agendas?: Array<IAgenda['_id']>;
@@ -1443,6 +1462,8 @@ export interface ISearchParams {
     featured?: boolean;
     include_scheduled_updates?: boolean;
     event_item?: Array<IEventItem['_id']>;
+    description_text?: string;
+    headline?: string;
 
     // Pagination
     page?: number;
@@ -1476,6 +1497,7 @@ export interface ISearchAPIParams {
     source?: string;
     coverage_user_id?: string;
     priority?: string;
+    ednote?: string;
 
     // Event Params
     reference?: string;
@@ -1483,6 +1505,14 @@ export interface ISearchAPIParams {
     calendars?: string;
     no_calendar_assigned?: boolean;
     only_future?: boolean;
+    invitation_details?: string;
+    accreditation_details?: string;
+    registration_details?: string;
+    internal_note?: string;
+    accreditation_info?: string;
+    definition_short?: string;
+    definition_long?: string;
+    registration?: string;
 
     // Planning Params
     agendas?: string;
@@ -1496,6 +1526,8 @@ export interface ISearchAPIParams {
     include_scheduled_updates?: boolean;
     event_item?: string;
     coverage_assignment_status?: ICoverageAssigned['qcode']
+    description_text?: string;
+    headline?: string;
 
     // Pagination
     page?: number;

--- a/client/utils/search.ts
+++ b/client/utils/search.ts
@@ -46,6 +46,8 @@ function commonParamsToSearchParams(params: ICommonSearchParams<IEventOrPlanning
         sort_field: params.sortField ?? SORT_FIELD.SCHEDULE,
         source: params.advancedSearch?.source,
         priority: params.advancedSearch?.priority,
+        internal_note: params.advancedSearch?.internal_note,
+        ednote: params.advancedSearch?.ednote,
     };
 }
 
@@ -81,6 +83,8 @@ function searchParamsToCommonParams(params: ISearchParams): ICommonSearchParams<
             language: params.language,
             source: params.source,
             priority: params.priority,
+            internal_note: params.internal_note,
+            ednote: params.ednote,
         },
     };
 }
@@ -98,7 +102,9 @@ export function planningParamsToSearchParams(params: IPlanningSearchParams): ISe
         no_agenda_assigned: params.noAgendaAssigned,
         agendas: params.agendas,
         coverage_user_id: params.coverage_user_id,
-        coverage_assignment_status: params.coverage_assignment_status
+        coverage_assignment_status: params.coverage_assignment_status,
+        description_text: params.advancedSearch?.description_text,
+        headline: params.advancedSearch?.headline,
     };
 }
 
@@ -121,6 +127,8 @@ export function searchParamsToPlanningParams(params: ISearchParams): IPlanningSe
             g2_content_type: params.g2_content_type,
             noCoverage: params.no_coverage,
             urgency: params.urgency,
+            description_text: params.description_text,
+            headline: params.headline,
         },
     };
 }
@@ -133,6 +141,13 @@ export function eventParamsToSearchParams(params: IEventSearchParams): ISearchPa
         location: params.advancedSearch?.location,
         no_calendar_assigned: params.noCalendarAssigned,
         calendars: params.calendars,
+        accreditation_info: params.advancedSearch?.accreditation_info,
+        invitation_details: params.advancedSearch?.invitation_details,
+        accreditation_details: params.advancedSearch?.accreditation_details,
+        registration_details: params.advancedSearch?.registration_details,
+        definition_short: params.advancedSearch?.definition_short,
+        definition_long: params.advancedSearch?.definition_long,
+        registration: params.advancedSearch?.registration,
     };
 }
 
@@ -149,6 +164,13 @@ export function searchParamsToEventParams(params: ISearchParams): IEventSearchPa
             ...common.advancedSearch,
             location: params.location,
             reference: params.reference,
+            accreditation_info: params.accreditation_info,
+            invitation_details: params.invitation_details,
+            accreditation_details: params.accreditation_details,
+            registration_details: params.registration_details,
+            definition_short: params.definition_short,
+            definition_long: params.definition_long,
+            registration: params.registration,
         },
     };
 }

--- a/e2e/cypress/e2e/search/search_combined.cy.ts
+++ b/e2e/cypress/e2e/search/search_combined.cy.ts
@@ -2,6 +2,8 @@ import {setup, login, addItems, waitForPageLoad} from '../../support/common';
 import {AdvancedSearch, PlanningList} from '../../support/planning';
 import {TEST_EVENTS, createEventFor} from '../../fixtures/events';
 import {TEST_PLANNINGS, createPlanningFor} from '../../fixtures/planning';
+import {ADVANCED_SEARCH} from '../../fixtures/planning_types';
+import {CVs} from '../../fixtures/cvs';
 
 describe('Search.Combined: searching events and planning', () => {
     const search = new AdvancedSearch();
@@ -22,9 +24,30 @@ describe('Search.Combined: searching events and planning', () => {
             TEST_PLANNINGS.draft,
             TEST_PLANNINGS.spiked,
         ]);
+        addItems('vocabularies', [
+            CVs.EVENT_TYPES,
+        ]);
+        addItems('planning_types', [
+            ADVANCED_SEARCH,
+        ]);
+
+        cy.reload(); // when adding vocabularies, the page needs to be reloaded to reflect the changes
+
         search.viewEventsAndPlanning();
         search.toggleSearchPanel();
         search.openAllToggleBoxes();
+
+        // custom CVs
+        search.runSearchTests([{
+            params: {event_types: 'Foo'},
+            expectedCount: 2,
+            clearAfter: true,
+        },
+        {
+            params: {event_types: 'Bar'},
+            expectedCount: 0,
+            clearAfter: true,
+        }]);
 
         search.runSearchTests([{
             params: {},

--- a/e2e/cypress/e2e/search/search_events.cy.ts
+++ b/e2e/cypress/e2e/search/search_events.cy.ts
@@ -1,6 +1,8 @@
 import {setup, login, addItems, waitForPageLoad} from '../../support/common';
 import {AdvancedSearch, PlanningList, EventEditor} from '../../support/planning';
 import {TEST_EVENTS, createEventFor, LOCATIONS} from '../../fixtures/events';
+import {ADVANCED_SEARCH} from '../../fixtures/planning_types';
+import {CVs} from '../../fixtures/cvs';
 
 describe('Search.Events: searching events', () => {
     const search = new AdvancedSearch();
@@ -22,9 +24,103 @@ describe('Search.Events: searching events', () => {
             TEST_EVENTS.draft,
             TEST_EVENTS.spiked,
         ]);
+        addItems('vocabularies', [
+            CVs.EVENT_TYPES,
+        ]);
+        addItems('planning_types', [
+            ADVANCED_SEARCH,
+        ]);
+
+        cy.reload(); // when adding vocabularies, the page needs to be reloaded to reflect the changes
+
         search.viewEventsOnly();
         search.toggleSearchPanel();
         search.openAllToggleBoxes();
+
+        search.runSearchTests([{
+            params: {event_types: 'Foo'},
+            expectedCount: 1,
+            clearAfter: true,
+        },
+        {
+            params: {event_types: 'Bar'},
+            expectedCount: 0,
+            clearAfter: true,
+        }]);
+
+        // events text fields
+        search.runSearchTests([
+            {
+                params: {reference: 'REF-1234'},
+                expectedCount: 1,
+                clearAfter: true,
+            },
+            {
+                params: {reference: 'REF-non-existing'},
+                expectedCount: 0,
+                clearAfter: true,
+            },
+            {
+                params: {definition_short: 'short description'},
+                expectedCount: 1,
+                clearAfter: true,
+            },
+            {
+                params: {definition_short: 'non-existing'},
+                expectedCount: 0,
+                clearAfter: true,
+            },
+            {
+                params: {definition_long: 'non-existing'},
+                expectedCount: 0,
+                clearAfter: true,
+            },
+            {
+                params: {definition_long: 'long description'},
+                expectedCount: 1,
+                clearAfter: true,
+            },
+            {
+                params: {registration_details: 'non-existing'},
+                expectedCount: 0,
+                clearAfter: true,
+            },
+            {
+                params: {registration_details: 'registration details'},
+                expectedCount: 1,
+                clearAfter: true,
+            },
+            {
+                params: {invitation_details: 'non-existing'},
+                expectedCount: 0,
+                clearAfter: true,
+            },
+            {
+                params: {invitation_details: 'invitation details'},
+                expectedCount: 1,
+                clearAfter: true,
+            },
+            {
+                params: {accreditation_info: 'non-existing'},
+                expectedCount: 0,
+                clearAfter: true,
+            },
+            {
+                params: {accreditation_info: 'accreditation info'},
+                expectedCount: 1,
+                clearAfter: true,
+            },
+            {
+                params: {registration: 'non-existing'},
+                expectedCount: 0,
+                clearAfter: true,
+            },
+            {
+                params: {registration: 'registration'},
+                expectedCount: 1,
+                clearAfter: true,
+            },
+        ]);
 
         search.runSearchTests([{
             params: {},
@@ -60,6 +156,7 @@ describe('Search.Events: searching events', () => {
             params: {subject: ['archaeology', 'music']},
             expectedCount: 1,
             clearAfter: true,
+
         }, {
             params: {state: ['Draft']},
             expectedCount: 1,

--- a/e2e/cypress/e2e/search/search_planning.cy.ts
+++ b/e2e/cypress/e2e/search/search_planning.cy.ts
@@ -1,6 +1,8 @@
 import {setup, login, addItems, waitForPageLoad} from '../../support/common';
 import {AdvancedSearch, PlanningList, PlanningEditor} from '../../support/planning';
 import {TEST_PLANNINGS, createPlanningFor} from '../../fixtures/planning';
+import {ADVANCED_SEARCH} from '../../fixtures/planning_types';
+import {CVs} from '../../fixtures/cvs';
 
 describe('Search.Planning: searching planning items', () => {
     const search = new AdvancedSearch();
@@ -19,9 +21,76 @@ describe('Search.Planning: searching planning items', () => {
             TEST_PLANNINGS.spiked,
             TEST_PLANNINGS.featured,
         ]);
+        addItems('vocabularies', [
+            CVs.EVENT_TYPES,
+        ]);
+        addItems('planning_types', [
+            ADVANCED_SEARCH,
+        ]);
+
+        cy.reload(); // when adding vocabularies, the page needs to be reloaded to reflect the changes
+
         search.viewPlanningOnly();
         search.toggleSearchPanel();
         search.openAllToggleBoxes();
+
+        // custom CVs
+        search.runSearchTests([
+            {
+                params: {event_types: 'Foo'},
+                expectedCount: 1,
+                clearAfter: true,
+            },
+            {
+                params: {event_types: 'Bar'},
+                expectedCount: 0,
+                clearAfter: true,
+            },
+        ]);
+ 
+        // text fields
+        search.runSearchTests([
+            {
+                params: {description_text: 'description text'},
+                expectedCount: 1,
+                clearAfter: true,
+            },
+            {
+                params: {description_text: 'non-existing text'},
+                expectedCount: 0,
+                clearAfter: true,
+            },
+            {
+                params: {name: 'name'},
+                expectedCount: 1,
+                clearAfter: true,
+            },
+            {
+                params: {name: 'non-existing'},
+                expectedCount: 0,
+                clearAfter: true,
+            },
+            {
+                params: {ednote: 'editorial note'},
+                expectedCount: 1,
+                clearAfter: true,
+            },
+            {
+                params: {ednote: 'non-existing note'},
+                expectedCount: 0,
+                clearAfter: true,
+            },
+            {
+                params: {headline: 'planning headline'},
+                expectedCount: 1,
+                clearAfter: true,
+            },
+            {
+                params: {headline: 'non-existing headline'},
+                expectedCount: 0,
+                clearAfter: true,
+            },
+        ]);
 
         search.runSearchTests([{
             params: {},

--- a/e2e/cypress/fixtures/cvs.ts
+++ b/e2e/cypress/fixtures/cvs.ts
@@ -50,4 +50,17 @@ export const CVs = {
             {qcode: 'de', name: 'German', is_active: true},
         ]
     },
+    EVENT_TYPES: {
+        _id: 'event_types',
+        display_name: 'Event types',
+        type: 'manageable',
+        unique_field: 'qcode',
+        schema_field: "subject",
+        selection_type: "multi selection",
+        service: {all: 1},
+        items: [
+            {qcode: 'foo', name: 'Foo', is_active: true},
+            {qcode: 'bar', name: 'Bar', is_active: true},
+        ]
+    }
 };

--- a/e2e/cypress/fixtures/events.ts
+++ b/e2e/cypress/fixtures/events.ts
@@ -53,6 +53,7 @@ export const TEST_EVENTS = {
         subject: [
             {qcode: '01001000', name: 'archaeology', parent: '01000000'},
             {qcode: '01011000', name: 'music', parent: '01000000'},
+            {qcode: 'foo', name: 'Foo', scheme: 'event_types'},
         ],
         calendars: [
             {qcode: 'sport', name: 'Sport'},
@@ -62,6 +63,13 @@ export const TEST_EVENTS = {
             name: LOCATIONS.sydney_opera_house.name,
             address: LOCATIONS.sydney_opera_house.address,
         }],
+        reference: 'REF-1234',
+        definition_short: 'Short description of the event',
+        definition_long: 'Long description of the event',
+        registration_details: 'Registration details',
+        invitation_details: 'Invitation details',
+        accreditation_info: 'Accreditation info',
+        registration: 'Registration info',
     }),
     spiked: getEventForDate(getDateStringFor.today(), {
         ...BASE_EVENT,

--- a/e2e/cypress/fixtures/planning.ts
+++ b/e2e/cypress/fixtures/planning.ts
@@ -22,7 +22,13 @@ export const TEST_PLANNINGS = {
         subject: [
             {qcode: '01001000', name: 'archaeology', parent: '01000000'},
             {qcode: '01011000', name: 'music', parent: '01000000'},
+            {qcode: 'foo', name: 'Foo', scheme: 'event_types'},
+            {qcode: 'bar', name: 'Bar'},
         ],
+        description_text: 'description text',
+        name: 'planning name',
+        ednote: 'editorial note',
+        headline: 'planning headline',
     }),
     spiked: getPlanningForDate(getDateStringFor.today(), {
         ...BASE_PLANNING,

--- a/e2e/cypress/fixtures/planning_types.ts
+++ b/e2e/cypress/fixtures/planning_types.ts
@@ -1,0 +1,504 @@
+export const ADVANCED_SEARCH = {
+    "_id": "advanced_search",
+    "name": "advanced_search",
+    "init_version": 3,
+    "editor": {
+        "event": {
+            "full_text": {
+                "enabled": true,
+                "index": 1,
+                "group": "common",
+                "search_enabled": false,
+                "filter_enabled": true
+            },
+            "name": {
+                "enabled": true,
+                "index": 2,
+                "group": "common",
+                "search_enabled": true,
+                "filter_enabled": true
+            },
+            "slugline": {
+                "enabled": true,
+                "index": 3,
+                "group": "common",
+                "search_enabled": true,
+                "filter_enabled": true
+            },
+            "language": {
+                "enabled": false,
+                "index": 4,
+                "group": "common",
+                "search_enabled": true,
+                "filter_enabled": true
+            },
+            "internal_note": {
+                "enabled": true,
+                "index": 5,
+                "group": "common",
+                "search_enabled": true,
+                "filter_enabled": true
+            },
+            "state": {
+                "enabled": true,
+                "index": 1,
+                "group": "states",
+                "search_enabled": true,
+                "filter_enabled": true
+            },
+            "posted": {
+                "enabled": true,
+                "index": 2,
+                "group": "states",
+                "search_enabled": true,
+                "filter_enabled": true
+            },
+            "spike_state": {
+                "enabled": true,
+                "index": 3,
+                "group": "states",
+                "search_enabled": true,
+                "filter_enabled": true
+            },
+            "include_killed": {
+                "enabled": true,
+                "index": 4,
+                "group": "states",
+                "search_enabled": true,
+                "filter_enabled": true
+            },
+            "lock_state": {
+                "enabled": true,
+                "index": 5,
+                "group": "states",
+                "search_enabled": true,
+                "filter_enabled": true
+            },
+            "source": {
+                "enabled": true,
+                "index": 6,
+                "group": "states",
+                "search_enabled": true,
+                "filter_enabled": true
+            },
+            "start_date": {
+                "enabled": true,
+                "index": 1,
+                "group": "dates",
+                "search_enabled": true,
+                "filter_enabled": true
+            },
+            "end_date": {
+                "enabled": true,
+                "index": 2,
+                "group": "dates",
+                "search_enabled": true,
+                "filter_enabled": true
+            },
+            "date_filter": {
+                "enabled": true,
+                "index": 3,
+                "group": "dates",
+                "search_enabled": true,
+                "filter_enabled": true
+            },
+            "no_calendar_assigned": {
+                "enabled": true,
+                "index": 1,
+                "group": "events",
+                "search_enabled": true,
+                "filter_enabled": true
+            },
+            "calendars": {
+                "enabled": true,
+                "index": 2,
+                "group": "events",
+                "search_enabled": true,
+                "filter_enabled": true
+            },
+            "reference": {
+                "enabled": true,
+                "index": 3,
+                "group": "events",
+                "search_enabled": true,
+                "filter_enabled": true
+            },
+            "location": {
+                "enabled": true,
+                "index": 4,
+                "group": "events",
+                "search_enabled": true,
+                "filter_enabled": true
+            },
+            "event_types": {
+              "enabled": true,
+              "index": 5,
+              "group": "events",
+              "search_enabled": true,
+              "filter_enabled": true
+            },
+            "invitation_details": {
+              "enabled": true,
+              "index": 6,
+              "group": "events",
+              "search_enabled": true,
+              "filter_enabled": true
+            },
+            "definition_short": {
+                "enabled": true,
+                "index": 7,
+                "group": "events",
+                "search_enabled": true,
+                "filter_enabled": true
+            },
+            "definition_long": {
+                "enabled": true,
+                "index": 8,
+                "group": "events",
+                "search_enabled": true,
+                "filter_enabled": true
+            },
+            "registration_details": {
+                "enabled": true,
+                "index": 9,
+                "group": "events",
+                "search_enabled": true,
+                "filter_enabled": true
+            },
+            "accreditation_info": {
+                "enabled": true,
+                "index": 10,
+                "group": "events",
+                "search_enabled": true,
+                "filter_enabled": true
+            },
+            "registration": {
+                "enabled": true,
+                "index": 11,
+                "group": "events",
+                "search_enabled": true,
+                "filter_enabled": true
+            }
+        },
+        "planning": {
+            "full_text": {
+                "enabled": true,
+                "index": 1,
+                "group": "common",
+                "search_enabled": false,
+                "filter_enabled": true
+            },
+            "name": {
+                "enabled": true,
+                "index": 2,
+                "group": "common",
+                "search_enabled": true,
+                "filter_enabled": true
+            },
+            "slugline": {
+                "enabled": true,
+                "index": 3,
+                "group": "common",
+                "search_enabled": true,
+                "filter_enabled": true
+            },
+            "language": {
+                "enabled": false,
+                "index": 4,
+                "group": "common",
+                "search_enabled": true,
+                "filter_enabled": true
+            },
+            "internal_note": {
+                "enabled": true,
+                "index": 5,
+                "group": "common",
+                "search_enabled": true,
+                "filter_enabled": true
+            },
+            "ednote": {
+                "enabled": true,
+                "index": 6,
+                "group": "common",
+                "search_enabled": true,
+                "filter_enabled": true
+            },
+            "state": {
+                "enabled": true,
+                "index": 1,
+                "group": "states",
+                "search_enabled": true,
+                "filter_enabled": true
+            },
+            "posted": {
+                "enabled": true,
+                "index": 2,
+                "group": "states",
+                "search_enabled": true,
+                "filter_enabled": true
+            },
+            "spike_state": {
+                "enabled": true,
+                "index": 3,
+                "group": "states",
+                "search_enabled": true,
+                "filter_enabled": true
+            },
+            "include_killed": {
+                "enabled": true,
+                "index": 4,
+                "group": "states",
+                "search_enabled": true,
+                "filter_enabled": true
+            },
+            "lock_state": {
+                "enabled": true,
+                "index": 5,
+                "group": "states",
+                "search_enabled": true,
+                "filter_enabled": true
+            },
+            "exclude_rescheduled_and_cancelled": {
+                "enabled": true,
+                "index": 6,
+                "group": "states",
+                "search_enabled": true,
+                "filter_enabled": true
+            },
+            "source": {
+                "enabled": true,
+                "index": 7,
+                "group": "states",
+                "search_enabled": true,
+                "filter_enabled": true
+            },
+            "start_date": {
+                "enabled": true,
+                "index": 1,
+                "group": "dates",
+                "search_enabled": true,
+                "filter_enabled": true
+            },
+            "end_date": {
+                "enabled": true,
+                "index": 2,
+                "group": "dates",
+                "search_enabled": true,
+                "filter_enabled": true
+            },
+            "date_filter": {
+                "enabled": true,
+                "index": 3,
+                "group": "dates",
+                "search_enabled": true,
+                "filter_enabled": true
+            },
+            "no_agenda_assigned": {
+                "enabled": true,
+                "index": 1,
+                "group": "planning",
+                "search_enabled": true,
+                "filter_enabled": true
+            },
+            "agendas": {
+                "enabled": true,
+                "index": 2,
+                "group": "planning",
+                "search_enabled": true,
+                "filter_enabled": true
+            },
+            "no_coverage": {
+                "enabled": true,
+                "index": 3,
+                "group": "planning",
+                "search_enabled": true,
+                "filter_enabled": true
+            },
+            "g2_content_type": {
+                "enabled": true,
+                "index": 4,
+                "group": "planning",
+                "search_enabled": true,
+                "filter_enabled": true
+            },
+            "urgency": {
+                "enabled": true,
+                "index": 5,
+                "group": "planning",
+                "search_enabled": true,
+                "filter_enabled": true
+            },
+            "coverage_assignment_status": {
+                "enabled": true,
+                "index": 6,
+                "group": "planning",
+                "search_enabled": true,
+                "filter_enabled": true
+            },
+            "ad_hoc_planning": {
+                "enabled": false,
+                "index": 6,
+                "group": "planning",
+                "search_enabled": true,
+                "filter_enabled": true
+            },
+            "featured": {
+                "enabled": true,
+                "index": 7,
+                "group": "planning",
+                "search_enabled": true,
+                "filter_enabled": true
+            },
+            "include_scheduled_updates": {
+                "enabled": false,
+                "index": 8,
+                "group": "planning",
+                "search_enabled": true,
+                "filter_enabled": true
+            },
+            "event_types": {
+              "enabled": true,
+              "index": 9,
+              "group": "planning",
+              "search_enabled": true,
+              "filter_enabled": true
+            },
+            "description_text": {
+                "enabled": true,
+                "index": 10,
+                "group": "planning",
+                "search_enabled": true,
+                "filter_enabled": true
+            },
+            "headline": {
+                "enabled": true,
+                "index": 11,
+                "group": "planning",
+                "search_enabled": true,
+                "filter_enabled": true
+            },
+        },
+        "combined": {
+            "full_text": {
+                "enabled": true,
+                "index": 1,
+                "group": "common",
+                "search_enabled": false,
+                "filter_enabled": true
+            },
+            "name": {
+                "enabled": true,
+                "index": 2,
+                "group": "common",
+                "search_enabled": true,
+                "filter_enabled": true
+            },
+            "slugline": {
+                "enabled": true,
+                "index": 3,
+                "group": "common",
+                "search_enabled": true,
+                "filter_enabled": true
+            },
+            "language": {
+                "enabled": false,
+                "index": 4,
+                "group": "common",
+                "search_enabled": true,
+                "filter_enabled": true
+            },
+            "state": {
+                "enabled": true,
+                "index": 1,
+                "group": "states",
+                "search_enabled": true,
+                "filter_enabled": true
+            },
+            "posted": {
+                "enabled": true,
+                "index": 2,
+                "group": "states",
+                "search_enabled": true,
+                "filter_enabled": true
+            },
+            "spike_state": {
+                "enabled": true,
+                "index": 3,
+                "group": "states",
+                "search_enabled": true,
+                "filter_enabled": true
+            },
+            "include_killed": {
+                "enabled": true,
+                "index": 4,
+                "group": "states",
+                "search_enabled": true,
+                "filter_enabled": true
+            },
+            "lock_state": {
+                "enabled": true,
+                "index": 5,
+                "group": "states",
+                "search_enabled": true,
+                "filter_enabled": true
+            },
+            "source": {
+                "enabled": true,
+                "index": 6,
+                "group": "states",
+                "search_enabled": true,
+                "filter_enabled": true
+            },
+            "start_date": {
+                "enabled": true,
+                "index": 1,
+                "group": "dates",
+                "search_enabled": true,
+                "filter_enabled": true
+            },
+            "end_date": {
+                "enabled": true,
+                "index": 2,
+                "group": "dates",
+                "search_enabled": true,
+                "filter_enabled": true
+            },
+            "date_filter": {
+                "enabled": true,
+                "index": 3,
+                "group": "dates",
+                "search_enabled": true,
+                "filter_enabled": true
+            },
+            "calendars": {
+                "enabled": true,
+                "index": 1,
+                "group": "events",
+                "search_enabled": true,
+                "filter_enabled": true
+            },
+            "reference": {
+                "enabled": false,
+                "index": 2,
+                "group": "events",
+                "search_enabled": true,
+                "filter_enabled": true
+            },
+            "agendas": {
+                "enabled": true,
+                "index": 1,
+                "group": "planning",
+                "search_enabled": true,
+                "filter_enabled": true
+            },
+            "event_types": {
+              "enabled": true,
+              "index": 5,
+              "group": "common",
+              "search_enabled": true,
+              "filter_enabled": true
+            }
+        }
+    },
+    "schema": {}
+}

--- a/e2e/cypress/support/planning/advancedSearch.ts
+++ b/e2e/cypress/support/planning/advancedSearch.ts
@@ -122,6 +122,51 @@ export class AdvancedSearch {
                 getSearchPanel,
                 '[data-test-id=field-month_day] select'
             ),
+            reference: new Input(
+                getSearchPanel,
+                '[data-test-id=field-reference] input',
+            ),
+            definition_short: new Input(
+                getSearchPanel,
+                '[data-test-id=field-definition_short] input',
+            ),
+            definition_long: new Input(
+                getSearchPanel,
+                '[data-test-id=field-definition_long] input',
+            ),
+            registration_details: new Input(
+                getSearchPanel,
+                '[data-test-id=field-registration_details] input',
+            ),
+            invitation_details: new Input(
+                getSearchPanel,
+                '[data-test-id=field-invitation_details] input',
+            ),
+            accreditation_info: new Input(
+                getSearchPanel,
+                '[data-test-id=field-accreditation_info] input',
+            ),
+            registration: new Input(
+                getSearchPanel,
+                '[data-test-id=field-registration] input',
+            ),
+            event_types: new TreeSelect(
+                getSearchPanel,
+                '[data-test-id=field-event_types]',
+                true,
+            ),
+            description_text: new Input(
+                getSearchPanel,
+                '[data-test-id=field-description_text] input',
+            ),
+            ednote: new Input(
+                getSearchPanel,
+                '[data-test-id=field-ednote] input',
+            ),
+            headline: new Input(
+                getSearchPanel,
+                '[data-test-id=field-headline] input',
+            ),
         };
         this.list = new PlanningList();
     }
@@ -222,7 +267,7 @@ export class AdvancedSearch {
         }
 
         if (run.expectedCount != null) {
-            this.list.expectItemCount(run.expectedCount);
+            this.list.expectItemCount(run.expectedCount, 5000);
         }
 
         if (run.expectedText?.length) {

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -20,11 +20,15 @@ services:
         image: redis:alpine
         networks:
             - e2e
+        ports:
+            - "6379:6379"
 
     mongo:
         image: mongo:6
         networks:
             - e2e
+        ports:
+            - "27017:27017"
         tmpfs:
             - /data/db
 

--- a/e2e/server/hypercorn_config.py
+++ b/e2e/server/hypercorn_config.py
@@ -8,5 +8,5 @@ access_log_format = "%(m)s %(U)s status=%(s)s time=%(T)ss size=%(B)sb"
 
 loglevel = "warning"
 
-use_reload = "SUPERDESK_RELOAD" in os.environ
+use_reloader = "SUPERDESK_RELOAD" in os.environ
 timeout = int(os.environ.get("WEB_TIMEOUT", 500))

--- a/server/features/search.feature
+++ b/server/features/search.feature
@@ -449,3 +449,181 @@ Feature: Search Feature
             ]
         }
         """
+
+    @auth
+    Scenario: Search events by custom CV
+        Given "events"
+            """
+            [
+                {
+                    "guid": "event_123",
+                    "name": "event",
+                    "subject": [
+                        {"name": "Foo", "qcode": "foo", "scheme": "scheme1"},
+                        {"name": "Bar", "qcode": "bar", "scheme": "scheme1"}
+                    ],
+                    "dates": {
+                        "start": "2035-01-02T00:00:00+0000",
+                        "end": "2035-01-03T00:00:00+0000"
+                    }
+                }
+            ]
+            """
+
+        When we get "/events_planning_search?subject=scheme1:foo"
+        Then we get list with 1 items
+
+        When we get "/events_planning_search?subject=scheme2:foo"
+        Then we get list with 0 items
+
+        When we get "/events_planning_search?subject=foo"
+        Then we get list with 0 items
+
+    @auth
+    Scenario: Search events by text fields
+        Given "events"
+            """
+            [
+                {
+                    "guid": "event_123",
+                    "name": "event",
+                    "ednote": "ednote text",
+                    "internal_note": "internal note text",
+                    "slugline": "test slugline",
+                    "definition_short": "short value",
+                    "definition_long": "long value",
+                    "registration_details": "registration details text",
+                    "invitation_details": "invitation details text",
+                    "accreditation_info": "accreditation info text",
+                    "reference": "reference text",
+                    "registration": "registration text",
+                    "dates": {
+                        "start": "2035-01-02T00:00:00+0000",
+                        "end": "2035-01-03T00:00:00+0000"
+                    }
+                }
+            ]
+            """
+
+        When we get "/events_planning_search?slugline=test"
+        Then we get list with 1 items
+
+        When we get "/events_planning_search?slugline=foo"
+        Then we get list with 0 items
+
+        When we get "/events_planning_search?ednote=text"
+        Then we get list with 1 items
+
+        When we get "/events_planning_search?ednote=foo"
+        Then we get list with 0 items
+
+        When we get "/events_planning_search?internal_note=text"
+        Then we get list with 1 items
+
+        When we get "/events_planning_search?internal_note=foo"
+        Then we get list with 0 items
+
+        When we get "/events_planning_search?repo=events&definition_short=short"
+        Then we get list with 1 items
+
+        When we get "/events_planning_search?repo=events&definition_short=long"
+        Then we get list with 0 items
+
+        When we get "/events_planning_search?repo=events&definition_long=long"
+        Then we get list with 1 items
+
+        When we get "/events_planning_search?repo=events&definition_long=short"
+        Then we get list with 0 items
+
+        When we get "/events_planning_search?repo=events&registration_details=details"
+        Then we get list with 1 items
+
+        When we get "/events_planning_search?repo=events&registration_details=foo"
+        Then we get list with 0 items
+
+        When we get "/events_planning_search?repo=events&invitation_details=invitation"
+        Then we get list with 1 items
+
+        When we get "/events_planning_search?repo=events&invitation_details=foo"
+        Then we get list with 0 items
+
+        When we get "/events_planning_search?repo=events&accreditation_info=info"
+        Then we get list with 1 items
+
+        When we get "/events_planning_search?repo=events&accreditation_info=foo"
+        Then we get list with 0 items
+
+        When we get "/events_planning_search?repo=events&reference=reference"
+        Then we get list with 1 items
+
+        When we get "/events_planning_search?repo=events&reference=foo"
+        Then we get list with 0 items
+
+        When we get "/events_planning_search?repo=events&registration=registration"
+        Then we get list with 1 items
+
+        When we get "/events_planning_search?repo=events&registration=foo"
+        Then we get list with 0 items
+
+    @auth
+    Scenario: Search planning by text fields
+        Given "planning"
+            """
+            [
+                {
+                    "guid": "event_123",
+                    "name": "event",
+                    "ednote": "ednote text",
+                    "internal_note": "internal note text",
+                    "abstract": "abstract text",
+                    "headline": "headline text",
+                    "slugline": "slugline text",
+                    "keywords": ["keywords", "text"],
+                    "priority": 2,
+                    "description_text": "description text",
+                    "planning_date": "2035-07-31T00:00:00+0000"
+                }
+            ]
+            """
+
+        When we get "/events_planning_search?slugline=slugline"
+        Then we get list with 1 items
+
+        When we get "/events_planning_search?slugline=foo"
+        Then we get list with 0 items
+
+        When we get "/events_planning_search?ednote=ednote"
+        Then we get list with 1 items
+
+        When we get "/events_planning_search?ednote=foo"
+        Then we get list with 0 items
+
+        When we get "/events_planning_search?internal_note=internal"
+        Then we get list with 1 items
+
+        When we get "/events_planning_search?internal_note=foo"
+        Then we get list with 0 items
+
+        When we get "/events_planning_search?repo=planning&description_text=description"
+        Then we get list with 1 items
+
+        When we get "/events_planning_search?repo=planning&description_text=foo"
+        Then we get list with 0 items
+
+        When we get "/events_planning_search?repo=planning&abstract=abstract"
+        Then we get list with 1 items
+
+        When we get "/events_planning_search?repo=planning&abstract=foo"
+        Then we get list with 0 items
+
+        When we get "/events_planning_search?repo=planning&headline=headline"
+        Then we get list with 1 items
+
+        When we get "/events_planning_search?repo=planning&headline=foo"
+        Then we get list with 0 items
+
+        When we get "/events_planning_search?repo=planning&keywords=keywords"
+        Then we get list with 1 items
+
+        When we get "/events_planning_search?repo=planning&keywords=foo"
+        Then we get list with 0 items

--- a/server/planning/planning/planning_schema.py
+++ b/server/planning/planning/planning_schema.py
@@ -241,7 +241,7 @@ planning_schema = {
     "subject": {
         "type": "list",
         "mapping": {
-            "type": "object",
+            "type": "nested",
             "dynamic": False,
             "properties": {
                 "qcode": not_analyzed,

--- a/server/planning/planning/planning_schema.py
+++ b/server/planning/planning/planning_schema.py
@@ -243,6 +243,7 @@ planning_schema = {
         "mapping": {
             "type": "nested",
             "dynamic": False,
+            "include_in_parent": True,
             "properties": {
                 "qcode": not_analyzed,
                 "name": {

--- a/server/planning/search/queries/common.py
+++ b/server/planning/search/queries/common.py
@@ -30,8 +30,11 @@ from planning.content_profiles.utils import get_multilingual_fields
 logger = logging.getLogger(__name__)
 
 
+Params = Dict[str, Any]
+
+
 FilterFunctionType = (
-    Callable[[dict, elastic.ElasticQuery], None] | Callable[[dict, elastic.ElasticQuery], Awaitable[None]]
+    Callable[[Params, elastic.ElasticQuery], None] | Callable[[Params, elastic.ElasticQuery], Awaitable[None]]
 )
 
 
@@ -197,8 +200,47 @@ def search_anpa_category(params: Dict[str, Any], query: elastic.ElasticQuery):
 def search_subject(params: Dict[str, Any], query: elastic.ElasticQuery):
     subjects = str_to_array(params.get("subject"))
 
-    if len(subjects):
-        query.must.append(elastic.terms(field="subject.qcode", values=subjects))
+    subjects_by_scheme: Dict[str, List[str]] = {}
+    for subject in subjects:
+        scheme, code = subject.split(":", 1) if ":" in subject else ("", subject)
+        subjects_by_scheme.setdefault(scheme, []).append(code)
+
+    for scheme, codes in subjects_by_scheme.items():
+        if scheme:
+            query.must.append(
+                elastic.nested(
+                    "subject",
+                    {
+                        "bool": {
+                            "must": [
+                                elastic.term(field="subject.scheme", value=scheme),
+                                elastic.terms(field="subject.qcode", values=codes),
+                            ]
+                        }
+                    },
+                )
+            )
+        else:
+            query.must.append(
+                elastic.nested(
+                    "subject",
+                    {
+                        "bool": {
+                            "must": [
+                                elastic.terms(field="subject.qcode", values=codes),
+                                {
+                                    "bool": {
+                                        "should": [
+                                            elastic.term(field="subject.scheme", value=""),
+                                            {"bool": {"must_not": elastic.field_exists("subject.scheme")}},
+                                        ],
+                                    },
+                                },
+                            ]
+                        }
+                    },
+                )
+            )
 
 
 def search_posted(params: Dict[str, Any], query: elastic.ElasticQuery):
@@ -501,6 +543,19 @@ def search_priority(params: Dict[str, Any], query: elastic.ElasticQuery):
         query.must.append(elastic.terms(field="priority", values=priorities))
 
 
+def search_invitation_details(params: Dict[str, Any], query: elastic.ElasticQuery):
+    if params.get("invitation_details"):
+        query.must.append(elastic.match_phrase(field="invitation_details", value=params["invitation_details"]))
+
+
+def search_ednote(params: Dict[str, Any], query: elastic.ElasticQuery):
+    search_text_field(params, query, "ednote")
+
+
+def search_internal_note(params: Dict[str, Any], query: elastic.ElasticQuery):
+    search_text_field(params, query, "internal_note")
+
+
 COMMON_SEARCH_FILTERS: list[FilterFunctionType] = [
     search_item_ids,
     search_name,
@@ -517,10 +572,13 @@ COMMON_SEARCH_FILTERS: list[FilterFunctionType] = [
     search_original_creator,
     search_source,
     search_priority,
+    search_invitation_details,
+    search_ednote,
+    search_internal_note,
 ]
 
 
-COMMON_PARAMS: List[str] = [
+COMMON_PARAMS = [
     "item_ids",
     "name",
     "tz_offset",
@@ -553,4 +611,6 @@ COMMON_PARAMS: List[str] = [
     "original_creator",
     "source",
     "priority",
+    "ednote",
+    "internal_note",
 ]

--- a/server/planning/search/queries/elastic.py
+++ b/server/planning/search/queries/elastic.py
@@ -21,7 +21,7 @@ from planning.common import get_start_of_next_week, sanitize_query_text
 class ElasticQuery:
     """Utility class to build elastic queries"""
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Default all filters to empty arrays"""
 
         self.must: List[Dict[str, Any]] = []

--- a/server/planning/search/queries/events.py
+++ b/server/planning/search/queries/events.py
@@ -22,6 +22,7 @@ from .common import (
     get_sort_order,
     search_text_field,
     FilterFunctionType,
+    Params,
 )
 
 
@@ -328,6 +329,30 @@ def set_search_sort(params: Dict[str, Any], query: elastic.ElasticQuery):
     query.sort.append({field: {"order": order}})
 
 
+def search_definition_short(params: Params, query: elastic.ElasticQuery):
+    search_text_field(params, query, "definition_short")
+
+
+def search_definition_long(params: Params, query: elastic.ElasticQuery):
+    search_text_field(params, query, "definition_long")
+
+
+def search_registration_details(params: Params, query: elastic.ElasticQuery):
+    search_text_field(params, query, "registration_details")
+
+
+def search_invitation_details(params: Params, query: elastic.ElasticQuery):
+    search_text_field(params, query, "invitation_details")
+
+
+def search_accreditation_info(params: Params, query: elastic.ElasticQuery):
+    search_text_field(params, query, "accreditation_info")
+
+
+def search_registration(params: Params, query: elastic.ElasticQuery):
+    search_text_field(params, query, "registration")
+
+
 EVENT_SEARCH_FILTERS: list[FilterFunctionType] = [
     search_events,
     search_slugline,
@@ -337,15 +362,28 @@ EVENT_SEARCH_FILTERS: list[FilterFunctionType] = [
     search_no_calendar_assigned,
     search_dates,
     set_search_sort,
+    search_definition_short,
+    search_definition_long,
+    search_registration_details,
+    search_accreditation_info,
+    search_invitation_details,
+    search_registration,
 ]
 
 EVENT_SEARCH_FILTERS.extend(COMMON_SEARCH_FILTERS)
 
-EVENT_PARAMS: List[str] = [
+EVENT_PARAMS = [
     "reference",
     "location",
     "calendars",
     "no_calendar_assigned",
+    "definition_short",
+    "definition_long",
+    "registration_details",
+    "invitation_details",
+    "accreditation_info",
+    "reference",
+    "registration",
 ]
 
 EVENT_PARAMS.extend(COMMON_PARAMS)

--- a/server/planning/search/queries/planning.py
+++ b/server/planning/search/queries/planning.py
@@ -26,6 +26,7 @@ from .common import (
     get_sort_order,
     search_text_field,
     FilterFunctionType,
+    Params,
 )
 
 
@@ -341,6 +342,28 @@ def search_coverage_assignment_status(params: Dict[str, Any], query: elastic.Ela
             )
 
 
+def search_description_text(params: Params, query: elastic.ElasticQuery):
+    search_text_field(params, query, "description_text")
+
+
+def search_abstract(params: Params, query: elastic.ElasticQuery):
+    search_text_field(params, query, "abstract")
+
+
+def search_headline(params: Params, query: elastic.ElasticQuery):
+    search_text_field(params, query, "headline")
+
+
+def search_keywords(params: Params, query: elastic.ElasticQuery):
+    search_text_field(params, query, "keywords")
+
+
+def search_priority(params: Params, query: elastic.ElasticQuery):
+    priority = str_to_number(params.get("priority"))
+    if priority is not None:
+        query.must.append(elastic.term(field="priority", value=priority))
+
+
 PLANNING_SEARCH_FILTERS: list[FilterFunctionType] = [
     search_planning,
     search_agendas,
@@ -357,11 +380,16 @@ PLANNING_SEARCH_FILTERS: list[FilterFunctionType] = [
     set_search_sort,
     search_coverage_assigned_user,
     search_coverage_assignment_status,
+    search_description_text,
+    search_abstract,
+    search_headline,
+    search_keywords,
+    search_priority,
 ]
 
 PLANNING_SEARCH_FILTERS.extend(COMMON_SEARCH_FILTERS)
 
-PLANNING_PARAMS: List[str] = [
+PLANNING_PARAMS = [
     "agendas",
     "no_agenda_assigned",
     "ad_hoc_planning",
@@ -374,6 +402,12 @@ PLANNING_PARAMS: List[str] = [
     "event_item",
     "coverage_user_id",
     "coverage_assignment_status",
+    "description_text",
+    "abstract",
+    "headline",
+    "slugline",
+    "keywords",
+    "priority",
 ]
 
 PLANNING_PARAMS.extend(COMMON_PARAMS)

--- a/server/planning/search/queries/planning.py
+++ b/server/planning/search/queries/planning.py
@@ -358,12 +358,6 @@ def search_keywords(params: Params, query: elastic.ElasticQuery):
     search_text_field(params, query, "keywords")
 
 
-def search_priority(params: Params, query: elastic.ElasticQuery):
-    priority = str_to_number(params.get("priority"))
-    if priority is not None:
-        query.must.append(elastic.term(field="priority", value=priority))
-
-
 PLANNING_SEARCH_FILTERS: list[FilterFunctionType] = [
     search_planning,
     search_agendas,
@@ -384,7 +378,6 @@ PLANNING_SEARCH_FILTERS: list[FilterFunctionType] = [
     search_abstract,
     search_headline,
     search_keywords,
-    search_priority,
 ]
 
 PLANNING_SEARCH_FILTERS.extend(COMMON_SEARCH_FILTERS)


### PR DESCRIPTION
and add missing core text fields

STT-113

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

### Front-end checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)

Resolves: #[issue-number]

