### PR TITLE
Add a new toggle field 'Multiple Coverages' to the Coverages [STT-1294]

### DIFF
--- a/client/components/ContentProfiles/FieldTab/FieldEditor.tsx
+++ b/client/components/ContentProfiles/FieldTab/FieldEditor.tsx
@@ -113,7 +113,7 @@ export class FieldEditor extends React.Component<IProps, IState> {
             'schema.read_only': {
                 enabled:
                     this.props.item.name === nameof('related_plannings') ||
-                    this.props.item.name === nameof('multiple_coverages')
+                    this.props.item.name === nameof('multiple_content')
             },
             'schema.planning_auto_publish': {
                 enabled: this.props.item.name === nameof('related_plannings')
@@ -140,7 +140,7 @@ export class FieldEditor extends React.Component<IProps, IState> {
             'schema.default_value': {
                 enabled:
                     this.props.item.name === 'priority' ||
-                    this.props.item.name === nameof('multiple_coverages')
+                    this.props.item.name === nameof('multiple_content')
             },
         };
         const noOptionsAvailable = !(
@@ -248,7 +248,7 @@ export class FieldEditor extends React.Component<IProps, IState> {
                                         },
                                         fieldProps
                                     )}
-                                    {this.props.item.name === nameof('multiple_coverages') &&
+                                    {this.props.item.name === nameof('multiple_content') &&
                                         fieldProps['schema.default_value'].enabled ? (
                                             <div className="form__row">
                                                 <Checkbox

--- a/client/components/ContentProfiles/FieldTab/FieldEditor.tsx
+++ b/client/components/ContentProfiles/FieldTab/FieldEditor.tsx
@@ -137,7 +137,11 @@ export class FieldEditor extends React.Component<IProps, IState> {
                     !['language', 'location'].includes(this.props.item.name)
                 )
             )},
-            'schema.default_value': {enabled: this.props.item.name === 'priority'},
+            'schema.default_value': {
+                enabled:
+                    this.props.item.name === 'priority' ||
+                    this.props.item.name === nameof('multiple_coverages')
+            },
         };
         const noOptionsAvailable = !(
             Object.values(fieldProps)

--- a/client/components/ContentProfiles/FieldTab/FieldEditor.tsx
+++ b/client/components/ContentProfiles/FieldTab/FieldEditor.tsx
@@ -137,11 +137,7 @@ export class FieldEditor extends React.Component<IProps, IState> {
                     !['language', 'location'].includes(this.props.item.name)
                 )
             )},
-            'schema.default_value': {
-                enabled:
-                    this.props.item.name === 'priority' ||
-                    this.props.item.name === nameof('multiple_content')
-            },
+            'schema.default_value': {enabled: this.props.item.name === 'priority'},
         };
         const noOptionsAvailable = !(
             Object.values(fieldProps)
@@ -248,17 +244,16 @@ export class FieldEditor extends React.Component<IProps, IState> {
                                         },
                                         fieldProps
                                     )}
-                                    {this.props.item.name === nameof('multiple_content') &&
-                                        fieldProps['schema.default_value'].enabled ? (
-                                            <div className="form__row">
-                                                <Checkbox
-                                                    checked={Boolean(this.props.item.schema.default_value)}
-                                                    label={{text: gettext('Default Value')}}
-                                                    onChange={(value) => this.onChange('schema.default_value', value)}
-                                                    disabled={false}
-                                                />
-                                            </div>
-                                        ) : null}
+                                    {this.props.item.name === nameof('multiple_content') ? (
+                                        <div className="form__row">
+                                            <Checkbox
+                                                checked={Boolean(this.props.item.schema.default_value)}
+                                                label={{text: gettext('Default Value')}}
+                                                onChange={(value) => this.onChange('schema.default_value', value)}
+                                                disabled={false}
+                                            />
+                                        </div>
+                                    ) : null}
                                 </React.Fragment>
                             )}
                         </div>

--- a/client/components/ContentProfiles/FieldTab/FieldEditor.tsx
+++ b/client/components/ContentProfiles/FieldTab/FieldEditor.tsx
@@ -5,6 +5,7 @@ import {
     IPlanningContentProfile,
     IProfileSchemaTypeString,
     IEventFormProfile,
+    ICoverageFormProfile,
 } from '../../../interfaces';
 
 import {superdeskApi, planningApi} from '../../../superdeskApi';
@@ -93,7 +94,10 @@ export class FieldEditor extends React.Component<IProps, IState> {
             multilingual.isEnabled(this.props.profile);
         const storeState = planningApi.redux.store.getState();
         const allCoverageProfileIds = coverageProfiles(storeState).map((x) => x._id);
-        const nameof = superdeskApi.helpers.nameof<IEventFormProfile['editor']>;
+        const nameof = superdeskApi.helpers.nameof<
+            Partial<IEventFormProfile['editor']> &
+            Partial<ICoverageFormProfile['editor']>
+        >;
 
         const fieldProps = {
             'schema.show_in_embedded_editor': {
@@ -106,7 +110,11 @@ export class FieldEditor extends React.Component<IProps, IState> {
                     && allCoverageProfileIds.includes(this.props.profile._id) === false,
             },
             'schema.required': {enabled: !(this.props.disableRequired || this.props.systemRequired)},
-            'schema.read_only': {enabled: this.props.item.name === nameof('related_plannings')},
+            'schema.read_only': {
+                enabled:
+                    this.props.item.name === nameof('related_plannings') ||
+                    this.props.item.name === nameof('multiple_coverages')
+            },
             'schema.planning_auto_publish': {
                 enabled: this.props.item.name === nameof('related_plannings')
             },

--- a/client/components/ContentProfiles/FieldTab/FieldEditor.tsx
+++ b/client/components/ContentProfiles/FieldTab/FieldEditor.tsx
@@ -248,6 +248,17 @@ export class FieldEditor extends React.Component<IProps, IState> {
                                         },
                                         fieldProps
                                     )}
+                                    {this.props.item.name === nameof('multiple_coverages') &&
+                                        fieldProps['schema.default_value'].enabled ? (
+                                            <div className="form__row">
+                                                <Checkbox
+                                                    checked={Boolean(this.props.item.schema.default_value)}
+                                                    label={{text: gettext('Default Value')}}
+                                                    onChange={(value) => this.onChange('schema.default_value', value)}
+                                                    disabled={false}
+                                                />
+                                            </div>
+                                        ) : null}
                                 </React.Fragment>
                             )}
                         </div>

--- a/client/components/fields/resources/planning.ts
+++ b/client/components/fields/resources/planning.ts
@@ -3,6 +3,7 @@ import {registerEditorField} from './registerEditorFields';
 import {superdeskApi} from '../../../superdeskApi';
 
 import {EditorFieldMultilingualText} from '../editor/base/multilingualText';
+import {EditorFieldToggle} from '../editor/base/toggle';
 
 registerEditorField(
     'description_text',
@@ -23,4 +24,13 @@ registerEditorField(
     }),
     null,
     true
+);
+
+registerEditorField(
+    'multiple_content',
+    EditorFieldToggle,
+    () => ({
+        label: superdeskApi.localization.gettext('Multiple Content'),
+        field: 'planning.multiple_content',
+    })
 );

--- a/client/interfaces.ts
+++ b/client/interfaces.ts
@@ -1291,7 +1291,7 @@ export interface ICoverageFormProfile {
         news_coverage_status: IProfileEditorField;
         scheduled: IProfileEditorField;
         slugline: IProfileEditorField;
-        multiple_coverages: IProfileEditorField;
+        multiple_content: IProfileEditorField;
     };
     name: 'coverage';
     schema: {
@@ -1308,7 +1308,7 @@ export interface ICoverageFormProfile {
         news_coverage_status: IProfileSchemaTypeList;
         scheduled: IProfileSchemaTypeDateTime;
         slugline: IProfileSchemaTypeString;
-        multiple_coverages: IProfileSchemaType;
+        multiple_content: IProfileSchemaType;
     };
 }
 

--- a/client/interfaces.ts
+++ b/client/interfaces.ts
@@ -1291,6 +1291,7 @@ export interface ICoverageFormProfile {
         news_coverage_status: IProfileEditorField;
         scheduled: IProfileEditorField;
         slugline: IProfileEditorField;
+        multiple_coverages: IProfileEditorField;
     };
     name: 'coverage';
     schema: {
@@ -1307,6 +1308,7 @@ export interface ICoverageFormProfile {
         news_coverage_status: IProfileSchemaTypeList;
         scheduled: IProfileSchemaTypeDateTime;
         slugline: IProfileSchemaTypeString;
+        multiple_coverages: IProfileSchemaType;
     };
 }
 

--- a/client/utils/contentProfiles.ts
+++ b/client/utils/contentProfiles.ts
@@ -304,6 +304,8 @@ export function getFieldNameTranslated(field: string): string {
         return gettext('Priority');
     case 'related_items':
         return gettext('Related Articles');
+    case 'multiple_coverages':
+        return gettext('Multiple Coverages');
     }
 
     return field;

--- a/client/utils/contentProfiles.ts
+++ b/client/utils/contentProfiles.ts
@@ -304,8 +304,8 @@ export function getFieldNameTranslated(field: string): string {
         return gettext('Priority');
     case 'related_items':
         return gettext('Related Articles');
-    case 'multiple_coverages':
-        return gettext('Multiple Coverages');
+    case 'multiple_content':
+        return gettext('Multiple Content');
     }
 
     return field;

--- a/server/planning/commands/flag_expired_items_test.py
+++ b/server/planning/commands/flag_expired_items_test.py
@@ -265,7 +265,7 @@ class FlagExpiredItemsTest(BaseFlagExpiredItemsTest):
             },
         )
 
-    async def test_event_with_single_planning_multiple_coverages(self):
+    async def test_event_with_single_planning_multiple_content(self):
         await self.insert(
             "events",
             [

--- a/server/planning/commands/flag_expired_items_test.py
+++ b/server/planning/commands/flag_expired_items_test.py
@@ -265,7 +265,7 @@ class FlagExpiredItemsTest(BaseFlagExpiredItemsTest):
             },
         )
 
-    async def test_event_with_single_planning_multiple_content(self):
+    async def test_event_with_single_planning_multiple_coverages(self):
         await self.insert(
             "events",
             [

--- a/server/planning/content_profiles/profiles/coverage.py
+++ b/server/planning/content_profiles/profiles/coverage.py
@@ -32,7 +32,7 @@ class CoverageSchema(BaseSchema):
     no_content_linking = BooleanField()
     scheduled_updates = schema.ListField()
     priority = schema.IntegerField()
-    multiple_content = MultipleContentField(read_only=True, default_value=True)
+    multiple_content = MultipleContentField(read_only=False, default_value=False)
 
 
 DEFAULT_COVERAGE_PROFILE = {
@@ -75,7 +75,7 @@ DEFAULT_COVERAGE_PROFILE = {
             "index": 9,
         },
         "multiple_content": {
-            "enabled": True,
+            "enabled": False,
             "index": 10,
         },
         "subject": {"enabled": False},

--- a/server/planning/content_profiles/profiles/coverage.py
+++ b/server/planning/content_profiles/profiles/coverage.py
@@ -10,7 +10,7 @@
 
 import superdesk.schema as schema
 
-from .fields import subjectField, BaseSchema, DateTimeField, BooleanField, TextField, MultipleCoveragesField
+from .fields import subjectField, BaseSchema, DateTimeField, BooleanField, TextField, MultipleContentField
 
 
 class CoverageSchema(BaseSchema):
@@ -32,7 +32,7 @@ class CoverageSchema(BaseSchema):
     no_content_linking = BooleanField()
     scheduled_updates = schema.ListField()
     priority = schema.IntegerField()
-    multiple_coverages = MultipleCoveragesField(read_only=True, default_value=True)
+    multiple_content = MultipleContentField(read_only=True, default_value=True)
 
 
 DEFAULT_COVERAGE_PROFILE = {
@@ -74,7 +74,7 @@ DEFAULT_COVERAGE_PROFILE = {
             "enabled": True,
             "index": 9,
         },
-        "multiple_coverages": {
+        "multiple_content": {
             "enabled": True,
             "index": 10,
         },

--- a/server/planning/content_profiles/profiles/coverage.py
+++ b/server/planning/content_profiles/profiles/coverage.py
@@ -10,7 +10,7 @@
 
 import superdesk.schema as schema
 
-from .fields import subjectField, BaseSchema, DateTimeField, BooleanField, TextField
+from .fields import subjectField, BaseSchema, DateTimeField, BooleanField, TextField, MultipleCoveragesField
 
 
 class CoverageSchema(BaseSchema):
@@ -32,6 +32,7 @@ class CoverageSchema(BaseSchema):
     no_content_linking = BooleanField()
     scheduled_updates = schema.ListField()
     priority = schema.IntegerField()
+    multiple_coverages = MultipleCoveragesField(read_only=True, default_value=True)
 
 
 DEFAULT_COVERAGE_PROFILE = {
@@ -72,6 +73,10 @@ DEFAULT_COVERAGE_PROFILE = {
         "scheduled_updates": {
             "enabled": True,
             "index": 9,
+        },
+        "multiple_coverages": {
+            "enabled": True,
+            "index": 10,
         },
         "subject": {"enabled": False},
         # Fields disabled by default

--- a/server/planning/content_profiles/profiles/fields.py
+++ b/server/planning/content_profiles/profiles/fields.py
@@ -137,3 +137,16 @@ subjectField = schema.ListField(
         },
     },
 )
+
+
+class MultipleCoveragesField(StringField):
+    def __init__(
+        self,
+        required: bool = False,
+        default_value: bool = False,
+        read_only: bool = False,
+    ):
+        super().__init__(required=required)
+        self.schema["default_value"] = default_value
+        self.schema["read_only"] = read_only
+        self.schema["required"] = required    

--- a/server/planning/content_profiles/profiles/fields.py
+++ b/server/planning/content_profiles/profiles/fields.py
@@ -139,7 +139,7 @@ subjectField = schema.ListField(
 )
 
 
-class MultipleCoveragesField(StringField):
+class MultipleCoveragesField(BooleanField):
     def __init__(
         self,
         required: bool = False,

--- a/server/planning/content_profiles/profiles/fields.py
+++ b/server/planning/content_profiles/profiles/fields.py
@@ -149,4 +149,4 @@ class MultipleCoveragesField(StringField):
         super().__init__(required=required)
         self.schema["default_value"] = default_value
         self.schema["read_only"] = read_only
-        self.schema["required"] = required    
+        self.schema["required"] = required

--- a/server/planning/content_profiles/profiles/fields.py
+++ b/server/planning/content_profiles/profiles/fields.py
@@ -139,7 +139,7 @@ subjectField = schema.ListField(
 )
 
 
-class MultipleCoveragesField(BooleanField):
+class MultipleContentField(BooleanField):
     def __init__(
         self,
         required: bool = False,


### PR DESCRIPTION
STT-1294

<img width="790" height="689" alt="image" src="https://github.com/user-attachments/assets/beab18e2-50cc-483f-80a9-dedc21c1510b" />


<img width="780" height="682" alt="image" src="https://github.com/user-attachments/assets/944e41d8-e407-46da-ba16-99bfc5864fb2" />


### Front-end checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [x] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [x] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [x] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [x] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [x] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [x] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [x] This pull request is not adding redux based modals
- [x] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [x] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)

Resolves: #[STT-1294]



[STT-1294]: https://sofab.atlassian.net/browse/STT-1294?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ