### PR TITLE
Improve coverage add to workflow handling

### DIFF
--- a/client/api/coverages.ts
+++ b/client/api/coverages.ts
@@ -12,6 +12,10 @@ function cancelCoverageOrScheduledUpdate<T extends IPlanningCoverageItem | ICove
     nextItem.planning.workflow_status_reason = cancellationReason;
     nextItem.workflow_status = WORKFLOW_STATE.CANCELLED;
 
+    if ('add_coverage_to_workflow' in nextItem) {
+        nextItem.add_coverage_to_workflow = false;
+    }
+
     if (nextItem.assigned_to?.state != null) {
         nextItem.assigned_to.state = WORKFLOW_STATE.CANCELLED;
     }

--- a/client/components/ContentProfiles/CoverageProfileModal.tsx
+++ b/client/components/ContentProfiles/CoverageProfileModal.tsx
@@ -170,10 +170,14 @@ export class CoverageProfilesModal extends React.Component<IProps, IState> {
     updateFields(fields: Array<IProfileFieldEntry>) {
         const profileCloned = cloneDeep(this.state.profile);
 
+        // Make sure `add_to_workflow is always first so
+        // it renders first in the editor
+        profileCloned.editor.add_coverage_to_workflow.index = 0;
+
         fields.forEach((item, index) => {
             profileCloned.editor[item.name] = {...item.field};
             profileCloned.schema[item.name] = {...item.schema};
-            profileCloned.editor[item.name].index = index;
+            profileCloned.editor[item.name].index = index + 1;
         });
 
         this.setState({

--- a/client/components/ContentProfiles/FieldTab/index.tsx
+++ b/client/components/ContentProfiles/FieldTab/index.tsx
@@ -269,7 +269,9 @@ export class FieldTab extends React.Component<IProps, IState> {
                             <FieldList
                                 profile={this.props.profile}
                                 group={undefined}
-                                fields={getGroupFieldsSorted(this.props.profile)}
+                                fields={getGroupFieldsSorted(this.props.profile)
+                                    .filter((field) => field.name !== 'add_coverage_to_workflow')
+                                }
                                 unusedFields={unusedFields}
                                 systemRequiredFields={this.props.systemRequiredFields}
                                 onSortChange={this.updateFieldOrder}
@@ -289,7 +291,9 @@ export class FieldTab extends React.Component<IProps, IState> {
                                     key={group._id}
                                     profile={this.props.profile}
                                     group={group}
-                                    fields={getGroupFieldsSorted(this.props.profile, group._id)}
+                                    fields={getGroupFieldsSorted(this.props.profile, group._id)
+                                        .filter((field) => field.name !== 'add_coverage_to_workflow')
+                                    }
                                     unusedFields={unusedFields}
                                     onSortChange={this.updateFieldOrder}
                                     insertField={this.insertField}

--- a/client/components/Coverages/CoverageEditor/CoverageForm.tsx
+++ b/client/components/Coverages/CoverageEditor/CoverageForm.tsx
@@ -4,7 +4,7 @@ import {get, forEach, partition} from 'lodash';
 import moment from 'moment';
 import {appConfig} from 'appConfig';
 import {planningApi, superdeskApi} from '../../../superdeskApi';
-import {IArticle, IDesk, IVocabularyItem} from 'superdesk-api';
+import {Dictionary, IArticle, IDesk, IVocabularyItem} from 'superdesk-api';
 import {
     EDITOR_TYPE,
     ICoverageScheduledUpdate,
@@ -19,7 +19,7 @@ import {
     IPlanningContentProfile,
 } from '../../../interfaces';
 import * as selectors from '../../../selectors';
-import {planningUtils, generateTempId, assignmentUtils} from '../../../utils';
+import {planningUtils, generateTempId, assignmentUtils, isItemExpired} from '../../../utils';
 import {WORKFLOW_STATE} from '../../../constants';
 import {EditorFieldSelect} from '../../fields/editor/base/select';
 import {renderFieldsForPanel} from '../../fields';
@@ -29,6 +29,7 @@ import {coverageProfiles} from '../../../selectors/coverageProfiles';
 import '../style.scss';
 import {VOCABULARIES_TO_BE_EXCLUDED} from '../../../utils/contentProfiles';
 import {isCustomVocabulary} from '../../../helpers';
+import {isCoverageAssigned, isCoverageDraft} from '../../../utils/planning';
 
 interface IOwnProps {
     field: string;
@@ -312,7 +313,6 @@ export class CoverageFormComponent extends React.Component<IProps, IState> {
 
     toggleAddToWorkflow() {
         const {vocabulary} = superdeskApi.entities;
-        const {gettext} = superdeskApi.localization;
         const coverageStatuses = vocabulary
             .getAll()
             .get('newscoveragestatus').items as Array<IPlanningNewsCoverageStatus>;
@@ -339,22 +339,9 @@ export class CoverageFormComponent extends React.Component<IProps, IState> {
                 ],
             );
         } else {
-            superdeskApi.ui.confirm(gettext('This will also remove coverage\'s assignment'))
-                .then((response) => {
-                    if (response) {
-                        this.props.onChange(
-                            'coverages',
-                            [
-                                ...coveragesWithoutUpdated,
-                                {
-                                    ...this.props.value,
-                                    workflow_status: 'draft',
-                                    assigned_to: {},
-                                    add_coverage_to_workflow: add_coverage_to_workflow,
-                                },
-                            ],
-                        );
-                    }
+            planningApi.coverages.cancelCoverage(this.props.coverages, this.props.value)
+                .then((nextCoverages) => {
+                    this.props.onChange('coverages', nextCoverages);
                 });
         }
     }
@@ -432,7 +419,7 @@ export class CoverageFormComponent extends React.Component<IProps, IState> {
                 },
             }), {});
 
-        const fieldProps = {
+        const fieldProps: Dictionary<keyof IPlanningCoverageItem, any> = {
             ...customCVFields,
             ...textFieldConfigs,
             contact_info: {
@@ -443,15 +430,6 @@ export class CoverageFormComponent extends React.Component<IProps, IState> {
             anpa_category: {
                 field: 'planning.anpa_category',
                 onChange: this.onAnpaCategoryChange,
-            },
-            add_coverage_to_workflow: {
-                onChange: this.toggleAddToWorkflow,
-                planningItem: this.props.item,
-                disabled: !planningUtils.canAddCoverageToWorkflow(
-                    this.props.value,
-                    this.props.diff,
-                    {ignoreAutoAssignConfig: true},
-                ),
             },
             g2_content_type: {
                 readOnly: this.props.readOnly || readOnlyFields.g2_content_type,
@@ -552,6 +530,29 @@ export class CoverageFormComponent extends React.Component<IProps, IState> {
             },
             priority: {field: 'planning.priority'},
         };
+
+        if (appConfig.planning_auto_assign_to_workflow != true) {
+            const shouldDisableToggle = () => {
+                if (this.props.value.add_coverage_to_workflow != true) {
+                    return !(isCoverageDraft(this.props.value)
+                        && isCoverageAssigned(this.props.value)
+                        && !isItemExpired(this.props.diff));
+                } else {
+                    return !planningUtils.canCancelCoverage(this.props.value, this.props.item);
+                }
+            };
+
+            fieldProps.add_coverage_to_workflow = {
+                onChange: this.toggleAddToWorkflow,
+                planningItem: this.props.item,
+
+                /**
+                 * A coverage can be added to workflow if it is in draft state,
+                 * is assigned and the associated planning item is not expired.
+                 */
+                disabled: shouldDisableToggle(),
+            };
+        }
 
         /**
          * `editor.dom.fields` aren't being passed anymore because we no longer have access to it

--- a/client/components/Coverages/CoverageEditor/index.tsx
+++ b/client/components/Coverages/CoverageEditor/index.tsx
@@ -28,6 +28,7 @@ import {getRelatedEventIdsForPlanning} from '../../../utils/planning';
 import {planningApi} from '../../../superdeskApi';
 import {planningApis} from '../../../api';
 import * as selectors from '../../../selectors';
+import {appConfig} from 'superdesk-core/scripts/appConfig';
 
 interface IOwnProps {
     testId?: string;
@@ -248,7 +249,13 @@ export class CoverageEditorComponent extends React.PureComponent<IProps> {
                 },
             ];
 
-            if (planningUtils.canCancelCoverage(value, diff)) {
+            if (
+                planningUtils.canCancelCoverage(value, diff)
+
+                // Show only if adding coverages to workflow is handled automatically
+                // thus toggle in the editor is hidden
+                && appConfig.planning_auto_assign_to_workflow === true
+            ) {
                 itemActions.push({
                     label: gettext('Cancel coverage'),
                     icon: 'icon-close-small',

--- a/client/components/fields/editor/AddCoverageToWorkflow.tsx
+++ b/client/components/fields/editor/AddCoverageToWorkflow.tsx
@@ -6,6 +6,7 @@ import {superdeskApi} from '../../../superdeskApi';
 import {Tooltip} from '@sourcefabric/common';
 import {isItemExpired, planningUtils} from '../../../utils';
 import {IPlanningItem} from 'globals';
+import {WORKFLOW_STATE} from '../../../constants';
 
 type IProps = IEditorFieldProps<IPlanningCoverageItem> & {planningItem: IPlanningItem};
 
@@ -14,6 +15,10 @@ export class EditorFieldAddCoverageToWorkflow extends React.PureComponent<IProps
         const {gettext} = superdeskApi.localization;
         const coverage = this.props.item;
         const planning = this.props.planningItem;
+
+        if (coverage.workflow_status === WORKFLOW_STATE.CANCELLED) {
+            return gettext('Coverage was cancelled');
+        }
 
         if (!planningUtils.isCoverageDraft(coverage)) {
             return gettext('Coverage must be in draft status');
@@ -42,7 +47,10 @@ export class EditorFieldAddCoverageToWorkflow extends React.PureComponent<IProps
                 <EditorFieldToggle
                     {...this.props}
                     field="add_coverage_to_workflow"
-                    label={gettext('Add to workflow')}
+                    label={this.props.item.add_coverage_to_workflow
+                        ? gettext('Cancel coverage')
+                        : gettext('Add to workflow')
+                    }
                     defaultValue={false}
                 />
             </Tooltip>

--- a/client/utils/contentProfiles.ts
+++ b/client/utils/contentProfiles.ts
@@ -259,98 +259,98 @@ export function getFieldNameTranslated(field: string): string {
     const {gettext} = superdeskApi.localization;
 
     switch (field) {
-        case 'recurring_rules':
-            return gettext('Recurring Rules');
-        case 'dates':
-            return gettext('Dates');
-        case 'language':
-            return gettext('Language');
-        case 'slugline':
-            return gettext('Slugline');
-        case 'name':
-            return gettext('Name');
-        case 'definition_short':
-            return gettext('Description Short');
-        case 'reference':
-            return gettext('Reference');
-        case 'calendars':
-            return gettext('Calendars');
-        case 'place':
-            return gettext('Place');
-        case 'occur_status':
-            return gettext('Occur Status');
-        case 'location':
-            return gettext('Location');
-        case 'event_contact_info':
-            return gettext('Contacts');
-        case 'anpa_category':
-            return superdeskApi.entities.vocabulary.getVocabulary('categories').display_name ?? gettext('ANPA Category');
-        case 'subject':
-            return gettext('Subject');
-        case 'definition_long':
-            return gettext('Description Long');
-        case 'internal_note':
-            return gettext('Internal Note');
-        case 'ednote':
-            return gettext('Editorial Note');
-        case 'files':
-            return gettext('Files');
-        case 'links':
-            return gettext('Links');
-        case 'related_plannings':
-            return gettext('Related Plannings');
-        case 'planning_date':
-            return gettext('Planning Date');
-        case 'description_text':
-            return gettext('Description Text');
-        case 'agendas':
-            return gettext('Agendas');
-        case 'urgency':
-            return gettext('Urgency');
-        case 'marked_for_not_publication':
-            return gettext('Marked For Not Publication');
-        case 'overide_auto_assign_to_workflow':
-            return gettext('Override Auto Assign to Workflow');
-        case 'associated_event':
-            return gettext('Associated Event');
-        case 'coverages':
-            return gettext('Coverages');
-        case 'headline':
-            return gettext('Headline');
-        case 'g2_content_type':
-            return gettext('Content Type');
-        case 'add_coverage_to_workflow':
-            return gettext('Add Coverage To Workflow');
-        case 'genre':
-            return gettext('Genre');
-        case 'news_coverage_status':
-            return gettext('Coverage Status');
-        case 'scheduled':
-            return gettext('Scheduled');
-        case 'scheduled_updates':
-            return gettext('Scheduled Updates');
-        case 'contact_info':
-            return gettext('Contacts');
-        case 'keyword':
-            return gettext('Keywords');
-        case 'no_content_linking':
-            return gettext('No Content Linking');
-        case 'xmp_file':
-            return gettext('XMP File');
-        case 'registration_details':
-            return gettext('Registration Details');
-        case 'invitation_details':
-            return gettext('Invitation Details');
-        case 'accreditation_info':
-            return gettext('Accreditation Info');
-        case 'accreditation_deadline':
-            return gettext('Accreditation Deadline');
-        case 'priority':
-            return gettext('Priority');
-        case 'related_items':
-            return gettext('Related Articles');
-        case 'multiple_content':
-            return gettext('Multiple Content');
+    case 'recurring_rules':
+        return gettext('Recurring Rules');
+    case 'dates':
+        return gettext('Dates');
+    case 'language':
+        return gettext('Language');
+    case 'slugline':
+        return gettext('Slugline');
+    case 'name':
+        return gettext('Name');
+    case 'definition_short':
+        return gettext('Description Short');
+    case 'reference':
+        return gettext('Reference');
+    case 'calendars':
+        return gettext('Calendars');
+    case 'place':
+        return gettext('Place');
+    case 'occur_status':
+        return gettext('Occur Status');
+    case 'location':
+        return gettext('Location');
+    case 'event_contact_info':
+        return gettext('Contacts');
+    case 'anpa_category':
+        return superdeskApi.entities.vocabulary.getVocabulary('categories').display_name ?? gettext('ANPA Category');
+    case 'subject':
+        return gettext('Subject');
+    case 'definition_long':
+        return gettext('Description Long');
+    case 'internal_note':
+        return gettext('Internal Note');
+    case 'ednote':
+        return gettext('Editorial Note');
+    case 'files':
+        return gettext('Files');
+    case 'links':
+        return gettext('Links');
+    case 'related_plannings':
+        return gettext('Related Plannings');
+    case 'planning_date':
+        return gettext('Planning Date');
+    case 'description_text':
+        return gettext('Description Text');
+    case 'agendas':
+        return gettext('Agendas');
+    case 'urgency':
+        return gettext('Urgency');
+    case 'marked_for_not_publication':
+        return gettext('Marked For Not Publication');
+    case 'overide_auto_assign_to_workflow':
+        return gettext('Override Auto Assign to Workflow');
+    case 'associated_event':
+        return gettext('Associated Event');
+    case 'coverages':
+        return gettext('Coverages');
+    case 'headline':
+        return gettext('Headline');
+    case 'g2_content_type':
+        return gettext('Content Type');
+    case 'add_coverage_to_workflow':
+        return gettext('Add Coverage To Workflow');
+    case 'genre':
+        return gettext('Genre');
+    case 'news_coverage_status':
+        return gettext('Coverage Status');
+    case 'scheduled':
+        return gettext('Scheduled');
+    case 'scheduled_updates':
+        return gettext('Scheduled Updates');
+    case 'contact_info':
+        return gettext('Contacts');
+    case 'keyword':
+        return gettext('Keywords');
+    case 'no_content_linking':
+        return gettext('No Content Linking');
+    case 'xmp_file':
+        return gettext('XMP File');
+    case 'registration_details':
+        return gettext('Registration Details');
+    case 'invitation_details':
+        return gettext('Invitation Details');
+    case 'accreditation_info':
+        return gettext('Accreditation Info');
+    case 'accreditation_deadline':
+        return gettext('Accreditation Deadline');
+    case 'priority':
+        return gettext('Priority');
+    case 'related_items':
+        return gettext('Related Articles');
+    case 'multiple_content':
+        return gettext('Multiple Content');
     }
 
     return field;

--- a/client/utils/contentProfiles.ts
+++ b/client/utils/contentProfiles.ts
@@ -142,7 +142,7 @@ export function getUnusedProfileFields(
             }
         }));
 
-    const profileFields = getProfileFields(profile);
+    const profileFields = getProfileFields(profile).filter((field) => field.name !== 'add_coverage_to_workflow');
 
     const usedVocabularies = new Set(
         profileFields
@@ -259,98 +259,98 @@ export function getFieldNameTranslated(field: string): string {
     const {gettext} = superdeskApi.localization;
 
     switch (field) {
-    case 'recurring_rules':
-        return gettext('Recurring Rules');
-    case 'dates':
-        return gettext('Dates');
-    case 'language':
-        return gettext('Language');
-    case 'slugline':
-        return gettext('Slugline');
-    case 'name':
-        return gettext('Name');
-    case 'definition_short':
-        return gettext('Description Short');
-    case 'reference':
-        return gettext('Reference');
-    case 'calendars':
-        return gettext('Calendars');
-    case 'place':
-        return gettext('Place');
-    case 'occur_status':
-        return gettext('Occur Status');
-    case 'location':
-        return gettext('Location');
-    case 'event_contact_info':
-        return gettext('Contacts');
-    case 'anpa_category':
-        return superdeskApi.entities.vocabulary.getVocabulary('categories').display_name ?? gettext('ANPA Category');
-    case 'subject':
-        return gettext('Subject');
-    case 'definition_long':
-        return gettext('Description Long');
-    case 'internal_note':
-        return gettext('Internal Note');
-    case 'ednote':
-        return gettext('Editorial Note');
-    case 'files':
-        return gettext('Files');
-    case 'links':
-        return gettext('Links');
-    case 'related_plannings':
-        return gettext('Related Plannings');
-    case 'planning_date':
-        return gettext('Planning Date');
-    case 'description_text':
-        return gettext('Description Text');
-    case 'agendas':
-        return gettext('Agendas');
-    case 'urgency':
-        return gettext('Urgency');
-    case 'marked_for_not_publication':
-        return gettext('Marked For Not Publication');
-    case 'overide_auto_assign_to_workflow':
-        return gettext('Override Auto Assign to Workflow');
-    case 'associated_event':
-        return gettext('Associated Event');
-    case 'coverages':
-        return gettext('Coverages');
-    case 'headline':
-        return gettext('Headline');
-    case 'g2_content_type':
-        return gettext('Content Type');
-    case 'add_coverage_to_workflow':
-        return gettext('Add Coverage To Workflow');
-    case 'genre':
-        return gettext('Genre');
-    case 'news_coverage_status':
-        return gettext('Coverage Status');
-    case 'scheduled':
-        return gettext('Scheduled');
-    case 'scheduled_updates':
-        return gettext('Scheduled Updates');
-    case 'contact_info':
-        return gettext('Contacts');
-    case 'keyword':
-        return gettext('Keywords');
-    case 'no_content_linking':
-        return gettext('No Content Linking');
-    case 'xmp_file':
-        return gettext('XMP File');
-    case 'registration_details':
-        return gettext('Registration Details');
-    case 'invitation_details':
-        return gettext('Invitation Details');
-    case 'accreditation_info':
-        return gettext('Accreditation Info');
-    case 'accreditation_deadline':
-        return gettext('Accreditation Deadline');
-    case 'priority':
-        return gettext('Priority');
-    case 'related_items':
-        return gettext('Related Articles');
-    case 'multiple_content':
-        return gettext('Multiple Content');
+        case 'recurring_rules':
+            return gettext('Recurring Rules');
+        case 'dates':
+            return gettext('Dates');
+        case 'language':
+            return gettext('Language');
+        case 'slugline':
+            return gettext('Slugline');
+        case 'name':
+            return gettext('Name');
+        case 'definition_short':
+            return gettext('Description Short');
+        case 'reference':
+            return gettext('Reference');
+        case 'calendars':
+            return gettext('Calendars');
+        case 'place':
+            return gettext('Place');
+        case 'occur_status':
+            return gettext('Occur Status');
+        case 'location':
+            return gettext('Location');
+        case 'event_contact_info':
+            return gettext('Contacts');
+        case 'anpa_category':
+            return superdeskApi.entities.vocabulary.getVocabulary('categories').display_name ?? gettext('ANPA Category');
+        case 'subject':
+            return gettext('Subject');
+        case 'definition_long':
+            return gettext('Description Long');
+        case 'internal_note':
+            return gettext('Internal Note');
+        case 'ednote':
+            return gettext('Editorial Note');
+        case 'files':
+            return gettext('Files');
+        case 'links':
+            return gettext('Links');
+        case 'related_plannings':
+            return gettext('Related Plannings');
+        case 'planning_date':
+            return gettext('Planning Date');
+        case 'description_text':
+            return gettext('Description Text');
+        case 'agendas':
+            return gettext('Agendas');
+        case 'urgency':
+            return gettext('Urgency');
+        case 'marked_for_not_publication':
+            return gettext('Marked For Not Publication');
+        case 'overide_auto_assign_to_workflow':
+            return gettext('Override Auto Assign to Workflow');
+        case 'associated_event':
+            return gettext('Associated Event');
+        case 'coverages':
+            return gettext('Coverages');
+        case 'headline':
+            return gettext('Headline');
+        case 'g2_content_type':
+            return gettext('Content Type');
+        case 'add_coverage_to_workflow':
+            return gettext('Add Coverage To Workflow');
+        case 'genre':
+            return gettext('Genre');
+        case 'news_coverage_status':
+            return gettext('Coverage Status');
+        case 'scheduled':
+            return gettext('Scheduled');
+        case 'scheduled_updates':
+            return gettext('Scheduled Updates');
+        case 'contact_info':
+            return gettext('Contacts');
+        case 'keyword':
+            return gettext('Keywords');
+        case 'no_content_linking':
+            return gettext('No Content Linking');
+        case 'xmp_file':
+            return gettext('XMP File');
+        case 'registration_details':
+            return gettext('Registration Details');
+        case 'invitation_details':
+            return gettext('Invitation Details');
+        case 'accreditation_info':
+            return gettext('Accreditation Info');
+        case 'accreditation_deadline':
+            return gettext('Accreditation Deadline');
+        case 'priority':
+            return gettext('Priority');
+        case 'related_items':
+            return gettext('Related Articles');
+        case 'multiple_content':
+            return gettext('Multiple Content');
     }
 
     return field;

--- a/client/utils/planning.tsx
+++ b/client/utils/planning.tsx
@@ -70,7 +70,7 @@ import {confirmAddingRelatedItems} from './confirmAddingRelatedItems';
 import {getOpenEditorType} from './editor';
 import {coverageProfiles} from '../selectors/coverageProfiles';
 
-const isCoverageAssigned = (coverage: IPlanningCoverageItem) => coverage.assigned_to?.desk != null;
+export const isCoverageAssigned = (coverage: IPlanningCoverageItem) => coverage.assigned_to?.desk != null;
 
 function isCancelPlanWithEventDisabled(): boolean {
     return (planningApi.events.getEditorProfile().schema.related_plannings?.cancel_plan_with_event ?? true) === false;
@@ -359,22 +359,24 @@ function isCoverageCancelled(coverage: IPlanningCoverageItem): boolean {
     return get(coverage, 'workflow_status') === WORKFLOW_STATE.CANCELLED;
 }
 
+/**
+ * A coverage can be cancelled if the associated planning item hasn't expired
+ * and it wasn't already cancelled
+ * and the coverage was already created
+ * and its assigned state is `null` or not `completed`.
+ */
 function canCancelCoverage(
     coverage: IPlanningCoverageItem,
     planning: IPlanningItem,
     field: string = 'coverage_id'
 ): boolean {
-    return (
-        !isItemExpired(planning) &&
-        (
-            !isCoverageCancelled(coverage) &&
-            isExistingItem(coverage, field) &&
-            (
-                !get(coverage, 'assigned_to.state')
-                || get(coverage, 'assigned_to.state') !== ASSIGNMENTS.WORKFLOW_STATE.COMPLETED
-            )
-        )
-    );
+    return !isItemExpired(planning)
+        && !isCoverageCancelled(coverage)
+        && isExistingItem(coverage, field)
+        && (
+            coverage.assigned_to?.state == null
+            || coverage.assigned_to?.state !== 'completed'
+        );
 }
 
 function canAddCoverageToWorkflow(
@@ -1334,7 +1336,7 @@ function getFeaturedPlanningItemsForDate(items: Array<IPlanningItem>, date: mome
     return [];
 }
 
-function isCoverageDraft(coverage: IPlanningCoverageItem | ICoverageScheduledUpdate): boolean {
+export function isCoverageDraft(coverage: IPlanningCoverageItem | ICoverageScheduledUpdate): boolean {
     return get(coverage, 'workflow_status') === WORKFLOW_STATE.DRAFT;
 }
 function isCoverageInWorkflow(coverage: IPlanningCoverageItem): boolean {


### PR DESCRIPTION
SDESK-7772

### Purpose
Improve the interaction for adding a coverage to workflow and canceling it. 

### What has changed
Since the add to workflow field always comes enabled from the backend and is always needed, it was removed from the coverage profile config. The order of fields also got changed, so that add to workflow toggle is always the first profile field in the editor, whenever visible. 

The toggle is now visible only if adding coverages to workflow is manual on the instance. The toggle now allows users to cancel a coverage, if it was previously added to workflow also only on manual instances. 

If adding coverages to workflow is configured to be automatic, the toggle is hidden from the label, and the "Cancel" coverage action is shown in the three dots menu of a coverage. 

### Steps to test
Set `planning_auto_assign_to_workflow` to `true`. You should now see only a "Cancel" action in the three dots menu of a coverage. 

Set `planning_auto_assign_to_workflow` to `false`. You should now see the "Add to workflow" toggle as the first field in the coverage editor, regardless if you made changes to the coverage profile or not. After you assign the coverage, you should be able to add it to workflow. After saving the whole planning item, you should be able to "Cancel" the coverage by using the toggle off. Once you save the planning item, you should not be able to add it to workflow again. 

### Screenshots

Field, no longer in the profile config:
<img width="813" height="551" alt="image" src="https://github.com/user-attachments/assets/be37321b-6a03-4a27-bfda-d4e8d2486af7" />

---

Adding to workflow manually:
<img width="587" height="441" alt="image" src="https://github.com/user-attachments/assets/3782c00b-b760-4c17-8f1c-7ae1e33a77f2" />

---

Cancelling a coverage in workflow:

<img width="587" height="441" alt="image" src="https://github.com/user-attachments/assets/f330387e-e2d8-48fd-9ae7-4d6ac10b5253" />
--- 
<img width="587" height="441" alt="image" src="https://github.com/user-attachments/assets/13f98274-48d7-41f9-871d-5b5e6768b8f8" />
---
<img width="587" height="441" alt="image" src="https://github.com/user-attachments/assets/08ace3bf-a464-4e67-96bd-80f2f935bbb1" />
