### PR TITLE
[SDESK-7747] Fix `Edit Planning` not invoked after `Add to Planning` from authoring widget

### DIFF
--- a/client/planning-extension/src/planning-details-widget.tsx
+++ b/client/planning-extension/src/planning-details-widget.tsx
@@ -36,6 +36,18 @@ export class PlanningDetailsWidget extends React.PureComponent<IArticleSideWidge
         }
     }
 
+    componentDidUpdate = (_prevProps: IArticleSideWidgetComponentType, prevState: IState): void => {
+        const {assignment_id} = this.props.article;
+        const {planningId} = this.state;
+
+        if (assignment_id == null) return;
+
+        // refetch if there's a valid assignment but not planning data or different planning data
+        if (!planningId || planningId !== prevState.planningId)
+            this.fetchPlanningInfo(assignment_id);
+    }
+
+
     componentWillUnmount() {
         this.unsubscribeFromUpdates();
     }


### PR DESCRIPTION
### Purpose
Fixes the bug where the Planning Details widget did not update after performing Add to Planning from the authoring widget. Ensures the widget always reflects the correct planning information when the assignment context changes.

### What has changed
- Added `componentDidUpdate` to the widget to refetch planning info when:
  - `assignment_id` changes, or
  - no planning data is present.
- Guarantees the widget displays up-to-date planning details after "Add to Planning" is performed.

### Steps to test
Please follow the steps in the video attached to the ticket [SDESK-7747]

Fixes: [SDESK-7747]



[SDESK-7747]: https://sofab.atlassian.net/browse/SDESK-7747?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SDESK-7747]: https://sofab.atlassian.net/browse/SDESK-7747?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ