### PR TITLE
add locations field to planning/coverage

### DIFF
--- a/server/features/content_profiles_event.feature
+++ b/server/features/content_profiles_event.feature
@@ -164,7 +164,7 @@ Feature: Event Content Profiles
             },
             "location": {
                 "required": false,
-                "type": "string"
+                "type": "list"
             },
             "name": {
                 "required": true,

--- a/server/planning/content_profiles/profiles/coverage.py
+++ b/server/planning/content_profiles/profiles/coverage.py
@@ -34,6 +34,7 @@ class CoverageSchema(BaseSchema):
     scheduled_updates = schema.ListField()
     priority = schema.IntegerField()
     multiple_content = MultipleContentField(read_only=False, default_value=False)
+    location = schema.ListField()
 
 
 DEFAULT_COVERAGE_PROFILE = {

--- a/server/planning/content_profiles/profiles/event.py
+++ b/server/planning/content_profiles/profiles/event.py
@@ -30,7 +30,7 @@ class EventSchema(BaseSchema):
     internal_note = TextField(field_type="multi_line", expandable=True)
     language = LanguageField()
     links = schema.ListField()
-    location = schema.StringField()
+    location = schema.ListField()
     name = TextField(required=True, field_type="single_line")
     occur_status = schema.DictField()
     occur_status.schema["schema"] = {

--- a/server/planning/content_profiles/profiles/planning.py
+++ b/server/planning/content_profiles/profiles/planning.py
@@ -38,6 +38,7 @@ class PlanningSchema(BaseSchema):
     custom_vocabularies = schema.ListField()
     associated_event = schema.NoneField()
     coverages = schema.ListField()
+    location = schema.ListField()
 
 
 DEFAULT_PLANNING_PROFILE = {

--- a/server/planning/events/events_schema.py
+++ b/server/planning/events/events_schema.py
@@ -216,23 +216,7 @@ events_schema = {
     "subject": planning_schema["subject"],
     "slugline": metadata_schema["slugline"],
     # Item metadata
-    "location": {
-        "type": "list",
-        "mapping": {
-            "type": "object",
-            "dynamic": False,
-            "properties": {
-                "qcode": not_analyzed,
-                "name": {"type": "string"},
-                "address": {"type": "object", "dynamic": True},
-                "geo": {"type": "string"},
-                "location": {"type": "geo_point"},
-                "translations": {"enabled": False},  # explicitly disable
-                "details": {"type": "string"},
-            },
-        },
-        "nullable": True,
-    },
+    "location": planning_schema["location"],
     "participant": {
         "type": "list",
         "mapping": {"properties": {"qcode": not_analyzed, "name": not_analyzed}},

--- a/server/planning/planning/planning_schema.py
+++ b/server/planning/planning/planning_schema.py
@@ -39,6 +39,24 @@ assigned_to_schema = {
     },
 }
 
+location_schema = {
+    "type": "list",
+    "mapping": {
+        "type": "object",
+        "dynamic": False,
+        "properties": {
+            "qcode": not_analyzed,
+            "name": {"type": "string"},
+            "address": {"type": "object", "dynamic": True},
+            "geo": {"type": "string"},
+            "location": {"type": "geo_point"},
+            "translations": {"enabled": False},  # explicitly disable
+            "details": {"type": "string"},
+        },
+    },
+    "nullable": True,
+}
+
 coverage_schema = {
     # Identifiers
     "coverage_id": {"type": "string", "mapping": not_analyzed},
@@ -112,7 +130,54 @@ coverage_schema = {
             "priority": metadata_schema["priority"],
             "multiple_content": {"type": "boolean", "default": False},
             "anpa_category": metadata_schema["anpa_category"],
+            "location": location_schema,
         },  # end planning dict schema
+        "mapping": {
+            "type": "object",
+            "dynamic": False,
+            "properties": {
+                "ednote": metadata_schema["ednote"]["mapping"],
+                "g2_content_type": {"type": "keyword"},
+                "coverage_provider": {"type": "keyword"},
+                "contact_info": {"type": "keyword"},
+                "item_class": {"type": "keyword"},
+                "item_count": {"type": "keyword"},
+                "news_coverage_status": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "keyword"},
+                        "qcode": {"type": "keyword"},
+                    },
+                },
+                "scheduled": {"type": "date"},
+                "service": {"properties": {"qcode": {"type": "keyword"}, "name": {"type": "keyword"}}},
+                "news_content_characteristics": {
+                    "properties": {"name": {"type": "keyword"}, "value": {"type": "keyword"}}
+                },
+                "planning_ext_property": {
+                    "properties": {
+                        "qcode": {"type": "keyword"},
+                        "value": {"type": "keyword"},
+                        "name": {"type": "keyword"},
+                    }
+                },
+                "by": {"type": "text"},
+                "credit_line": {"type": "text"},
+                "dateline": {"type": "text"},
+                "description_text": metadata_schema["description_text"]["mapping"],
+                "genre": metadata_schema["genre"]["mapping"],
+                "headline": metadata_schema["headline"]["mapping"],
+                "keyword": {"type": "text"},
+                "language": metadata_schema["language"]["mapping"],
+                "slugline": metadata_schema["slugline"]["mapping"],
+                "subject": metadata_schema["subject"]["mapping"],
+                "internal_note": {"type": "text"},
+                "workflow_status_reason": {"type": "text"},
+                "priority": {"type": "keyword"},
+                "anpa_category": metadata_schema["anpa_category"]["mapping"],
+                "location": location_schema["mapping"],
+            },
+        },
     },  # end planning
     "news_coverage_status": {
         "type": "dict",
@@ -168,6 +233,8 @@ coverage_schema = {
         },
     },  # end scheduled_updates
 }  # end coverage_schema
+
+coverage_mapping = {k: v["mapping"] for k, v in coverage_schema.items() if v.get("mapping")}
 
 event_type = deepcopy(Resource.rel("events", type="string"))
 event_type["mapping"] = not_analyzed
@@ -291,6 +358,7 @@ planning_schema = {
     "priority": metadata_schema["priority"],
     "urgency": metadata_schema["urgency"],
     "profile": metadata_schema["profile"],
+    "location": location_schema,
     # These next two are for spiking/unspiking and purging of planning/agenda items
     "state": WORKFLOW_STATE_SCHEMA,
     "expiry": {"type": "datetime", "nullable": True},
@@ -309,20 +377,8 @@ planning_schema = {
         },
         "mapping": {
             "type": "nested",
-            "properties": {
-                "coverage_id": not_analyzed,
-                "planning": {
-                    "type": "object",
-                    "properties": {
-                        "slugline": metadata_schema["slugline"]["mapping"],
-                        "multiple_content": {"type": "boolean"},
-                    },
-                },
-                "assigned_to": assigned_to_schema["mapping"],
-                "original_creator": {
-                    "type": "keyword",
-                },
-            },
+            "dynamic": False,
+            "properties": coverage_mapping,
         },
     },
     # field to sync coverage scheduled information


### PR DESCRIPTION
STT-1317

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

### Front-end checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)

Resolves: #[issue-number]

