### PR TITLE
[SDESK-7760] - Add missing fields to json events ingest tests and sample file

### DIFF
--- a/server/planning/feed_parsers/event_format_sample.json
+++ b/server/planning/feed_parsers/event_format_sample.json
@@ -174,5 +174,12 @@
 		"name": "random123"
 	},
 	"slugline": "TEST slugline",
-	"ednote": "TEST editorial note"
+	"ednote": "TEST editorial note",
+	"registration_details": "TEST Registration details",
+	"invitation_details": "TEST Invitation details",
+	"accreditation_info": "TEST Accreditation info",
+	"accreditation_deadline": "2021-03-15T10:00:00+0000",
+	"reference": "2021/00000001",
+	"priority": 3,
+	"language": "en"
 }

--- a/server/planning/feed_parsers/event_json_tests.py
+++ b/server/planning/feed_parsers/event_json_tests.py
@@ -91,3 +91,11 @@ class EventJsonFeedParserTestCase(TestCase):
             assert int(events[0]["location"][0]["location"]["lon"]) == 10
 
             assert "actioned_date" not in events[0]
+
+            assert events[0]["registration_details"] == "TEST Registration details"
+            assert events[0]["invitation_details"] == "TEST Invitation details"
+            assert events[0]["accreditation_info"] == "TEST Accreditation info"
+            assert events[0]["accreditation_deadline"].isoformat() == "2021-03-15T10:00:00+00:00"
+            assert events[0]["reference"] == "2021/00000001"
+            assert events[0]["priority"] == 3
+            assert events[0]["language"] == "en"

--- a/server/planning/feed_parsers/superdesk_event_json.py
+++ b/server/planning/feed_parsers/superdesk_event_json.py
@@ -69,6 +69,9 @@ class EventJsonFeedParser(FileFeedParser):
         if superdesk_event.get("firstcreated"):
             superdesk_event["firstcreated"] = self.datetime(superdesk_event["firstcreated"])
 
+        if superdesk_event.get("accreditation_deadline"):
+            superdesk_event["accreditation_deadline"] = self.datetime(superdesk_event["accreditation_deadline"])
+
         if superdesk_event.get("subject"):
             subject_code_items = get_subjectcodeitems()
 


### PR DESCRIPTION
### Purpose
Add missing fields to JSON events ingest tests and sample file

### What has changed
- Added the 7 highlighted missing fields in `event_format_sample.json`
- Added datetime conversion logic for `accreditation_deadline` field to ensure proper parsing in `_transform_from_superdesk_event`
- Added test assertions to verify all new fields are correctly parsed

### Steps to test
1. Run the JSON event parser tests
2. Check that the sample JSON file contains all the new fields with correct formatting

Resolves: [SDESK-7760](https://sofab.atlassian.net/browse/SDESK-7760)



[SDESK-7760]: https://sofab.atlassian.net/browse/SDESK-7760?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ