### PR TITLE
keep assignment status on move with multiple content enabled

### DIFF
--- a/server/features/assignments_multi_content.feature
+++ b/server/features/assignments_multi_content.feature
@@ -533,3 +533,35 @@ Feature: Assignment with multiple linked content
         """
         {"lock_action": "__none__"}
         """
+
+    @auth
+    Scenario: Sending to desk keeps assignment in progress
+        When we post to "/assignments/content"
+        """
+        [{"assignment_id": "#ASSIGNMENT_ID#"}]
+        """
+        Then we get OK response
+        Then we store "CONTENT_1_ID" with value "#content._id#" to context
+
+        When we get "/assignments/#ASSIGNMENT_ID#"
+        Then we get existing resource
+        """
+        {"assigned_to": {"state": "in_progress"}}
+        """
+
+        When we post to "desks"
+        """
+        {"name": "Finance"}
+        """
+        Then we get ok response
+
+        When we post to "/archive/#CONTENT_1_ID#/move"
+        """
+        [{"task": {"desk": "#desks._id#", "stage": "#desks.incoming_stage#"}}]
+        """
+
+        When we get "/assignments/#ASSIGNMENT_ID#"
+        Then we get existing resource
+        """
+        {"assigned_to": {"state": "in_progress"}}
+        """

--- a/server/planning/assignments/assignments.py
+++ b/server/planning/assignments/assignments.py
@@ -985,9 +985,11 @@ class AssignmentsService(AsyncBaseService):
                 )
                 updated_assignment.get("assigned_to")["desk"] = assignment_update_data.get("item_desk_id")
                 updated_assignment.get("assigned_to")["assignor_user"] = assignment_update_data.get("item_user_id")
-                updated_assignment.get("assigned_to")["state"] = get_next_assignment_status(
-                    updated_assignment, ASSIGNMENT_WORKFLOW_STATE.SUBMITTED
-                )
+
+                if not assignment_allows_multiple_content_linked(assignment):
+                    updated_assignment.get("assigned_to")["state"] = get_next_assignment_status(
+                        updated_assignment, ASSIGNMENT_WORKFLOW_STATE.SUBMITTED
+                    )
 
                 await self._update_assignment_and_notify(updated_assignment, assignment)
                 await AssignmentsHistoryAsyncService().on_item_updated(


### PR DESCRIPTION
STT-1323

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

### Front-end checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)

Resolves: #[issue-number]

