### PR TITLE
[STT-1299] Assignment page improvements for multi content linked to Assignments

### DIFF
--- a/client/actions/assignments/api.ts
+++ b/client/actions/assignments/api.ts
@@ -1,6 +1,7 @@
 import moment from 'moment-timezone';
 import {get, cloneDeep, has, pick} from 'lodash';
 
+import {IArticle} from 'superdesk-api';
 import {appConfig} from 'appConfig';
 import {IAssignmentItem, ISearchQueryOperator} from '../../interfaces';
 import {planningApi} from '../../superdeskApi';
@@ -11,7 +12,6 @@ import {ASSIGNMENTS, ALL_DESKS, SORT_DIRECTION} from '../../constants';
 import planningUtils from '../../utils/planning';
 import {getErrorMessage, isExistingItem, gettext} from '../../utils';
 import planningActions from '../planning/api';
-import {assignmentsViewRequiresArchiveItems} from '../../components/Assignments/AssignmentItem/fields';
 
 export const SEARCH_QUERY_OPERATORS: Array<ISearchQueryOperator> = ['must', 'must_not', 'should'];
 
@@ -263,9 +263,7 @@ const fetchAssignmentById = (id, force = false, recieve = true) => (
 const receivedAssignments = (assignments) => (
     (dispatch) => {
         dispatch(actions.contacts.fetchContactsFromAssignments(assignments));
-        if (assignmentsViewRequiresArchiveItems()) {
-            dispatch(actions.assignments.api.loadArchiveItems(assignments));
-        }
+        dispatch(actions.assignments.api.loadArchiveItems(assignments));
         dispatch({
             type: ASSIGNMENTS.ACTIONS.RECEIVED_ASSIGNMENTS,
             payload: assignments,
@@ -531,11 +529,11 @@ const removeAssignment = (assignment) => (
     )
 );
 
-function unlink(assignment: IAssignmentItem) {
+function unlink(assignment: IAssignmentItem, itemId: IArticle['_id']) {
     return (dispatch, getState, {api, notify}) => (
         api('assignments_unlink').save({}, {
             assignment_id: assignment._id,
-            item_id: get(assignment, 'item_ids[0]'),
+            item_id: itemId,
         })
             .then(() => {
                 notify.success(gettext('Assignment reverted.'));

--- a/client/actions/assignments/notifications.ts
+++ b/client/actions/assignments/notifications.ts
@@ -366,30 +366,6 @@ const onAssignmentDeleted = (_e, data) => (
     }
 );
 
-export const onContentUpdate = (_e, data) => (
-    (dispatch, getState) => {
-        const updatedItems = Object.keys(data.items);
-        const currentItems = Object.values(selectors.getStoredArchiveItems(getState()));
-        const refetchAssignments = [];
-
-        for (const itemId of updatedItems) {
-            const updatedItemInState = currentItems.find((i) => i._id === itemId);
-
-            if (updatedItemInState != null) {
-                refetchAssignments.push(updatedItemInState.assignment_id);
-                break;
-            }
-        }
-
-        if (refetchAssignments.length > 0) {
-            const assignments = Object.values(getState().assignment.assignments);
-            const updateAssignments = assignments.filter((a) => refetchAssignments.includes(a._id));
-
-            dispatch(actions.assignments.api.loadArchiveItems(updateAssignments));
-        }
-    }
-);
-
 // eslint-disable-next-line consistent-this
 const self = {
     onAssignmentCreated,
@@ -399,7 +375,6 @@ const self = {
     onAssignmentRemoved,
     onAssignmentDeleteFailed,
     onAssignmentDeleted,
-    onContentUpdate,
 };
 
 // Map of notification name and Action Event to execute
@@ -414,7 +389,6 @@ self.events = {
     'assignments:delete:fail': () => (self.onAssignmentDeleteFailed),
     'assignments:delete': () => (self.onAssignmentDeleted),
     'assignments:accepted': () => (self.onAssignmentUpdated),
-    'content:update': () => (self.onContentUpdate),
 };
 
 export default self;

--- a/client/actions/assignments/tests/api_test.ts
+++ b/client/actions/assignments/tests/api_test.ts
@@ -541,8 +541,8 @@ describe('actions.assignments.api', () => {
         it('adds the assignments to the store', () => {
             store.dispatch(assignmentsApi.receivedAssignments(data.assignments));
 
-            expect(store.dispatch.callCount).toBe(3);
-            expect(store.dispatch.args[2][0]).toEqual({
+            expect(store.dispatch.callCount).toBe(4);
+            expect(store.dispatch.args[3][0]).toEqual({
                 type: ASSIGNMENTS.ACTIONS.RECEIVED_ASSIGNMENTS,
                 payload: data.assignments,
             });

--- a/client/actions/assignments/ui.ts
+++ b/client/actions/assignments/ui.ts
@@ -1,6 +1,7 @@
 import {get, cloneDeep, forEach} from 'lodash';
 import moment from 'moment';
 
+import {IArticle} from 'superdesk-api';
 import {planningApi, superdeskApi} from '../../superdeskApi';
 import {IAssignmentItem} from '../../interfaces';
 
@@ -370,14 +371,22 @@ const addToAssignmentListGroup = (assignmentIds, totalNoOfItems, group) => ({
  * @param {object} assignment - The Assignment to preview
  * @return object
  */
-const preview = (assignment) => (
+const preview = (
+    assignment: IAssignmentItem,
+    initialTab?: 'ASSIGNMENT' | 'CONTENT' | 'HISTORY',
+    archiveItem?: IArticle,
+) => (
     (dispatch, getState, {$timeout, $location}) => (
         dispatch(assignments.api.loadPlanningAndEvent(assignment))
             .then(() => {
                 $timeout(() => $location.search('assignment', get(assignment, '_id', null)));
                 return dispatch({
                     type: ASSIGNMENTS.ACTIONS.PREVIEW_ASSIGNMENT,
-                    payload: assignment,
+                    payload: {
+                        assignmentId: assignment._id,
+                        initialTab: initialTab ?? 'ASSIGNMENT',
+                        archiveItemId: archiveItem?._id,
+                    },
                 });
             })
     )

--- a/client/actions/notifications.ts
+++ b/client/actions/notifications.ts
@@ -1,8 +1,11 @@
 import {get} from 'lodash';
 
-import {planningApi} from '../superdeskApi';
+import {IArticle} from 'superdesk-api';
+import {planningApi, superdeskApi} from '../superdeskApi';
 
+import {ASSIGNMENTS} from '../constants';
 import contacts from './contacts';
+import {getStoredArchiveItems} from '../selectors';
 
 /**
  * WS Action when a new Planning item is created
@@ -20,9 +23,21 @@ const onContactsUpdated = (_e, data) => (
 );
 
 function onResourceCreatedOrUpdated(_e, data) {
-    return () => {
+    return (dispatch, getState) => {
         if (data.resource === 'planning_types') {
             planningApi.contentProfiles.updateProfilesInStore();
+        } else if (['archive', 'archived', 'published'].includes(data.resource)) {
+            const loadedArticles = getStoredArchiveItems(getState());
+
+            if (loadedArticles[data._id] != null) {
+                // This item is loaded into the Redux store, grab a fresh copy now
+                superdeskApi.dataApi.findOne<IArticle>(data.resource, data._id).then((updatedItem) => {
+                    dispatch({
+                        type: ASSIGNMENTS.ACTIONS.RECEIVED_ARCHIVE,
+                        payload: [updatedItem],
+                    });
+                });
+            }
         }
     };
 }

--- a/client/apps/Assignments/AssignmentPreview.tsx
+++ b/client/apps/Assignments/AssignmentPreview.tsx
@@ -28,7 +28,7 @@ export class AssignmentPreviewComponent extends React.Component {
 
     constructor(props) {
         super(props);
-        this.state = {tab: TABS.ASSIGNMENT};
+        this.state = {tab: TABS[props.initialTab] || TABS.ASSIGNMENT};
 
         this.setActiveTab = this.setActiveTab.bind(this);
         this.closePanel = this.closePanel.bind(this);
@@ -64,11 +64,14 @@ export class AssignmentPreviewComponent extends React.Component {
         this.tabs[1].enabled = assignmentUtils.assignmentHasContent(this.props.assignment);
     }
 
-    componentWillReceiveProps(nextProps) {
-        // When changing Assignment items,  if the new Assignment has content
-        // Then enable the CONTENT tab
-        if (get(nextProps, 'assignment._id') !== get(this.props, 'assignment._id')) {
-            this.tabs[TABS.CONTENT].enabled = assignmentUtils.assignmentHasContent(nextProps.assignment);
+    componentDidUpdate(prevProps: Readonly<{}>, prevState: Readonly<{}>, snapshot?: any) {
+        if (prevProps.assignment?._id !== this.props.assignment?._id) {
+            // When changing Assignment items,  if the new Assignment has content
+            // Then enable the CONTENT tab
+            this.tabs[TABS.CONTENT].enabled = assignmentUtils.assignmentHasContent(this.props.assignment);
+        }
+        if (prevProps.initialTab !== this.props.initialTab) {
+            this.setActiveTab(TABS[this.props.initialTab] || TABS.ASSIGNMENT);
         }
     }
 
@@ -152,6 +155,7 @@ AssignmentPreviewComponent.propTypes = {
     lockedItems: PropTypes.object,
     hideItemActions: PropTypes.bool,
     showFulfilAssignment: PropTypes.bool,
+    initialTab: PropTypes.string,
 };
 
 const mapStateToProps = (state) => ({
@@ -159,6 +163,7 @@ const mapStateToProps = (state) => ({
     users: selectors.general.users(state),
     previewOpened: selectors.getPreviewAssignmentOpened(state),
     lockedItems: selectors.locks.getLockedItems(state),
+    initialTab: selectors.getInitialTab(state),
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/client/components/Archive/ArchiveItem.tsx
+++ b/client/components/Archive/ArchiveItem.tsx
@@ -1,58 +1,120 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
+import moment from 'moment';
 
-import {Item, Border, ItemType, Column, Row} from '../UI/List';
-import {PriorityLabel, UrgencyLabel} from '../';
+import {ContentListItem, IconButton, Label} from 'superdesk-ui-framework/react';
+
+import {IArticle} from 'superdesk-api';
+import {superdeskApi} from '../../superdeskApi';
+import {Row} from '../UI/List';
+import {ItemIcon} from '../';
+import {UrgencyLabel} from '../';
 import * as selectors from '../../selectors';
 
-export const ArchiveItemComponent = ({item, priorities, urgencies, urgencyLabel}) => (
-    <Item
-        shadow={2}
-        noHover={true}
-        className="archive-item"
-    >
-        <Border state="locked" />
-        <ItemType
-            item={item}
-            hasCheck={false}
-        />
-        <Column>
-            <Row>
-                <UrgencyLabel
-                    item={item}
-                    label={urgencyLabel}
-                    urgencies={urgencies}
-                    tooltipFlow="down"
-                    inline={true}
-                />
-                <PriorityLabel
-                    item={item}
-                    priorities={priorities}
-                    tooltipFlow="down"
-                />
-            </Row>
-        </Column>
-        <Column>
-            <Row>
-                <span className="sd-overflow-ellipsis sd-list-item--element-grow">
-                    <span className="sd-list-item__slugline">{item.slugline}</span>
-                    {item.headline}
-                </span>
-            </Row>
-        </Column>
-    </Item>
-);
+interface IProps {
+    item: IArticle;
+    urgencies: any;
+    urgencyLabel: any;
+    use2Lines?: boolean;
+    onClick?(): void;
+    onDoubleClick?(): void;
+}
 
-ArchiveItemComponent.propTypes = {
-    item: PropTypes.object,
-    priorities: PropTypes.array,
-    urgencies: PropTypes.array,
-    urgencyLabel: PropTypes.string,
-};
+export function ArchiveItemComponent({item, urgencies, urgencyLabel, use2Lines, onClick, onDoubleClick}: IProps) {
+    const {gettext} = superdeskApi.localization;
+    const stateProps: Label['props'] = ['PUBLISHED', 'SCHEDULED', 'CORRECTED'].includes(item.state) ? {
+        type: 'success',
+        style: 'translucent',
+        text: gettext('Completed'),
+    } : {
+        type: 'warning',
+        style: 'translucent',
+        text: gettext('In Progress'),
+    };
+
+    return (
+        <ContentListItem
+            onClick={onClick}
+            onDoubleClick={onDoubleClick}
+            locked={item.lock_action != null}
+            action={(
+                <IconButton
+                    icon="external"
+                    ariaValue={gettext('Open Coverage')}
+                    onClick={() => {
+                        superdeskApi.ui.article.edit(item._id);
+                    }}
+                />
+            )}
+            itemColum={[
+                {
+                    itemRow: [{content: (<ItemIcon item={item} />)}],
+                    border: true,
+                },
+                {
+                    border: true,
+                    itemRow: [{content: (
+                        <Row>
+                            <UrgencyLabel
+                                item={item}
+                                label={urgencyLabel}
+                                urgencies={urgencies}
+                                tooltipFlow="down"
+                                inline={true}
+                            />
+                        </Row>
+                    )}],
+                },
+                {
+                    fullwidth: true,
+                    itemRow: use2Lines !== true ? [{content: (
+                        <Row>
+                            <span className="sd-overflow-ellipsis sd-list-item--element-grow">
+                                <span className="sd-list-item__slugline">{item.slugline}</span>
+                                <Label {...stateProps} />
+                                {item.headline}
+                                <div className="sd-list-item__element-lm-10">
+                                    <span className="sd-list-item__text-label pe-0-5">
+                                        {gettext('Genre:')}
+                                    </span>
+                                    <span className="sd-overflow-ellipsis sd-list-item__text-strong">
+                                        <span>{item.genre?.[0]?.name}</span>
+                                    </span>
+                                </div>
+                            </span>
+                            <time className="sd-margin-s--auto">{moment(item.versioncreated).fromNow()}</time>
+                        </Row>
+                    )}] : [
+                        {content: (
+                            <React.Fragment>
+                                <span className="sd-overflow-ellipsis sd-list-item--element-grow">
+                                    <span className="sd-list-item__slugline">{item.slugline}</span>
+                                    {item.headline}
+                                </span>
+                                <time className="sd-margin-s--auto">{moment(item.versioncreated).fromNow()}</time>
+                            </React.Fragment>
+                        )},
+                        {content: (
+                            <React.Fragment>
+                                <Label {...stateProps} />
+                                <div className="sd-list-item__element-lm-10">
+                                    <span className="sd-list-item__text-label pe-0-5">
+                                        {gettext('Genre:')}
+                                    </span>
+                                    <span className="sd-overflow-ellipsis sd-list-item__text-strong">
+                                        <span>{item.genre?.[0]?.name}</span>
+                                    </span>
+                                </div>
+                            </React.Fragment>
+                        )}
+                    ]
+                }
+            ]}
+        />
+    );
+}
 
 const mapStateToProps = (state) => ({
-    priorities: selectors.getArchivePriorities(state),
     urgencies: selectors.getUrgencies(state),
     urgencyLabel: selectors.vocabs.urgencyLabel(state),
 });

--- a/client/components/Archive/ArchivePreview/ArchivePreviewAuditInformation.tsx
+++ b/client/components/Archive/ArchivePreview/ArchivePreviewAuditInformation.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+
+import {IArticle} from 'superdesk-api';
+import {superdeskApi} from '../../../superdeskApi';
+
+import {getCreator} from '../../../utils';
+import {AuditInformation} from '../../AuditInformation';
+
+
+interface IProps {
+    item: IArticle;
+}
+
+export function ArchivePreviewAuditInformationComponent({item}: IProps) {
+    const {UserAvatar, Spacer} = superdeskApi.components;
+    const users = Object.values(superdeskApi.entities.users.getAllUsers());
+
+    const createdBy = getCreator(item, 'original_creator', users);
+    const updatedBy = getCreator(item, 'version_creator', users);
+    const creationDate = item._created;
+    const updatedDate = item._updated;
+    const versionCreator = updatedBy?.display_name ?
+        updatedBy :
+        users.find((user) => user._id === updatedBy);
+
+    return (
+        <Spacer gap="8" noGrow>
+            <UserAvatar userId={item.version_creator} />
+            <AuditInformation
+                createdBy={createdBy}
+                updatedBy={versionCreator}
+                createdAt={creationDate}
+                updatedAt={updatedDate}
+                showStateInformation
+                item={item}
+            />
+        </Spacer>
+    );
+}

--- a/client/components/Archive/ArchivePreview/ArchivePreviewMetadataList.tsx
+++ b/client/components/Archive/ArchivePreview/ArchivePreviewMetadataList.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import {ContentDivider, SimpleList, SimpleListItem} from 'superdesk-ui-framework/react';
+
+import {IArticle} from 'superdesk-api';
+import {superdeskApi} from '../../../superdeskApi';
+
+interface IProps {
+    item: IArticle;
+}
+
+export function ArchivePreviewMetadataList({item}: IProps) {
+    const {gettext} = superdeskApi.localization;
+
+    const desk = superdeskApi.entities.desk.getDeskById(item.task.desk);
+    const stage = superdeskApi.entities.desk.getStageById(item.task.stage);
+    const wordCountLabel = gettext(
+        '{{ wordCount }} words',
+        {wordCount: item.word_count ?? 0},
+    );
+
+    return desk == null ? null : (
+        <SimpleList border={true} density="comfortable">
+            <SimpleListItem>
+                <span className="text-color-muted">{gettext('Desk:')}</span>
+                <span className="font-bold">{desk.name}</span>
+                <span className="text-color-muted">/ {stage.name}</span>
+                <ContentDivider orientation="vertical" margin="x-small" />
+                <span className="text-color-muted">{wordCountLabel}</span>
+            </SimpleListItem>
+            {(item.ednote?.length ?? 0) === 0 ? null : (
+                <SimpleListItem>
+                    <span className="text-color-muted">
+                        {gettext('Editorial Note:')}
+                    </span>
+                    <span className="text-red--800">
+                        {item.ednote}
+                    </span>
+                </SimpleListItem>
+            )}
+        </SimpleList>
+    );
+}

--- a/client/components/Archive/ArchivePreview/index.tsx
+++ b/client/components/Archive/ArchivePreview/index.tsx
@@ -1,312 +1,177 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
-import {get, map} from 'lodash';
-import classNames from 'classnames';
 
-import {AuditInformation, HtmlPreview, StateLabel, ItemRendition, PriorityLabel, UrgencyLabel} from '../../';
-import {getCreator} from '../../../utils';
-import * as actions from '../../../actions';
+import {
+    ToggleBox,
+    SimpleList,
+    SimpleListItem,
+    ContentDivider,
+    Heading,
+    PanelContentBlock,
+} from 'superdesk-ui-framework/react';
+
+import {IArticle} from 'superdesk-api';
+import {superdeskApi} from '../../../superdeskApi';
+import {IAssignmentItem} from '../../../interfaces';
 import * as selectors from '../../../selectors';
 
-import './style.scss';
+import {HtmlPreview, ItemRendition} from '../../';
+import {ArchiveItem} from '../ArchiveItem';
+import {AuditInformation} from '../../';
+import {getCreator} from '../../../utils';
 
-class ArchivePreviewComponent extends React.Component {
-    constructor(props) {
-        super(props);
-        this.state = {headerOpen: true};
-        this.toggleHeader = this.toggleHeader.bind(this);
-    }
 
-    componentDidMount() {
-        // When mounting this component, if the Assignment item is set
-        // then load the associated Archive item now
-        const {assignment, loadArchiveItem} = this.props;
+interface IProps {
+    assignment: IAssignmentItem;
+    archiveItems: {[itemId: string]: IArticle};
+    selectedArchiveItemId: IArticle['_id'];
+}
 
-        if (get(assignment, '_id', null) !== null) {
-            loadArchiveItem(assignment);
-        }
-    }
-
-    componentWillReceiveProps(nextProps) {
-        // If the Assignment item has changed, then load the associated Archive item
-        const nextId = get(nextProps, 'assignment._id', null);
-        const currentId = get(this.props, 'assignment._id', null);
-
-        if (nextId !== currentId) {
-            this.props.loadArchiveItem(nextProps.assignment);
-        }
-    }
-
-    toggleHeader() {
-        this.setState({headerOpen: !this.state.headerOpen});
-    }
-
+class ArchivePreviewComponent extends React.PureComponent<IProps> {
     render() {
-        const {archive, users, priorities, urgencies, urgencyLabel} = this.props;
+        const {gettext} = superdeskApi.localization;
+        const {UserAvatar} = superdeskApi.components;
+        const users = Object.values(superdeskApi.entities.users.getAllUsers());
 
-        if (archive === null) {
-            return null;
-        }
+        const relatedItems = this.props.assignment.linked_items
+            .map((itemLink) => (this.props.archiveItems[itemLink._id]))
+            .filter((item) => (item != null));
 
-        const createdBy = getCreator(archive, 'original_creator', users);
-        const updatedBy = getCreator(archive, 'version_creator', users);
-        const creationDate = get(archive, '_created');
-        const updatedDate = get(archive, '_updated');
-        const versionCreator = get(updatedBy, 'display_name') ? updatedBy :
-            users.find((user) => user._id === updatedBy);
-        const archiveType = get(archive, 'type', 'text');
-
-        return (
-            <div className="ArchivePreview content">
-                <div className="ArchivePreview__audit side-panel__content-block side-panel__content-block--pad-small">
-                    <div className="side-panel__content-block-inner">
-                        <AuditInformation
-                            createdBy={createdBy}
-                            updatedBy={versionCreator}
-                            createdAt={creationDate}
-                            updatedAt={updatedDate}
-                        />
-                    </div>
-                </div>
-
-                <div
-                    className={classNames(
-                        'ArchivePreview__header',
-                        'side-panel__content-block',
-                        'side-panel__content-block--pad-small',
-                        'side-panel__content-block--flex',
-                        {active: this.state.headerOpen}
-                    )}
+        return relatedItems.map((archive) => (
+            <PanelContentBlock key={archive._id} className="ArchivePreview content-item-preview">
+                <ToggleBox
+                    key={archive._id + '-' + (this.props.selectedArchiveItemId == archive._id).toString()}
+                    variant="custom-header"
+                    header={(<ArchiveItem item={archive} use2Lines={true} />)}
+                    initiallyOpen={relatedItems.length === 1 || this.props.selectedArchiveItemId === archive._id}
+                    getToggleButtonLabel={(isOpen) => isOpen ? gettext('Show less') : gettext('Show more')}
                 >
-                    {this.state.headerOpen && (
-                        <div className="ArchivePreview__header-left side-panel__content-block-inner">
-                            <div>
-                                <span
-                                    data-sd-tooltip={`Article Type: ${archive.type}`}
-                                    data-flow="right"
-                                >
-                                    <i className={`coverage-icon icon-${archive.type}`} />
-                                </span>
-                            </div>
+                    {(() => {
+                        const createdBy = getCreator(archive, 'original_creator', users);
+                        const updatedBy = getCreator(archive, 'version_creator', users);
+                        const creationDate = archive._created;
+                        const updatedDate = archive._updated;
+                        const versionCreator = updatedBy?.display_name ?
+                            updatedBy :
+                            users.find((user) => user._id === updatedBy);
 
-                            {get(archive, 'priority') && (
-                                <div>
-                                    <PriorityLabel
-                                        item={archive}
-                                        priorities={priorities}
-                                    />
-                                </div>
-                            )}
-
-                            {get(archive, 'urgency') && (
-                                <div>
-                                    <UrgencyLabel
-                                        item={archive}
-                                        urgencies={urgencies}
-                                        label={urgencyLabel}
-                                    />
-                                </div>
-                            )}
-
-                        </div>
-                    )}
-
-                    {this.state.headerOpen && (
-                        <div
-                            className="ArchivePreview__header-middle side-panel__content-block-inner
-                        side-panel__content-block-inner--grow"
-                        >
-                            {get(archive, 'slugline') &&
-                                <HtmlPreview className="sd-text__slugline" html={archive.slugline} />
-                            }
-
-                            {get(archive, 'anpa_take_key') && (
-                                <div>
-                                    <span className="metaLabel">takekey: </span>
-                                    <span>{archive.anpa_take_key}</span>
-                                </div>
-                            )}
-                            {get(archive, 'ednote') && (
-                                <div>
-                                    <span className="metaLabel">EdNote: </span>
-                                    <span className="sd-text__ednote">{archive.ednote}</span>
-                                </div>
-                            )}
-                            {get(archive, 'company_codes.length', 0) > 0 && (
-                                <div>
-                                    <span className="metaLabel">Company Codes: </span>
-                                    <span>{map(archive.company_codes, 'qcode').join(', ')}</span>
-                                </div>
-                            )}
-
-                            <div>
-                                <StateLabel
+                        return (
+                            <div className="flex-row p-1 gap-1">
+                                <UserAvatar userId={archive.version_creator} />
+                                <AuditInformation
+                                    createdBy={createdBy}
+                                    updatedBy={versionCreator}
+                                    createdAt={creationDate}
+                                    updatedAt={updatedDate}
+                                    showStateInformation
                                     item={archive}
-                                    withPubStatus={false}
                                 />
-                                {get(archive, 'embargo') &&
-                                    <span className="state-label state_embargo">Embargo</span>
-                                }
-                                {get(archive, 'flags.marked_for_not_publication') &&
-                                    <span className="state-label not-for-publication">Not for Publication</span>
-                                }
-                                {get(archive, 'flags.marked_for_legal') &&
-                                    <span className="state-label legal">Legal</span>
-                                }
-                                {get(archive, 'flags.marked_for_sms') &&
-                                    <span className="state-label sms">Sms</span>
-                                }
-                                {get(archive, 'rewritten_by') &&
-                                    <span className="state-label updated">Updated</span>
-                                }
                             </div>
+                        );
+                    })()}
+                    <SimpleList border={true} density="comfortable">
+                        {(() => {
+                            const desk = superdeskApi.entities.desk.getDeskById(archive.task.desk);
+                            const stage = superdeskApi.entities.desk.getStageById(archive.task.stage);
+                            const wordCountLabel = gettext(
+                                '{{ wordCount }} words',
+                                {wordCount: archive.word_count ?? 0},
+                            );
 
-                            {get(archive, '_type') !== 'archived' && (
-                                <div>
-                                    <span><b>{get(archive, '_deskName')}</b> / {get(archive, '_stageName')}</span>
-                                </div>
-                            )}
-                        </div>
+                            return desk == null ? null : (
+                                <SimpleListItem>
+                                    <span className="text-color-muted">{gettext('Desk:')}</span>
+                                    <span className="font-bold">{desk.name}</span>
+                                    <span className="text-color-muted">/ {stage.name}</span>
+                                    <ContentDivider orientation="vertical" margin="x-small" />
+                                    <span className="text-color-muted">{wordCountLabel}</span>
+                                </SimpleListItem>
+                            );
+                        })()}
+                        {(archive.ednote?.length ?? 0) === 0 ? null : (
+                            <SimpleListItem>
+                                <span className="text-color-muted">{gettext('Editorial Note:')}</span>
+                                <span className="text-red--800">
+                                    {archive.ednote}
+                                </span>
+                            </SimpleListItem>
+                        )}
+                    </SimpleList>
+                    {(archive.type === 'composite' || (archive.headline?.length ?? 0) === 0) ? null : (
+                        <Heading type="h2">
+                            {archive.headline}
+                        </Heading>
                     )}
 
-                    {this.state.headerOpen && (
-                        <div
-                            className="ArchivePreview__header-right side-panel__content-block-inner
-                        side-panel__content-block-inner--right"
-                        >
-                            {archiveType === 'text' && (
+                    <div className="content">
+                        <div className="core-content">
+                            {archive.associations?.featuremedia == null ? null : (
                                 <div>
-                                    <span className="word-count">
-                                        <b>{get(archive, 'word_count', 0)}</b> <span>words</span>
-                                    </span>
+                                    <ItemRendition item={archive.associations.featuremedia} />
+                                    <p>{archive.associations.featuremedia.description_text}</p>
                                 </div>
                             )}
 
-                            {get(archive, 'source') && (
+                            {!(archive.type === 'picture' || archive.type === 'graphic') ? null : (
                                 <div>
-                                    <span>{archive.source}</span>
+                                    <span>{gettext('Original')}</span>
+                                    <ItemRendition item={archive} />
                                 </div>
                             )}
 
-                            {get(archive, 'highlights.length', 0) > 0 && (
+                            {archive.type !== 'audio' ? null : (
                                 <div>
-                                    <i className={archive.highlights.length > 1 ? 'icon-multi-star' : 'icon-start'} />
+                                    <audio controls>
+                                        <source
+                                            src={archive.renditions?.original?.href}
+                                            type={archive.renditions?.original?.mimetype}
+                                        />
+                                    </audio>
                                 </div>
                             )}
 
-                            {get(archive, 'marked_desks.length', 0) > 0 && (
+                            {archive.type !== 'video' ? null : (
                                 <div>
-                                    <i className="icon-bell" />
+                                    <video controls>
+                                        <source
+                                            src={archive.renditions?.original?.href}
+                                            type={archive.renditions?.original?.mimetype}
+                                        />
+                                    </video>
                                 </div>
+                            )}
+
+                            {(archive.abstract?.length ?? 0) == 0 ? null : (
+                                <HtmlPreview className="text abstract" html={archive.abstract} />
+                            )}
+                            {(archive.byline?.length ?? 0) == 0 ? null : (
+                                <HtmlPreview className="text byline" html={archive.byline} />
+                            )}
+                            {(archive.dateline?.text?.length ?? 0) == 0 ? null : (
+                                <HtmlPreview className="text dateline" html={archive.dateline.text} />
+                            )}
+                            {(archive.body_html?.length ?? 0) == 0 ? null : (
+                                <HtmlPreview className="text body-text html-preview" html={archive.body_html} />
+                            )}
+                            {(archive.body_footer?.length ?? 0) == 0 ? null : (
+                                <HtmlPreview className="text body-footer" html={archive.body_footer} />
+                            )}
+                            {(archive.sign_off?.length ?? 0) == 0 ? null : (
+                                <HtmlPreview className="text sign-off" html={archive.sign_off} />
                             )}
                         </div>
-                    )}
-
-                    <button
-                        className={classNames(
-                            'preview-header__toggle',
-                            {active: !this.state.headerOpen}
-                        )}
-                        onClick={this.toggleHeader}
-                    >
-                        <i className="icon-chevron-up-thin" />
-                    </button>
-                </div>
-
-                <div
-                    className="ArchivePreview__content side-panel__content-block
-                side-panel__content-block--pad-small"
-                >
-                    {archiveType !== 'composite' && get(archive, 'headline') && (
-                        <div>
-                            <span className="headline">{archive.headline}</span>
-                        </div>
-                    )}
-
-                    <div className="core-content">
-                        {get(archive, 'associations.featuremedia') && (
-                            <div>
-                                <ItemRendition item={archive.associations.featuremedia} />
-                                <p>{get(archive, 'associations.featuremedia.description_text')}</p>
-                            </div>
-                        )}
-
-                        {(archiveType === 'picture' || archiveType === 'graphic') && (
-                            <div>
-                                <span>Original</span>
-                                <ItemRendition item={archive} />
-                            </div>
-                        )}
-
-                        {archiveType === 'audio' && (
-                            <div>
-                                <audio controls="controls">
-                                    <source
-                                        src={get(archive, 'renditions.original.href')}
-                                        type={get(archive, 'renditions.original.mimetype')}
-                                    />
-                                </audio>
-                            </div>
-                        )}
-
-                        {archiveType === 'video' && (
-                            <div>
-                                <video controls="controls">
-                                    <source
-                                        src={get(archive, 'renditions.original.href')}
-                                        type={get(archive, 'renditions.original.mimetype')}
-                                    />
-                                </video>
-                            </div>
-                        )}
-
-                        {get(archive, 'abstract') &&
-                        <HtmlPreview className="text abstract" html={archive.abstract} />}
-                        {get(archive, 'byline') &&
-                        <HtmlPreview className="text byline" html={archive.byline} />}
-                        {get(archive, 'dateline.text') &&
-                        <HtmlPreview className="text dateline" html={archive.dateline.text} />}
-                        {get(archive, 'body_html') &&
-                        <HtmlPreview className="text body-text" html={archive.body_html} />}
-                        {get(archive, 'body_footer') &&
-                        <HtmlPreview className="text body-footer" html={archive.body_footer} />}
-                        {get(archive, 'sign_off') &&
-                        <HtmlPreview className="text sign-off" html={archive.sign_off} />}
                     </div>
-                </div>
-            </div>
-        );
+
+                </ToggleBox>
+            </PanelContentBlock>
+        ));
     }
 }
 
-ArchivePreviewComponent.propTypes = {
-    archive: PropTypes.object,
-    users: PropTypes.oneOfType([
-        PropTypes.array,
-        PropTypes.object,
-    ]),
-    assignment: PropTypes.object,
-    loadArchiveItem: PropTypes.func,
-    priorities: PropTypes.array,
-    urgencies: PropTypes.array,
-    urgencyLabel: PropTypes.string,
-};
-
 const mapStateToProps = (state) => ({
     assignment: selectors.getCurrentAssignment(state),
-    archive: selectors.getCurrentAssignmentArchiveItem(state),
-    users: selectors.general.users(state),
-    priorities: selectors.getArchivePriorities(state),
-    urgencies: selectors.getUrgencies(state),
-    urgencyLabel: selectors.vocabs.urgencyLabel(state),
+    archiveItems: selectors.getStoredArchiveItems(state),
+    selectedArchiveItemId: selectors.getSelectedArchiveItemId(state),
 });
 
-const mapDispatchToProps = (dispatch) => (
-    {loadArchiveItem: (assignment) => dispatch(actions.assignments.api.loadArchiveItem(assignment))}
-);
-
-export const ArchivePreview = connect(
-    mapStateToProps,
-    mapDispatchToProps
-)(ArchivePreviewComponent);
+export const ArchivePreview = connect(mapStateToProps)(ArchivePreviewComponent);

--- a/client/components/Archive/ArchivePreview/index.tsx
+++ b/client/components/Archive/ArchivePreview/index.tsx
@@ -1,14 +1,7 @@
 import React from 'react';
 import {connect} from 'react-redux';
 
-import {
-    ToggleBox,
-    SimpleList,
-    SimpleListItem,
-    ContentDivider,
-    Heading,
-    PanelContentBlock,
-} from 'superdesk-ui-framework/react';
+import {ToggleBox, Heading, PanelContentBlock} from 'superdesk-ui-framework/react';
 
 import {IArticle} from 'superdesk-api';
 import {superdeskApi} from '../../../superdeskApi';
@@ -17,8 +10,8 @@ import * as selectors from '../../../selectors';
 
 import {HtmlPreview, ItemRendition} from '../../';
 import {ArchiveItem} from '../ArchiveItem';
-import {AuditInformation} from '../../';
-import {getCreator} from '../../../utils';
+import {ArchivePreviewAuditInformationComponent} from './ArchivePreviewAuditInformation';
+import {ArchivePreviewMetadataList} from './ArchivePreviewMetadataList';
 
 
 interface IProps {
@@ -38,65 +31,18 @@ class ArchivePreviewComponent extends React.PureComponent<IProps> {
             .filter((item) => (item != null));
 
         return relatedItems.map((archive) => (
-            <PanelContentBlock key={archive._id} className="ArchivePreview content-item-preview">
+            <PanelContentBlock
+                key={archive._id + '-' + (this.props.selectedArchiveItemId == archive._id)}
+                className="ArchivePreview content-item-preview"
+            >
                 <ToggleBox
-                    key={archive._id + '-' + (this.props.selectedArchiveItemId == archive._id).toString()}
                     variant="custom-header"
                     header={(<ArchiveItem item={archive} use2Lines={true} />)}
                     initiallyOpen={relatedItems.length === 1 || this.props.selectedArchiveItemId === archive._id}
                     getToggleButtonLabel={(isOpen) => isOpen ? gettext('Show less') : gettext('Show more')}
                 >
-                    {(() => {
-                        const createdBy = getCreator(archive, 'original_creator', users);
-                        const updatedBy = getCreator(archive, 'version_creator', users);
-                        const creationDate = archive._created;
-                        const updatedDate = archive._updated;
-                        const versionCreator = updatedBy?.display_name ?
-                            updatedBy :
-                            users.find((user) => user._id === updatedBy);
-
-                        return (
-                            <div className="flex-row p-1 gap-1">
-                                <UserAvatar userId={archive.version_creator} />
-                                <AuditInformation
-                                    createdBy={createdBy}
-                                    updatedBy={versionCreator}
-                                    createdAt={creationDate}
-                                    updatedAt={updatedDate}
-                                    showStateInformation
-                                    item={archive}
-                                />
-                            </div>
-                        );
-                    })()}
-                    <SimpleList border={true} density="comfortable">
-                        {(() => {
-                            const desk = superdeskApi.entities.desk.getDeskById(archive.task.desk);
-                            const stage = superdeskApi.entities.desk.getStageById(archive.task.stage);
-                            const wordCountLabel = gettext(
-                                '{{ wordCount }} words',
-                                {wordCount: archive.word_count ?? 0},
-                            );
-
-                            return desk == null ? null : (
-                                <SimpleListItem>
-                                    <span className="text-color-muted">{gettext('Desk:')}</span>
-                                    <span className="font-bold">{desk.name}</span>
-                                    <span className="text-color-muted">/ {stage.name}</span>
-                                    <ContentDivider orientation="vertical" margin="x-small" />
-                                    <span className="text-color-muted">{wordCountLabel}</span>
-                                </SimpleListItem>
-                            );
-                        })()}
-                        {(archive.ednote?.length ?? 0) === 0 ? null : (
-                            <SimpleListItem>
-                                <span className="text-color-muted">{gettext('Editorial Note:')}</span>
-                                <span className="text-red--800">
-                                    {archive.ednote}
-                                </span>
-                            </SimpleListItem>
-                        )}
-                    </SimpleList>
+                    <ArchivePreviewAuditInformationComponent item={archive} />
+                    <ArchivePreviewMetadataList item={archive} />
                     {(archive.type === 'composite' || (archive.headline?.length ?? 0) === 0) ? null : (
                         <Heading type="h2">
                             {archive.headline}

--- a/client/components/Archive/ArchivePreview/style.scss
+++ b/client/components/Archive/ArchivePreview/style.scss
@@ -2,107 +2,15 @@
 @import '~superdesk-core/styles/sass/variables.scss';
 
 .ArchivePreview {
-    .content-container {
-        position: relative !important;
+    // Fix issue with box header having white background
+    .new-collapse-box__header {
+        background-color: var(--sd-colour-panel-bg--100);
     }
 
-    &__header {
-        position: relative;
-        padding-bottom: 5px !important;
-        padding-top: 0 !important;
-
-        &.active {
-            padding-bottom: 2rem !important;
-        }
-
-        &-left {
-            padding-right: 8px;
-        }
-
-        &-middle {
-            padding-left: 12px;
-            padding-right: 12px;
-            border-left: 1px solid #e2e2e2;
-
-            .metaLabel {
-                color: #999;
-                text-transform: uppercase;
-            }
-
-            .sd-text__ednote {
-                color: #d25932;
-            }
-        }
-
-        &-right {
-            padding-left: 8px;
-            border-left: 1px solid #e2e2e2;
-        }
-
-        .coverage-icon {
-            opacity: 0.6;
-        }
-
-        @include box-sizing(border-box);
-        @include box-shadow(0px 1px 3px -1px rgba(0,0,0,0.2));
-
-        .preview-header__toggle {
-            position: absolute;
-            width: 21px;
-            height: 21px;
-            border: 0;
-            padding: 0;
-            left: 50%;
-            margin-left: -10.5px;
-            bottom: -11px;
-            background-color: $white;
-            z-index: 3;
-            line-height: 0;
-            @include border-radius(50%);
-            @include box-shadow(0px 0px 3px 0px rgba(0,0,0,0.4));
-            @include transition(transform 0.5s);
-            i { height: 15px; }
-            &.active { @include rotate(180deg); }
-        }
-
-        div {
-            margin-bottom: 5px;
-        }
-    }
-
-    &__content {
-        margin-top: 20px;
-        font-size: 14px;
-
-        video {
-            width: 100%;
-        }
-
-        img {
-            width: 100%;
-        }
-
-        .headline {
-            font-size: 19px;
-            line-height: 120%;
-            font-weight: 500;
-            color: #333;
-        }
-
-        div {
-            margin-bottom: 20px;
-        }
-
+    .core-content {
+        // fix p margin when inside toggle box
         p {
-            margin: 0 0 9px 0;
-        }
-
-        .body-text {
-            line-height: 140%;
-        }
-
-        .preview-overlay {
-            margin-bottom: 0 !important;
+            margin-block-end: 2rem !important;
         }
     }
 }

--- a/client/components/Assignments/AssignmentGroupList.tsx
+++ b/client/components/Assignments/AssignmentGroupList.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {connect} from 'react-redux';
 import {get, throttle} from 'lodash';
 
+import {IArticle} from 'superdesk-api';
 import {superdeskApi} from '../../superdeskApi';
 
 import {UI, KEYCODES} from '../../constants';
@@ -10,6 +11,7 @@ import * as actions from '../../actions';
 import {assignmentUtils} from '../../utils';
 
 import {AssignmentItem} from './AssignmentItem';
+import {AssignmentMultiTextItem} from './AssignmentItem/AssignmentMultiTextItem';
 import {Header, Group} from '../UI/List';
 import {OrderDirectionIcon} from '../OrderBar';
 import {ListItemLoader} from 'superdesk-ui-framework/react/components/ListItemLoader';
@@ -56,6 +58,7 @@ interface IProps {
     contacts?: any;
     isLoading?: boolean;
     dayField?: string;
+    archiveItems: {[itemId: string]: IArticle};
 }
 
 interface IState {
@@ -214,6 +217,7 @@ class AssignmentGroupListComponent extends React.Component<IProps, IState> {
             contentTypes,
             desks,
             contacts,
+            archiveItems,
         } = this.props;
 
         const assignment = this.props.assignments[index];
@@ -226,11 +230,14 @@ class AssignmentGroupListComponent extends React.Component<IProps, IState> {
         const assignedDesk = desks.find((desk) => get(assignment, 'assigned_to.desk') === desk._id);
 
         return (
-            <AssignmentItem
+            <AssignmentMultiTextItem
                 key={assignment._id}
                 assignment={assignment}
                 onClick={this.props.preview.bind(this, assignment)}
                 onDoubleClick={onDoubleClick}
+                onDoubleClickArchiveItem={(archiveItem: IArticle) => (
+                    this.props.preview(assignment, 'CONTENT', archiveItem)
+                )}
                 assignedUser={assignedUser}
                 isCurrentUser={isCurrentUser}
                 lockedItems={this.props.lockedItems}
@@ -248,6 +255,7 @@ class AssignmentGroupListComponent extends React.Component<IProps, IState> {
                 contentTypes={contentTypes}
                 assignedDesk={assignedDesk}
                 contacts={contacts}
+                archiveItems={archiveItems}
             />
         );
     }
@@ -361,11 +369,14 @@ const mapStateToProps = (state, ownProps) => {
         desks: selectors.general.desks(state),
         contacts: selectors.general.contactsById(state),
         isLoading: assignmentDataSelector.isLoading(state),
+        archiveItems: selectors.getStoredArchiveItems(state),
     };
 };
 
 const mapDispatchToProps = (dispatch) => ({
-    preview: (assignment) => dispatch(actions.assignments.ui.preview(assignment)),
+    preview: (assignment, initialTab, archiveItem) => (
+        dispatch(actions.assignments.ui.preview(assignment, initialTab, archiveItem))
+    ),
     reassign: (assignment) => dispatch(actions.assignments.ui.reassign(assignment)),
     completeAssignment: (assignment) => dispatch(actions.assignments.ui.complete(assignment)),
     revertAssignment: (assignment) => dispatch(actions.assignments.ui.revert(assignment)),

--- a/client/components/Assignments/AssignmentItem/AssignmentMultiTextItem.tsx
+++ b/client/components/Assignments/AssignmentItem/AssignmentMultiTextItem.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+
+import {superdeskApi} from '../../../superdeskApi';
+import {IAssignmentItemProps, AssignmentItem} from './index';
+import {ArchiveItem} from '../../Archive';
+import {NestedItem} from '../../UI/List';
+
+interface IState {
+    expanded: boolean;
+}
+
+export class AssignmentMultiTextItem extends React.Component<IAssignmentItemProps, IState> {
+    constructor(props: IAssignmentItemProps) {
+        super(props);
+
+        this.state = {expanded: false};
+        this.toggleVisibility = this.toggleVisibility.bind(this);
+    }
+
+    private toggleVisibility() {
+        this.setState({expanded: !this.state.expanded});
+    }
+
+    render() {
+        if ((this.props.assignment.linked_items?.length ?? 0) <= 1) {
+            return (<AssignmentItem {...this.props} />);
+        }
+
+        const relatedItems = this.props.assignment.linked_items
+            .map((itemLink) => (this.props.archiveItems[itemLink._id]))
+            .filter((item) => (item != null));
+
+        return (
+            <NestedItem
+                parentItem={(
+                    <AssignmentItem
+                        {...this.props}
+                        relatedUI={{
+                            visible: this.state.expanded,
+                            toggleVisibility: this.toggleVisibility,
+                        }}
+                    />
+                )}
+                expanded={this.state.expanded}
+                marginBottom={this.state.expanded}
+                nestedChildren={this.state.expanded !== true ? null :
+                    relatedItems.map((item) => (
+                        <ArchiveItem
+                            key={item._id}
+                            item={item}
+                            use2Lines={false}
+                            onClick={() => this.props.onDoubleClickArchiveItem(item)}
+                            onDoubleClick={() => superdeskApi.ui.article.edit(item._id)}
+                        />
+                    ))
+                }
+            />
+        );
+    }
+}

--- a/client/components/Assignments/AssignmentItem/fields/Content.tsx
+++ b/client/components/Assignments/AssignmentItem/fields/Content.tsx
@@ -13,7 +13,7 @@ export const ContentComponent = ({assignment}: IProps) => {
     const itemEventIds = (assignment.linked_items ?? []).map((item) => item.event_id);
     const numberOfContent = (new Set(itemEventIds)).size;
 
-    if (!numberOfContent) {
+    if (numberOfContent === 0) {
         return null;
     }
 

--- a/client/components/Assignments/AssignmentItem/fields/Content.tsx
+++ b/client/components/Assignments/AssignmentItem/fields/Content.tsx
@@ -1,17 +1,29 @@
 import React from 'react';
-import {assignmentUtils} from '../../../../utils';
-import {Label} from '../../..';
+
+import {Label} from 'superdesk-ui-framework/react';
+
+import {superdeskApi} from '../../../../superdeskApi';
+import {IAssignmentItem} from '../../../../interfaces';
 
 interface IProps {
-    assignment: any;
+    assignment: IAssignmentItem;
 }
 
 export const ContentComponent = ({assignment}: IProps) => {
-    const hasContent = assignmentUtils.assignmentHasContent(assignment);
+    const itemEventIds = (assignment.linked_items ?? []).map((item) => item.event_id);
+    const numberOfContent = (new Set(itemEventIds)).size;
 
-    if (!hasContent) {
+    if (!numberOfContent) {
         return null;
     }
 
-    return <Label text="Content" isHollow={true} iconType="darkBlue2" />;
+    const {gettext} = superdeskApi.localization;
+
+    return (
+        <Label
+            type="highlight"
+            style="translucent"
+            text={gettext('Content: {{ numberOfContent }}', {numberOfContent})}
+        />
+    );
 };

--- a/client/components/Assignments/AssignmentItem/fields/DueDate.tsx
+++ b/client/components/Assignments/AssignmentItem/fields/DueDate.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
 import moment from 'moment';
 import {get} from 'lodash';
-import {assignmentUtils, gettext} from '../../../../utils';
+
+import {Label} from 'superdesk-ui-framework/react';
+import {superdeskApi} from '../../../../superdeskApi';
+
+import {assignmentUtils} from '../../../../utils';
 import {AbsoluteDate} from '../../../AbsoluteDate';
 import {TO_BE_CONFIRMED_FIELD} from '../../../../constants';
 import {IAssignmentItem} from 'interfaces';
@@ -12,6 +16,7 @@ interface IProps {
 }
 
 export const DueDateComponent = ({assignment}: IProps) => {
+    const {gettext} = superdeskApi.localization;
     const isOverdue = assignmentUtils.isDue(assignment);
     const assignedToProvider = assignmentUtils.isAssignedToProvider(assignment);
     const planningSchedule = get(assignment, 'planning.scheduled');
@@ -36,9 +41,10 @@ export const DueDateComponent = ({assignment}: IProps) => {
                 <span>{gettext('\'not scheduled yet\'')}</span>
             )}
             {isOverdue && (
-                <span className="label label--warning label--hollow">
-                    {gettext('due')}
-                </span>
+                <Label
+                    type="warning"
+                    text={gettext('due')}
+                />
             )}
         </span>
     );

--- a/client/components/Assignments/AssignmentItem/fields/State.tsx
+++ b/client/components/Assignments/AssignmentItem/fields/State.tsx
@@ -1,11 +1,61 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import {StateLabel} from '../../../StateLabel';
+import {Label} from 'superdesk-ui-framework/react';
+
+import {superdeskApi} from '../../../../superdeskApi';
+import {ASSIGNMENT_STATE, IAssignmentItem} from '../../../../interfaces';
 
 interface IProps {
-    assignment: any;
+    assignment: IAssignmentItem;
 }
 
-export const StateComponent = ({assignment}: IProps) => (
-    <StateLabel item={assignment.assigned_to} />
-);
+export function StateComponent({assignment}: IProps) {
+    const {gettext} = superdeskApi.localization;
+    const state = assignment.assigned_to?.state ?? ASSIGNMENT_STATE.DRAFT;
+    let props: Label['props'];
+
+
+    switch (state) {
+    case ASSIGNMENT_STATE.DRAFT:
+        props = {
+            type: 'default',
+            style: 'translucent',
+            text: gettext('Draft'),
+        };
+        break;
+    case ASSIGNMENT_STATE.ASSIGNED:
+    case ASSIGNMENT_STATE.SUBMITTED:
+        props = {
+            type: 'default',
+            style: 'translucent',
+            text: gettext('Assigned'),
+        };
+        break;
+    case ASSIGNMENT_STATE.IN_PROGRESS:
+        props = {
+            type: 'warning',
+            style: 'translucent',
+            text: gettext('In Progress'),
+        };
+        break;
+    case ASSIGNMENT_STATE.COMPLETED:
+        props = {
+            type: 'success',
+            style: 'translucent',
+            text: gettext('Completed'),
+        };
+        break;
+    case ASSIGNMENT_STATE.CANCELLED:
+        props = {
+            type: 'alert',
+            style: 'translucent',
+            text: gettext('Cancelled'),
+        };
+        break;
+    default:
+        return superdeskApi.helpers.assertNever(state);
+    }
+
+    return (
+        <Label {...props} />
+    );
+}

--- a/client/components/Assignments/AssignmentItem/fields/index.ts
+++ b/client/components/Assignments/AssignmentItem/fields/index.ts
@@ -86,11 +86,3 @@ const DEFAULT_ASSSIGNMENTS_LIST_VIEW: {
 // Get fields config for a single assignment view
 export const getAssignmentsListView = () =>
     appConfig.assignmentsList || DEFAULT_ASSSIGNMENTS_LIST_VIEW;
-
-// Returns true if assignments list view requrires archive items data
-export const assignmentsViewRequiresArchiveItems = (): boolean => {
-    const listViewConfig = getAssignmentsListView();
-    const fields = [...listViewConfig.firstLine, ...listViewConfig.secondLine];
-
-    return fields.includes('headline');
-};

--- a/client/components/Assignments/AssignmentItem/index.tsx
+++ b/client/components/Assignments/AssignmentItem/index.tsx
@@ -4,7 +4,7 @@ import {get, debounce, Cancelable} from 'lodash';
 import {OverlayTrigger, Tooltip} from 'react-bootstrap';
 
 import {superdeskApi} from '../../../superdeskApi';
-import {IUser, IDesk} from 'superdesk-api';
+import {IUser, IDesk, IArticle} from 'superdesk-api';
 import {
     IAssignmentItem,
     IAssignmentPriority,
@@ -25,7 +25,7 @@ import {Item, Border, Column, Row} from '../../UI/List';
 
 import {getComponentForField, getAssignmentsListView} from './fields';
 
-interface IProps {
+export interface IAssignmentItemProps {
     assignment: IAssignmentItem;
     lockedItems: ILockedItems;
     isCurrentUser: boolean;
@@ -38,6 +38,7 @@ interface IProps {
     assignedUser?: IUser;
     assignedDesk?: IDesk;
     contacts: {[key: string]: IContactItem};
+    archiveItems: {[itemId: string]: IArticle};
 
     onClick(assignment: IAssignmentItem): void;
     onDoubleClick(assignment: IAssignmentItem): void;
@@ -47,6 +48,11 @@ interface IProps {
     startWorking(assignment: IAssignmentItem): void;
     removeAssignment(assignment: IAssignmentItem): void;
     revertAssignment(assignment: IAssignmentItem): void;
+    onDoubleClickArchiveItem(item: IArticle): void;
+    relatedUI?: {
+        visible: boolean;
+        toggleVisibility(): void;
+    }
 }
 
 interface IState {
@@ -54,7 +60,7 @@ interface IState {
     hover: boolean;
 }
 
-export class AssignmentItem extends React.Component<IProps, IState> {
+export class AssignmentItem extends React.Component<IAssignmentItemProps, IState> {
     private _delayedClick: (() => void) & Cancelable | undefined;
 
     constructor(props) {
@@ -75,19 +81,9 @@ export class AssignmentItem extends React.Component<IProps, IState> {
         this.renderContentColumn = this.renderContentColumn.bind(this);
         this.renderAvatar = this.renderAvatar.bind(this);
         this.renderActionsMenu = this.renderActionsMenu.bind(this);
-        this.onFocus = this.onFocus.bind(this);
         this.onItemHoverOn = this.onItemHoverOn.bind(this);
         this.onItemHoverOff = this.onItemHoverOff.bind(this);
         this.handleKeyDown = this.handleKeyDown.bind(this);
-    }
-
-    onFocus(event: React.FocusEvent<HTMLLIElement>) {
-        const {querySelectorParent} = superdeskApi.utilities;
-
-        if (!querySelectorParent(event.target, 'button', {self: true})) {
-            // Don't trigger click event if focus went through menu or button inside the list item
-            this.props.onClick(this.props.assignment);
-        }
     }
 
     onItemHoverOn() {
@@ -104,7 +100,11 @@ export class AssignmentItem extends React.Component<IProps, IState> {
     }
 
     onDoubleClick() {
-        this.props.onDoubleClick(this.props.assignment);
+        if (this.props.assignment.planning?.multiple_content === true) {
+            this.props.relatedUI?.toggleVisibility();
+        } else {
+            this.props.onDoubleClick(this.props.assignment);
+        }
     }
 
     handleSingleAndDoubleClick(event: React.MouseEvent<HTMLLIElement>) {
@@ -264,7 +264,7 @@ export class AssignmentItem extends React.Component<IProps, IState> {
                 null,
                 assignment
             ),
-            [ASSIGNMENTS.ITEM_ACTIONS.PREVIEW_ARCHIVE.actionName]: this.onDoubleClick,
+            [ASSIGNMENTS.ITEM_ACTIONS.PREVIEW_ARCHIVE.actionName]: this.props.onDoubleClick,
             [ASSIGNMENTS.ITEM_ACTIONS.CONFIRM_AVAILABILITY.actionName]: completeAssignment.bind(
                 null,
                 assignment
@@ -282,7 +282,8 @@ export class AssignmentItem extends React.Component<IProps, IState> {
                 privileges,
                 lockedItems,
                 contentTypes,
-                itemActionsCallBack
+                itemActionsCallBack,
+                this.props.archiveItems,
             )
             : [];
 

--- a/client/components/Assignments/AssignmentPreviewContainer/index.tsx
+++ b/client/components/Assignments/AssignmentPreviewContainer/index.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import {connect} from 'react-redux';
 import {get} from 'lodash';
 
-import {IDesk, IUser} from 'superdesk-api';
+import {IDesk, IUser, IArticle} from 'superdesk-api';
 import {
     IAssignmentItem,
     IAssignmentPriority,
@@ -53,6 +53,7 @@ interface IStateProps {
     currentWorkspace: 'ASSIGNMENTS' | 'AUTHORING' | 'AUTHORING_WIDGET';
     contentTypes: Array<IG2ContentType>;
     files: Array<IFile>;
+    archiveItems: {[itemId: string]: IArticle};
 }
 
 interface IDispatchProps {
@@ -121,7 +122,9 @@ class AssignmentPreviewContainerComponent extends React.Component<IProps> {
             privileges,
             lockedItems,
             contentTypes,
-            itemActionsCallBack);
+            itemActionsCallBack,
+            this.props.archiveItems,
+        );
     }
 
     render() {
@@ -270,6 +273,7 @@ const mapStateToProps = (state) => ({
     currentWorkspace: selectors.general.currentWorkspace(state),
     contentTypes: selectors.general.contentTypes(state),
     files: selectors.general.files(state),
+    archiveItems: selectors.getStoredArchiveItems(state),
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/client/components/AuditInformation/index.tsx
+++ b/client/components/AuditInformation/index.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import {get} from 'lodash';
 import moment from 'moment';
 
-import {IUser} from 'superdesk-api';
+import {IArticle, IUser} from 'superdesk-api';
 import {IEventOrPlanningItem, IPlanningCoverageItem, IIngestProvider, IFeaturedPlanningItem} from '../../interfaces';
 import {superdeskApi} from '../../superdeskApi';
 
@@ -23,7 +23,7 @@ interface IProps {
     postedBy?: IUser | IIngestProvider['id'] | undefined;
     postedAt?: string;
     showStateInformation?: boolean;
-    item?: IEventOrPlanningItem | IPlanningCoverageItem;
+    item?: IEventOrPlanningItem | IPlanningCoverageItem | IArticle;
     withPadding?: boolean;
 }
 

--- a/client/components/UI/List/NestedItem.tsx
+++ b/client/components/UI/List/NestedItem.tsx
@@ -7,6 +7,7 @@ interface IProps {
     parentItem: React.ReactNode,
     nestedChildren: React.ReactNode;
     noMarginTop?: boolean;
+    marginBottom?: boolean;
 }
 
 export class NestedItem extends React.PureComponent<IProps> {
@@ -19,6 +20,7 @@ export class NestedItem extends React.PureComponent<IProps> {
                         'sd-list-item-nested--collapsed': this.props.collapsed ?? true,
                         'sd-list-item-nested--expanded': this.props.expanded,
                         'sd-margin-t--0': this.props.noMarginTop,
+                        'mb-2': this.props.marginBottom === true,
                     }
                 )}
             >

--- a/client/constants/planning.ts
+++ b/client/constants/planning.ts
@@ -111,6 +111,7 @@ export const PLANNING = {
     },
     G2_CONTENT_TYPE: {
         TEXT: 'text',
+        MULTIPLE_TEXT: 'multiple_text',
         VIDEO: 'video',
         LIVE_VIDEO: 'live_video',
         AUDIO: 'audio',

--- a/client/interfaces.ts
+++ b/client/interfaces.ts
@@ -889,6 +889,12 @@ export interface IAssignmentItem extends IBaseRestApiResponse {
     lock_session: string;
     lock_action: string;
     _to_delete: boolean;
+    item_ids?: Array<string>; // Populated by API upon response (not stored in DB)
+    linked_items?: Array<{
+        _id: IArticle['_id'];
+        _type: IArticle['_type'];
+        event_id: IArticle['event_id'];
+    }>;
 }
 
 export interface IBaseListItemProps<T> {

--- a/client/reducers/assignment.ts
+++ b/client/reducers/assignment.ts
@@ -9,6 +9,8 @@ const initialState = {
     assignments: {},
     baseQuery: {must: []},
     currentAssignmentId: null,
+    selectedArchiveItemId: null,
+    initialTab: null,
     filterBy: 'Desk',
     filterByPriority: null,
     filterByType: null,
@@ -204,7 +206,10 @@ const assignmentReducer = createReducer(initialState, {
         {
             ...state,
             previewOpened: true,
-            currentAssignmentId: getItemId(payload) || payload,
+            currentAssignmentId: payload.assignmentId,
+            initialTab: payload.initialTab,
+            selectedArchiveItemId: payload.archiveItemId ?? null,
+
             readOnly: true,
         }
     ),
@@ -214,6 +219,8 @@ const assignmentReducer = createReducer(initialState, {
             ...state,
             previewOpened: false,
             currentAssignmentId: null,
+            initialTab: null,
+            selectedArchiveItemId: null,
             readOnly: true,
         }
     ),
@@ -254,23 +261,19 @@ const assignmentReducer = createReducer(initialState, {
     },
 
     [ASSIGNMENTS.ACTIONS.RECEIVED_ARCHIVE]: (state, payload) => {
-        const archiveItems = {};
-
-        if (Array.isArray(payload)) { // Multiple items
-            for (const newItem of payload) {
-                if (newItem.assignment_id) {
-                    archiveItems[newItem.assignment_id] = newItem;
-                }
-            }
-        } else { // One single item
-            archiveItems[payload.assignment_id] = payload;
-        }
-
+        // Store Archive items by their ID
         return {
             ...state,
             archive: {
                 ...state.archive,
-                ...archiveItems,
+                ...(Array.isArray(payload) ? payload : [payload]).reduce(
+                    (archiveItems, item) => {
+                        archiveItems[item._id] = item;
+
+                        return archiveItems;
+                    },
+                    {}
+                ),
             },
         };
     },
@@ -287,6 +290,8 @@ const assignmentReducer = createReducer(initialState, {
                 if (state.currentAssignmentId === a) {
                     state.previewOpened = false;
                     state.currentAssignmentId = null;
+                    state.initialTab = null;
+                    state.selectedArchiveItemId = null;
                 }
 
                 // Remove this assignment from any list groups

--- a/client/reducers/tests/assignment_test.ts
+++ b/client/reducers/tests/assignment_test.ts
@@ -362,13 +362,17 @@ describe('assignment', () => {
         it('PREVIEW_ASSIGNMENT', () => {
             const result = assignment(state, {
                 type: 'PREVIEW_ASSIGNMENT',
-                payload: 'as1',
+                payload: {
+                    assignmentId: 'as1',
+                    initialTab: 'ASSIGNMENT',
+                },
             });
 
             expect(result).toEqual({
                 ...initialState,
                 previewOpened: true,
                 currentAssignmentId: 'as1',
+                initialTab: 'ASSIGNMENT',
                 readOnly: true,
             });
         });
@@ -481,7 +485,10 @@ describe('assignment', () => {
 
                 result = assignment(result, {
                     type: 'PREVIEW_ASSIGNMENT',
-                    payload: 'as1',
+                    payload: {
+                        assignmentId: 'as1',
+                        initialTab: 'ASSIGNMENT',
+                    },
                 });
 
                 result = assignment(result, {
@@ -508,7 +515,10 @@ describe('assignment', () => {
 
                 result = assignment(result, {
                     type: 'PREVIEW_ASSIGNMENT',
-                    payload: 'as2',
+                    payload: {
+                        assignmentId: 'as2',
+                        initialTab: 'ASSIGNMENT',
+                    },
                 });
 
                 result = assignment(result, {

--- a/client/selectors/assignments.ts
+++ b/client/selectors/assignments.ts
@@ -150,6 +150,8 @@ export const getAssignmentListSingleGroupView = (state) => get(state,
 
 export const getPreviewAssignmentOpened = (state) => !!get(state, 'assignment.previewOpened');
 export const getCurrentAssignmentId = (state) => get(state, 'assignment.currentAssignmentId');
+export const getSelectedArchiveItemId = (state) => get(state, 'assignment.selectedArchiveItemId');
+export const getInitialTab = (state) => get(state, 'assignment.initialTab');
 export const getAssignmentPriorities = (state) => get(state, 'vocabularies.assignment_priority', []);
 export const getArchivePriorities = (state) => get(state, 'vocabularies.priority', []);
 export const getUrgencies = (state) => get(state, 'vocabularies.urgency', []);

--- a/client/utils/assignments.ts
+++ b/client/utils/assignments.ts
@@ -1,7 +1,7 @@
 import {get, includes, isNil, find} from 'lodash';
 import moment from 'moment';
 
-import {IVocabularyItem} from 'superdesk-api';
+import {IArticle, IVocabularyItem} from 'superdesk-api';
 import {
     IAssignmentItem,
     ISession,
@@ -200,6 +200,13 @@ const getContactLabel = (assignment) => (
         gettext('Coverage Contact')
 );
 
+function getArticleNameForOpenCoverageAction(item: IArticle): string {
+    const name = item.headline || item.slugline;
+    const genre = item?.genre?.[0]?.name;
+
+    return genre != null ? `${genre} - ${name}` : name;
+}
+
 function getAssignmentActions(
     assignment: IAssignmentItem,
     session: ISession,
@@ -207,6 +214,7 @@ function getAssignmentActions(
     lockedItems: ILockedItems,
     contentTypes: Array<IG2ContentType>,
     callBacks: {[key: string]: (...args: Array<any>) => any},
+    archiveItems: {[itemId: string]: IArticle},
 ) {
     if (!isExistingItem(assignment) || lockUtils.isLockRestricted(assignment, session, lockedItems)) {
         return [];
@@ -268,11 +276,23 @@ function getAssignmentActions(
             break;
 
         case ASSIGNMENTS.ITEM_ACTIONS.PREVIEW_ARCHIVE.actionName:
-            callBacks[callBackName] &&
-                actions.push({
-                    ...ASSIGNMENTS.ITEM_ACTIONS.PREVIEW_ARCHIVE,
-                    callback: callBacks[callBackName].bind(null, assignment),
-                });
+            if (callBacks[callBackName] != null) {
+                if ((assignment.linked_items?.length ?? 0) > 1) {
+                    actions.push({
+                        ...ASSIGNMENTS.ITEM_ACTIONS.PREVIEW_ARCHIVE,
+                        callback: assignment.linked_items.map((linkedItem) => ({
+                            label: getArticleNameForOpenCoverageAction(archiveItems[linkedItem._id]),
+                            callback: superdeskApi.ui.article.edit.bind(null, linkedItem._id),
+                        })),
+
+                    });
+                } else {
+                    actions.push({
+                        ...ASSIGNMENTS.ITEM_ACTIONS.PREVIEW_ARCHIVE,
+                        callback: callBacks[callBackName].bind(null, assignment),
+                    });
+                }
+            }
             break;
 
         case ASSIGNMENTS.ITEM_ACTIONS.REVERT_AVAILABILITY.actionName:

--- a/client/utils/index.ts
+++ b/client/utils/index.ts
@@ -17,7 +17,7 @@ import {
     JUMP_INTERVAL,
     ICoverageScheduledUpdate,
 } from '../interfaces';
-import {IUser} from 'superdesk-api';
+import {IArticle, IUser} from 'superdesk-api';
 import {superdeskApi} from '../superdeskApi';
 
 import planningApp from '../reducers';
@@ -290,7 +290,7 @@ export const notifyError = (notify, error, defaultMessage) => {
  * @return {object} The user object found or ingest provider id, otherwise nothing is returned
  */
 export function getCreator(
-    item: IEventOrPlanningItem | IPlanningCoverageItem | IFeaturedPlanningItem | ICoverageScheduledUpdate,
+    item: IEventOrPlanningItem | IPlanningCoverageItem | IFeaturedPlanningItem | ICoverageScheduledUpdate | IArticle,
     creator: string,
     users: Array<IUser>
 ): IUser | IIngestProvider['id'] | undefined {

--- a/client/utils/planning.tsx
+++ b/client/utils/planning.tsx
@@ -1382,10 +1382,15 @@ function getCoverageIcon(
         : getItemWorkflowState(coverage.assigned_to) === WORKFLOW_STATE.CANCELLED;
     const iconType: 'normal' | 'cancelled' = cancelled ? 'cancelled' : 'normal';
     const iconForUnknownType = cancelled ? 'icon-file-cancel' : 'icon-file';
+    const contentType = coverage?.planning?.multiple_content === true ? PLANNING.G2_CONTENT_TYPE.MULTIPLE_TEXT : type;
 
     const coverageIcons = {
         [PLANNING.G2_CONTENT_TYPE.TEXT]: {
             normal: 'icon-text',
+            cancelled: 'icon-text-cancel',
+        },
+        [PLANNING.G2_CONTENT_TYPE.MULTIPLE_TEXT]: {
+            normal: 'icon-takes-package',
             cancelled: 'icon-text-cancel',
         },
         [PLANNING.G2_CONTENT_TYPE.VIDEO]: {
@@ -1418,7 +1423,7 @@ function getCoverageIcon(
         },
     };
 
-    return coverageIcons[type]?.[iconType] ?? iconForUnknownType;
+    return coverageIcons[contentType]?.[iconType] ?? iconForUnknownType;
 }
 
 function getCoverageIconColor(item: IPlanningCoverageItem): string | undefined {

--- a/client/utils/testData.ts
+++ b/client/utils/testData.ts
@@ -512,6 +512,8 @@ export const assignmentInitialState = {
     assignments: {},
     baseQuery: {must: []},
     currentAssignmentId: null,
+    selectedArchiveItemId: null,
+    initialTab: null,
     filterBy: 'Desk',
     filterByPriority: null,
     filterByType: null,

--- a/client/utils/testUtils.ts
+++ b/client/utils/testUtils.ts
@@ -19,6 +19,10 @@ Object.assign(appConfig, {
 });
 
 export const getTestActionStore = () => {
+    const apiSpy = sinon.spy((resource) => (store.spies.api[resource]));
+
+    apiSpy.query = sinon.spy(() => (Promise.resolve({_items: []})));
+
     let store = {
         spies: {
             api: {
@@ -167,7 +171,7 @@ export const getTestActionStore = () => {
                 pop: sinon.spy(),
             },
             $timeout: sinon.spy((func) => func()),
-            api: sinon.spy((resource) => (store.spies.api[resource])),
+            api: apiSpy,
             $location: {search: sinon.spy(
                 (key, value = null) => {
                     if (key) {
@@ -238,6 +242,12 @@ export const getTestActionStore = () => {
                 initWorkspace: sinon.spy(
                     (workspaceName, onLoadWorkspace) => onLoadWorkspace(store)
                 ),
+            },
+            search: {
+                query: () => ({
+                    filter: () => false,
+                    getCriteria: () => ({}),
+                }),
             },
         },
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -4,8 +4,9 @@ var webpackConfig = require('./webpack.config.js')
 
 module.exports = function(config) {
     // in karma, entry is read from files prop
-    // webpackConfig.entry = {}
-    // webpackConfig.devtool = 'inline-source-map'
+    webpackConfig.entry = {}
+    webpackConfig.devtool = 'eval';
+    webpackConfig.mode = 'development';
     config.set({
 
         // base path that will be used to resolve all patterns (eg. files, exclude)

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,18 +28,18 @@
       "dev": true
     },
     "@babel/parser": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.0.tgz",
-      "integrity": "sha512-jVZGvOxOuNSsuQuLRTh13nU0AogFlw32w/MT+LV6D3sP5WdbW61E77RnkbaO2dUvmPAYrBDJXGn5gGS6tH4j8g==",
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.3.tgz",
+      "integrity": "sha512-7+Ey1mAgYqFAx2h0RuoxcQT5+MlG3GTV0TQrgr7/ZliKsm/MNDxVVutlWaziMq7wJNAz8MTqz55XLpWvva6StA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.28.0"
+        "@babel/types": "^7.28.2"
       }
     },
     "@babel/runtime": {
-      "version": "7.27.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
-      "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q=="
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.3.tgz",
+      "integrity": "sha512-9uIQ10o0WGdpP6GDhXcdOJPJuDgFtIDtN/9+ArJQ2NAfAmiuhTQdzkaTGR33v43GYS2UrSA0eX2pPPHoFVvpxA=="
     },
     "@babel/types": {
       "version": "7.28.2",
@@ -101,9 +101,9 @@
       }
     },
     "@popperjs/core": {
-      "version": "2.10.2",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.10.2.tgz",
-      "integrity": "sha512-IXf3XA7+XyN7CP9gGh/XB0UxVMlvARGEgGXLubFICsUMGz6Q+DU+i4gGlpOxTjKvXjkJDJC8YdqdKkDj9qZHEQ=="
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A=="
     },
     "@reach/observe-rect": {
       "version": "1.2.0",
@@ -174,11 +174,6 @@
         "tippy.js": "^6.3.7"
       },
       "dependencies": {
-        "date-fns": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
-          "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg=="
-        },
         "react-sortable-hoc": {
           "version": "1.11.0",
           "resolved": "https://registry.npmjs.org/react-sortable-hoc/-/react-sortable-hoc-1.11.0.tgz",
@@ -205,23 +200,6 @@
         "fbjs": "^1.0.0",
         "immutable": "3.8.2",
         "object-assign": "^4.1.1"
-      },
-      "dependencies": {
-        "fbjs": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-1.0.0.tgz",
-          "integrity": "sha512-MUgcMEJaFhCaF1QtWGnmq9ZDRAzECTCRAF7O6UZIlAlkTs1SasiX9aP0Iw7wfD2mJ7wDTNfg2w7u5fSCwJk1OA==",
-          "requires": {
-            "core-js": "^2.4.1",
-            "fbjs-css-vars": "^1.0.0",
-            "isomorphic-fetch": "^2.1.1",
-            "loose-envify": "^1.0.0",
-            "object-assign": "^4.1.0",
-            "promise": "^7.1.1",
-            "setimmediate": "^1.0.5",
-            "ua-parser-js": "^0.7.18"
-          }
-        }
       }
     },
     "@superdesk/primereact": {
@@ -418,12 +396,11 @@
       }
     },
     "@types/hoist-non-react-statics": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.6.tgz",
-      "integrity": "sha512-lPByRJUer/iN/xa4qpyL0qmL11DqNW81iU/IG1S3uvRUq4oKagz8VCxZjiWkumgt66YT3vOdDgZ0o32sGKtCEw==",
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.7.tgz",
+      "integrity": "sha512-PQTyIulDkIDro8P+IHbKCsw7U2xxBYflVzW/FgWdCAePD9xGSidgA76/GeJ6lBKoblyhf9pBY763gbrN+1dI8g==",
       "dev": true,
       "requires": {
-        "@types/react": "*",
         "hoist-non-react-statics": "^3.3.0"
       }
     },
@@ -473,12 +450,12 @@
       "dev": true
     },
     "@types/node": {
-      "version": "24.0.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.3.tgz",
-      "integrity": "sha512-R4I/kzCYAdRLzfiCabn9hxWfbuHS573x+r0dJMkkzThEa7pbrcDWK+9zu3e7aBOouf+rQAciqPFMnxwr0aWgKg==",
+      "version": "24.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
+      "integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
       "dev": true,
       "requires": {
-        "undici-types": "~7.8.0"
+        "undici-types": "~7.10.0"
       }
     },
     "@types/node-forge": {
@@ -901,9 +878,9 @@
       "dev": true
     },
     "@xmldom/xmldom": {
-      "version": "0.8.10",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
-      "integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==",
+      "version": "0.8.11",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
+      "integrity": "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==",
       "dev": true
     },
     "@xtuc/ieee754": {
@@ -1711,16 +1688,6 @@
       "resolved": "https://registry.npmjs.org/binary-search/-/binary-search-1.3.6.tgz",
       "integrity": "sha512-nbE1WxOTTrUWIfsfZ4aHGYu5DOuNkbxGokjV6Z2kxfJK3uaAb8zNK1muzOeipoLHZjInT4Br88BHpzevc681xA==",
       "dev": true
-    },
-    "bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "file-uri-to-path": "1.0.0"
-      }
     },
     "bluebird": {
       "version": "3.7.2",
@@ -2766,9 +2733,9 @@
       }
     },
     "css-what": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
-      "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
       "dev": true
     },
     "cssesc": {
@@ -2835,10 +2802,9 @@
       }
     },
     "date-fns": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.7.0.tgz",
-      "integrity": "sha512-wxYp2PGoUDN5ZEACc61aOtYFvSsJUylIvCjpjDOqM1UDaKIIuMJ9fAnMYFHV3TQaDpfTVxhwNK/GiCaHKuemTA==",
-      "dev": true
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg=="
     },
     "date-format": {
       "version": "4.0.14",
@@ -4215,26 +4181,18 @@
       }
     },
     "fbjs": {
-      "version": "0.8.18",
-      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.18.tgz",
-      "integrity": "sha512-EQaWFK+fEPSoibjNy8IxUtaFOMXcWsY0JaVrQoZR9zC8N2Ygf9iDITPWjUTVIax95b6I742JFLqASHfsag/vKA==",
-      "dev": true,
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-1.0.0.tgz",
+      "integrity": "sha512-MUgcMEJaFhCaF1QtWGnmq9ZDRAzECTCRAF7O6UZIlAlkTs1SasiX9aP0Iw7wfD2mJ7wDTNfg2w7u5fSCwJk1OA==",
       "requires": {
-        "core-js": "^1.0.0",
+        "core-js": "^2.4.1",
+        "fbjs-css-vars": "^1.0.0",
         "isomorphic-fetch": "^2.1.1",
         "loose-envify": "^1.0.0",
         "object-assign": "^4.1.0",
         "promise": "^7.1.1",
         "setimmediate": "^1.0.5",
-        "ua-parser-js": "^0.7.30"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-          "integrity": "sha512-ZiPp9pZlgxpWRu0M+YWbm6+aQ84XEfH1JRXvfOc/fILWI0VKhLC2LX13X1NYq4fULzLMq7Hfh43CSo2/aIaUPA==",
-          "dev": true
-        }
+        "ua-parser-js": "^0.7.18"
       }
     },
     "fbjs-css-vars": {
@@ -4281,13 +4239,6 @@
       "resolved": "https://registry.npmjs.org/file-sync-cmp/-/file-sync-cmp-0.1.1.tgz",
       "integrity": "sha512-0k45oWBokCqh2MOexeYKpyqmGKG+8mQ2Wd8iawx+uWd/weWJQAZ6SoPybagdCI4xFisag8iAR77WPm4h3pTfxA==",
       "dev": true
-    },
-    "file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "dev": true,
-      "optional": true
     },
     "fill-range": {
       "version": "7.1.1",
@@ -6234,14 +6185,6 @@
         "gopd": "^1.2.0",
         "has-tostringtag": "^1.0.2",
         "hasown": "^2.0.2"
-      },
-      "dependencies": {
-        "gopd": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-          "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-          "dev": true
-        }
       }
     },
     "is-relative": {
@@ -6600,9 +6543,9 @@
           }
         },
         "tmp": {
-          "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
-          "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+          "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
           "dev": true
         }
       }
@@ -6728,9 +6671,9 @@
       "dev": true
     },
     "launch-editor": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.11.0.tgz",
-      "integrity": "sha512-R/PIF14L6e2eHkhvQPu7jDRCr0msfCYCxbYiLgkkAGi0dVPWuM+RrsPu0a5dpuNe0KWGL3jpAkOlv53xGfPheQ==",
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.11.1.tgz",
+      "integrity": "sha512-SEET7oNfgSaB6Ym0jufAdCeo3meJVeCaaDyzRygy0xsp2BFKCprcfHljTq4QkzTLUxEKkFK6OK4811YM2oSrRg==",
       "dev": true,
       "requires": {
         "picocolors": "^1.1.1",
@@ -7423,13 +7366,6 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
-    },
-    "nan": {
-      "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.23.0.tgz",
-      "integrity": "sha512-1UxuyYGdoQHcGg87Lkqm3FzefucTa0NAiOcuRsDmysep3c1LVCRK2krrUDafMWtjSG04htvAmvg96+SDknOmgQ==",
-      "dev": true,
-      "optional": true
     },
     "nanoid": {
       "version": "3.3.11",
@@ -8185,9 +8121,9 @@
           "dev": true
         },
         "jsonfile": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+          "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.6",
@@ -9261,14 +9197,6 @@
         "get-proto": "^1.0.1",
         "gopd": "^1.2.0",
         "set-function-name": "^2.0.2"
-      },
-      "dependencies": {
-        "gopd": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-          "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-          "dev": true
-        }
       }
     },
     "regexpp": {
@@ -11020,7 +10948,7 @@
       }
     },
     "superdesk-core": {
-      "version": "github:superdesk/superdesk-client-core#9b82a6ba96c6acdb048f4b7c0e9fbbb876e97fb0",
+      "version": "github:superdesk/superdesk-client-core#404ef0e9445f2322cebc24e4cfa7ff8035536f89",
       "from": "github:superdesk/superdesk-client-core#develop",
       "dev": true,
       "requires": {
@@ -11119,7 +11047,7 @@
         "sass-loader": "^10.5.2",
         "shallow-equal": "^3.1.0",
         "shortid": "2.2.8",
-        "superdesk-ui-framework": "4.0.71",
+        "superdesk-ui-framework": "4.0.75",
         "ts-loader": "^8.4.0",
         "typescript": "~4.9.5",
         "uuid": "8.3.1",
@@ -11129,20 +11057,11 @@
         "webpack-dev-server": "^4.15.2"
       },
       "dependencies": {
-        "@sourcefabric/common": {
-          "version": "0.0.69",
-          "resolved": "https://registry.npmjs.org/@sourcefabric/common/-/common-0.0.69.tgz",
-          "integrity": "sha512-Uopya/TWgewqPz0T1SxNIpT92ujeKYQ8ba3OPTDcBYOAL4Bs58ONljaRA+FrOFtEzRpJzeBuUz9t8Vovb/ko+Q==",
-          "dev": true,
-          "requires": {
-            "date-fns": "^4.1.0",
-            "lodash": "4.17.19",
-            "primereact": "^6.0.2",
-            "react": "16.9.0",
-            "react-dom": "16.9.0",
-            "react-sortable-hoc": "^1.11.0",
-            "tippy.js": "^6.3.7"
-          }
+        "@popperjs/core": {
+          "version": "2.10.2",
+          "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.10.2.tgz",
+          "integrity": "sha512-IXf3XA7+XyN7CP9gGh/XB0UxVMlvARGEgGXLubFICsUMGz6Q+DU+i4gGlpOxTjKvXjkJDJC8YdqdKkDj9qZHEQ==",
+          "dev": true
         },
         "@types/lodash": {
           "version": "4.14.117",
@@ -11156,11 +11075,26 @@
           "integrity": "sha512-DTt3GhOUDKhh4ONwIJW4lmhyotQmV2LjNlGK/J2hkwUcqcbKkCLAdJPtxQnxnlc7SR3f1CEXCyMmc7WLUsWbNA==",
           "dev": true
         },
-        "date-fns": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
-          "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+        "core-js": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "integrity": "sha512-ZiPp9pZlgxpWRu0M+YWbm6+aQ84XEfH1JRXvfOc/fILWI0VKhLC2LX13X1NYq4fULzLMq7Hfh43CSo2/aIaUPA==",
           "dev": true
+        },
+        "fbjs": {
+          "version": "0.8.18",
+          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.18.tgz",
+          "integrity": "sha512-EQaWFK+fEPSoibjNy8IxUtaFOMXcWsY0JaVrQoZR9zC8N2Ygf9iDITPWjUTVIax95b6I742JFLqASHfsag/vKA==",
+          "dev": true,
+          "requires": {
+            "core-js": "^1.0.0",
+            "isomorphic-fetch": "^2.1.1",
+            "loose-envify": "^1.0.0",
+            "object-assign": "^4.1.0",
+            "promise": "^7.1.1",
+            "setimmediate": "^1.0.5",
+            "ua-parser-js": "^0.7.30"
+          }
         },
         "json5": {
           "version": "0.5.1",
@@ -11217,60 +11151,21 @@
             "invariant": "^2.2.4",
             "prop-types": "^15.5.7"
           }
-        },
-        "superdesk-ui-framework": {
-          "version": "4.0.71",
-          "resolved": "https://registry.npmjs.org/superdesk-ui-framework/-/superdesk-ui-framework-4.0.71.tgz",
-          "integrity": "sha512-f6G5pHponQ6936w/N/+HnVRC8pzNpYqRj3lvVWDk+uTgg/gpeQp/NSniAkNBCElz2s1U3QuJkZL4vx7wLgX3iQ==",
-          "dev": true,
-          "requires": {
-            "@popperjs/core": "^2.4.0",
-            "@sourcefabric/common": "0.0.66",
-            "@superdesk/primereact": "^5.0.2-13",
-            "@superdesk/react-resizable-panels": "0.0.39",
-            "chart.js": "^2.9.3",
-            "date-fns": "^4.1.0",
-            "popper-max-size-modifier": "^0.2.0",
-            "popper.js": "1.14.4",
-            "primeicons": "2.0.0",
-            "react-beautiful-dnd": "^13.0.0",
-            "react-id-generator": "^3.0.0",
-            "react-scrollspy": "^3.4.3",
-            "tippy.js": "^6.3.7",
-            "weekstart": "^2.0.0"
-          },
-          "dependencies": {
-            "@sourcefabric/common": {
-              "version": "0.0.66",
-              "resolved": "https://registry.npmjs.org/@sourcefabric/common/-/common-0.0.66.tgz",
-              "integrity": "sha512-fgxp7rZKNrfiL9c21+imXqdcFWRDudw/VSwlcbGch+dtkXDdH4owSPfTdR/Sb/UClcbrGgZQHK0asQF2XpVpDA==",
-              "dev": true,
-              "requires": {
-                "date-fns": "^4.1.0",
-                "lodash": "4.17.19",
-                "primereact": "^6.0.2",
-                "react": "16.9.0",
-                "react-dom": "16.9.0",
-                "react-sortable-hoc": "^1.11.0",
-                "tippy.js": "^6.3.7"
-              }
-            }
-          }
         }
       }
     },
     "superdesk-ui-framework": {
-      "version": "4.0.57",
-      "resolved": "https://registry.npmjs.org/superdesk-ui-framework/-/superdesk-ui-framework-4.0.57.tgz",
-      "integrity": "sha512-bIOOskwZ39lyU7oxRlehqtlh+uoCX12V0B+lHW/skRbKMo99AMMS0WLbaU8lPDT0azlDH02RpEbyfNmksqcEFw==",
+      "version": "4.0.75",
+      "resolved": "https://registry.npmjs.org/superdesk-ui-framework/-/superdesk-ui-framework-4.0.75.tgz",
+      "integrity": "sha512-zeSTO1P8amAcpTaK1F00lUJXVnadHw+bu4p7sLmdvdfrXUd5KAclXuC11WZD4tFSz7C4ppjgK0W1QLEATPisrA==",
       "dev": true,
       "requires": {
         "@popperjs/core": "^2.4.0",
-        "@sourcefabric/common": "0.0.63",
+        "@sourcefabric/common": "0.0.66",
         "@superdesk/primereact": "^5.0.2-13",
         "@superdesk/react-resizable-panels": "0.0.39",
         "chart.js": "^2.9.3",
-        "date-fns": "2.7.0",
+        "date-fns": "^4.1.0",
         "popper-max-size-modifier": "^0.2.0",
         "popper.js": "1.14.4",
         "primeicons": "2.0.0",
@@ -11282,12 +11177,12 @@
       },
       "dependencies": {
         "@sourcefabric/common": {
-          "version": "0.0.63",
-          "resolved": "https://registry.npmjs.org/@sourcefabric/common/-/common-0.0.63.tgz",
-          "integrity": "sha512-YG/hWOt+KToNafaAMYW0/T4QiSLxx5mD4VhWvu3G5NTSFcfASwmiR3hpb7QzUOP6akFiQZ42V2JYhQZMsJNySw==",
+          "version": "0.0.66",
+          "resolved": "https://registry.npmjs.org/@sourcefabric/common/-/common-0.0.66.tgz",
+          "integrity": "sha512-fgxp7rZKNrfiL9c21+imXqdcFWRDudw/VSwlcbGch+dtkXDdH4owSPfTdR/Sb/UClcbrGgZQHK0asQF2XpVpDA==",
           "dev": true,
           "requires": {
-            "date-fns": "2.7.0",
+            "date-fns": "^4.1.0",
             "lodash": "4.17.19",
             "primereact": "^6.0.2",
             "react": "16.9.0",
@@ -11833,9 +11728,9 @@
       }
     },
     "ua-parser-js": {
-      "version": "0.7.40",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.40.tgz",
-      "integrity": "sha512-us1E3K+3jJppDBa3Tl0L3MOJiGhe1C6P0+nIvQAFYbxlMAx0h81eOwLmU57xgqToduDDPx3y5QsdjPfDu+FgOQ=="
+      "version": "0.7.41",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.41.tgz",
+      "integrity": "sha512-O3oYyCMPYgNNHuO7Jjk3uacJWZF8loBgwrfd/5LE/HyZ3lUIOdniQ7DNXJcIgZbwioZxk0fLfI4EVnetdiX5jg=="
     },
     "uglify-js": {
       "version": "2.6.4",
@@ -11943,9 +11838,9 @@
       }
     },
     "undici-types": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
-      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
       "dev": true
     },
     "union-value": {
@@ -12319,11 +12214,7 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "bindings": "^1.5.0",
-            "nan": "^2.12.1"
-          }
+          "optional": true
         },
         "glob-parent": {
           "version": "3.1.0",
@@ -12998,14 +12889,6 @@
         "get-proto": "^1.0.1",
         "gopd": "^1.2.0",
         "has-tostringtag": "^1.0.2"
-      },
-      "dependencies": {
-        "gopd": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-          "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-          "dev": true
-        }
       }
     },
     "wildcard": {

--- a/server/planning/assignments/assignments.py
+++ b/server/planning/assignments/assignments.py
@@ -119,9 +119,19 @@ class AssignmentsService(AsyncBaseService):
         """Populate `item_ids` with ids for all linked Archive items for an Assignment"""
         items = await (await self.get_archive_items_for_assignments([str(doc.get(ID_FIELD)) for doc in docs])).to_list()
         for doc in docs:
-            ids = [str(item.get("_id")) for item in items if str(item.get("assignment_id")) == str(doc.get("_id"))]
-            if len(ids):
-                doc["item_ids"] = ids
+            linked_items = [
+                {
+                    "_id": item.get("_id"),
+                    "_type": item.get("_type"),
+                    "event_id": item.get("event_id"),
+                }
+                for item in items
+                if str(item.get("assignment_id")) == str(doc.get("_id"))
+            ]
+
+            if len(linked_items):
+                doc["item_ids"] = [item["_id"] for item in linked_items]
+                doc["linked_items"] = linked_items
 
             self.set_type(doc, doc)
 


### PR DESCRIPTION
### Purpose
Improve the Assignments page for showing/interacting with multiple content that is linked to an Assignment.

### What has changed
* Update Redux store to store multiple content items per Assignment
* Add expandable list item in Assignment Lists to show all linked content items
* Use toggle boxes to show all linked content items in the preview panel
* Update visuals based on mock ups provided in the ticket

<!-- [For UI changes]
### Screenshots
-->
<img width="1265" height="637" alt="image" src="https://github.com/user-attachments/assets/ba79165e-318d-4dad-9e5e-7d98a1a10009" />
<img width="727" height="492" alt="image" src="https://github.com/user-attachments/assets/b954cb22-0d01-4457-9b64-16b92185b9df" />
<img width="542" height="418" alt="image" src="https://github.com/user-attachments/assets/8329692d-2d0b-4719-8db8-34f64807229d" />
<img width="535" height="677" alt="image" src="https://github.com/user-attachments/assets/6dc8f7bc-aef6-41dc-b3c8-1f50b8285a95" />


### Front-end checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [x] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [x] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [x] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [x] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [x] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [x] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [x] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [x] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)

Resolves: [STT-1299](https://sofab.atlassian.net/browse/STT-1299)



[STT-1299]: https://sofab.atlassian.net/browse/STT-1299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ