### PR TITLE
[SDESK-7734] - Removed planning items from the event are reverted back when the event is updated

### DIFF
--- a/client/components/Events/ManageEventTemplatesModal.tsx
+++ b/client/components/Events/ManageEventTemplatesModal.tsx
@@ -14,7 +14,7 @@ interface IEventTemplate extends IBaseRestApiResponse {
     template_name: string;
 }
 
-const getItemComponent = (nameField: IFormField) =>
+const getItemComponent = (nameField: IFormField<IEventTemplate>) =>
     class ItemComponent extends React.PureComponent<IPropsGenericFormItemComponent<any>> {
         render(): React.ReactNode {
             const {item, page} = this.props;
@@ -56,16 +56,16 @@ export class ManageEventTemplatesModal extends React.PureComponent<IProps> {
 
         const {gettext} = superdeskApi.localization;
         const {getGenericHttpEntityListPageComponent} = superdeskApi.components;
-        const {FormFieldType} = superdeskApi.forms;
+        const {GenericFormFieldType} = superdeskApi.forms;
 
-        const nameField: IFormField = {
+        const nameField: IFormField<IEventTemplate> = {
             label: gettext('Template name'),
-            type: FormFieldType.plainText,
+            type: GenericFormFieldType.plainText,
             field: 'template_name',
             required: true,
         };
 
-        const formConfig: IFormGroup = {
+        const formConfig: IFormGroup<IEventTemplate> = {
             direction: 'vertical',
             type: 'inline',
             form: [nameField],

--- a/package-lock.json
+++ b/package-lock.json
@@ -10969,7 +10969,7 @@
       }
     },
     "superdesk-core": {
-      "version": "github:superdesk/superdesk-client-core#a48ba14b8e0d46b94d087f5a6e16ba6a91e7ba05",
+      "version": "github:superdesk/superdesk-client-core#d7deb093223bbb478eb2f9a7353b53eb190f7dd2",
       "from": "github:superdesk/superdesk-client-core#develop",
       "dev": true,
       "requires": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,9 +42,9 @@
       "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q=="
     },
     "@babel/types": {
-      "version": "7.28.1",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.1.tgz",
-      "integrity": "sha512-x0LvFTekgSX+83TI28Y9wYPUfzrnl2aT5+5QLnO6v7mSJYtEEevuDRN0F0uSHRk1G1IWZC43o00Y0xDDrpBGPQ==",
+      "version": "7.28.2",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.2.tgz",
+      "integrity": "sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==",
       "dev": true,
       "requires": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -2445,16 +2445,16 @@
       }
     },
     "compression": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.0.tgz",
-      "integrity": "sha512-k6WLKfunuqCYD3t6AsuPGvQWaKwuLLh2/xHNcX4qE+vIfDNXpSqnrhwA7O53R7WVQUnt8dVAIW+YHr7xTgOgGA==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.1.tgz",
+      "integrity": "sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==",
       "dev": true,
       "requires": {
         "bytes": "3.1.2",
         "compressible": "~2.0.18",
         "debug": "2.6.9",
         "negotiator": "~0.6.4",
-        "on-headers": "~1.0.2",
+        "on-headers": "~1.1.0",
         "safe-buffer": "5.2.1",
         "vary": "~1.1.2"
       },
@@ -4513,9 +4513,9 @@
       }
     },
     "fs-monkey": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.0.6.tgz",
-      "integrity": "sha512-b1FMfwetIKymC0eioW7mTywihSQE4oLzQn1dB6rZB5fx/3NpNEdAWeCSMB+60/AeT0TCXsxzAlcYVEFCTAksWg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.1.0.tgz",
+      "integrity": "sha512-QMUezzXWII9EV5aTFXW1UBVUO77wYPpjqIF8/AviUCThNeSYZykpoTixUeaNNBwmCev0AMDWMAni+f8Hxb1IFw==",
       "dev": true
     },
     "fs-write-stream-atomic": {
@@ -5748,6 +5748,12 @@
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
       "dev": true
     },
+    "immer": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.1.tgz",
+      "integrity": "sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==",
+      "dev": true
+    },
     "immutable": {
       "version": "3.8.2",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
@@ -6708,13 +6714,13 @@
       "dev": true
     },
     "launch-editor": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.10.0.tgz",
-      "integrity": "sha512-D7dBRJo/qcGX9xlvt/6wUYzQxjh5G1RvZPgPv8vi4KRU99DVQL/oW7tnVOCCTm2HGeo3C5HvGE5Yrh6UBoZ0vA==",
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.11.1.tgz",
+      "integrity": "sha512-SEET7oNfgSaB6Ym0jufAdCeo3meJVeCaaDyzRygy0xsp2BFKCprcfHljTq4QkzTLUxEKkFK6OK4811YM2oSrRg==",
       "dev": true,
       "requires": {
-        "picocolors": "^1.0.0",
-        "shell-quote": "^1.8.1"
+        "picocolors": "^1.1.1",
+        "shell-quote": "^1.8.3"
       }
     },
     "lazy-cache": {
@@ -7839,9 +7845,9 @@
       }
     },
     "on-headers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
-      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
       "dev": true
     },
     "once": {
@@ -8165,9 +8171,9 @@
           "dev": true
         },
         "jsonfile": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+          "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.6",
@@ -10969,13 +10975,13 @@
       }
     },
     "superdesk-core": {
-      "version": "github:superdesk/superdesk-client-core#d7deb093223bbb478eb2f9a7353b53eb190f7dd2",
+      "version": "github:superdesk/superdesk-client-core#b82d6e418f1579315486bba8fc9f66231df26205",
       "from": "github:superdesk/superdesk-client-core#develop",
       "dev": true,
       "requires": {
         "@metadata/exif": "github:superdesk/exif#431066d",
         "@popperjs/core": "2.10.2",
-        "@sourcefabric/common": "0.0.66",
+        "@sourcefabric/common": "0.0.69",
         "@sourcefabric/date-fns-tz": "^1.2.1",
         "@sourcefabric/draft-js": "^0.11.5",
         "@types/angular": "~1.6.0",
@@ -11024,6 +11030,7 @@
         "hls.js": "0.12.4",
         "html-loader": "^1.3.2",
         "htmldiff-js": "github:superdesk/htmldiff-js#master",
+        "immer": "^10.1.1",
         "immutable": "3.8.2",
         "jquery": "3.3.1",
         "jquery-jcrop": "0.9.13",
@@ -11067,7 +11074,7 @@
         "sass-loader": "^10.5.2",
         "shallow-equal": "^3.1.0",
         "shortid": "2.2.8",
-        "superdesk-ui-framework": "4.0.67",
+        "superdesk-ui-framework": "4.0.75",
         "ts-loader": "^8.4.0",
         "typescript": "~4.9.5",
         "uuid": "8.3.1",
@@ -11078,9 +11085,9 @@
       },
       "dependencies": {
         "@sourcefabric/common": {
-          "version": "0.0.66",
-          "resolved": "https://registry.npmjs.org/@sourcefabric/common/-/common-0.0.66.tgz",
-          "integrity": "sha512-fgxp7rZKNrfiL9c21+imXqdcFWRDudw/VSwlcbGch+dtkXDdH4owSPfTdR/Sb/UClcbrGgZQHK0asQF2XpVpDA==",
+          "version": "0.0.69",
+          "resolved": "https://registry.npmjs.org/@sourcefabric/common/-/common-0.0.69.tgz",
+          "integrity": "sha512-Uopya/TWgewqPz0T1SxNIpT92ujeKYQ8ba3OPTDcBYOAL4Bs58ONljaRA+FrOFtEzRpJzeBuUz9t8Vovb/ko+Q==",
           "dev": true,
           "requires": {
             "date-fns": "^4.1.0",
@@ -11167,9 +11174,9 @@
           }
         },
         "superdesk-ui-framework": {
-          "version": "4.0.67",
-          "resolved": "https://registry.npmjs.org/superdesk-ui-framework/-/superdesk-ui-framework-4.0.67.tgz",
-          "integrity": "sha512-fQvXN/QbwPkHad15+z1QweH7mWv+iOw4LXeFw1+OK/thN+O6PWYl6QEQJUP1qCsEObin0IA/+QkO3WPZCTePgQ==",
+          "version": "4.0.75",
+          "resolved": "https://registry.npmjs.org/superdesk-ui-framework/-/superdesk-ui-framework-4.0.75.tgz",
+          "integrity": "sha512-zeSTO1P8amAcpTaK1F00lUJXVnadHw+bu4p7sLmdvdfrXUd5KAclXuC11WZD4tFSz7C4ppjgK0W1QLEATPisrA==",
           "dev": true,
           "requires": {
             "@popperjs/core": "^2.4.0",
@@ -11186,6 +11193,23 @@
             "react-scrollspy": "^3.4.3",
             "tippy.js": "^6.3.7",
             "weekstart": "^2.0.0"
+          },
+          "dependencies": {
+            "@sourcefabric/common": {
+              "version": "0.0.66",
+              "resolved": "https://registry.npmjs.org/@sourcefabric/common/-/common-0.0.66.tgz",
+              "integrity": "sha512-fgxp7rZKNrfiL9c21+imXqdcFWRDudw/VSwlcbGch+dtkXDdH4owSPfTdR/Sb/UClcbrGgZQHK0asQF2XpVpDA==",
+              "dev": true,
+              "requires": {
+                "date-fns": "^4.1.0",
+                "lodash": "4.17.19",
+                "primereact": "^6.0.2",
+                "react": "16.9.0",
+                "react-dom": "16.9.0",
+                "react-sortable-hoc": "^1.11.0",
+                "tippy.js": "^6.3.7"
+              }
+            }
           }
         }
       }
@@ -11442,37 +11466,11 @@
         "typed-array-buffer": "^1.0.3"
       },
       "dependencies": {
-        "is-typed-array": {
-          "version": "1.1.15",
-          "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
-          "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
-          "dev": true,
-          "requires": {
-            "which-typed-array": "^1.1.16"
-          }
-        },
-        "isarray": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-          "dev": true
-        },
         "safe-buffer": {
           "version": "5.2.1",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
           "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
           "dev": true
-        },
-        "typed-array-buffer": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
-          "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
-          "dev": true,
-          "requires": {
-            "call-bound": "^1.0.3",
-            "es-errors": "^1.3.0",
-            "is-typed-array": "^1.1.14"
-          }
         }
       }
     },
@@ -13088,9 +13086,9 @@
       "dev": true
     },
     "yaml": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
-      "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
+      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
       "dev": true
     },
     "yargs": {

--- a/server/planning/events/events.py
+++ b/server/planning/events/events.py
@@ -546,12 +546,13 @@ class EventsService(AsyncBaseService):
         updates.setdefault("versioncreated", utcnow())
 
         # Extract the ``embedded_planning`` from the updates
+        embedded_planning_present = "embedded_planning" in updates
         embedded_planning = get_events_embedded_planning(updates)
 
         item = self.backend.update(self.datasource, id, updates, original)
 
         # Process ``embedded_planning`` field, and sync Event metadata with associated Planning/Coverages
-        await sync_event_metadata_with_planning_items(original, updates, embedded_planning)
+        await sync_event_metadata_with_planning_items(original, updates, embedded_planning, embedded_planning_present)
 
         return item
 

--- a/server/planning/events/events_sync/__init__.py
+++ b/server/planning/events/events_sync/__init__.py
@@ -19,7 +19,7 @@ from planning.utils import parse_date
 from planning.utils import get_related_planning_for_events
 from planning.content_profiles.utils import AllContentProfileData
 from planning.common import get_config_event_fields_to_sync_with_planning
-from planning.types import Event, EmbeddedPlanningDict, StringFieldTranslation
+from planning.types import Event, EmbeddedPlanningDict, StringFieldTranslation, Planning
 from planning.types.event import EmbeddedPlanning as EmbeddedPlanningModel
 
 from .common import VocabsSyncData, SyncItemData, SyncData
@@ -45,6 +45,7 @@ async def sync_event_metadata_with_planning_items(
     original: Optional[Event],
     updates: Event,
     embedded_planning: list[EmbeddedPlanningDict] | list[EmbeddedPlanningModel],
+    embedded_planning_present: bool,
 ):
     embedded_planning = [
         cast(EmbeddedPlanningDict, obj.to_dict()) if isinstance(obj, EmbeddedPlanningModel) else obj
@@ -100,11 +101,42 @@ async def sync_event_metadata_with_planning_items(
     if not len(sync_fields):
         # There are no fields to sync with the Event
         # So only update the Planning items based on the ``embedded_planning`` Event field
+
+        # 1) Update embedded items and collect the IDs of embedded, existing planning items
+        embedded_existing_ids: set[str] = set()
+        pending_planning_updates: list[tuple[str, Planning]] = []
+
         for planning_original, planning_updates, update_required in get_existing_plannings_from_embedded_planning(
             event_updated, event_translations, embedded_planning, profiles, vocabs
         ):
+            embedded_existing_ids.add(planning_original["_id"])
             if update_required:
-                await planning_service.patch_async(planning_original["_id"], planning_updates)
+                pending_planning_updates.append((planning_original["_id"], planning_updates))
+
+        for planning_id, payload in pending_planning_updates:
+            await planning_service.patch_async(planning_id, payload)
+
+        # 2. Unlink removed planning items
+        if embedded_planning_present:
+            existing_linked_planning_items = get_related_planning_for_events([event_updated["_id"]], "primary")
+            linked_ids: set[str] = {p["_id"] for p in existing_linked_planning_items}
+
+            # Anything linked but not present in the embedded set should be unlinked
+            ids_to_unlink = linked_ids - embedded_existing_ids
+
+            for planning_id in ids_to_unlink:
+                planning_item = next((p for p in existing_linked_planning_items if p["_id"] == planning_id), None)
+                if not planning_item:
+                    continue
+
+                current_related_events = planning_item.get("related_events") or []
+                pruned_related_events = [
+                    rel for rel in current_related_events if rel.get("_id") != event_updated["_id"]
+                ]
+
+                if pruned_related_events != current_related_events:
+                    await planning_service.patch_async(planning_id, {"related_events": pruned_related_events})
+
         return
 
     coverage_sync_fields = set(field for field in sync_fields if field in COVERAGE_SYNC_FIELDS)

--- a/server/planning/events/events_sync/__init__.py
+++ b/server/planning/events/events_sync/__init__.py
@@ -84,6 +84,11 @@ async def sync_event_metadata_with_planning_items(
     )
     event_translations = deepcopy(event_sync_data.updated_translations or event_sync_data.original_translations)
 
+    pre_linked_ids: set[str] = set()
+    if original:
+        pre_linked_items = get_related_planning_for_events([event_updated["_id"]])
+        pre_linked_ids = {p["_id"] for p in pre_linked_items}
+
     # Create any new Planning items (and their coverages), based on the ``embedded_planning`` Event field
     await create_new_plannings_from_embedded_planning(
         event_updated, event_translations, embedded_planning, profiles, vocabs
@@ -112,10 +117,18 @@ async def sync_event_metadata_with_planning_items(
             if update_required:
                 await planning_service.patch_async(planning_original["_id"], planning_updates)
 
-        # 2. Unlink removed planning items
+        # 2) Include any planning IDs that were created in this request (post-creation minus pre-creation)
+        existing_linked_planning_items = get_related_planning_for_events([event_updated["_id"]])
+        post_linked_ids = {p["_id"] for p in existing_linked_planning_items}
+        newly_linked_ids = post_linked_ids - pre_linked_ids
+
+        # Merge the keep set with the newly linked IDs so we don't accidentally unlink them
+        embedded_existing_ids.update(newly_linked_ids)
+
+        # 3) If embedded planning data was provided, unlink planning items no longer embedded
         if embedded_planning_present:
-            existing_linked_planning_items = get_related_planning_for_events([event_updated["_id"]])
-            linked_ids: set[str] = {p["_id"] for p in existing_linked_planning_items}
+            # use the items we just fetched
+            linked_ids: set[str] = post_linked_ids
 
             # Anything linked but not present in the embedded set should be unlinked
             ids_to_unlink = linked_ids - embedded_existing_ids

--- a/server/planning/events/events_sync/__init__.py
+++ b/server/planning/events/events_sync/__init__.py
@@ -45,7 +45,7 @@ async def sync_event_metadata_with_planning_items(
     original: Optional[Event],
     updates: Event,
     embedded_planning: list[EmbeddedPlanningDict] | list[EmbeddedPlanningModel],
-    embedded_planning_present: bool,
+    embedded_planning_present: bool = False,
 ):
     embedded_planning = [
         cast(EmbeddedPlanningDict, obj.to_dict()) if isinstance(obj, EmbeddedPlanningModel) else obj

--- a/server/planning/events/events_sync/__init__.py
+++ b/server/planning/events/events_sync/__init__.py
@@ -104,21 +104,17 @@ async def sync_event_metadata_with_planning_items(
 
         # 1) Update embedded items and collect the IDs of embedded, existing planning items
         embedded_existing_ids: set[str] = set()
-        pending_planning_updates: list[tuple[str, Planning]] = []
 
         for planning_original, planning_updates, update_required in get_existing_plannings_from_embedded_planning(
             event_updated, event_translations, embedded_planning, profiles, vocabs
         ):
             embedded_existing_ids.add(planning_original["_id"])
             if update_required:
-                pending_planning_updates.append((planning_original["_id"], planning_updates))
-
-        for planning_id, payload in pending_planning_updates:
-            await planning_service.patch_async(planning_id, payload)
+                await planning_service.patch_async(planning_original["_id"], planning_updates)
 
         # 2. Unlink removed planning items
         if embedded_planning_present:
-            existing_linked_planning_items = get_related_planning_for_events([event_updated["_id"]], "primary")
+            existing_linked_planning_items = get_related_planning_for_events([event_updated["_id"]])
             linked_ids: set[str] = {p["_id"] for p in existing_linked_planning_items}
 
             # Anything linked but not present in the embedded set should be unlinked

--- a/server/planning/events/events_sync/events_sync_tests.py
+++ b/server/planning/events/events_sync/events_sync_tests.py
@@ -1,5 +1,6 @@
 import pytz
 
+from contextlib import ExitStack
 from datetime import datetime
 from copy import deepcopy
 from typing import Any
@@ -45,27 +46,34 @@ class SyncEventMetadataWithPlanningItemsTest(EventsBaseTestCase):
         updated_event = deepcopy(self.get_base_event())
         embedded_planning = self.build_embedded_planning(updated_event)
 
-        # Mocks for dependencies inside the module under test
-        with patch(
-            f"{MODULE}.AllContentProfileData.get", new=AsyncMock(return_value=MagicMock())
-        ) as profiles_get_mock, patch(f"{MODULE}.get_resource_service") as get_resource_service_mock, patch(
-            f"{MODULE}.create_new_plannings_from_embedded_planning", new=AsyncMock()
-        ) as create_new_plannings_mock, patch(
-            f"{MODULE}.get_existing_plannings_from_embedded_planning"
-        ) as get_existing_plannings_mock:
-            vocab_service = MagicMock()
-            vocab_service.find_one.side_effect = [{"items": []}, {"items": []}]
-            planning_service = MagicMock()
-            planning_service.patch_async = AsyncMock()
+        vocab_service = MagicMock()
+        vocab_service.find_one.side_effect = [{"items": []}, {"items": []}]
 
-            def select_resource_service(resource_name: str):
-                if resource_name == "vocabularies":
-                    return vocab_service
-                if resource_name == "planning":
-                    return planning_service
-                return MagicMock()
+        planning_service = MagicMock()
+        planning_service.patch_async = AsyncMock()
 
-            get_resource_service_mock.side_effect = select_resource_service
+        def select_resource_service(resource_name: str):
+            services = {
+                "vocabularies": vocab_service,
+                "planning": planning_service,
+            }
+            return services.get(resource_name, MagicMock())
+
+        with ExitStack() as stack:
+            profiles_get = stack.enter_context(
+                patch(f"{MODULE}.AllContentProfileData.get", new=AsyncMock(return_value=MagicMock()))
+            )
+            get_resource_service = stack.enter_context(
+                patch(f"{MODULE}.get_resource_service")
+            )
+            create_new_plannings = stack.enter_context(
+                patch(f"{MODULE}.create_new_plannings_from_embedded_planning", new=AsyncMock())
+            )
+            get_existing_plannings = stack.enter_context(
+                patch(f"{MODULE}.get_existing_plannings_from_embedded_planning")
+            )
+            
+            get_resource_service.side_effect = select_resource_service
 
             await sync_event_metadata_with_planning_items(
                 original=original_event,
@@ -75,10 +83,10 @@ class SyncEventMetadataWithPlanningItemsTest(EventsBaseTestCase):
             )
 
             # Assert expectations for creation path
-            create_new_plannings_mock.assert_awaited_once()
-            get_existing_plannings_mock.assert_not_called()
+            create_new_plannings.assert_awaited_once()
+            get_existing_plannings.assert_not_called()
             planning_service.patch_async.assert_not_awaited()
-            profiles_get_mock.assert_awaited()
+            profiles_get.assert_awaited()
 
     async def test_no_sync_fields_embedded_updates_and_unlink(self):
         """
@@ -116,32 +124,43 @@ class SyncEventMetadataWithPlanningItemsTest(EventsBaseTestCase):
             {"_id": "pl3", "related_events": [{"_id": original_event["_id"]}, {"_id": "keep"}]},
         ]
 
-        with patch(
-            f"{MODULE}.AllContentProfileData.get", new=AsyncMock(return_value=MagicMock())
-        ) as profiles_get_mock, patch(
-            f"{MODULE}.get_config_event_fields_to_sync_with_planning", return_value=set()
-        ) as get_sync_config_mock, patch(
-            f"{MODULE}.get_resource_service"
-        ) as get_resource_service_mock, patch(
-            f"{MODULE}.create_new_plannings_from_embedded_planning", new=AsyncMock()
-        ) as create_new_plannings_mock, patch(
-            f"{MODULE}.get_existing_plannings_from_embedded_planning", side_effect=existing_plannings_generator
-        ), patch(
-            f"{MODULE}.get_related_planning_for_events", return_value=related_planning
-        ) as get_related_planning_mock:
-            vocab_service = MagicMock()
-            vocab_service.find_one.side_effect = [{"items": []}, {"items": []}]
-            planning_service = MagicMock()
-            planning_service.patch_async = AsyncMock()
+        vocab_service = MagicMock()
+        vocab_service.find_one.side_effect = [{"items": []}, {"items": []}]
+        planning_service = MagicMock()
+        planning_service.patch_async = AsyncMock()
 
-            def select_resouce_service(resource_name: str):
-                if resource_name == "vocabularies":
-                    return vocab_service
-                if resource_name == "planning":
-                    return planning_service
-                return MagicMock()
+        def select_resource_service(name: str):
+            return {
+                "vocabularies": vocab_service,
+                "planning": planning_service,
+            }.get(name, MagicMock())
 
-            get_resource_service_mock.side_effect = select_resouce_service
+        with ExitStack() as stack:
+            profiles_get = stack.enter_context(
+                patch(f"{MODULE}.AllContentProfileData.get",
+                    new=AsyncMock(return_value=MagicMock()))
+            )
+            get_sync_config = stack.enter_context(
+                patch(f"{MODULE}.get_config_event_fields_to_sync_with_planning",
+                    return_value=set())
+            )
+            get_resource_service = stack.enter_context(
+                patch(f"{MODULE}.get_resource_service")
+            )
+            create_new_plannings = stack.enter_context(
+                patch(f"{MODULE}.create_new_plannings_from_embedded_planning",
+                    new=AsyncMock())
+            )
+            get_existing_plannings = stack.enter_context(
+                patch(f"{MODULE}.get_existing_plannings_from_embedded_planning",
+                    side_effect=existing_plannings_generator)
+            )
+            get_related_planning = stack.enter_context(
+                patch(f"{MODULE}.get_related_planning_for_events",
+                    return_value=related_planning)
+            )
+
+            get_resource_service.side_effect = select_resource_service
 
             await sync_event_metadata_with_planning_items(
                 original=original_event,
@@ -150,25 +169,23 @@ class SyncEventMetadataWithPlanningItemsTest(EventsBaseTestCase):
                 embedded_planning_present=embedded_planning_present,
             )
 
-            # 1) create_new always runs
-            create_new_plannings_mock.assert_awaited_once()
+            # Assert 1) create_new always runs
+            create_new_plannings.assert_awaited_once()
 
-            # 2) Embedded updates: only pl2 should be patched
+            # Assert 2) Embedded updates: only pl2 should be patched for slugline
             planning_service.patch_async.assert_any_await("pl2", {"slugline": "needs-update"})
 
-            # 3) Unlink: pl3 is linked but not embedded so patch related_events to prune evt1
-            # Build expected pruned list for pl3
-            pruned_pl3 = [{"_id": "keep"}]  # original had evt1 + keep, we remove evt1
+            # Assert 3) Unlink: pl3 should have event pruned from related_events
+            pruned_pl3 = [{"_id": "keep"}]
             planning_service.patch_async.assert_any_await("pl3", {"related_events": pruned_pl3})
 
-            # Ensure we didn't patch pl1 (no update required and still embedded)
-            # We can check that there's no patch call for pl1 with slugline or related_events removing evt1
-            calls_str = [str(c) for c in planning_service.patch_async.await_args_list]
-            assert not any("('pl1'," in s and "slugline" in s for s in calls_str)
+            # Ensure no patch for pl1 at all (still embedded + no update required)
+            patched_ids = [call.args[0] for call in planning_service.patch_async.await_args_list]
+            assert "pl1" not in patched_ids
 
-            get_sync_config_mock.assert_called_once()
-            get_related_planning_mock.assert_called_once()
-            profiles_get_mock.assert_awaited()
+            get_sync_config.assert_called_once()
+            assert get_related_planning.call_count == 2
+            profiles_get.assert_awaited()
 
     async def test_sync_fields_present_embedded_item(self):
         """
@@ -199,38 +216,58 @@ class SyncEventMetadataWithPlanningItemsTest(EventsBaseTestCase):
             updates_dict["headline"] = "synced-headline"
             sync_data.planning.updates = updates_dict
 
-        with patch(
-            f"{MODULE}.AllContentProfileData.get",
-            new=AsyncMock(
-                return_value=MagicMock(
-                    events=MagicMock(is_multilingual=True),
-                    planning=MagicMock(is_multilingual=True),
+        vocab_service = MagicMock()
+        vocab_service.find_one.side_effect = [{"items": []}, {"items": []}]
+        planning_service = MagicMock()
+        planning_service.patch_async = AsyncMock()
+
+        def select_resource_service(name: str):
+            return {
+                "vocabularies": vocab_service,
+                "planning": planning_service,
+            }.get(name, MagicMock())
+
+        with ExitStack() as stack:
+            profiles_get = stack.enter_context(
+                patch(
+                    f"{MODULE}.AllContentProfileData.get",
+                    new=AsyncMock(
+                        return_value=MagicMock(
+                            events=MagicMock(is_multilingual=True),
+                            planning=MagicMock(is_multilingual=True),
+                        )
+                    ),
                 )
-            ),
-        ) as profiles_get_mock, patch(
-            f"{MODULE}.get_config_event_fields_to_sync_with_planning", return_value={"name", "language"}
-        ) as get_sync_config_mock, patch(
-            f"{MODULE}.get_resource_service"
-        ) as get_resource_service_mock, patch(
-            f"{MODULE}.create_new_plannings_from_embedded_planning", new=AsyncMock()
-        ) as create_new_plannings_mock, patch(
-            f"{MODULE}.get_existing_plannings_from_embedded_planning", side_effect=existing_plannings_generator
-        ), patch(
-            f"{MODULE}.sync_existing_planning_item", side_effect=sync_side_effect
-        ) as sync_existing_planning_item_mock:
-            vocab_service = MagicMock()
-            vocab_service.find_one.side_effect = [{"items": []}, {"items": []}]
-            planning_service = MagicMock()
-            planning_service.patch_async = AsyncMock()
+            )
+            get_sync_config = stack.enter_context(
+                patch(
+                    f"{MODULE}.get_config_event_fields_to_sync_with_planning",
+                    return_value={"name", "language"},
+                )
+            )
+            get_resource_service = stack.enter_context(
+                patch(f"{MODULE}.get_resource_service")
+            )
+            create_new_plannings = stack.enter_context(
+                patch(
+                    f"{MODULE}.create_new_plannings_from_embedded_planning",
+                    new=AsyncMock(),
+                )
+            )
+            get_existing_plannings = stack.enter_context(
+                patch(
+                    f"{MODULE}.get_existing_plannings_from_embedded_planning",
+                    side_effect=existing_plannings_generator,
+                )
+            )
+            sync_existing_planning_item = stack.enter_context(
+                patch(
+                    f"{MODULE}.sync_existing_planning_item",
+                    side_effect=sync_side_effect,
+                )
+            )
 
-            def select_resource_service(resource_name: str):
-                if resource_name == "vocabularies":
-                    return vocab_service
-                if resource_name == "planning":
-                    return planning_service
-                return MagicMock()
-
-            get_resource_service_mock.side_effect = select_resource_service
+            get_resource_service.side_effect = select_resource_service
 
             await sync_event_metadata_with_planning_items(
                 original=original_event,
@@ -239,16 +276,16 @@ class SyncEventMetadataWithPlanningItemsTest(EventsBaseTestCase):
                 embedded_planning_present=True,
             )
 
-            # sync should have been invoked for our single embedded item
-            assert sync_existing_planning_item_mock.call_count == 1
+            # Assert: sync invoked for the single embedded item
+            assert sync_existing_planning_item.call_count == 1
 
-            # Patch must be called since sync_data.update_planning=True in side_effect
+            # Assert: patch called once with merged updates from embedded + sync
             planning_service.patch_async.assert_awaited_once_with(
                 "pl-sync",
                 {"slugline": "from-embedded", "headline": "synced-headline"},
             )
 
-            # create_new always runs first
-            create_new_plannings_mock.assert_awaited_once()
-            get_sync_config_mock.assert_called_once()
-            profiles_get_mock.assert_awaited()
+            # Assert: create_new runs first; config and profiles fetched
+            create_new_plannings.assert_awaited_once()
+            get_sync_config.assert_called_once()
+            profiles_get.assert_awaited()

--- a/server/planning/events/events_sync/events_sync_tests.py
+++ b/server/planning/events/events_sync/events_sync_tests.py
@@ -63,16 +63,14 @@ class SyncEventMetadataWithPlanningItemsTest(EventsBaseTestCase):
             profiles_get = stack.enter_context(
                 patch(f"{MODULE}.AllContentProfileData.get", new=AsyncMock(return_value=MagicMock()))
             )
-            get_resource_service = stack.enter_context(
-                patch(f"{MODULE}.get_resource_service")
-            )
+            get_resource_service = stack.enter_context(patch(f"{MODULE}.get_resource_service"))
             create_new_plannings = stack.enter_context(
                 patch(f"{MODULE}.create_new_plannings_from_embedded_planning", new=AsyncMock())
             )
             get_existing_plannings = stack.enter_context(
                 patch(f"{MODULE}.get_existing_plannings_from_embedded_planning")
             )
-            
+
             get_resource_service.side_effect = select_resource_service
 
             await sync_event_metadata_with_planning_items(
@@ -137,27 +135,22 @@ class SyncEventMetadataWithPlanningItemsTest(EventsBaseTestCase):
 
         with ExitStack() as stack:
             profiles_get = stack.enter_context(
-                patch(f"{MODULE}.AllContentProfileData.get",
-                    new=AsyncMock(return_value=MagicMock()))
+                patch(f"{MODULE}.AllContentProfileData.get", new=AsyncMock(return_value=MagicMock()))
             )
             get_sync_config = stack.enter_context(
-                patch(f"{MODULE}.get_config_event_fields_to_sync_with_planning",
-                    return_value=set())
+                patch(f"{MODULE}.get_config_event_fields_to_sync_with_planning", return_value=set())
             )
-            get_resource_service = stack.enter_context(
-                patch(f"{MODULE}.get_resource_service")
-            )
+            get_resource_service = stack.enter_context(patch(f"{MODULE}.get_resource_service"))
             create_new_plannings = stack.enter_context(
-                patch(f"{MODULE}.create_new_plannings_from_embedded_planning",
-                    new=AsyncMock())
+                patch(f"{MODULE}.create_new_plannings_from_embedded_planning", new=AsyncMock())
             )
             get_existing_plannings = stack.enter_context(
-                patch(f"{MODULE}.get_existing_plannings_from_embedded_planning",
-                    side_effect=existing_plannings_generator)
+                patch(
+                    f"{MODULE}.get_existing_plannings_from_embedded_planning", side_effect=existing_plannings_generator
+                )
             )
             get_related_planning = stack.enter_context(
-                patch(f"{MODULE}.get_related_planning_for_events",
-                    return_value=related_planning)
+                patch(f"{MODULE}.get_related_planning_for_events", return_value=related_planning)
             )
 
             get_resource_service.side_effect = select_resource_service
@@ -245,9 +238,7 @@ class SyncEventMetadataWithPlanningItemsTest(EventsBaseTestCase):
                     return_value={"name", "language"},
                 )
             )
-            get_resource_service = stack.enter_context(
-                patch(f"{MODULE}.get_resource_service")
-            )
+            get_resource_service = stack.enter_context(patch(f"{MODULE}.get_resource_service"))
             create_new_plannings = stack.enter_context(
                 patch(
                     f"{MODULE}.create_new_plannings_from_embedded_planning",

--- a/server/planning/events/events_sync/events_sync_tests.py
+++ b/server/planning/events/events_sync/events_sync_tests.py
@@ -1,0 +1,254 @@
+import pytz
+
+from datetime import datetime
+from copy import deepcopy
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from planning.events.events_tests import EventsBaseTestCase
+from planning.events.events_sync import sync_event_metadata_with_planning_items
+from planning.events.events import get_events_embedded_planning
+
+
+MODULE = "planning.events.events_sync"
+
+
+class SyncEventMetadataWithPlanningItemsTest(EventsBaseTestCase):
+    def get_base_event(self) -> dict[str, Any]:
+        return {
+            "_id": "evt1",
+            "name": "evt1",
+            "dates": {
+                "start": datetime(2099, 1, 1, 12, 0, tzinfo=pytz.UTC),
+                "end": datetime(2099, 1, 1, 13, 0, tzinfo=pytz.UTC),
+            },
+            "translations": [],
+        }
+
+    def build_embedded_planning(self, updates: dict[str, Any], plans: list[dict] | None = None):
+        plans = plans or [
+            {
+                "planning_id": "pl1",
+                "coverages": [],
+            }
+        ]
+        tmp = deepcopy(updates)
+        tmp["embedded_planning"] = plans
+        return get_events_embedded_planning(deepcopy(tmp))
+
+    async def test_creation_path_early_return(self):
+        """
+        CASE 1: When original is empty function should call create_new_plannings_from_embedded_planning once
+        and do an early return
+        """
+        original_event = {}  # new event ( will go down the creation path)
+        updated_event = deepcopy(self.get_base_event())
+        embedded_planning = self.build_embedded_planning(updated_event)
+
+        # Mocks for dependencies inside the module under test
+        with patch(
+            f"{MODULE}.AllContentProfileData.get", new=AsyncMock(return_value=MagicMock())
+        ) as profiles_get_mock, patch(f"{MODULE}.get_resource_service") as get_resource_service_mock, patch(
+            f"{MODULE}.create_new_plannings_from_embedded_planning", new=AsyncMock()
+        ) as create_new_plannings_mock, patch(
+            f"{MODULE}.get_existing_plannings_from_embedded_planning"
+        ) as get_existing_plannings_mock:
+            vocab_service = MagicMock()
+            vocab_service.find_one.side_effect = [{"items": []}, {"items": []}]
+            planning_service = MagicMock()
+            planning_service.patch_async = AsyncMock()
+
+            def select_resource_service(resource_name: str):
+                if resource_name == "vocabularies":
+                    return vocab_service
+                if resource_name == "planning":
+                    return planning_service
+                return MagicMock()
+
+            get_resource_service_mock.side_effect = select_resource_service
+
+            await sync_event_metadata_with_planning_items(
+                original=original_event,
+                updates=updated_event,
+                embedded_planning=embedded_planning,
+                embedded_planning_present=False,
+            )
+
+            # Assert expectations for creation path
+            create_new_plannings_mock.assert_awaited_once()
+            get_existing_plannings_mock.assert_not_called()
+            planning_service.patch_async.assert_not_awaited()
+            profiles_get_mock.assert_awaited()
+
+    async def test_no_sync_fields_embedded_updates_and_unlink(self):
+        """
+        CASE 2: When no sync fields are present, we update only embedded items that need updates
+        and unlink any planning items linked to the event but not present in embedded list
+        """
+        original_event = self.get_base_event()
+        updated_fields = {"name": "updated title"}  # not part of sync set
+        embedded_planning = self.build_embedded_planning(
+            updates=original_event,
+            plans=[
+                {"planning_id": "pl1", "coverages": [{}]},
+                {"planning_id": "pl2", "coverages": [{}]},
+            ],
+        )
+        embedded_planning_present = True
+
+        # Two embedded items: only pl2 requires update
+        def existing_plannings_generator(*_args, **_kwargs):
+            yield (
+                {"_id": "pl1", "related_events": [{"_id": original_event["_id"]}]},
+                {"slugline": "no-op"},
+                False,  # update_required
+            )
+            yield (
+                {"_id": "pl2", "related_events": [{"_id": original_event["_id"]}]},
+                {"slugline": "needs-update"},
+                True,  # update_required
+            )
+
+        # Linked planning also includes pl3 (not embedded) which should be unlinked from evt1
+        related_planning = [
+            {"_id": "pl1", "related_events": [{"_id": original_event["_id"]}, {"_id": "other"}]},
+            {"_id": "pl2", "related_events": [{"_id": original_event["_id"]}]},
+            {"_id": "pl3", "related_events": [{"_id": original_event["_id"]}, {"_id": "keep"}]},
+        ]
+
+        with patch(
+            f"{MODULE}.AllContentProfileData.get", new=AsyncMock(return_value=MagicMock())
+        ) as profiles_get_mock, patch(
+            f"{MODULE}.get_config_event_fields_to_sync_with_planning", return_value=set()
+        ) as get_sync_config_mock, patch(
+            f"{MODULE}.get_resource_service"
+        ) as get_resource_service_mock, patch(
+            f"{MODULE}.create_new_plannings_from_embedded_planning", new=AsyncMock()
+        ) as create_new_plannings_mock, patch(
+            f"{MODULE}.get_existing_plannings_from_embedded_planning", side_effect=existing_plannings_generator
+        ), patch(
+            f"{MODULE}.get_related_planning_for_events", return_value=related_planning
+        ) as get_related_planning_mock:
+            vocab_service = MagicMock()
+            vocab_service.find_one.side_effect = [{"items": []}, {"items": []}]
+            planning_service = MagicMock()
+            planning_service.patch_async = AsyncMock()
+
+            def select_resouce_service(resource_name: str):
+                if resource_name == "vocabularies":
+                    return vocab_service
+                if resource_name == "planning":
+                    return planning_service
+                return MagicMock()
+
+            get_resource_service_mock.side_effect = select_resouce_service
+
+            await sync_event_metadata_with_planning_items(
+                original=original_event,
+                updates=updated_fields,
+                embedded_planning=embedded_planning,
+                embedded_planning_present=embedded_planning_present,
+            )
+
+            # 1) create_new always runs
+            create_new_plannings_mock.assert_awaited_once()
+
+            # 2) Embedded updates: only pl2 should be patched
+            planning_service.patch_async.assert_any_await("pl2", {"slugline": "needs-update"})
+
+            # 3) Unlink: pl3 is linked but not embedded so patch related_events to prune evt1
+            # Build expected pruned list for pl3
+            pruned_pl3 = [{"_id": "keep"}]  # original had evt1 + keep, we remove evt1
+            planning_service.patch_async.assert_any_await("pl3", {"related_events": pruned_pl3})
+
+            # Ensure we didn't patch pl1 (no update required and still embedded)
+            # We can check that there's no patch call for pl1 with slugline or related_events removing evt1
+            calls_str = [str(c) for c in planning_service.patch_async.await_args_list]
+            assert not any("('pl1'," in s and "slugline" in s for s in calls_str)
+
+            get_sync_config_mock.assert_called_once()
+            get_related_planning_mock.assert_called_once()
+            profiles_get_mock.assert_awaited()
+
+    async def test_sync_fields_present_embedded_item(self):
+        """
+        CASE 3: When sync fields are present
+          - We call sync_existing_planning_item for embedded items
+          - If it sets update_planning=True, we patch the item
+          - It also covers both update_required=True and False paths
+        """
+        original_event = self.get_base_event()
+        updated_fields = {"name": "new title", "languages": ["en"]}  # intersects configured sync fields
+        embedded_planning = self.build_embedded_planning(
+            updates=original_event,
+            plans=[{"planning_id": "pl-sync", "coverages": [{}]}],
+        )
+
+        # Yield one embedded item with update_required=False (sync logic may still set update_planning=True)
+        def existing_plannings_generator(*_args, **_kwargs):
+            yield (
+                {"_id": "pl-sync", "translations": []},
+                {"slugline": "from-embedded"},
+                False,  # update_required
+            )
+
+        # Side-effect: emulate sync deciding that planning needs updating
+        def sync_side_effect(sync_data, sync_fields, profiles, coverage_sync_fields):
+            sync_data.update_planning = True
+            updates_dict = sync_data.planning.updates or {}
+            updates_dict["headline"] = "synced-headline"
+            sync_data.planning.updates = updates_dict
+
+        with patch(
+            f"{MODULE}.AllContentProfileData.get",
+            new=AsyncMock(
+                return_value=MagicMock(
+                    events=MagicMock(is_multilingual=True),
+                    planning=MagicMock(is_multilingual=True),
+                )
+            ),
+        ) as profiles_get_mock, patch(
+            f"{MODULE}.get_config_event_fields_to_sync_with_planning", return_value={"name", "language"}
+        ) as get_sync_config_mock, patch(
+            f"{MODULE}.get_resource_service"
+        ) as get_resource_service_mock, patch(
+            f"{MODULE}.create_new_plannings_from_embedded_planning", new=AsyncMock()
+        ) as create_new_plannings_mock, patch(
+            f"{MODULE}.get_existing_plannings_from_embedded_planning", side_effect=existing_plannings_generator
+        ), patch(
+            f"{MODULE}.sync_existing_planning_item", side_effect=sync_side_effect
+        ) as sync_existing_planning_item_mock:
+            vocab_service = MagicMock()
+            vocab_service.find_one.side_effect = [{"items": []}, {"items": []}]
+            planning_service = MagicMock()
+            planning_service.patch_async = AsyncMock()
+
+            def select_resource_service(resource_name: str):
+                if resource_name == "vocabularies":
+                    return vocab_service
+                if resource_name == "planning":
+                    return planning_service
+                return MagicMock()
+
+            get_resource_service_mock.side_effect = select_resource_service
+
+            await sync_event_metadata_with_planning_items(
+                original=original_event,
+                updates=updated_fields,
+                embedded_planning=embedded_planning,
+                embedded_planning_present=True,
+            )
+
+            # sync should have been invoked for our single embedded item
+            assert sync_existing_planning_item_mock.call_count == 1
+
+            # Patch must be called since sync_data.update_planning=True in side_effect
+            planning_service.patch_async.assert_awaited_once_with(
+                "pl-sync",
+                {"slugline": "from-embedded", "headline": "synced-headline"},
+            )
+
+            # create_new always runs first
+            create_new_plannings_mock.assert_awaited_once()
+            get_sync_config_mock.assert_called_once()
+            profiles_get_mock.assert_awaited()


### PR DESCRIPTION
### Purpose
This PR fixes the incorrect unlinking and syncing behavior between Events and their related Planning items.

### What has changed
  - Unlink only when `embedded_planning` is present in the payload.
  - Preserve unrelated `related_events` links when unlinking.

### Steps to test
1. Create an Event with no Planning items.
2. Add at least 2 Planning items to an Event. Observe that they are linked successfully.
3. Remove one or more Planning items. Observe that only the removed items should be unlinked from the event and the remaining items remain linked.
4. Update Event fields unrelated to related planning e.g event name and observe the planning items remain linked


Resolves: #[SDESK-7734](https://sofab.atlassian.net/browse/SDESK-7734)


[SDESK-7734]: https://sofab.atlassian.net/browse/SDESK-7734?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ