### PR TITLE
[STT-1296] Support linking content to Assignments with multiple_content

### DIFF
--- a/client/actions/assignments/api.ts
+++ b/client/actions/assignments/api.ts
@@ -164,6 +164,7 @@ const query = ({
     size = null,
     ignoreScheduledUpdates = false,
     max_results = null,
+    baseQuery = null,
 }) => (
     (dispatch, getState, {api}) => {
         const filterByValues = {
@@ -176,10 +177,20 @@ const query = ({
         let sort = '[("' + (get(filterByValues, orderByField, 'planning.scheduled')) + '", '
             + (orderDirection === SORT_DIRECTION.ASCENDING ? 1 : -1) + ')]';
 
-        const baseQuery = selectors.getBaseAssignmentQuery(getState());
+        const baseElasticQuery = selectors.getBaseAssignmentQuery(getState());
+
+        if (baseQuery) {
+            // Combine the elastic queries from the provided baseQuery and the one from the redux store
+            for (const field of ['must', 'must_not', 'should']) {
+                if (baseQuery[field]) {
+                    baseElasticQuery[field] = (baseElasticQuery[field] || []).concat(baseQuery[field]);
+                }
+            }
+        }
+
         const query = constructQuery({
             systemTimezone: appConfig.default_timezone,
-            baseQuery: baseQuery,
+            baseQuery: baseElasticQuery,
             searchQuery: searchQuery,
             deskId: deskId,
             userId: userId,

--- a/client/actions/assignments/api.ts
+++ b/client/actions/assignments/api.ts
@@ -2,7 +2,7 @@ import moment from 'moment-timezone';
 import {get, cloneDeep, has, pick} from 'lodash';
 
 import {appConfig} from 'appConfig';
-import {IAssignmentItem} from '../../interfaces';
+import {IAssignmentItem, ISearchQueryOperator} from '../../interfaces';
 import {planningApi} from '../../superdeskApi';
 
 import * as selectors from '../../selectors';
@@ -12,6 +12,8 @@ import planningUtils from '../../utils/planning';
 import {getErrorMessage, isExistingItem, gettext} from '../../utils';
 import planningActions from '../planning/api';
 import {assignmentsViewRequiresArchiveItems} from '../../components/Assignments/AssignmentItem/fields';
+
+export const SEARCH_QUERY_OPERATORS: Array<ISearchQueryOperator> = ['must', 'must_not', 'should'];
 
 const setBaseQuery = ({must = []}) => ({
     type: ASSIGNMENTS.ACTIONS.SET_BASE_QUERY,
@@ -181,7 +183,7 @@ const query = ({
 
         if (baseQuery) {
             // Combine the elastic queries from the provided baseQuery and the one from the redux store
-            for (const field of ['must', 'must_not', 'should']) {
+            for (const field of SEARCH_QUERY_OPERATORS) {
                 if (baseQuery[field]) {
                     baseElasticQuery[field] = (baseElasticQuery[field] || []).concat(baseQuery[field]);
                 }

--- a/client/actions/assignments/ui.ts
+++ b/client/actions/assignments/ui.ts
@@ -212,7 +212,7 @@ const queryAndSetAssignmentListGroups = (groupKey, page = 1) => (
         if (group.max_results) {
             querySearchSettings.max_results = group.max_results;
         }
-        if (group.baseQuery) {
+        if (group.baseQuery != null) {
             querySearchSettings.baseQuery = group.baseQuery;
         }
 

--- a/client/actions/assignments/ui.ts
+++ b/client/actions/assignments/ui.ts
@@ -202,12 +202,18 @@ const queryAndSetAssignmentListGroups = (groupKey, page = 1) => (
         const assignmentListSelectors = selectors.getAssignmentGroupSelectors[groupKey];
         const group = ASSIGNMENTS.LIST_GROUPS[groupKey];
 
-        querySearchSettings.states = group.states;
+        if (!group.excludeStatesFromQuery) {
+            querySearchSettings.states = group.states;
+        }
+
         querySearchSettings.page = page;
         querySearchSettings.dateFilter = group.dateFilter;
         querySearchSettings.orderDirection = assignmentListSelectors.sortOrder(getState());
         if (group.max_results) {
             querySearchSettings.max_results = group.max_results;
+        }
+        if (group.baseQuery) {
+            querySearchSettings.baseQuery = group.baseQuery;
         }
 
         return dispatch(assignments.api.query(querySearchSettings))
@@ -460,7 +466,7 @@ const onFulFilAssignment = (assignment) => (
                 return Promise.resolve(item);
             }, (error) => {
                 notify.error(
-                    getErrorMessage(error, 'Failed to fulfil assignment.')
+                    getErrorMessage(error, 'Failed to link to assignment.')
                 );
                 $scope.reject();
                 dispatch(actions.actionInProgress(false));

--- a/client/components/Assignments/AssignmentPreviewContainer/index.tsx
+++ b/client/components/Assignments/AssignmentPreviewContainer/index.tsx
@@ -176,7 +176,7 @@ class AssignmentPreviewContainerComponent extends React.Component<IProps> {
                         <ContentBlockInner grow={true}>
                             <Button
                                 type="primary"
-                                text={gettext('Fulfil Assignment')}
+                                text={gettext('Link to Assignment')}
                                 onClick={() => {
                                     onFulFilAssignment(assignment);
                                 }}

--- a/client/constants/assignments.ts
+++ b/client/constants/assignments.ts
@@ -2,6 +2,27 @@ import {superdeskApi} from '../superdeskApi';
 
 export const editPlanningParam = 'editPlanningItem';
 
+const linkableAssignmentStateQuery = {
+    must: [
+        {
+            bool: {
+                should: [
+                    {terms: {'assigned_to.state': ['assigned', 'submitted']}},
+                    {
+                        bool: {
+                            must: [
+                                {term: {'assigned_to.state': 'in_progress'}},
+                                {term: {'planning.multiple_content': true}},
+                            ],
+                        },
+                    },
+                ],
+                minimum_should_match: 1,
+            },
+        },
+    ],
+};
+
 export const ASSIGNMENTS = {
     ACTIONS: {
         RECEIVED_ASSIGNMENTS: 'RECEIVED_ASSIGNMENTS',
@@ -119,6 +140,8 @@ export const ASSIGNMENTS = {
             states: ['assigned', 'submitted'],
             emptyMessage: 'There are no current assignments',
             dateFilter: 'current',
+            baseQuery: linkableAssignmentStateQuery,
+            excludeStatesFromQuery: true,
         },
         TODAY: {
             id: 'TODAY',
@@ -126,6 +149,8 @@ export const ASSIGNMENTS = {
             states: ['assigned', 'submitted'],
             emptyMessage: 'There are no assignments for today',
             dateFilter: 'today',
+            baseQuery: linkableAssignmentStateQuery,
+            excludeStatesFromQuery: true,
         },
         FUTURE: {
             id: 'FUTURE',
@@ -133,6 +158,8 @@ export const ASSIGNMENTS = {
             states: ['assigned', 'submitted'],
             emptyMessage: 'There are no future assignments',
             dateFilter: 'future',
+            baseQuery: linkableAssignmentStateQuery,
+            excludeStatesFromQuery: true,
         },
     },
     DEFAULT_LIST_GROUPS: ['TODO', 'IN_PROGRESS', 'COMPLETED'],

--- a/client/interfaces.ts
+++ b/client/interfaces.ts
@@ -2450,3 +2450,5 @@ export interface IPlanningAPI {
         unlockFeaturedPlanning(): Promise<void>;
     };
 }
+
+export type ISearchQueryOperator = 'must' | 'must_not' | 'should';

--- a/client/planning-extension/src/extension.ts
+++ b/client/planning-extension/src/extension.ts
@@ -169,7 +169,7 @@ const extension: IExtension = {
                 permittedActions.push({
                     label: gettext('Add to Planning'),
                     groupId: planningActionsGroupId,
-                    icon: 'calendar-list',
+                    icon: 'icon-calendar-list',
                     onTrigger: () => {
                         const customEvent = new CustomEvent('planning:addToPlanning', {detail: item});
 
@@ -182,7 +182,7 @@ const extension: IExtension = {
                 permittedActions.push({
                     label: gettext('Unlink as Coverage'),
                     groupId: planningActionsGroupId,
-                    icon: 'cut',
+                    icon: 'icon-cut',
                     onTrigger: () => {
                         superdesk.entities.article.get(item._id).then((_item) => {
                             window.dispatchEvent(new CustomEvent(
@@ -196,9 +196,9 @@ const extension: IExtension = {
 
             if (canFulfilAssignment(item)) {
                 permittedActions.push({
-                    label: superdesk.localization.gettext('Fulfil assignment'),
+                    label: superdesk.localization.gettext('Link to Assignment'),
                     groupId: planningActionsGroupId,
-                    icon: 'calendar-list',
+                    icon: 'icon-calendar-list',
                     onTrigger: () => {
                         superdesk.entities.article.get(item._id).then((_item) => {
                             window.dispatchEvent(new CustomEvent(

--- a/client/planning-extension/src/planning-details-widget.tsx
+++ b/client/planning-extension/src/planning-details-widget.tsx
@@ -151,7 +151,7 @@ export class PlanningDetailsWidget extends React.PureComponent<IArticleSideWidge
                                 />
                                 <div className="sd-margin-t--1" />
                                 <Button
-                                    text={gettext('Fulfil Assignment')}
+                                    text={gettext('Link to Assignment')}
                                     icon="bolt"
                                     onClick={this.dispatchFulfilAssignment}
                                     expand

--- a/client/utils/assignments.ts
+++ b/client/utils/assignments.ts
@@ -106,7 +106,16 @@ function canFulfilAssignment(
 ) {
     return !!privileges[PRIVILEGES.ARCHIVE] &&
         isNotLockRestricted(assignment, session, lockedItems) &&
-        get(assignment, 'assigned_to.state') === ASSIGNMENTS.WORKFLOW_STATE.ASSIGNED;
+        (
+            assignment.assigned_to?.state === ASSIGNMENTS.WORKFLOW_STATE.ASSIGNED ||
+            (
+                assignment.planning?.multiple_content &&
+                [
+                    ASSIGNMENTS.WORKFLOW_STATE.SUBMITTED,
+                    ASSIGNMENTS.WORKFLOW_STATE.IN_PROGRESS,
+                ].includes(assignment.assigned_to?.state)
+            )
+        );
 }
 
 const isAssignmentInEditableState = (assignment) => (


### PR DESCRIPTION
### Purpose
Now that we have the ability to perform 'Start Working' multiple times on the same Assignment, we need the ability to link multiple content to the 1 Assignment.

### What has changed
* Rename the 'Fulfil Assignment' action to 'Link to Assignment'
* Modify the query for the modal, so we get all Assignment that can have content linked to it
* Fixed icons in list item actions in monitoring (missing `icon-` prefix)

Resolves: [STT-1296](https://sofab.atlassian.net/browse/STT-1296)



[STT-1296]: https://sofab.atlassian.net/browse/STT-1296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ