### PR TITLE
[STT-1260] - Fix location details error in the embedded events editor 

### DIFF
--- a/client/planning-extension/src/authoring-react-fields/location/editor.tsx
+++ b/client/planning-extension/src/authoring-react-fields/location/editor.tsx
@@ -2,32 +2,36 @@ import * as React from 'react';
 import {IEditorComponentProps} from 'superdesk-api';
 import {ILocationFieldConfig, ILocationFieldUserPreferences, ILocationValueOperational} from './interfaces';
 import {extensionBridge} from '../../extension_bridge';
+import {cloneDeep, set} from 'lodash';
 
 type IProps = IEditorComponentProps<ILocationValueOperational, ILocationFieldConfig, ILocationFieldUserPreferences>;
 
 export class Editor extends React.PureComponent<IProps> {
     render() {
         const {EditorFieldLocation} = extensionBridge.editor.fields;
-
-        const convertedValue = (() => {
-            if (this.props.value?.[0] != null) {
-                return this.props.value[0];
-            }
-
-            return this.props.value;
-        })();
+        const location = Array.isArray(this.props.value) ? this.props.value[0] : this.props.value;
 
         return (
             <EditorFieldLocation
                 field="location"
                 enableExternalSearch
-                item={{
-                    location: convertedValue,
-                }}
+                item={{location: location ?? {}}}
                 required={this.props.config.required}
                 disabled={this.props.config.readOnly}
-                onChange={(_field, value) => {
-                    this.props.onChange(value);
+                onChange={(field: string, value: any) => {
+                    const currentDetails = location?.details;
+                    const valueCopy = {location: cloneDeep(location ?? {})};
+
+                    set(valueCopy, field, value);
+
+                    // Preserve location.details if a new location was selected without details
+                    if (field === 'location' && currentDetails != null && value?.details == null) {
+                        valueCopy.location = {
+                            ...valueCopy.location,
+                            details: currentDetails
+                        };
+                    }
+                    this.props.onChange([valueCopy.location]);
                 }}
             />
         );


### PR DESCRIPTION
### Purpose
Fix location details field integration in planning editor.

### What has changed
- Added logic to ensure location and location.details are saved as needed and don't break the editor

### Steps to test
1. Have Location and Location details fields in the embedded event editor
2. Create a planning item
3. Create an event from the planning item form
4. Fill in the Location in the embedded editor, save the embedded event. Observe that it saves as expected.
5. Fill in the Location details in the embedded event editor, save the embedded event. Observe that it saves as expected.
6. Remove either the location or the location details and save and observe it saves properly.

Resolves: #[STT-1260](https://sofab.atlassian.net/browse/STT-1260)


[STT-1260]: https://sofab.atlassian.net/browse/STT-1260