### PR TITLE
[STT-1203] Link content duplicates to Assignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,11 @@ Below sections include the config options that can be defined in settings.py.
     * If this option is not defined, or is an empty array, then all content types can be linked
     * Otherwise only the content types in the list are allowed to be linked to a coverage
     * This includes fulfilment of an Assignment
+* ASSIGNMENT_LINK_DUPLICATE_CONTENT
+    * Default to false
+    * When duplicating content that is linked to an Assignment with multiple content enabled,
+    * this setting determines whether the newly created duplicate item retains the Assignment link (if true)
+    * or removes the assignment_id from the duplicate item (if false).
 
 ### Development tools config
 

--- a/e2e/server/core-requirements.in
+++ b/e2e/server/core-requirements.in
@@ -1,3 +1,3 @@
 gunicorn==22.0.0
 honcho==1.0.1
-git+https://github.com/superdesk/superdesk-core.git@async#egg=superdesk-core
+git+https://github.com/superdesk/superdesk-core.git@develop-async#egg=superdesk-core

--- a/e2e/server/core-requirements.txt
+++ b/e2e/server/core-requirements.txt
@@ -324,7 +324,7 @@ six==1.17.0
     #   flask-oidc-ex
     #   oauth2client
     #   python-dateutil
-superdesk-core @ git+https://github.com/superdesk/superdesk-core.git@develop-async
+superdesk-core @ git+https://github.com/MarkLark86/superdesk-core.git@STT-1203
     # via -r core-requirements.in
 taskgroup==0.2.2
     # via hypercorn

--- a/e2e/server/core-requirements.txt
+++ b/e2e/server/core-requirements.txt
@@ -324,7 +324,7 @@ six==1.17.0
     #   flask-oidc-ex
     #   oauth2client
     #   python-dateutil
-superdesk-core @ git+https://github.com/MarkLark86/superdesk-core.git@STT-1203
+superdesk-core @ git+https://github.com/superdesk/superdesk-core.git@develop-async
     # via -r core-requirements.in
 taskgroup==0.2.2
     # via hypercorn

--- a/e2e/server/core-requirements.txt
+++ b/e2e/server/core-requirements.txt
@@ -14,13 +14,13 @@ aiofiles==24.1.0
     #   quart
 aiohappyeyeballs==2.6.1
     # via aiohttp
-aiohttp==3.12.13
+aiohttp==3.12.15
     # via
     #   aiobotocore
     #   elasticsearch
 aioitertools==0.12.0
     # via aiobotocore
-aiosignal==1.3.2
+aiosignal==1.4.0
     # via aiohttp
 amqp==5.3.1
     # via kombu
@@ -30,7 +30,7 @@ arrow==1.3.0
     # via
     #   eve-elastic
     #   superdesk-core
-asgiref==3.8.1
+asgiref==3.9.1
     # via superdesk-core
 async-timeout==5.0.1
     # via
@@ -63,7 +63,7 @@ botocore==1.37.3
     #   aiobotocore
     #   boto3
     #   s3transfer
-cachetools==6.1.0
+cachetools==6.2.0
     # via flask-oidc-ex
 celery[redis]==5.4.0
     # via superdesk-core
@@ -71,7 +71,7 @@ cerberus==1.3.7
     # via
     #   eve
     #   superdesk-core
-certifi==2025.6.15
+certifi==2025.8.3
     # via
     #   elastic-apm
     #   elasticsearch
@@ -81,11 +81,11 @@ cffi==1.17.1
     # via cryptography
 chardet==5.2.0
     # via superdesk-core
-charset-normalizer==3.4.2
+charset-normalizer==3.4.3
     # via
     #   reportlab
     #   requests
-ciso8601==2.3.2
+ciso8601==2.3.3
     # via eve-elastic
 click==8.2.1
     # via
@@ -97,13 +97,13 @@ click==8.2.1
     #   quart
 click-didyoumean==0.3.1
     # via celery
-click-plugins==1.1.1
+click-plugins==1.1.1.2
     # via celery
 click-repl==0.3.0
     # via celery
 croniter==6.0.0
     # via superdesk-core
-cryptography==45.0.4
+cryptography==45.0.6
     # via
     #   authlib
     #   jwcrypto
@@ -113,7 +113,7 @@ draftjs-exporter[lxml]==5.1.0
     # via superdesk-core
 ecs-logging==2.2.0
     # via elastic-apm
-elastic-apm[flask]==6.23.0
+elastic-apm[flask]==6.24.0
     # via superdesk-core
 elasticsearch[async]==7.17.12
     # via
@@ -129,7 +129,7 @@ exceptiongroup==1.3.0
     #   taskgroup
 feedparser==6.0.11
     # via superdesk-core
-flask==3.1.1
+flask==3.1.2
     # via
     #   flask-mail
     #   flask-oidc-ex
@@ -150,7 +150,7 @@ h11==0.16.0
     # via
     #   hypercorn
     #   wsproto
-h2==4.2.0
+h2==4.3.0
     # via hypercorn
 hachoir==3.3.0
     # via superdesk-core
@@ -188,7 +188,7 @@ jwcrypto==1.5.6
     # via
     #   flask-oidc-ex
     #   python-jwt
-kombu==5.4.2
+kombu==5.5.4
     # via
     #   celery
     #   superdesk-core
@@ -211,17 +211,19 @@ markupsafe==3.0.2
     #   werkzeug
 motor==3.7.1
     # via superdesk-core
-multidict==6.5.0
+multidict==6.6.4
     # via
     #   aiobotocore
     #   aiohttp
     #   yarl
 oauth2client==4.1.3
     # via flask-oidc-ex
-oauthlib==3.3.0
+oauthlib==3.3.1
     # via requests-oauthlib
 packaging==25.0
-    # via gunicorn
+    # via
+    #   gunicorn
+    #   kombu
 pillow==11.1.0
     # via
     #   reportlab
@@ -298,9 +300,9 @@ redis==5.2.1
     #   superdesk-core
 regex==2024.11.6
     # via superdesk-core
-reportlab==4.4.2
+reportlab==4.4.3
     # via superdesk-core
-requests==2.32.4
+requests==2.32.5
     # via
     #   python-twitter
     #   requests-oauthlib
@@ -311,7 +313,7 @@ rsa==4.9.1
     # via oauth2client
 s3transfer==0.11.3
     # via boto3
-sentry-sdk[quart]==2.30.0
+sentry-sdk[quart]==2.35.0
     # via superdesk-core
 sgmllib3k==1.0.0
     # via feedparser
@@ -322,18 +324,19 @@ six==1.17.0
     #   flask-oidc-ex
     #   oauth2client
     #   python-dateutil
-superdesk-core @ git+https://github.com/superdesk/superdesk-core.git@async
+superdesk-core @ git+https://github.com/superdesk/superdesk-core.git@develop-async
     # via -r core-requirements.in
 taskgroup==0.2.2
     # via hypercorn
 tomli==2.2.1
     # via hypercorn
-types-python-dateutil==2.9.0.20250516
+types-python-dateutil==2.9.0.20250822
     # via arrow
-types-pytz==2025.2.0.20250516
+types-pytz==2025.2.0.20250809
     # via quart-babel
-typing-extensions==4.14.0
+typing-extensions==4.15.0
     # via
+    #   aiosignal
     #   asgiref
     #   exceptiongroup
     #   hypercorn
@@ -374,7 +377,7 @@ werkzeug==3.1.3
     # via
     #   flask
     #   quart
-wrapt==1.17.2
+wrapt==1.17.3
     # via
     #   aiobotocore
     #   elastic-apm

--- a/server/features/content_duplicate.feature
+++ b/server/features/content_duplicate.feature
@@ -1,0 +1,163 @@
+Feature: Assignment with multiple linked content
+    Background: Setup Planning, Assignments and Content
+        Given "content_types"
+        """
+        [{"schema": {"body_html": {}, "slugline": {}, "headline": {}, "ednote": null }}]
+        """
+        And "content_templates"
+        """
+        [{"template_name": "Default", "template_type": "create", "data": {}}]
+        """
+        And "desks"
+        """
+        [{
+            "name": "Sports Desk", "members": [{"user": "#CONTEXT_USER_ID#"}],
+            "default_content_template": "#content_templates._id#",
+            "default_content_profile": "#content_types._id#"
+        }]
+        """
+        When we post to "planning"
+        """
+        [{
+            "guid": "plan1",
+            "slugline": "test slugline",
+            "planning_date": "2042-06-30",
+            "coverages": [{
+                "coverage_id": "txt-single",
+                "planning": {
+                    "slugline": "test slugline",
+                    "g2_content_type": "text"
+                },
+                "assigned_to": {
+                    "desk": "#desks._id#",
+                    "user": "#CONTEXT_USER_ID#"
+                },
+                "news_coverage_status": {"qcode": "ncostat:int"},
+                "workflow_status": "assigned"
+            }, {
+                "coverage_id": "txt-multi",
+                "planning": {
+                    "slugline": "test slugline",
+                    "g2_content_type": "text",
+                    "multiple_content": true
+                },
+                "assigned_to": {
+                    "desk": "#desks._id#",
+                    "user": "#CONTEXT_USER_ID#"
+                },
+                "news_coverage_status": {"qcode": "ncostat:int"},
+                "workflow_status": "assigned"
+            }]
+        }]
+        """
+        Then we get OK response
+        And we store assignment id in "SINGLE_ASSIGNMENT_ID" from coverage 0
+        And we store assignment id in "MULTI_ASSIGNMENT_ID" from coverage 1
+
+        # Create the initial 2 content items
+        When we post to "/assignments/content"
+        """
+        [{"assignment_id": "#SINGLE_ASSIGNMENT_ID#"}]
+        """
+        Then we get OK response
+        Then we store "SINGLE_CONTENT_1_ID" with value "#content._id#" to context
+        Then we get existing resource
+        """
+        {"_id": "#SINGLE_CONTENT_1_ID#", "assignment_id": "#SINGLE_ASSIGNMENT_ID#"}
+        """
+
+        When we post to "/assignments/content"
+        """
+        [{"assignment_id": "#MULTI_ASSIGNMENT_ID#"}]
+        """
+        Then we get OK response
+        Then we store "MULTI_CONTENT_1_ID" with value "#content._id#" to context
+        Then we get existing resource
+        """
+        {"_id": "#MULTI_CONTENT_1_ID#", "assignment_id": "#MULTI_ASSIGNMENT_ID#"}
+        """
+
+    @auth @planning_cvs
+    Scenario: Duplicating content removes assignment id
+        # Duplicate content from Assignment with multiple_content disabled
+        When we post to "/archive/#SINGLE_CONTENT_1_ID#/duplicate"
+        """
+        {"desk": "#desks._id#","type": "archive"}
+        """
+        Then we get OK response
+        Then we store "SINGLE_CONTENT_2_ID" with value "#duplicate._id#" to context
+
+        # Duplicate content from Assignment with multiple_content enabled
+        When we post to "/archive/#MULTI_CONTENT_1_ID#/duplicate"
+        """
+        {"desk": "#desks._id#","type": "archive"}
+        """
+        Then we get OK response
+        Then we store "MULTI_CONTENT_2_ID" with value "#duplicate._id#" to context
+
+        # Check all items from archive endpoint
+        When we get "archive"
+        Then we get list with 4 items
+        """
+        {"_items": [
+            {"_id": "#SINGLE_CONTENT_1_ID#", "assignment_id": "#SINGLE_ASSIGNMENT_ID#"},
+            {"_id": "#SINGLE_CONTENT_2_ID#", "assignment_id": "__none__"},
+            {"_id": "#MULTI_CONTENT_1_ID#", "assignment_id": "#MULTI_ASSIGNMENT_ID#"},
+            {"_id": "#MULTI_CONTENT_2_ID#", "assignment_id": "__none__"}
+        ]}
+        """
+
+    @auth @planning_cvs
+    Scenario: Duplicating content links to existing Assignment
+        Given config update
+        """
+        {"ASSIGNMENT_LINK_DUPLICATE_CONTENT": true}
+        """
+        # Duplicate content from Assignment with multiple_content disabled
+        When we post to "/archive/#SINGLE_CONTENT_1_ID#/duplicate"
+        """
+        {"desk": "#desks._id#","type": "archive"}
+        """
+        Then we get OK response
+        Then we store "SINGLE_CONTENT_2_ID" with value "#duplicate._id#" to context
+
+        # Duplicate content from Assignment with multiple_content enabled
+        When we post to "/archive/#MULTI_CONTENT_1_ID#/duplicate"
+        """
+        {"desk": "#desks._id#","type": "archive"}
+        """
+        Then we get OK response
+        Then we store "MULTI_CONTENT_2_ID" with value "#duplicate._id#" to context
+
+        # Check all items from archive endpoint
+        When we get "archive"
+        Then we get list with 4 items
+        """
+        {"_items": [
+            {"_id": "#SINGLE_CONTENT_1_ID#", "assignment_id": "#SINGLE_ASSIGNMENT_ID#"},
+            {"_id": "#SINGLE_CONTENT_2_ID#", "assignment_id": "__none__"},
+            {"_id": "#MULTI_CONTENT_1_ID#", "assignment_id": "#MULTI_ASSIGNMENT_ID#"},
+            {"_id": "#MULTI_CONTENT_2_ID#", "assignment_id": "#MULTI_ASSIGNMENT_ID#"}
+        ]}
+        """
+
+    @auth @planning_cvs
+    Scenario: Duplicating content to personal space removes Assignment ID
+        Given config update
+        """
+        {"ASSIGNMENT_LINK_DUPLICATE_CONTENT": true}
+        """
+        When we post to "/archive/#MULTI_CONTENT_1_ID#/duplicate"
+        """
+        {"desk": null,"type": "archive"}
+        """
+        Then we get OK response
+        Then we store "MULTI_CONTENT_2_ID" with value "#duplicate._id#" to context
+        When we get "archive"
+        Then we get list with 3 items
+        """
+        {"_items": [
+            {"_id": "#MULTI_CONTENT_1_ID#", "assignment_id": "#MULTI_ASSIGNMENT_ID#"},
+            {"_id": "#MULTI_CONTENT_2_ID#", "assignment_id": "__none__"}
+        ]}
+        """

--- a/server/planning/assignments/__init__.py
+++ b/server/planning/assignments/__init__.py
@@ -11,10 +11,16 @@
 import superdesk
 from quart_babel import lazy_gettext
 
+from superdesk.signals import item_duplicate_async, item_duplicated_async
 from planning import signals
 from .assignments import AssignmentsResource, AssignmentsService
 from .assignments_content import AssignmentsContentResource, AssignmentsContentService
-from .assignments_link import AssignmentsLinkResource, AssignmentsLinkService
+from .assignments_link import (
+    AssignmentsLinkResource,
+    AssignmentsLinkService,
+    on_archive_item_duplicate,
+    on_archive_item_duplicated,
+)
 from .assignments_unlink import AssignmentsUnlinkResource, AssignmentsUnlinkService
 from .assignments_complete import (
     AssignmentsCompleteResource,
@@ -143,6 +149,9 @@ def init_app(app):
     app.on_fetched_resource_published += assignments_publish_service.on_fetched_resource_archive
     app.on_fetched_item_published += assignments_publish_service.on_fetched_resource_archive
     app.on_updated_archive_spike += assignments_unlink_service.on_spike_item
+
+    item_duplicate_async.connect(on_archive_item_duplicate)
+    item_duplicated_async.connect(on_archive_item_duplicated)
 
     # Privileges
     superdesk.intrinsic_privilege(AssignmentsUnlockResource.endpoint_name, method=["POST"])

--- a/server/planning/assignments/assignments_link.py
+++ b/server/planning/assignments/assignments_link.py
@@ -6,9 +6,13 @@
 # AUTHORS and LICENSE files distributed with this source code, or
 # at https://www.sourcefabric.org/superdesk/license
 from copy import deepcopy
-from quart_babel import gettext as _
 
+from quart_babel import gettext as _
+from bson import ObjectId
+
+from superdesk.core import get_config
 from superdesk.resource_fields import ID_FIELD
+from superdesk.flask import g
 from superdesk import Resource, get_resource_service
 from superdesk.eve_async.service import AsyncBaseService
 from superdesk.errors import SuperdeskApiError
@@ -270,3 +274,72 @@ class AssignmentsLinkResource(Resource):
     item_methods = []
 
     privileges = {"POST": "archive"}
+
+
+async def _get_assignment_for_content_duplicate(item: dict) -> dict | None:
+    """Retrieve Assignment to link to the duplicate content item.
+
+    If this item returns None, then the newly created duplicate item is not to be linked to an Assignment.
+    Returns true if all of the following conditions are met:
+
+    * ``ASSIGNMENT_LINK_DUPLICATE_CONTENT`` setting is enabled
+    * The original item has ``assignment_id`` (linked to an Assignment)
+    * Assignment with ``assignment_id`` exists
+    * Item is not being duplicated to the personal space
+    * Assignment has ``planning.multiple_content`` enabled
+
+    :param: item: The content item where the Assignment is to be possibly linked to
+    :return: Returns the assignment data if it exists and meets the criteria for multiple content
+            link duplication. Otherwise, returns None.
+    """
+
+    if not get_config(bool, "ASSIGNMENT_LINK_DUPLICATE_CONTENT", False):
+        return None
+
+    assignment_id: ObjectId | None = item.get("assignment_id")
+    if not assignment_id:
+        return None
+    elif not (item.get("task") or {}).get("desk"):
+        return None
+
+    assignment: dict | None = g.get("archive_assignment")
+    if not assignment:
+        assignment = await get_resource_service("assignments").find_one_async(req=None, _id=assignment_id)
+        if not assignment:
+            logger.warning(f"Failed to find assignment {assignment_id} for duplicated item {item['_id']}")
+            return None
+        g.archive_assignment = assignment
+
+    if not assignment_allows_multiple_content_linked(assignment):
+        return None
+
+    return assignment
+
+
+async def on_archive_item_duplicate(updated: dict, original: dict, operation: str) -> None:
+    """Remove the ``assignment_id`` from the duplicated item.
+
+    Before the duplicated item is to be created, check to see if the new item is to be linked to the same Assignment.
+    If it is not, then remove the ``assignment_id`` from the duplicated item.
+    """
+
+    if not await _get_assignment_for_content_duplicate(updated):
+        updated.pop("assignment_id", None)
+
+
+async def on_archive_item_duplicated(updated: dict, original: dict, operation: str) -> None:
+    """Link the newly created duplicated item to the Assignment."""
+
+    assignment = await _get_assignment_for_content_duplicate(updated)
+    if assignment:
+        await get_resource_service("assignments_link").post_async(
+            [
+                {
+                    "assignment_id": assignment["_id"],
+                    "item_id": updated["_id"],
+                    "reassign": False,
+                    "force": True,  # Force the linking, even though this item has ``assignment_id``
+                    "skip_archive_update": True,  # No need to update item, as we've already done this
+                }
+            ]
+        )

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -23,4 +23,4 @@ aioresponses
 
 -e .
 # Install in editable state so we get feature fixtures
--e git+https://github.com/superdesk/superdesk-core.git@async#egg=superdesk-core
+-e git+https://github.com/superdesk/superdesk-core.git@develop-async#egg=superdesk-core

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -23,4 +23,4 @@ aioresponses
 
 -e .
 # Install in editable state so we get feature fixtures
--e git+https://github.com/MarkLark86/superdesk-core.git@STT-1203#egg=superdesk-core
+-e git+https://github.com/superdesk/superdesk-core.git@develop-async#egg=superdesk-core

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -23,4 +23,4 @@ aioresponses
 
 -e .
 # Install in editable state so we get feature fixtures
--e git+https://github.com/superdesk/superdesk-core.git@develop-async#egg=superdesk-core
+-e git+https://github.com/MarkLark86/superdesk-core.git@STT-1203#egg=superdesk-core


### PR DESCRIPTION
### Purpose
Add new ``ASSIGNMENT_LINK_DUPLICATE_CONTENT`` config that allows to link content duplicates to Assignments.

### What has changed
* New config ``ASSIGNMENT_LINK_DUPLICATE_CONTENT`` (defaults to false)
* Use `develop-async` branch from superdesk-core
* Add hooks for item_duplicate, which links the newly created item to an Assignment if required

Resolves: [STT-1203](https://sofab.atlassian.net/browse/STT-1203)
Depends on: https://github.com/superdesk/superdesk-core/pull/3016
Note: Temporarily uses STT-1203 branch from core (for test purposes)

[STT-1203]: https://sofab.atlassian.net/browse/STT-1203?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ