### PR TITLE
Add custom text field validation fix field changes

### DIFF
--- a/client/components/Coverages/CoverageEditor/CoverageForm.tsx
+++ b/client/components/Coverages/CoverageEditor/CoverageForm.tsx
@@ -29,6 +29,7 @@ import {coverageProfiles} from '../../../selectors/coverageProfiles';
 import '../style.scss';
 import {VOCABULARIES_TO_BE_EXCLUDED} from '../../../utils/contentProfiles';
 import {isCustomVocabulary} from '../../../helpers';
+import {notNullOrUndefined} from '@sourcefabric/common';
 
 interface IOwnProps {
     field: string;
@@ -109,6 +110,7 @@ export class CoverageFormComponent extends React.Component<IProps, IState> {
         this.onRemoveXmpFile = this.onRemoveXmpFile.bind(this);
         this.onContentTypeChange = this.onContentTypeChange.bind(this);
         this.toggleAddToWorkflow = this.toggleAddToWorkflow.bind(this);
+        this.onCustomTextFieldChange = this.onCustomTextFieldChange.bind(this);
         this.onAnpaCategoryChange = this.onAnpaCategoryChange.bind(this);
 
         this.dom = {
@@ -133,36 +135,27 @@ export class CoverageFormComponent extends React.Component<IProps, IState> {
 
     onChange(field: string, value: any) {
         const {onChange, index} = this.props;
-        const maybeCustomTextField = superdeskApi.entities.vocabulary.getVocabulary(field);
 
-        // Handle update of custom text field
-        if (maybeCustomTextField?.field_type === 'text') {
-            const coveragesWithoutUpdated =
-                this.props.coverages.filter((x) => x.coverage_id !== this.props.value.coverage_id);
+        onChange(
+            `coverages.${index}.${field}`,
+            value
+        );
+    }
 
+    onCustomTextFieldChange(fieldPath: string, value: string, fieldId: string) {
+        const {onChange, index} = this.props;
+
+        if (this.props.value.planning.fields == null) {
             onChange(
-                'coverages',
-                [
-                    ...coveragesWithoutUpdated,
-                    {
-                        ...this.props.value,
-                        planning: {
-                            ...this.props.value.planning,
-                            fields: [
-                                ...((this.props.value.planning.fields ?? []).filter((x) => x.field != field)),
-                                {
-                                    field: field,
-                                    value: value,
-                                },
-                            ],
-                        }
-                    },
-                ],
+                `coverages.${index}.planning.fields`,
+                [{field: fieldId, value: value}]
             );
         } else {
             onChange(
-                `coverages.${index}.${field}`,
-                value
+                // remove value from change path, because even though fields has items,
+                // we may not yet have this field in the array
+                `coverages.${index}.${fieldPath.replace('.value', '')}`,
+                {field: fieldId, value: value}
             );
         }
     }
@@ -431,12 +424,10 @@ export class CoverageFormComponent extends React.Component<IProps, IState> {
             allVocabularies,
             (vocabulary) => vocabulary?.field_type === 'text'
         );
-
-        const customCVFields = restOfVocabularies
-            .filter((x) =>
-                !VOCABULARIES_TO_BE_EXCLUDED.has(x._id)
-                && isCustomVocabulary(x),
-            )
+        const customCVFields = restOfVocabularies.filter((x) =>
+            !VOCABULARIES_TO_BE_EXCLUDED.has(x._id)
+            && isCustomVocabulary(x),
+        )
             .reduce((prev, curr) => ({
                 ...prev,
                 [curr._id]: {
@@ -445,9 +436,16 @@ export class CoverageFormComponent extends React.Component<IProps, IState> {
                 }
             }), {});
 
+        const coverageProfile =
+            coverageProfiles(planningApi.redux.store.getState()).find((x) => x._id === this.props.value.profile);
         const textFieldConfigs = customTextFields.reduce((prev, curr, i) => ({
             ...prev,
-            [curr._id]: {field: `planning.fields.[${i}].value`}
+            [curr._id]: {
+                field: `planning.fields.[${i}].value`,
+                required: coverageProfile.schema[curr._id].required,
+                actualFieldId: curr._id, // stores the actual field id from the pre-configured field, used for access
+                onChange: (_fieldPath, value, fieldId) => this.onCustomTextFieldChange(_fieldPath, value, fieldId),
+            },
         }), {});
 
         const fieldProps = {

--- a/client/components/UI/Form/TextArea.tsx
+++ b/client/components/UI/Form/TextArea.tsx
@@ -5,13 +5,35 @@ import {debounce} from 'lodash';
 
 import './style.scss';
 
+interface ITextAreaProps {
+    field?: string;
+    value?: string;
+    onChange?: (...args: any) => void;
+    autoHeight?: boolean;
+    autoHeightTimeout?: number;
+    nativeOnChange?: boolean;
+    placeholder?: string;
+    readOnly?: boolean;
+    paddingRight60?: boolean;
+    multiLine?: boolean;
+    className?: string;
+    initialFocus?: boolean;
+    actualFieldId?: string;
+    refNode?: (node: HTMLTextAreaElement | null) => void;
+    rows?: number;
+    [key: string]: any;
+}
+
 /**
  * @ngdoc react
  * @name TextArea
  * @description Auto-resizing component to multi-line text input
  */
-export class TextArea extends React.Component {
-    constructor(props) {
+export class TextArea extends React.Component<ITextAreaProps> {
+    dom: { input: HTMLTextAreaElement | null };
+    delayedResize: ((value?: string) => void) | null;
+
+    constructor(props: ITextAreaProps) {
         super(props);
         this.dom = {input: null};
         this.autoResize = this.autoResize.bind(this);
@@ -20,22 +42,22 @@ export class TextArea extends React.Component {
     }
 
     componentDidMount() {
-        this.delayedResize = debounce(this.autoResize, this.props.autoHeightTimeout);
-        if (this.props.autoHeight) {
+        this.delayedResize = debounce(this.autoResize, this.props.autoHeightTimeout || 50);
+        if (this.props.autoHeight ?? true) {
             this.delayedResize();
         }
         if (this.props.initialFocus) {
-            this.dom.input.focus();
+            this.dom.input?.focus();
         }
     }
 
-    componentWillReceiveProps(nextProps) {
-        if (this.props.autoHeight && nextProps.value !== this.props.value) {
-            this.delayedResize(nextProps.value);
+    componentWillReceiveProps(nextProps: ITextAreaProps) {
+        if ((this.props.autoHeight ?? true) && nextProps.value !== this.props.value) {
+            this.delayedResize?.(nextProps.value);
         }
     }
 
-    autoResize(value = null) {
+    autoResize(value: string | null = null) {
         if (this.dom.input) {
             if (value !== null) {
                 this.dom.input.value = value;
@@ -52,20 +74,21 @@ export class TextArea extends React.Component {
         }
     }
 
-    onChange(event) {
-        const {nativeOnChange, onChange, field, autoHeight, multiLine} = this.props;
+    onChange(event: React.ChangeEvent<HTMLTextAreaElement>) {
+        const {nativeOnChange, onChange, field, autoHeight = true, multiLine = true} = this.props;
 
-        if (nativeOnChange) {
+        if (nativeOnChange && typeof onChange === 'function') {
             onChange(event);
-        } else {
+        } else if (onChange && field) {
             onChange(
                 field,
-                multiLine ? event.target.value : event.target.value.replace('\n', '')
+                multiLine ? event.target.value : event.target.value.replace('\n', ''),
+                this.props.actualFieldId,
             );
         }
 
         if (autoHeight) {
-            this.delayedResize();
+            this.delayedResize?.();
         }
     }
 
@@ -73,7 +96,7 @@ export class TextArea extends React.Component {
         const {
             field,
             value,
-            autoHeight,
+            autoHeight = true,
             readOnly,
             placeholder,
             paddingRight60,
@@ -84,7 +107,11 @@ export class TextArea extends React.Component {
             // Remove these variables from the props variable
             // So they are not passed down to the textarea dom node
             // eslint-disable-next-line no-unused-vars
-            onChange, autoHeightTimeout, nativeOnChange, multiLine, initialFocus,
+            onChange,
+            autoHeightTimeout,
+            nativeOnChange,
+            multiLine = true,
+            initialFocus,
 
             ...props
         } = this.props;
@@ -117,31 +144,3 @@ export class TextArea extends React.Component {
         );
     }
 }
-
-TextArea.propTypes = {
-    field: PropTypes.string,
-    value: PropTypes.string,
-    onChange: PropTypes.func,
-    autoHeight: PropTypes.bool,
-    autoHeightTimeout: PropTypes.number,
-    nativeOnChange: PropTypes.bool,
-    placeholder: PropTypes.string,
-    readOnly: PropTypes.bool,
-    paddingRight60: PropTypes.bool,
-    multiLine: PropTypes.bool,
-    className: PropTypes.string,
-    initialFocus: PropTypes.bool,
-    refNode: PropTypes.func,
-    rows: PropTypes.number,
-};
-
-TextArea.defaultProps = {
-    readOnly: false,
-    autoHeight: true,
-    autoHeightTimeout: 50,
-    nativeOnChange: false,
-    paddingRight60: false,
-    multiLine: true,
-    initialFocus: false,
-    rows: 1,
-};

--- a/client/components/UI/Form/TextAreaInput.tsx
+++ b/client/components/UI/Form/TextAreaInput.tsx
@@ -27,6 +27,7 @@ export const TextAreaInput = ({
     refNode,
     rows,
     labelIcon,
+    actualFieldId,
     ...props
 }) => {
     const textareaId = uniqueId('textarea-');
@@ -35,6 +36,7 @@ export const TextAreaInput = ({
         <LineInput {...props} readOnly={readOnly}>
             <Label htmlFor={textareaId} text={label} icon={labelIcon} />
             <TextArea
+                actualFieldId={actualFieldId}
                 field={field}
                 value={value}
                 onChange={onChange}

--- a/client/validators/planning.ts
+++ b/client/validators/planning.ts
@@ -6,10 +6,11 @@ import * as selectors from '../selectors';
 import {gettext, getItemInArrayById} from '../utils';
 
 import {getVocabularyItemsForScheme, validateField, validators} from './index';
-import {ICoverageContentProfile, IPlanningCoverageItem} from 'interfaces';
-import {planningApi} from '../superdeskApi';
+import {ICoverageContentProfile, IPlanningCoverageItem, IPlanningItem} from 'interfaces';
+import {planningApi, superdeskApi} from '../superdeskApi';
 import {getCoverageFields} from '../api/editor/item_planning';
 import {vocabularies} from '../api/vocabularies';
+import {Dictionary} from 'superdesk-api';
 
 const validatePlanningScheduleDate = ({getState, field, value, errors, messages, diff, item}) => {
     // Only validate the schedule if it has changed
@@ -97,6 +98,7 @@ export const validateCoverages = ({
         const coverageProfile = getCoverageFields(coverage.planning.g2_content_type).profile;
 
         validateCoverageVocabularyFields(coverageProfile, errors, messages, diff.coverages[index]);
+        validateCoverageCustomTextFields(coverageProfile, errors, messages, diff.coverages[index]);
 
         const isValidSubject = coverageProfile.schema['subject']?.required
             ? !isEmpty((diff.coverages[index].subject ?? []).filter((x) => x.scheme == null))
@@ -172,6 +174,35 @@ export const validateCoverageVocabularyFields = (
         });
 };
 
+export const validateCoverageCustomTextFields = (
+    coverageProfile: ICoverageContentProfile,
+    errors: Dictionary<string, string>,
+    messages: Array<string>,
+    diff: IPlanningCoverageItem,
+): void => {
+    const allVocabularies = superdeskApi.entities.vocabulary.getAll().toArray();
+    const textFieldLabels = new Map(allVocabularies.map((x) => [x._id, x.display_name]));
+
+    Object.keys(coverageProfile.schema).filter((fieldId) => {
+        const hasNoDefinedValidator = !validators['coverage'][fieldId];
+        const isCustomTextField = coverageProfile.schema[fieldId].type === 'custom_text';
+
+        return hasNoDefinedValidator && isCustomTextField;
+    })
+        .forEach((fieldId) => {
+            const isInvalid = coverageProfile.schema[fieldId].required
+                ? ((diff.planning.fields ?? []).find((x) => x.field === fieldId)?.value ?? '').length < 1
+                : false;
+
+            if (isInvalid) {
+                errors[fieldId] = gettext('This field is required');
+                messages.push(gettext('{{ key }} is a required field', {key: textFieldLabels.get(fieldId)}));
+            } else {
+                errors[fieldId] = null;
+            }
+        });
+};
+
 const validateCoverageScheduleDate = ({
     getState,
     field,
@@ -202,7 +233,7 @@ const validateCoverageScheduleDate = ({
     const today = moment();
 
     if (!field.endsWith('_scheduledTime') &&
-            validateSchedule && moment.isMoment(value) && value.isBefore(today, 'day')) {
+        validateSchedule && moment.isMoment(value) && value.isBefore(today, 'day')) {
         set(errors, `${field}.date`, gettext('Date is in the past'));
 
         if (!canCreateInPast) {
@@ -252,7 +283,7 @@ const validateScheduledUpdatesDate = ({
                 'scheduled') : null;
 
             if ((coverageSchedule && schedule <= coverageSchedule) ||
-                    (previousSchedule && schedule <= previousSchedule)) {
+                (previousSchedule && schedule <= previousSchedule)) {
                 errors.scheduled_updates[planningSchedules.length - 1 - index] = {
                     planning: {
                         _scheduledTime: gettext('Should be after the previous scheduled update/coverage'),


### PR DESCRIPTION
STT-1309

### Purpose
Add validation for custom text fields in coverages. Fix onChange handling after noticing it previously worked, but wasn't accessing and storing field info how it should. 

### What has changed
Introduce validation for custom text fields. Change textArea component to support an additional property that is used later in the change handler for custom text fields. 