### PR TITLE
[STT-1295] Modify Assignment actions to support multiple content links

### DIFF
--- a/client/actions/assignments/api.ts
+++ b/client/actions/assignments/api.ts
@@ -330,29 +330,6 @@ const link = (assignment, newsItem, reassign) => (
 );
 
 /**
- * Action to create news item from assignment and template
- * @param {String} assignmentId - Id of the Assignment
- * @param {String} templateName - name of the template to use
- * @return Promise
- */
-const createFromTemplateAndShow = (assignmentId, templateName) => (
-    (dispatch, getState, {api, authoringWorkspace, notify}) => (
-        api('assignments_content').save({}, {
-            assignment_id: assignmentId,
-            template_name: templateName,
-        })
-            .then((item) => authoringWorkspace.edit(item),
-                (error) => {
-                    notify.error(
-                        getErrorMessage(error, 'Failed to lock the Assignment.')
-                    );
-                    return Promise.reject(error);
-                }
-            )
-    )
-);
-
-/**
  * Action to complete an assignment
  * @param {String} item - Assignment to be completed
  * @return Promise
@@ -564,7 +541,6 @@ const self = {
     fetchAssignmentById,
     save,
     link,
-    createFromTemplateAndShow,
     complete,
     revert,
     loadPlanningAndEvent,

--- a/client/actions/assignments/ui.ts
+++ b/client/actions/assignments/ui.ts
@@ -493,7 +493,7 @@ function revert(item: IAssignmentItem) {
             .then((lockedItem) => {
                 const contentTypes = selectors.general.contentTypes(getState());
 
-                if (!assignmentUtils.isTextAssignment(item, contentTypes) || item.planning?.multiple_coverages) {
+                if (!assignmentUtils.isTextAssignment(item, contentTypes) || item.planning?.multiple_content) {
                     return dispatch(assignments.api.revert(lockedItem))
                         .then((updatedItem) => {
                             notify.success(gettext('The assignment has been reverted.'));

--- a/client/actions/assignments/ui.ts
+++ b/client/actions/assignments/ui.ts
@@ -493,11 +493,11 @@ function revert(item: IAssignmentItem) {
             .then((lockedItem) => {
                 const contentTypes = selectors.general.contentTypes(getState());
 
-                if (!assignmentUtils.isTextAssignment(item, contentTypes)) {
+                if (!assignmentUtils.isTextAssignment(item, contentTypes) || item.planning?.multiple_coverages) {
                     return dispatch(assignments.api.revert(lockedItem))
-                        .then((lockedItem) => {
+                        .then((updatedItem) => {
                             notify.success(gettext('The assignment has been reverted.'));
-                            return Promise.resolve(lockedItem);
+                            return Promise.resolve(updatedItem);
                         }, (error) => {
                             notify.error(getErrorMessage(error, gettext('Failed to revert the assignment.')));
                             return Promise.reject(error);
@@ -655,14 +655,15 @@ function startWorking(assignment: IAssignmentItem) {
                         });
 
                         const onSelect = (template) => (
-                            dispatch(assignments.api.createFromTemplateAndShow(
+                            planningApi.assignments.createAndOpenArticleFromTemplate(
                                 assignment._id,
                                 template.template_name
-                            )).catch((error) => {
-                                planningApi.locks.unlockItem(assignment);
-                                notify.error(getErrorMessage(error, gettext('Failed to create an archive item.')));
-                                return Promise.reject(error);
-                            })
+                            )
+                                .catch((error) => {
+                                    planningApi.locks.unlockItem(assignment);
+                                    notify.error(getErrorMessage(error, gettext('Failed to create an archive item.')));
+                                    return Promise.reject(error);
+                                })
                         );
                         const onCancel = () => planningApi.locks.unlockItem(lockedAssignment);
 

--- a/client/api/assignments.ts
+++ b/client/api/assignments.ts
@@ -1,3 +1,4 @@
+import {IArticle} from 'superdesk-api';
 import {superdeskApi} from '../superdeskApi';
 import {IPlanningAPI, IAssignmentItem} from '../interfaces';
 
@@ -5,6 +6,18 @@ function getAssignmentById(assignmentId: IAssignmentItem['_id']): Promise<IAssig
     return superdeskApi.dataApi.findOne<IAssignmentItem>('assignments', assignmentId);
 }
 
+function createAndOpenArticleFromTemplate(assignmentId: IAssignmentItem['_id'], templateName: string): Promise<void> {
+    const payload: Partial<IArticle> & {template_name: string} = {
+        assignment_id: assignmentId,
+        template_name: templateName,
+    };
+
+    return superdeskApi.dataApi.create('assignments/content', payload).then((item) => {
+        superdeskApi.ui.article.edit(item._id);
+    });
+}
+
 export const assignments: IPlanningAPI['assignments'] = {
     getById: getAssignmentById,
+    createAndOpenArticleFromTemplate: createAndOpenArticleFromTemplate,
 };

--- a/client/interfaces.ts
+++ b/client/interfaces.ts
@@ -619,6 +619,7 @@ export interface ICoveragePlanningDetails {
     internal_note: string;
     workflow_status_reason: string;
     priority?: number;
+    multiple_coverages?: boolean;
 }
 
 export interface ICoverageScheduledUpdate {
@@ -2323,6 +2324,7 @@ export interface IPlanningAPI {
     };
     assignments: {
         getById(assignmentId: IAssignmentItem['_id']): Promise<IAssignmentItem>;
+        createAndOpenArticleFromTemplate(assignmentId: IAssignmentItem['_id'], templateName: string): Promise<void>;
     };
     coverages: {
         cancelCoverage(

--- a/client/interfaces.ts
+++ b/client/interfaces.ts
@@ -619,7 +619,7 @@ export interface ICoveragePlanningDetails {
     internal_note: string;
     workflow_status_reason: string;
     priority?: number;
-    multiple_coverages?: boolean;
+    multiple_content?: boolean;
 }
 
 export interface ICoverageScheduledUpdate {

--- a/client/utils/assignments.ts
+++ b/client/utils/assignments.ts
@@ -63,17 +63,40 @@ function canRemoveAssignment(
         self.isAssignmentInEditableState(assignment);
 }
 
-const canStartWorking = (assignment, session, privileges, contentTypes) => (
-    !!privileges[PRIVILEGES.ARCHIVE] &&
-    !get(assignment, 'lock_user') &&
-    self.isTextAssignment(assignment, contentTypes) &&
-    get(assignment, 'assigned_to.state') === ASSIGNMENTS.WORKFLOW_STATE.ASSIGNED &&
-    (
-        !get(assignment, 'assigned_to.user') ||
-        assignment.assigned_to.user === get(session, 'identity._id')
-    ) &&
-    !isAssignedToProvider(assignment)
-);
+function canStartWorking(
+    assignment: IAssignmentItem,
+    session: ISession,
+    privileges: IPrivileges,
+    contentTypes: Array<IG2ContentType>
+): boolean {
+    if (
+        !privileges[PRIVILEGES.ARCHIVE]
+        || isAssignedToProvider(assignment)
+        || !self.isTextAssignment(assignment, contentTypes)
+    ) {
+        return false;
+    }
+
+    if (assignment.planning?.multiple_coverages) {
+        // If this Assignment allows multiple content linked,
+        // make sure the Assignment is not in a completed state
+        return (
+            [
+                ASSIGNMENTS.WORKFLOW_STATE.ASSIGNED,
+                ASSIGNMENTS.WORKFLOW_STATE.IN_PROGRESS,
+                ASSIGNMENTS.WORKFLOW_STATE.SUBMITTED,
+            ].includes(assignment.assigned_to?.state)
+        );
+    } else {
+        // Otherwise if this Assignment only allows 1 content linked, then make sure the Assignment
+        // is not locked and assigned to the current user (or not assigned to anyone)
+        return (
+            assignment.assigned_to?.state === ASSIGNMENTS.WORKFLOW_STATE.ASSIGNED
+            && !assignment.lock_user
+            && (!assignment.assigned_to?.user || assignment.assigned_to?.user === session.identity._id)
+        );
+    }
+}
 
 function canFulfilAssignment(
     assignment: IAssignmentItem,

--- a/client/utils/assignments.ts
+++ b/client/utils/assignments.ts
@@ -77,7 +77,7 @@ function canStartWorking(
         return false;
     }
 
-    if (assignment.planning?.multiple_coverages) {
+    if (assignment.planning?.multiple_content) {
         // If this Assignment allows multiple content linked,
         // make sure the Assignment is not in a completed state
         return (

--- a/server/features/assignments_multi_content.feature
+++ b/server/features/assignments_multi_content.feature
@@ -26,7 +26,7 @@ Feature: Assignment with multiple linked content
                 "planning": {
                     "slugline": "test slugline",
                     "g2_content_type": "text",
-                    "multiple_coverages": true
+                    "multiple_content": true
                 },
                 "assigned_to": {
                     "desk": "#desks._id#",
@@ -45,7 +45,7 @@ Feature: Assignment with multiple linked content
         """
         {"coverages": [{
             "coverage_id": "#COVERAGE_ID#",
-            "planning": {"multiple_coverages": true},
+            "planning": {"multiple_content": true},
             "assigned_to": {"assignment_id": "#ASSIGNMENT_ID#", "state": "assigned"}
         }]}
         """
@@ -56,7 +56,7 @@ Feature: Assignment with multiple linked content
         """
 
     @auth
-    Scenario: Coverage without multiple_coverages enabled fails with start working
+    Scenario: Coverage without multiple_content enabled fails with start working
         When we post to "planning"
         """
         {
@@ -66,7 +66,7 @@ Feature: Assignment with multiple linked content
                 "planning": {
                     "slugline": "test slugline",
                     "g2_content_type": "text",
-                    "multiple_coverages": false
+                    "multiple_content": false
                 },
                 "assigned_to": {
                     "desk": "#desks._id#",

--- a/server/features/assignments_multi_content.feature
+++ b/server/features/assignments_multi_content.feature
@@ -1,0 +1,535 @@
+Feature: Assignment with multiple linked content
+    Background: Setup data
+        Given "content_types"
+        """
+        [{"schema": {"body_html": {}, "slugline": {}, "headline": {}, "ednote": null }}]
+        """
+        Given "content_templates"
+        """
+        [{"template_name": "Default", "template_type": "create", "data": {}}]
+        """
+        Given "desks"
+        """
+        [{
+            "name": "Sports Desk",
+            "members": [{"user": "#CONTEXT_USER_ID#"}],
+            "default_content_template": "#content_templates._id#",
+            "default_content_profile": "#content_types._id#"
+        }]
+        """
+        When we post to "planning"
+        """
+        [{
+            "slugline": "test slugline",
+            "planning_date": "2042-06-30",
+            "coverages": [{
+                "planning": {
+                    "slugline": "test slugline",
+                    "g2_content_type": "text",
+                    "multiple_coverages": true
+                },
+                "assigned_to": {
+                    "desk": "#desks._id#",
+                    "user": "#CONTEXT_USER_ID#"
+                },
+                "news_coverage_status": {"qcode": "ncostat:int"},
+                "workflow_status": "assigned"
+            }]
+        }]
+        """
+        Then we get OK response
+        And we store coverage id in "COVERAGE_ID" from coverage 0
+        And we store assignment id in "ASSIGNMENT_ID" from coverage 0
+        When we get "/planning/#planning._id#"
+        Then we get existing resource
+        """
+        {"coverages": [{
+            "coverage_id": "#COVERAGE_ID#",
+            "planning": {"multiple_coverages": true},
+            "assigned_to": {"assignment_id": "#ASSIGNMENT_ID#", "state": "assigned"}
+        }]}
+        """
+        When we get "/assignments_history"
+        Then we get list with 1 items
+        """
+        {"_items": [{"assignment_id": "#ASSIGNMENT_ID#", "operation": "create"}]}
+        """
+
+    @auth
+    Scenario: Coverage without multiple_coverages enabled fails with start working
+        When we post to "planning"
+        """
+        {
+            "slugline": "test slugline",
+            "planning_date": "2042-06-30",
+            "coverages": [{
+                "planning": {
+                    "slugline": "test slugline",
+                    "g2_content_type": "text",
+                    "multiple_coverages": false
+                },
+                "assigned_to": {
+                    "desk": "#desks._id#",
+                    "user": "#CONTEXT_USER_ID#"
+                },
+                "news_coverage_status": {"qcode": "ncostat:int"},
+                "workflow_status": "assigned"
+            }]
+        }
+        """
+        Then we get OK response
+        And we store assignment id in "ASSIGNMENT_ID" from coverage 0
+        When we post to "/assignments/content"
+        """
+        [{"assignment_id": "#ASSIGNMENT_ID#"}]
+        """
+        Then we get OK response
+        When we post to "/assignments/content"
+        """
+        [{"assignment_id": "#ASSIGNMENT_ID#"}]
+        """
+        Then we get error 400
+        """
+        {"_message": "Assignment workflow started. Cannot create content."}
+        """
+
+    @auth
+    Scenario: Can start working multiple times on a Coverage
+        # Make sure the Assignment is in ``assigned`` state
+        When we get "/assignments/#ASSIGNMENT_ID#"
+        Then we get existing resource
+        """
+        {"assigned_to": {"state": "assigned"}}
+        """
+
+        # Create the 1st content item and make sure Assignment is in ``in_progress`` state
+        When we post to "/assignments/content"
+        """
+        [{"assignment_id": "#ASSIGNMENT_ID#"}]
+        """
+        Then we get OK response
+        Then we store "CONTENT_1_ID" with value "#content._id#" to context
+        Then we get existing resource
+        """
+        {"_id": "#CONTENT_1_ID#", "assignment_id": "#ASSIGNMENT_ID#"}
+        """
+        When we get "/assignments/#ASSIGNMENT_ID#"
+        Then we get existing resource
+        """
+        {"assigned_to": {"state": "in_progress"}}
+        """
+
+        # Create the 2nd content item and make sure Assignment stays in ``in_progress`` state
+        When we post to "/assignments/content"
+        """
+        [{"assignment_id": "#ASSIGNMENT_ID#"}]
+        """
+        Then we get OK response
+        Then we store "CONTENT_2_ID" with value "#content._id#" to context
+        Then we get existing resource
+        """
+        {"_id": "#CONTENT_2_ID#", "assignment_id": "#ASSIGNMENT_ID#"}
+        """
+        When we get "/assignments/#ASSIGNMENT_ID#"
+        Then we get existing resource
+        """
+        {"assigned_to": {"state": "in_progress"}}
+        """
+
+        # Check Assignment history contains all entries
+        When we get "/assignments_history"
+        Then we get list with 3 items
+        """
+        {"_items": [
+            {"assignment_id": "#ASSIGNMENT_ID#", "operation": "create"},
+            {"assignment_id": "#ASSIGNMENT_ID#", "operation": "start_working"},
+            {"assignment_id": "#ASSIGNMENT_ID#", "operation": "start_working"}
+        ]}
+        """
+
+    @auth
+    Scenario: Publishing content does not mark Assignment as completed
+        When we configure content for publishing
+        And we configure planning for publishing
+        # Create 2 content items
+        When we post to "/assignments/content"
+        """
+        [{"assignment_id": "#ASSIGNMENT_ID#"}]
+        """
+        Then we get OK response
+        Then we store "CONTENT_1_ID" with value "#content._id#" to context
+        When we post to "/assignments/content"
+        """
+        [{"assignment_id": "#ASSIGNMENT_ID#"}]
+        """
+        Then we get OK response
+        Then we store "CONTENT_2_ID" with value "#content._id#" to context
+        When we get "/assignments/#ASSIGNMENT_ID#"
+        Then we get existing resource
+        """
+        {"assigned_to": {"state": "in_progress"}}
+        """
+
+        # Publish the 1st content item and make sure the Assignment stays in ``in_progress`` state
+        When we patch "/archive/#CONTENT_1_ID#"
+        """
+        {"headline": "test content 1"}
+        """
+        Then we get OK response
+        When we publish "#CONTENT_1_ID#" with "publish" type and "published" state
+        Then we get OK response
+        When we get "/assignments/#ASSIGNMENT_ID#"
+        Then we get existing resource
+        """
+        {"assigned_to": {"state": "in_progress"}}
+        """
+
+        # Publish the 2nd content item and make sure the Assignment stays in ``in_progress`` state
+        When we patch "/archive/#CONTENT_2_ID#"
+        """
+        {"headline": "test content 2"}
+        """
+        Then we get OK response
+        When we publish "#CONTENT_2_ID#" with "publish" type and "published" state
+        Then we get OK response
+        When we get "/assignments/#ASSIGNMENT_ID#"
+        Then we get existing resource
+        """
+        {"assigned_to": {"state": "in_progress"}}
+        """
+
+        # Check Assignment history contains all entries
+        When we get "/assignments_history"
+        Then we get list with 3 items
+        """
+        {"_items": [
+            {"assignment_id": "#ASSIGNMENT_ID#", "operation": "create"},
+            {"assignment_id": "#ASSIGNMENT_ID#", "operation": "start_working"},
+            {"assignment_id": "#ASSIGNMENT_ID#", "operation": "start_working"}
+        ]}
+        """
+
+    @auth
+    Scenario: Confirm then revert availability of Assignment keeps links to content items
+        # Create 2 content items
+        When we post to "/assignments/content"
+        """
+        [{"assignment_id": "#ASSIGNMENT_ID#"}]
+        """
+        Then we get OK response
+        Then we store "CONTENT_1_ID" with value "#content._id#" to context
+        When we post to "/assignments/content"
+        """
+        [{"assignment_id": "#ASSIGNMENT_ID#"}]
+        """
+        Then we get OK response
+        Then we store "CONTENT_2_ID" with value "#content._id#" to context
+        When we get "/assignments/#ASSIGNMENT_ID#"
+        Then we get existing resource
+        """
+        {"assigned_to": {"state": "in_progress"}}
+        """
+
+        # First mark Assignment as completed
+        When we post to "/assignments/#ASSIGNMENT_ID#/lock"
+        """
+        {"lock_action": "complete"}
+        """
+        Then we get OK response
+        When we perform complete on assignments "#ASSIGNMENT_ID#"
+        """
+        {}
+        """
+        Then we get OK response
+        When we get "/assignments/#ASSIGNMENT_ID#"
+        Then we get existing resource
+        """
+        {"assigned_to": {"state": "completed", "revert_state": "in_progress"}, "lock_action": "__none__"}
+        """
+        When we get "/archive"
+        Then we get list with 2 items
+        """
+        {
+        "_items": [
+            {"_id": "#CONTENT_1_ID#", "assignment_id": "#ASSIGNMENT_ID#"},
+            {"_id": "#CONTENT_2_ID#", "assignment_id": "#ASSIGNMENT_ID#"}
+        ]}
+        """
+
+        # Now revert the Assignment availability
+        When we post to "/assignments/#ASSIGNMENT_ID#/lock"
+        """
+        {"lock_action": "revert"}
+        """
+        Then we get OK response
+        When we perform revert on assignments "#ASSIGNMENT_ID#"
+        """
+        {}
+        """
+        Then we get OK response
+        When we get "/assignments/#ASSIGNMENT_ID#"
+        Then we get existing resource
+        """
+        {"assigned_to": {"state": "in_progress"}, "lock_action": "__none__"}
+        """
+        When we get "/archive"
+        Then we get list with 2 items
+        """
+        {
+        "_items": [
+            {"_id": "#CONTENT_1_ID#", "assignment_id": "#ASSIGNMENT_ID#"},
+            {"_id": "#CONTENT_2_ID#", "assignment_id": "#ASSIGNMENT_ID#"}
+        ]}
+        """
+
+        # Check Assignment history contains all entries
+        When we get "/assignments_history"
+        Then we get list with 5 items
+        """
+        {"_items": [
+            {"assignment_id": "#ASSIGNMENT_ID#", "operation": "create"},
+            {"assignment_id": "#ASSIGNMENT_ID#", "operation": "start_working"},
+            {"assignment_id": "#ASSIGNMENT_ID#", "operation": "start_working"},
+            {"assignment_id": "#ASSIGNMENT_ID#", "operation": "confirm"},
+            {"assignment_id": "#ASSIGNMENT_ID#", "operation": "revert"}
+        ]}
+        """
+
+    @auth
+    Scenario: Can link multiple content to an Assignment
+        # Create 2 content items
+        When we post to "/archive"
+        """
+        [{
+            "type": "text",
+            "headline": "test headline 1",
+            "slugline": "test slugline",
+            "task": {"desk": "#desks._id#", "stage": "#desks.incoming_stage#"}
+        }]
+        """
+        Then we get OK response
+        And we store "CONTENT_1_ID" with value "#archive._id#" to context
+        When we post to "/archive"
+        """
+        [{
+            "type": "text",
+            "headline": "test headline 2",
+            "slugline": "test slugline",
+            "task": {"desk": "#desks._id#", "stage": "#desks.incoming_stage#"}
+        }]
+        """
+        Then we get OK response
+        And we store "CONTENT_2_ID" with value "#archive._id#" to context
+
+        # Link both content items to the Assignment
+        When we post to "assignments/link"
+        """
+        [{
+            "assignment_id": "#ASSIGNMENT_ID#",
+            "item_id": "#CONTENT_1_ID#",
+            "reassign": true
+        }]
+        """
+        Then we get OK response
+        When we post to "assignments/link"
+        """
+        [{
+            "assignment_id": "#ASSIGNMENT_ID#",
+            "item_id": "#CONTENT_2_ID#",
+            "reassign": true
+        }]
+        """
+        Then we get OK response
+
+        # Check both content is linked to Assignment, and Assignment is moved to in_progress
+        When we get "/archive"
+        Then we get list with 2 items
+        """
+        {
+        "_items": [
+            {"_id": "#CONTENT_1_ID#", "assignment_id": "#ASSIGNMENT_ID#"},
+            {"_id": "#CONTENT_2_ID#", "assignment_id": "#ASSIGNMENT_ID#"}
+        ]}
+        """
+        When we get "/assignments/#ASSIGNMENT_ID#"
+        Then we get existing resource
+        """
+        {"assigned_to": {"state": "in_progress"}}
+        """
+
+        # Unlink 1 of the content from the Assignment, make sure Assignment says in_progress
+        When we post to "assignments/unlink" with success
+        """
+        [{
+            "assignment_id": "#ASSIGNMENT_ID#",
+            "item_id": "#CONTENT_1_ID#"
+        }]
+        """
+        When we get "/archive"
+        Then we get list with 2 items
+        """
+        {
+        "_items": [
+            {"_id": "#CONTENT_1_ID#", "assignment_id": "__none__"},
+            {"_id": "#CONTENT_2_ID#", "assignment_id": "#ASSIGNMENT_ID#"}
+        ]}
+        """
+        When we get "/assignments/#ASSIGNMENT_ID#"
+        Then we get existing resource
+        """
+        {"assigned_to": {"state": "in_progress"}}
+        """
+
+        # Unlink the 2nd content from the Assignment, make sure Assignment moved to assigned
+        When we post to "assignments/unlink" with success
+        """
+        [{
+            "assignment_id": "#ASSIGNMENT_ID#",
+            "item_id": "#CONTENT_2_ID#"
+        }]
+        """
+        When we get "/archive"
+        Then we get list with 2 items
+        """
+        {
+        "_items": [
+            {"_id": "#CONTENT_1_ID#", "assignment_id": "__none__"},
+            {"_id": "#CONTENT_2_ID#", "assignment_id": "__none__"}
+        ]}
+        """
+        When we get "/assignments/#ASSIGNMENT_ID#"
+        Then we get existing resource
+        """
+        {"assigned_to": {"state": "assigned"}}
+        """
+
+        # Check Assignment history contains all entries
+        When we get "/assignments_history"
+        Then we get list with 5 items
+        """
+        {"_items": [
+            {"assignment_id": "#ASSIGNMENT_ID#", "operation": "create"},
+            {"assignment_id": "#ASSIGNMENT_ID#", "operation": "content_link"},
+            {"assignment_id": "#ASSIGNMENT_ID#", "operation": "content_link"},
+            {"assignment_id": "#ASSIGNMENT_ID#", "operation": "unlink"},
+            {"assignment_id": "#ASSIGNMENT_ID#", "operation": "unlink"}
+        ]}
+        """
+
+    @auth
+    Scenario: Can spike multiple content from an Assignment
+        # Create 2 content items
+        When we post to "/assignments/content"
+        """
+        [{"assignment_id": "#ASSIGNMENT_ID#"}]
+        """
+        Then we get OK response
+        Then we store "CONTENT_1_ID" with value "#content._id#" to context
+        When we post to "/assignments/content"
+        """
+        [{"assignment_id": "#ASSIGNMENT_ID#"}]
+        """
+        Then we get OK response
+        Then we store "CONTENT_2_ID" with value "#content._id#" to context
+        When we get "/assignments/#ASSIGNMENT_ID#"
+        Then we get existing resource
+        """
+        {"assigned_to": {"state": "in_progress"}}
+        """
+
+        # Spike 1st content item
+        When we spike "#CONTENT_1_ID#"
+        Then we get OK response
+        When we get "/assignments/#ASSIGNMENT_ID#"
+        Then we get existing resource
+        """
+        {"assigned_to": {"state": "in_progress"}}
+        """
+
+        # Spike 2nd content item
+        When we spike "#CONTENT_2_ID#"
+        Then we get OK response
+        When we get "/assignments/#ASSIGNMENT_ID#"
+        Then we get existing resource
+        """
+        {"assigned_to": {"state": "assigned"}}
+        """
+
+        # Check Assignment history contains all entries
+        When we get "/assignments_history"
+        Then we get list with 5 items
+        """
+        {"_items": [
+            {"assignment_id": "#ASSIGNMENT_ID#", "operation": "create"},
+            {"assignment_id": "#ASSIGNMENT_ID#", "operation": "start_working"},
+            {"assignment_id": "#ASSIGNMENT_ID#", "operation": "start_working"},
+            {"assignment_id": "#ASSIGNMENT_ID#", "operation": "spike_unlink"},
+            {"assignment_id": "#ASSIGNMENT_ID#", "operation": "spike_unlink"}
+        ]}
+        """
+
+    @auth
+    Scenario: Multi content locks are not synced with Assignment
+        When we post to "/assignments/content"
+        """
+        [{"assignment_id": "#ASSIGNMENT_ID#"}]
+        """
+        Then we get OK response
+        Then we store "CONTENT_1_ID" with value "#content._id#" to context
+        When we post to "/assignments/content"
+        """
+        [{"assignment_id": "#ASSIGNMENT_ID#"}]
+        """
+        Then we get OK response
+        Then we store "CONTENT_2_ID" with value "#content._id#" to context
+        When we get "/assignments/#ASSIGNMENT_ID#"
+        Then we get existing resource
+        """
+        {"lock_action": "__none__"}
+        """
+
+        # Lock 1st content
+        When we post to "/archive/#CONTENT_1_ID#/lock"
+        """
+        {"lock_action": "edit"}
+        """
+        Then we get OK response
+        When we get "/assignments/#ASSIGNMENT_ID#"
+        Then we get existing resource
+        """
+        {"lock_action": "__none__"}
+        """
+
+        # Lock 2nd content
+        When we post to "/archive/#CONTENT_2_ID#/lock"
+        """
+        {"lock_action": "edit"}
+        """
+        Then we get OK response
+        When we get "/assignments/#ASSIGNMENT_ID#"
+        Then we get existing resource
+        """
+        {"lock_action": "__none__"}
+        """
+
+        # Unlock 1st content
+        When we post to "/archive/#CONTENT_1_ID#/unlock"
+        """
+        {}
+        """
+        Then we get OK response
+        Then we get existing resource
+        """
+        {"lock_action": "__none__"}
+        """
+
+        # Unlock 2nd content
+        When we post to "/archive/#CONTENT_2_ID#/unlock"
+        """
+        {}
+        """
+        Then we get OK response
+        Then we get existing resource
+        """
+        {"lock_action": "__none__"}
+        """

--- a/server/planning/assignments/assignments.py
+++ b/server/planning/assignments/assignments.py
@@ -69,7 +69,7 @@ from planning.common import (
 
 from planning.types import EventResourceModel
 from planning.planning_notifications import PlanningNotifications
-from planning.common import format_address, get_assginment_name
+from planning.common import format_address, get_assginment_name, assignment_allows_multiple_content_linked
 from .assignments_history import ASSIGNMENT_HISTORY_ACTIONS
 from .assignments_history_async import AssignmentsHistoryAsyncService
 from planning.utils import (
@@ -925,21 +925,29 @@ class AssignmentsService(AsyncBaseService):
             return
 
         assignment_update_data = await self._get_assignment_data_on_archive_update(updates, original)
+        current_assignment = assignment_update_data.get("assignment") or {}
+        current_assigned_to = current_assignment.get("assigned_to") or {}
+        if not current_assignment or current_assigned_to.get("user") == assignment_update_data.get("item_user_id"):
+            return
 
-        if assignment_update_data.get("assignment") and assignment_update_data["assignment"].get("assigned_to")[
-            "user"
-        ] != assignment_update_data.get("item_user_id"):
-            # re-assign the user to the lock user
-            updated_assignment = self._set_user_for_assignment(
-                assignment_update_data.get("assignment"),
-                assignment_update_data.get("item_user_id"),
-            )
-            updated_assignment.get("assigned_to")["state"] = get_next_assignment_status(
-                updated_assignment, ASSIGNMENT_WORKFLOW_STATE.IN_PROGRESS
-            )
-            await self._update_assignment_and_notify(updated_assignment, assignment_update_data.get("assignment"))
+        assignment_updates = self._set_user_for_assignment(
+            current_assignment,
+            assignment_update_data.get("item_user_id"),
+        )
+        assignment_updates["assigned_to"]["state"] = get_next_assignment_status(
+            current_assignment, ASSIGNMENT_WORKFLOW_STATE.IN_PROGRESS
+        )
+
+        update_required = False
+        for field in ("user", "assignor_user", "state"):
+            if current_assigned_to.get(field, "") != assignment_updates["assigned_to"].get(field, ""):
+                update_required = True
+                break
+
+        if update_required:
+            await self._update_assignment_and_notify(assignment_updates, current_assignment)
             await AssignmentsHistoryAsyncService().on_item_updated(
-                updated_assignment, assignment_update_data.get("assignment", {})
+                assignment_updates, assignment_update_data.get("assignment", {})
             )
 
     async def update_assignment_on_archive_operation(self, updates, original, operation=None):
@@ -991,7 +999,11 @@ class AssignmentsService(AsyncBaseService):
                         },
                     )
 
-                if updated_assignment.get("assigned_to")["state"] != ASSIGNMENT_WORKFLOW_STATE.COMPLETED:
+                multiple_content_allowed = assignment_allows_multiple_content_linked(assignment)
+                if (
+                    not multiple_content_allowed
+                    and updated_assignment.get("assigned_to")["state"] != ASSIGNMENT_WORKFLOW_STATE.COMPLETED
+                ):
                     updated_assignment.get("assigned_to")["state"] = get_next_assignment_status(
                         updated_assignment, ASSIGNMENT_WORKFLOW_STATE.COMPLETED
                     )
@@ -1006,11 +1018,14 @@ class AssignmentsService(AsyncBaseService):
                     # publish planning
                     await self.publish_planning(assignment.get("planning_item"))
 
-                assigned_to_user = get_resource_service("users").find_one(req=None, _id=get_user().get(ID_FIELD, ""))
-                assignee = assigned_to_user.get("display_name") if assigned_to_user else "Unknown"
-                target_user = assignment.get("assigned_to", {}).get("assignor_desk")
+                if not multiple_content_allowed and not original.get("rewrite_of"):
+                    # Send assignment completed notification
+                    assigned_to_user = await get_resource_service("users").find_one_async(
+                        req=None, _id=get_user().get(ID_FIELD, "")
+                    )
+                    assignee = assigned_to_user.get("display_name") if assigned_to_user else "Unknown"
+                    target_user = assignment.get("assigned_to", {}).get("assignor_desk")
 
-                if not original.get("rewrite_of"):
                     await PlanningNotifications().notify_assignment(
                         target_user=target_user,
                         message="assignment_complete_msg",
@@ -1189,7 +1204,10 @@ class AssignmentsService(AsyncBaseService):
         # If more than one archive item is associated with the assignment
         # No need to lock assignment in case of a rewrite document
         assignment = await self._get_assignment_from_archive_item({}, item)
-        if assignment and (
+        if not assignment:
+            return
+
+        if not assignment_allows_multiple_content_linked(assignment) and (
             not item.get("rewrite_of")
             or await get_resource_service("archive").count_async({"assignment_id": assignment[ID_FIELD]}) <= 1
         ):
@@ -1198,7 +1216,14 @@ class AssignmentsService(AsyncBaseService):
 
     async def sync_assignment_unlock(self, item, user_id):
         assignment = await self._get_assignment_from_archive_item({}, item)
-        if assignment and assignment.get(LOCK_USER) and assignment.get(LOCK_ACTION) == "content_edit":
+        if not assignment:
+            return
+
+        if (
+            not assignment_allows_multiple_content_linked(assignment)
+            and assignment.get(LOCK_USER)
+            and assignment.get(LOCK_ACTION) == "content_edit"
+        ):
             lock_service = get_component(LockService)
             await lock_service.unlock(assignment, user_id, get_auth()["_id"], "assignments")
 

--- a/server/planning/assignments/assignments_content.py
+++ b/server/planning/assignments/assignments_content.py
@@ -29,6 +29,7 @@ from planning.common import (
     get_next_assignment_status,
     get_coverage_for_assignment,
     get_archive_items_for_assignment,
+    assignment_allows_multiple_content_linked,
 )
 from planning.planning_notifications import PlanningNotifications
 from planning.archive import create_item_from_template
@@ -280,16 +281,29 @@ class AssignmentsContentService(AsyncBaseService):
             raise SuperdeskApiError.badRequestError("Assignment not found.")
 
         await assignment_service.validate_assignment_action(assignment)
-        if assignment.get("assigned_to").get("state") != ASSIGNMENT_WORKFLOW_STATE.ASSIGNED:
-            raise SuperdeskApiError.badRequestError("Assignment workflow started. Cannot create content.")
 
-        delivery = await get_resource_service("delivery").find_one_async(
-            req=None, assignment_id=assignment.get(ID_FIELD)
-        )
-        if delivery:
-            raise SuperdeskApiError.badRequestError(
-                "Content already exists for the assignment. " "Cannot create content."
-            )
+        try:
+            workflow_state = assignment["assigned_to"]["state"]
+        except (KeyError, TypeError):
+            workflow_state = ASSIGNMENT_WORKFLOW_STATE.DRAFT
+
+        if workflow_state == ASSIGNMENT_WORKFLOW_STATE.DRAFT:
+            raise SuperdeskApiError.badRequestError("Cannot create content from a draft Assignment.")
+        elif not assignment_allows_multiple_content_linked(assignment):
+            if workflow_state != ASSIGNMENT_WORKFLOW_STATE.ASSIGNED:
+                raise SuperdeskApiError.badRequestError("Assignment workflow started. Cannot create content.")
+
+            delivery_service = get_resource_service("delivery")
+            if await delivery_service.count_async({"assignment_id": assignment.get(ID_FIELD)}) > 0:
+                raise SuperdeskApiError.badRequestError(
+                    "Content already exists for the assignment. Cannot create content."
+                )
+        elif workflow_state not in [
+            ASSIGNMENT_WORKFLOW_STATE.ASSIGNED,
+            ASSIGNMENT_WORKFLOW_STATE.IN_PROGRESS,
+            ASSIGNMENT_WORKFLOW_STATE.SUBMITTED,
+        ]:
+            raise SuperdeskApiError.badRequestError("Assignment workflow completed. Cannot create content.")
 
         # Handle schedule_updates validation
         if assignment.get("scheduled_update_id"):

--- a/server/planning/assignments/assignments_link.py
+++ b/server/planning/assignments/assignments_link.py
@@ -21,6 +21,7 @@ from planning.common import (
     get_next_assignment_status,
     get_delivery_publish_time,
     is_content_link_to_coverage_allowed,
+    assignment_allows_multiple_content_linked,
 )
 from .assignments_history_async import AssignmentsHistoryAsyncService
 from apps.archive.common import get_user, is_assigned_to_a_desk
@@ -173,12 +174,8 @@ class AssignmentsLinkService(AsyncBaseService):
         if not is_assigned_to_a_desk(item):
             raise SuperdeskApiError.badRequestError("Content not in workflow. Cannot link assignment and content.")
 
-        if not item.get("rewrite_of"):
-            delivery = await get_resource_service("delivery").find_one_async(
-                req=None, assignment_id=doc.get("assignment_id")
-            )
-
-            if delivery:
+        if not item.get("rewrite_of") and not assignment_allows_multiple_content_linked(assignment):
+            if await get_resource_service("delivery").count_async({"assignment_id": doc.get("assignment_id")}) > 0:
                 raise SuperdeskApiError.badRequestError(
                     "Content already exists for the assignment. Cannot link assignment and content."
                 )

--- a/server/planning/assignments/assignments_revert.py
+++ b/server/planning/assignments/assignments_revert.py
@@ -19,7 +19,11 @@ from apps.archive.common import get_user, get_auth
 
 from .assignments import AssignmentsResource, assignments_schema
 from .assignments_history_async import AssignmentsHistoryAsyncService
-from planning.common import ASSIGNMENT_WORKFLOW_STATE, remove_lock_information
+from planning.common import (
+    ASSIGNMENT_WORKFLOW_STATE,
+    remove_lock_information,
+    assignment_allows_multiple_content_linked,
+)
 
 
 assignments_revert_schema = deepcopy(assignments_schema)
@@ -44,7 +48,9 @@ class AssignmentsRevertService(AsyncBaseService):
         assignments_service = get_resource_service("assignments")
         await assignments_service.validate_assignment_action(original)
 
-        if await assignments_service.is_text_assignment(original):
+        if not assignment_allows_multiple_content_linked(original) and await assignments_service.is_text_assignment(
+            original
+        ):
             raise SuperdeskApiError.forbiddenError("Cannot revert text assignments.")
 
         if assignment_state != ASSIGNMENT_WORKFLOW_STATE.COMPLETED:

--- a/server/planning/assignments/assignments_unlink.py
+++ b/server/planning/assignments/assignments_unlink.py
@@ -79,23 +79,37 @@ class AssignmentsUnlinkService(AsyncBaseService):
             doc.update(actioned_item)
 
             assignments = await self.get_all_assignments_for_coverage(assignment.get("coverage_item"))
-            async for a in assignments:
+            async for assignment in assignments:
                 # Update all assignments in the coverage including scheduled_updates
-                updates = {"assigned_to": deepcopy(a.get("assigned_to"))}
-                archive_items = await assignments_service.get_archive_items_for_assignment(a)
-                other_linked_items = [
-                    a async for a in archive_items if str(a.get(ID_FIELD)) != str(actioned_item[ID_FIELD])
-                ]
-                if len(other_linked_items) <= 0:
-                    updates["assigned_to"]["state"] = ASSIGNMENT_WORKFLOW_STATE.ASSIGNED
-                    await assignments_service.patch_async(a.get(ID_FIELD), updates)
+                updates = {"assigned_to": deepcopy(assignment.get("assigned_to"))}
+                archive_items = await assignments_service.get_archive_items_for_assignment(assignment)
+                other_items_in_chain: set[str] = set()
+                other_items_not_in_chain: set[str] = set()
+
+                async for other_item in archive_items:
+                    other_item_id = str(other_item.get(ID_FIELD))
+                    if other_item_id == str(actioned_item[ID_FIELD]):
+                        # This is the same item we're processing
+                        continue
+                    elif other_item.get("event_id") == actioned_item.get("event_id"):
+                        # This item is linked to the item we're processing
+                        other_items_in_chain.add(other_item_id)
+                    else:
+                        other_items_not_in_chain.add(other_item_id)
+
+                if not len(other_items_in_chain):
+                    if not len(other_items_not_in_chain):
+                        # There are no other items linked to this Assignment, change the state to ``assigned``
+                        updates["assigned_to"]["state"] = ASSIGNMENT_WORKFLOW_STATE.ASSIGNED
+                        await assignments_service.patch_async(assignment.get(ID_FIELD), updates)
+
                     assignment_history_service = AssignmentsHistoryAsyncService()
                     if spike:
                         await assignment_history_service.on_item_content_unlink(
-                            updates, a, ASSIGNMENT_HISTORY_ACTIONS.SPIKE_UNLINK
+                            updates, assignment, ASSIGNMENT_HISTORY_ACTIONS.SPIKE_UNLINK
                         )
                     else:
-                        await assignment_history_service.on_item_content_unlink(updates, a)
+                        await assignment_history_service.on_item_content_unlink(updates, assignment)
 
                     if not cancel:
                         user = get_user()
@@ -107,7 +121,7 @@ class AssignmentsUnlinkService(AsyncBaseService):
                             coverage_type=get_coverage_type_name(actioned_item.get("type", "")),
                             slugline=actioned_item.get("slugline"),
                             omit_user=True,
-                            assignment_id=a[ID_FIELD],
+                            assignment_id=assignment[ID_FIELD],
                             is_link=True,
                             no_email=True,
                         )

--- a/server/planning/common.py
+++ b/server/planning/common.py
@@ -884,3 +884,10 @@ def get_coverage_from_planning(planning_item: Planning, coverage_id: str) -> Opt
 def prepare_ingested_item_for_storage(doc: Union[Event, Planning]) -> None:
     doc.setdefault("state", "ingested")
     doc["ingest_pubstatus"] = doc.pop("pubstatus", "usable")  # pubstatus is set when posted
+
+
+def assignment_allows_multiple_content_linked(assignment: dict) -> bool:
+    try:
+        return assignment["planning"]["multiple_coverages"] is True
+    except (KeyError, TypeError):
+        return False

--- a/server/planning/common.py
+++ b/server/planning/common.py
@@ -888,6 +888,6 @@ def prepare_ingested_item_for_storage(doc: Union[Event, Planning]) -> None:
 
 def assignment_allows_multiple_content_linked(assignment: dict) -> bool:
     try:
-        return assignment["planning"]["multiple_coverages"] is True
+        return assignment["planning"]["multiple_content"] is True
     except (KeyError, TypeError):
         return False

--- a/server/planning/planning/planning_schema.py
+++ b/server/planning/planning/planning_schema.py
@@ -110,7 +110,7 @@ coverage_schema = {
             "internal_note": {"type": "string", "nullable": True},
             "workflow_status_reason": {"type": "string", "nullable": True},
             "priority": metadata_schema["priority"],
-            "multiple_coverages": {"type": "boolean", "default": False},
+            "multiple_content": {"type": "boolean", "default": False},
         },  # end planning dict schema
     },  # end planning
     "news_coverage_status": {
@@ -313,7 +313,7 @@ planning_schema = {
                     "type": "object",
                     "properties": {
                         "slugline": metadata_schema["slugline"]["mapping"],
-                        "multiple_coverages": {"type": "boolean"},
+                        "multiple_content": {"type": "boolean"},
                     },
                 },
                 "assigned_to": assigned_to_schema["mapping"],

--- a/server/planning/planning/planning_schema.py
+++ b/server/planning/planning/planning_schema.py
@@ -313,7 +313,7 @@ planning_schema = {
                     "type": "object",
                     "properties": {
                         "slugline": metadata_schema["slugline"]["mapping"],
-                        "multiple_coverages": coverage_schema["planning"]["schema"]["multiple_coverages"],
+                        "multiple_coverages": {"type": "boolean"},
                     },
                 },
                 "assigned_to": assigned_to_schema["mapping"],

--- a/server/planning/planning/planning_schema.py
+++ b/server/planning/planning/planning_schema.py
@@ -110,6 +110,7 @@ coverage_schema = {
             "internal_note": {"type": "string", "nullable": True},
             "workflow_status_reason": {"type": "string", "nullable": True},
             "priority": metadata_schema["priority"],
+            "multiple_coverages": {"type": "boolean", "default": False},
         },  # end planning dict schema
     },  # end planning
     "news_coverage_status": {

--- a/server/planning/planning/planning_schema.py
+++ b/server/planning/planning/planning_schema.py
@@ -313,6 +313,7 @@ planning_schema = {
                     "type": "object",
                     "properties": {
                         "slugline": metadata_schema["slugline"]["mapping"],
+                        "multiple_coverages": coverage_schema["planning"]["schema"]["multiple_coverages"],
                     },
                 },
                 "assigned_to": assigned_to_schema["mapping"],

--- a/server/planning/types/common.py
+++ b/server/planning/types/common.py
@@ -187,6 +187,10 @@ class CoverageInternalPlanning:
     internal_note: fields.HTML | None = None
     workflow_status_reason: str | None = None
     priority: int | None = None
+    multiple_coverages: bool = Field(
+        default=False,
+        description="If enabled, will allow multiple content items to be linked to this Coverage/Assignment",
+    )
 
 
 @dataclass

--- a/server/planning/types/common.py
+++ b/server/planning/types/common.py
@@ -187,7 +187,7 @@ class CoverageInternalPlanning:
     internal_note: fields.HTML | None = None
     workflow_status_reason: str | None = None
     priority: int | None = None
-    multiple_coverages: bool = Field(
+    multiple_content: bool = Field(
         default=False,
         description="If enabled, will allow multiple content items to be linked to this Coverage/Assignment",
     )


### PR DESCRIPTION
### Purpose
Modify Assignment actions with the support for allowing multiple 'start working' etc.

### What has changed
Frontend:
* Move `createFromTemplateAndShow` from a redux action to pure js
* Add checks for Assignment's `planning.multiple_coverages` for the `Revert` and `Start Working` actions

Backend:
* Update Assignment actions to allow multiple content links, if Assignment is still in workflow (aka not completed, cancelled etc)
* Add `multiple_coverages` to the Coverage/Assignment Planning schema (including searchable via Elasticsearch)
* Add behave tests for new feature

Resolves: [STT-1295](https://sofab.atlassian.net/browse/STT-1295)



[STT-1295]: https://sofab.atlassian.net/browse/STT-1295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ