### PR TITLE
[SDESK-7734] - Planning items not unlinked when removed from Events ContentAPI output

### DIFF
--- a/server/planning/content_api/resources/event.py
+++ b/server/planning/content_api/resources/event.py
@@ -17,9 +17,7 @@ from superdesk.core.resources import (
 from superdesk.core.resources.service import AsyncResourceService
 
 from content_api import MONGO_PREFIX, ELASTIC_PREFIX
-from planning.utils import get_related_planning_for_events
 
-from .planning import ContentAPIPlanningService
 from ..types import ContentAPIEventResource
 from ..output_formatters import ContentApiEventFormatter
 
@@ -43,12 +41,6 @@ class ContentAPIEventService(AsyncResourceService[ContentAPIEventResource]):
             await self.update(event_id, formatted_item)
         else:
             await self.create([formatted_item])
-
-        # Check for linked planning items to the event and update them as well
-        related_planning_item = get_related_planning_for_events([event_id]) or []
-        for planning_item in related_planning_item:
-            await ContentAPIPlanningService().publish_async(planning_item, subscribers)
-
 
 content_api_event_resource_config: ResourceConfig = ResourceConfig(
     name="events_capi",

--- a/server/planning/content_api/resources/event.py
+++ b/server/planning/content_api/resources/event.py
@@ -20,7 +20,7 @@ from content_api import MONGO_PREFIX, ELASTIC_PREFIX
 from planning.utils import get_related_planning_for_events
 
 from .planning import ContentAPIPlanningService
-from ..types import ContentAPIEventResource
+from ..types import ContentAPIEventResource, ContentAPIPlanningResource
 from ..output_formatters import ContentApiEventFormatter
 
 
@@ -44,10 +44,38 @@ class ContentAPIEventService(AsyncResourceService[ContentAPIEventResource]):
         else:
             await self.create([formatted_item])
 
-        # Check for linked planning items to the event and update them as well
-        related_planning_items = get_related_planning_for_events([event_id])
-        for planning_item in related_planning_items:
-            await ContentAPIPlanningService().publish_async(planning_item, subscribers)
+        # Get set of planning items linked to this event from core
+        planning_service = ContentAPIPlanningResource.get_service()
+        expected_plans = get_related_planning_for_events([event_id]) or []
+        expected_plan_ids = {p["_id"] for p in expected_plans}
+
+        # Get what is currently linked in planning content api db
+        cursor = await planning_service.find(
+            {"query": {"bool": {"must": [{"term": {"events.literal": event_id}}]}}},
+            max_results=500,
+            projection=["_id", "events"],
+        )
+        linked_plans = await cursor.to_list_raw()
+        linked_plan_ids = {p["_id"] for p in linked_plans}
+
+        # Unlink stale planning items - so they don't show in "plans" on fetch
+        stale_plan_ids = linked_plan_ids - expected_plan_ids
+        for plan_id in stale_plan_ids:
+            plan_doc = next((p for p in linked_plans if p["_id"] == plan_id), None)
+            if plan_doc is None:
+                plan_doc = await planning_service.find_by_id(plan_id)
+
+            existing_events = plan_doc.get("events") or []
+            updated_events = [ev for ev in existing_events if ev.get("literal") != event_id]
+
+            # Update only when there’s a change
+            if updated_events != existing_events:
+                await planning_service.update(plan_id, {"events": updated_events})
+                await ContentAPIPlanningService().publish_async({"_id": plan_id}, subscribers)
+
+        # Publish all still-linked planning items
+        for plan in expected_plans:
+            await ContentAPIPlanningService().publish_async(plan, subscribers)
 
 
 content_api_event_resource_config: ResourceConfig = ResourceConfig(

--- a/server/planning/content_api/resources/event.py
+++ b/server/planning/content_api/resources/event.py
@@ -66,7 +66,7 @@ class ContentAPIEventService(AsyncResourceService[ContentAPIEventResource]):
                 plan_doc = await planning_service.find_by_id(plan_id)
 
             existing_events = plan_doc.get("events") or []
-            updated_events = [ev for ev in existing_events if ev.get("literal") != event_id]
+            updated_events = [event for event in existing_events if event.get("literal") != event_id]
 
             # Update only when there’s a change
             if updated_events != existing_events:

--- a/server/planning/content_api/resources/event.py
+++ b/server/planning/content_api/resources/event.py
@@ -42,6 +42,7 @@ class ContentAPIEventService(AsyncResourceService[ContentAPIEventResource]):
         else:
             await self.create([formatted_item])
 
+
 content_api_event_resource_config: ResourceConfig = ResourceConfig(
     name="events_capi",
     data_class=ContentAPIEventResource,

--- a/server/planning/content_api/resources/event.py
+++ b/server/planning/content_api/resources/event.py
@@ -20,7 +20,7 @@ from content_api import MONGO_PREFIX, ELASTIC_PREFIX
 from planning.utils import get_related_planning_for_events
 
 from .planning import ContentAPIPlanningService
-from ..types import ContentAPIEventResource, ContentAPIPlanningResource
+from ..types import ContentAPIEventResource
 from ..output_formatters import ContentApiEventFormatter
 
 
@@ -44,38 +44,10 @@ class ContentAPIEventService(AsyncResourceService[ContentAPIEventResource]):
         else:
             await self.create([formatted_item])
 
-        # Get set of planning items linked to this event from core
-        planning_service = ContentAPIPlanningResource.get_service()
-        expected_plans = get_related_planning_for_events([event_id]) or []
-        expected_plan_ids = {p["_id"] for p in expected_plans}
-
-        # Get what is currently linked in planning content api db
-        cursor = await planning_service.find(
-            {"query": {"bool": {"must": [{"term": {"events.literal": event_id}}]}}},
-            max_results=500,
-            projection=["_id", "events"],
-        )
-        linked_plans = await cursor.to_list_raw()
-        linked_plan_ids = {p["_id"] for p in linked_plans}
-
-        # Unlink stale planning items - so they don't show in "plans" on fetch
-        stale_plan_ids = linked_plan_ids - expected_plan_ids
-        for plan_id in stale_plan_ids:
-            plan_doc = next((p for p in linked_plans if p["_id"] == plan_id), None)
-            if plan_doc is None:
-                plan_doc = await planning_service.find_by_id(plan_id)
-
-            existing_events = plan_doc.get("events") or []
-            updated_events = [event for event in existing_events if event.get("literal") != event_id]
-
-            # Update only when there’s a change
-            if updated_events != existing_events:
-                await planning_service.update(plan_id, {"events": updated_events})
-                await ContentAPIPlanningService().publish_async({"_id": plan_id}, subscribers)
-
-        # Publish all still-linked planning items
-        for plan in expected_plans:
-            await ContentAPIPlanningService().publish_async(plan, subscribers)
+        # Check for linked planning items to the event and update them as well
+        related_planning_item = get_related_planning_for_events([event_id]) or []
+        for planning_item in related_planning_item:
+            await ContentAPIPlanningService().publish_async(planning_item, subscribers)
 
 
 content_api_event_resource_config: ResourceConfig = ResourceConfig(

--- a/server/planning/events/events_sync/__init__.py
+++ b/server/planning/events/events_sync/__init__.py
@@ -237,9 +237,7 @@ async def sync_event_metadata_with_planning_items(
                 continue
 
             current_related_events = planning_item.get("related_events") or []
-            pruned_related_events = [
-                rel for rel in current_related_events if rel.get("_id") != event_updated["_id"]
-            ]
+            pruned_related_events = [rel for rel in current_related_events if rel.get("_id") != event_updated["_id"]]
 
             if pruned_related_events != current_related_events:
                 await planning_service.patch_async(planning_id, {"related_events": pruned_related_events})

--- a/server/planning/events/events_sync/__init__.py
+++ b/server/planning/events/events_sync/__init__.py
@@ -19,7 +19,7 @@ from planning.utils import parse_date
 from planning.utils import get_related_planning_for_events
 from planning.content_profiles.utils import AllContentProfileData
 from planning.common import get_config_event_fields_to_sync_with_planning
-from planning.types import Event, EmbeddedPlanningDict, StringFieldTranslation, Planning
+from planning.types import Event, EmbeddedPlanningDict, StringFieldTranslation
 from planning.types.event import EmbeddedPlanning as EmbeddedPlanningModel
 
 from .common import VocabsSyncData, SyncItemData, SyncData
@@ -218,3 +218,28 @@ async def sync_event_metadata_with_planning_items(
         )
         if sync_data.update_planning:
             await planning_service.patch_async(sync_data.planning.original["_id"], sync_data.planning.updates)
+
+    # Unlink planning items no longer embedded (even when sync_fields are present)
+    if embedded_planning_present:
+        existing_linked_planning_items = get_related_planning_for_events([event_updated["_id"]])
+        post_linked_ids = {p["_id"] for p in existing_linked_planning_items}
+
+        newly_linked_ids = post_linked_ids - pre_linked_ids
+
+        ids_to_maintain: set[str] = set(processed_planning_ids)
+        ids_to_maintain.update(newly_linked_ids)
+
+        ids_to_unlink = post_linked_ids - ids_to_maintain
+
+        for planning_id in ids_to_unlink:
+            planning_item = next((p for p in existing_linked_planning_items if p["_id"] == planning_id), None)
+            if not planning_item:
+                continue
+
+            current_related_events = planning_item.get("related_events") or []
+            pruned_related_events = [
+                rel for rel in current_related_events if rel.get("_id") != event_updated["_id"]
+            ]
+
+            if pruned_related_events != current_related_events:
+                await planning_service.patch_async(planning_id, {"related_events": pruned_related_events})


### PR DESCRIPTION
### Purpose
This PR ensure planning items in the Content API are correctly synced with their related events when added and when removed.
Previously, removed planning items still linked to the event in the database causing stale connections when event is fetched by `add_plan_ids_to_event` function.

### What has changed
- Unlinks stale planning items no longer related to the event by checking the related events from the core and those in the content_api database and doing a comparison to figure out which to unlink.

### Steps to test
1. Create an event with two linked planning items and post it. Check the events contentapi output to see both planning items.
2. Remove one planning item.
3. Check events contentapi output again to see that one planning item is left.
4. Verify in MongoDB too that only the correct planning item remains linked to the events in the `events` key.
5. Confirm the unlinked planning item has no link to the event in the `events` key.


Resolves: Part 2 of #[SDESK-7734](https://sofab.atlassian.net/browse/SDESK-7734)


[SDESK-7734]: https://sofab.atlassian.net/browse/SDESK-7734?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ