### PR TITLE
Use improved abstraction for custom_text fields

### DIFF
--- a/client/components/Coverages/CoverageEditor/CoverageForm.tsx
+++ b/client/components/Coverages/CoverageEditor/CoverageForm.tsx
@@ -133,38 +133,11 @@ export class CoverageFormComponent extends React.Component<IProps, IState> {
 
     onChange(field: string, value: any) {
         const {onChange, index} = this.props;
-        const maybeCustomTextField = superdeskApi.entities.vocabulary.getVocabulary(field);
 
-        // Handle update of custom text field
-        if (maybeCustomTextField?.field_type === 'text') {
-            const coveragesWithoutUpdated =
-                this.props.coverages.filter((x) => x.coverage_id !== this.props.value.coverage_id);
-
-            onChange(
-                'coverages',
-                [
-                    ...coveragesWithoutUpdated,
-                    {
-                        ...this.props.value,
-                        planning: {
-                            ...this.props.value.planning,
-                            fields: [
-                                ...((this.props.value.planning.fields ?? []).filter((x) => x.field != field)),
-                                {
-                                    field: field,
-                                    value: value,
-                                },
-                            ],
-                        }
-                    },
-                ],
-            );
-        } else {
-            onChange(
-                `coverages.${index}.${field}`,
-                value
-            );
-        }
+        onChange(
+            `coverages.${index}.${field}`,
+            value
+        );
     }
 
     onTimeToBeConfirmed() {
@@ -427,7 +400,7 @@ export class CoverageFormComponent extends React.Component<IProps, IState> {
         };
 
         const allVocabularies = superdeskApi.entities.vocabulary.getAll().toArray();
-        const [customTextFields, restOfVocabularies] = partition(
+        const [_, restOfVocabularies] = partition(
             allVocabularies,
             (vocabulary) => vocabulary?.field_type === 'text'
         );
@@ -445,10 +418,16 @@ export class CoverageFormComponent extends React.Component<IProps, IState> {
                 }
             }), {});
 
-        const textFieldConfigs = customTextFields.reduce((prev, curr, i) => ({
-            ...prev,
-            [curr._id]: {field: `planning.fields.[${i}].value`}
-        }), {});
+        const textFieldConfigs = Object.keys(profile.schema)
+            .filter((field) => profile.schema[field]?.type === 'custom_text')
+            .reduce((prev, field) => ({
+                ...prev,
+                [field]: {
+                    field: field,
+                    storageField: 'planning.fields',
+                    valueStoredAsArray: true,
+                },
+            }), {});
 
         const fieldProps = {
             ...customCVFields,

--- a/client/components/fields/editor/CustomText.interface.ts
+++ b/client/components/fields/editor/CustomText.interface.ts
@@ -1,0 +1,6 @@
+import {IEditorFieldProps} from 'interfaces';
+
+export interface ICustomTextFieldProps extends IEditorFieldProps {
+    storageField: string;
+    valueStoredAsArray?: boolean;
+}

--- a/client/components/fields/editor/CustomText.interface.ts
+++ b/client/components/fields/editor/CustomText.interface.ts
@@ -1,4 +1,4 @@
-import {IEditorFieldProps} from 'interfaces';
+import {IEditorFieldProps} from '../../../interfaces';
 
 export interface ICustomTextFieldProps extends IEditorFieldProps {
     storageField: string;

--- a/client/components/fields/editor/CustomText.tsx
+++ b/client/components/fields/editor/CustomText.tsx
@@ -1,0 +1,90 @@
+import * as React from 'react';
+import {get} from 'lodash';
+
+import {superdeskApi} from '../../../superdeskApi';
+import {ICoveragePlanningDetails} from '../../../interfaces';
+import {ICustomTextFieldProps} from './CustomText.interface';
+
+import {Input} from 'superdesk-ui-framework/react';
+import {Row, TextAreaInput} from '../../UI/Form';
+
+export class EditorFieldCustomText extends React.PureComponent<ICustomTextFieldProps> {
+    render() {
+        const {
+            field,
+            item,
+            storageField,
+            errors,
+            testId,
+            required,
+            schema,
+            disabled,
+            invalid,
+            showErrors,
+            language,
+        } = this.props;
+
+        const cv = superdeskApi.entities.vocabulary.getVocabulary(field);
+        const isSingleLine = cv.field_type === 'text' && cv.field_options?.single === true;
+
+        let value: string;
+        let onChange: (newValue: string) => void;
+
+        if (this.props.valueStoredAsArray) {
+            const fields: ICoveragePlanningDetails['fields'] = get(item, storageField ?? 'fields', []) || [];
+
+            value = fields.find((f) => f.field === field)?.value ?? '';
+            onChange = (newValue: string) => {
+                const otherFields = fields.filter((f) => f.field !== field);
+
+                this.props.onChange(
+                    storageField ?? 'fields',
+                    [...otherFields, {field: field, value: newValue}],
+                );
+            };
+        } else {
+            value = get(item, storageField ?? field, '') ?? '';
+            onChange = (newValue: string) => {
+                this.props.onChange(storageField ?? field, newValue);
+            };
+        }
+
+        const error: string | undefined = get(errors ?? {}, field);
+        const label = cv?.translations?.display_name?.[language] ?? cv?.display_name ?? this.props.label;
+
+        return (
+            <Row
+                key={cv?._id}
+                id={`form-row-${cv?.display_name}`}
+                testId={testId?.length ? testId : cv?._id}
+            >
+                {isSingleLine ? (
+                    <Input
+                        value={value}
+                        type="text"
+                        label={label}
+                        required={required ?? schema?.required}
+                        disabled={disabled}
+                        maxLength={schema?.maxlength}
+                        error={showErrors ? error : undefined}
+                        onChange={onChange}
+                    />
+                ) : (
+                    <TextAreaInput
+                        field={field}
+                        value={value}
+                        label={label}
+                        required={required ?? schema?.required}
+                        readOnly={disabled}
+                        maxLength={schema?.maxlength}
+                        invalid={invalid ?? (error != null && showErrors)}
+                        noMargin={true}
+                        onChange={(_field: string, newValue: string) => {
+                            onChange(newValue);
+                        }}
+                    />
+                )}
+            </Row>
+        );
+    }
+}

--- a/client/extension_bridge.ts
+++ b/client/extension_bridge.ts
@@ -43,7 +43,7 @@ import {VOCABULARIES_TO_BE_EXCLUDED} from './utils/contentProfiles';
 import {isCustomVocabulary} from './helpers';
 import {ICustomCVFieldProps} from './components/fields/editor/CustomCV.interface';
 import {ICustomTextFieldProps} from 'components/fields/editor/CustomText.interface';
-import {EditorFieldCustomText} from 'components/fields/editor/CustomText';
+import {EditorFieldCustomText} from './components/fields/editor/CustomText';
 import {appConfig} from 'appConfig';
 
 // KEEP IN SYNC WITH client/planning-extension/src/extension_bridge.ts

--- a/client/extension_bridge.ts
+++ b/client/extension_bridge.ts
@@ -39,14 +39,12 @@ import {EditorFieldEventRecurringRules} from './components/fields/editor/EventRe
 import {IEventScheduleFieldProps} from './components/fields/editor/EventSchedule.interface';
 import {EditorFieldEventSchedule} from './components/fields/editor/EventSchedule';
 import {EditorFieldCV} from './components/fields/editor/CustomCV';
-import {EditorFieldText} from './components/fields/editor/base/text';
-import {EditorFieldTextArea} from './components/fields/editor/base/textArea';
 import {VOCABULARIES_TO_BE_EXCLUDED} from './utils/contentProfiles';
 import {isCustomVocabulary} from './helpers';
 import {ICustomCVFieldProps} from './components/fields/editor/CustomCV.interface';
+import {ICustomTextFieldProps} from 'components/fields/editor/CustomText.interface';
+import {EditorFieldCustomText} from 'components/fields/editor/CustomText';
 import {appConfig} from 'appConfig';
-import {IEditorFieldTextAreaProps} from 'components/fields/editor/base/textArea.interface';
-import {IEditorFieldTextProps} from 'components/fields/editor/base/text.interface';
 
 // KEEP IN SYNC WITH client/planning-extension/src/extension_bridge.ts
 interface IExtensionBridge {
@@ -79,8 +77,7 @@ interface IExtensionBridge {
             EditorFieldEventRecurringRules: React.ComponentType<IEditorFieldEventRecurringRulesProps>;
             EditorFieldEventSchedule: React.ComponentType<IEventScheduleFieldProps>;
             EditorFieldCV: React.ComponentType<ICustomCVFieldProps>;
-            EditorFieldText: React.ComponentType<IEditorFieldTextProps>;
-            EditorFieldTextArea: React.ComponentType<IEditorFieldTextAreaProps>;
+            EditorFieldCustomText: React.ComponentType<ICustomTextFieldProps>;
         },
     }
     ui: {
@@ -147,8 +144,7 @@ export const extensionBridge: IExtensionBridge = {
             EditorFieldEventRecurringRules: EditorFieldEventRecurringRules,
             EditorFieldEventSchedule: EditorFieldEventSchedule,
             EditorFieldCV: EditorFieldCV,
-            EditorFieldText: EditorFieldText,
-            EditorFieldTextArea: EditorFieldTextArea,
+            EditorFieldCustomText: EditorFieldCustomText,
         },
     },
     ui: {

--- a/client/planning-extension/src/extension.ts
+++ b/client/planning-extension/src/extension.ts
@@ -313,14 +313,9 @@ const extension: IExtension = {
         });
 
         customTextFields.forEach((field) => {
-            const isSingleLine = field.field_options?.single ?? false;
-            const TextField = isSingleLine
-                ? extensionBridge.editor.fields.EditorFieldText
-                : extensionBridge.editor.fields.EditorFieldTextArea;
-
             registerEditorField(
                 field._id,
-                TextField as any,
+                extensionBridge.editor.fields.EditorFieldCustomText as any,
                 () => ({
                     label: field.display_name,
                     field: field._id,

--- a/client/planning-extension/src/extension_bridge.ts
+++ b/client/planning-extension/src/extension_bridge.ts
@@ -14,9 +14,8 @@ import {IPropsEditorFieldCoverages} from '../../components/fields/editor/coverag
 import {IEditorFieldLocationProps} from '../../components/fields/editor/Location.interface';
 import {IEditorFieldEventRecurringRulesProps} from '../../components/fields/editor/EventRecurringRules.interface';
 import {IEventScheduleFieldProps} from '../../components/fields/editor/EventSchedule.interface';
-import {IEditorFieldTextProps} from '../../components/fields/editor/base/text.interface';
-import {IEditorFieldTextAreaProps} from '../../components/fields/editor/base/textArea.interface';
 import {ICustomCVFieldProps} from '../../components/fields/editor/CustomCV.interface';
+import {ICustomTextFieldProps} from '../../components/fields/editor/CustomText.interface';
 
 interface IEditorFieldVocabularyProps extends IEditorFieldProps {
     options: Array<any>;
@@ -59,8 +58,7 @@ interface IExtensionBridge {
             EditorFieldEventRecurringRules: React.ComponentType<IEditorFieldEventRecurringRulesProps>;
             EditorFieldEventSchedule: React.ComponentType<IEventScheduleFieldProps>;
             EditorFieldCV: React.ComponentType<ICustomCVFieldProps>;
-            EditorFieldText: React.ComponentType<IEditorFieldTextProps>;
-            EditorFieldTextArea: React.ComponentType<IEditorFieldTextAreaProps>;
+            EditorFieldCustomText: React.ComponentType<ICustomTextFieldProps>;
         },
     }
     ui: {


### PR DESCRIPTION
STT-1309

### Purpose
@MarkLark86 came up with a better abstraction similar to the CustomCV field implementation. Since in the future we'll be adding custom text fields to planning and events, this is better suited for that. Also cleans up the change handling in CoverageForm.tsx. 

### What has changed
Abstract change handling in a custom component responsible for `custom_text` field type. 