### PR TITLE
add custom fields to coverage schema

### DIFF
--- a/server/features/planning.feature
+++ b/server/features/planning.feature
@@ -287,7 +287,10 @@ Feature: Planning
                     "planning": {
                         "ednote": "test coverage, I want 250 words",
                         "headline": "test headline",
-                        "slugline": "test slugline"
+                        "slugline": "test slugline",
+                        "fields": [
+                            {"value": "<p>test content</p>", "field": "custom"}
+                        ]
                     }
                 }
             ]
@@ -310,7 +313,10 @@ Feature: Planning
                     "planning": {
                         "ednote": "test coverage, I want 250 words",
                         "headline": "test headline",
-                        "slugline": "test slugline"
+                        "slugline": "test slugline",
+                        "fields": [
+                            {"value": "<p>test content</p>", "field": "custom"}
+                        ]
                     }
                 }
             ]
@@ -329,7 +335,10 @@ Feature: Planning
                     "planning": {
                         "ednote": "test coverage, I want 250 words",
                         "headline": "test headline",
-                        "slugline": "test slugline"
+                        "slugline": "test slugline",
+                        "fields": [
+                            {"value": "<p>test content</p>", "field": "custom"}
+                        ]
                     },
                     "assigned_to": {
                         "desk": "Politic Desk",
@@ -355,7 +364,11 @@ Feature: Planning
                     "planning": {
                         "ednote": "test coverage, I want 250 words",
                         "headline": "test headline",
-                        "slugline": "test slugline"
+                        "slugline": "test slugline",
+                        "fields": [
+                            {"value": "<p>test content</p>", "field": "custom"}
+                        ]
+         
                     },
                     "assigned_to": {
                         "desk": "Politic Desk",
@@ -368,6 +381,19 @@ Feature: Planning
         """
         When we get "assignments/#firstassignment#"
         Then we get OK response
+        """
+        {
+            "_id": "#firstassignment#",
+            "planning": {
+                "ednote": "test coverage, I want 250 words",
+                "headline": "test headline",
+                "slugline": "test slugline",
+                "fields": [
+                    {"value": "<p>test content</p>", "field": "custom"}
+                ]
+            }
+        }
+        """
 
 
     @auth

--- a/server/features/planning.feature
+++ b/server/features/planning.feature
@@ -290,6 +290,9 @@ Feature: Planning
                         "slugline": "test slugline",
                         "fields": [
                             {"value": "<p>test content</p>", "field": "custom"}
+                        ],
+                        "subject": [
+                            {"name": "test", "qcode": "test", "scheme": "test"}
                         ]
                     }
                 }
@@ -316,6 +319,9 @@ Feature: Planning
                         "slugline": "test slugline",
                         "fields": [
                             {"value": "<p>test content</p>", "field": "custom"}
+                        ],
+                        "subject": [
+                            {"name": "test", "qcode": "test", "scheme": "test"}
                         ]
                     }
                 }
@@ -338,6 +344,9 @@ Feature: Planning
                         "slugline": "test slugline",
                         "fields": [
                             {"value": "<p>test content</p>", "field": "custom"}
+                        ],
+                        "subject": [
+                            {"name": "test", "qcode": "test", "scheme": "test"}
                         ]
                     },
                     "assigned_to": {
@@ -367,6 +376,9 @@ Feature: Planning
                         "slugline": "test slugline",
                         "fields": [
                             {"value": "<p>test content</p>", "field": "custom"}
+                        ],
+                        "subject": [
+                            {"name": "test", "qcode": "test", "scheme": "test"}
                         ]
          
                     },
@@ -390,6 +402,9 @@ Feature: Planning
                 "slugline": "test slugline",
                 "fields": [
                     {"value": "<p>test content</p>", "field": "custom"}
+                ],
+                "subject": [
+                    {"name": "test", "qcode": "test", "scheme": "test"}
                 ]
             }
         }

--- a/server/planning/planning/planning_schema.py
+++ b/server/planning/planning/planning_schema.py
@@ -111,6 +111,16 @@ coverage_schema = {
             "workflow_status_reason": {"type": "string", "nullable": True},
             "priority": metadata_schema["priority"],
             "multiple_content": {"type": "boolean", "default": False},
+            "fields": {
+                "type": "list",
+                "schema": {
+                    "type": "dict",
+                    "schema": {
+                        "field": {"type": "string"},
+                        "value": {"type": "string"},
+                    },
+                },
+            },
         },  # end planning dict schema
     },  # end planning
     "news_coverage_status": {
@@ -319,6 +329,13 @@ planning_schema = {
                 "assigned_to": assigned_to_schema["mapping"],
                 "original_creator": {
                     "type": "keyword",
+                },
+                "fields": {
+                    "type": "nested",
+                    "properties": {
+                        "field": not_analyzed,
+                        "value": metadata_schema["body_html"]["mapping"],
+                    },
                 },
             },
         },


### PR DESCRIPTION
STT-1308 STT-1243

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

### Front-end checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)

Resolves: #[issue-number]

