### PR TITLE
Update store after change

### DIFF
--- a/client/actions/exportTemplates.ts
+++ b/client/actions/exportTemplates.ts
@@ -1,6 +1,7 @@
+import {ExportTemplatesActions} from '../constants/exportTemplates';
 import {IPlanningExportTemplate} from '../interfaces';
 
 export const updateTemplates = (updatedTemplates: Array<IPlanningExportTemplate>) => ({
-    type: 'UPDATE_EXPORT_TEMPLATES',
+    type: ExportTemplatesActions.UPDATE_EXPORT_TEMPLATES,
     payload: updatedTemplates,
 });

--- a/client/actions/exportTemplates.ts
+++ b/client/actions/exportTemplates.ts
@@ -1,0 +1,6 @@
+import {IPlanningExportTemplate} from '../interfaces';
+
+export const updateTemplates = (updatedTemplates: Array<IPlanningExportTemplate>) => ({
+    type: 'UPDATE_EXPORT_TEMPLATES',
+    payload: updatedTemplates,
+});

--- a/client/actions/multiSelect.ts
+++ b/client/actions/multiSelect.ts
@@ -41,7 +41,8 @@ const selectEvents = (eventId, all = false, multi = false, name = '') => (
 
         return dispatch({
             type: MULTISELECT.ACTIONS.SELECT_EVENT,
-            payload: {eventId: eventId,
+            payload: {
+                eventId: eventId,
                 name: name,
             },
         });
@@ -89,7 +90,8 @@ const selectPlannings = (planningId, all = false, multi = false, name = '') => (
 
         return dispatch({
             type: MULTISELECT.ACTIONS.SELECT_PLANNING,
-            payload: {planningId: planningId,
+            payload: {
+                planningId: planningId,
                 name: name,
             },
         });
@@ -156,7 +158,7 @@ const downloadEvents = (url, data) => {
     req.responseType = 'blob';
     req.setRequestHeader('Content-Type', 'application/json;charset=UTF-8');
 
-    req.onload = function(event) {
+    req.onload = (event) => {
         var blob = req.response;
         var fileName = '';
 
@@ -294,7 +296,7 @@ const exportAsArticle = (items = [], download) => (
                 items: sortableItems,
                 action: exportArticlesDispatch,
                 desks: [...selectors.general.userDesks(getState()), personalWorkspace],
-                templates: templates.filter((t) => download ? t.download : !t.download),
+                templates: templates,
                 defaultTemplate: templates.find((t) =>
                     (isPlanning && t.name === 'default_planning') || (!isPlanning && t.name === 'default_event')),
                 defaultDesk: defaultDesk,

--- a/client/actions/multiSelect.ts
+++ b/client/actions/multiSelect.ts
@@ -296,7 +296,10 @@ const exportAsArticle = (items = [], download) => (
                 items: sortableItems,
                 action: exportArticlesDispatch,
                 desks: [...selectors.general.userDesks(getState()), personalWorkspace],
-                templates: templates,
+
+                // If download is `true`, template is meant only for download, otherwise
+                // it can be used for both
+                templates: templates.filter((t) => download ? t.download : !t.download),
                 defaultTemplate: templates.find((t) =>
                     (isPlanning && t.name === 'default_planning') || (!isPlanning && t.name === 'default_event')),
                 defaultDesk: defaultDesk,

--- a/client/actions/notifications.ts
+++ b/client/actions/notifications.ts
@@ -62,7 +62,7 @@ function onResourceCreatedOrUpdated(_e, data) {
                     const updatedTemplates = (() => {
                         const maybeExistingTemplate = existingTemplates.find((t) => t._id === template._id);
 
-                        if (maybeExistingTemplate === null) { // new template
+                        if (maybeExistingTemplate == null) { // new template
                             return [...existingTemplates, template];
                         } else {
                             return existingTemplates.map((t) => t._id === template._id ? template : t);

--- a/client/actions/notifications.ts
+++ b/client/actions/notifications.ts
@@ -96,7 +96,7 @@ self.events = {
     'contacts:update': () => self.onContactsUpdated,
     'resource:updated': () => self.onResourceCreatedOrUpdated,
     'resource:created': () => self.onResourceCreatedOrUpdated,
-    'resource:deleted': () => self.onResourceCreatedOrUpdated,
+    'resource:deleted': () => self.onResourceDeleted,
 };
 
 export default self;

--- a/client/actions/notifications.ts
+++ b/client/actions/notifications.ts
@@ -6,6 +6,22 @@ import {planningApi, superdeskApi} from '../superdeskApi';
 import {ASSIGNMENTS} from '../constants';
 import contacts from './contacts';
 import {getStoredArchiveItems} from '../selectors';
+import {updateTemplates} from './exportTemplates';
+import {IPlanningExportTemplate} from 'interfaces';
+import {getExportTemplates} from '../selectors/general';
+import {PLANNING_EXPORT_TEMPLATES_RESOURCE} from '../constants/exportTemplates';
+
+type NotificationHandler = (_e: any, data: any) => (dispatch: any, getState?: any) => any;
+
+type NotificationActions = {
+    onContactsUpdated: NotificationHandler;
+    onResourceCreatedOrUpdated: NotificationHandler;
+    onResourceDeleted: NotificationHandler;
+
+    events?: {
+        [key: string]: NotificationHandler;
+    };
+};
 
 /**
  * WS Action when a new Planning item is created
@@ -38,14 +54,41 @@ function onResourceCreatedOrUpdated(_e, data) {
                     });
                 });
             }
+        } else if (data.resource === PLANNING_EXPORT_TEMPLATES_RESOURCE) {
+            superdeskApi.dataApi.findOne<IPlanningExportTemplate>(data.resource, data._id)
+                .then((template) => {
+                    const existingTemplates = getExportTemplates(getState()) ?? [];
+
+                    const updatedTemplates = (() => {
+                        const maybeExistingTemplate = existingTemplates.find((t) => t._id === template._id);
+
+                        if (maybeExistingTemplate === null) { // new template
+                            return [...existingTemplates, template];
+                        } else {
+                            return existingTemplates.map((t) => t._id === template._id ? template : t);
+                        }
+                    })();
+
+                    dispatch(updateTemplates(updatedTemplates));
+                });
         }
     };
 }
 
+const onResourceDeleted = (_e, data) => (dispatch, getState) => {
+    if (data.resource === PLANNING_EXPORT_TEMPLATES_RESOURCE) {
+        const updatedTemplates = getExportTemplates(getState())
+            .filter((t) => t._id !== data._id);
+
+        dispatch(updateTemplates(updatedTemplates));
+    }
+};
+
 // eslint-disable-next-line consistent-this
-const self = {
+const self: NotificationActions = {
     onContactsUpdated,
     onResourceCreatedOrUpdated,
+    onResourceDeleted,
 };
 
 // Map of notification name and Action Event to execute
@@ -53,6 +96,7 @@ self.events = {
     'contacts:update': () => self.onContactsUpdated,
     'resource:updated': () => self.onResourceCreatedOrUpdated,
     'resource:created': () => self.onResourceCreatedOrUpdated,
+    'resource:deleted': () => self.onResourceCreatedOrUpdated,
 };
 
 export default self;

--- a/client/components/ExportTemplates/ManageExportTemplates.tsx
+++ b/client/components/ExportTemplates/ManageExportTemplates.tsx
@@ -4,10 +4,8 @@ import {Modal} from 'superdesk-ui-framework/react';
 import {gettext} from '../../utils';
 import {IFormField, IFormGroup} from 'superdesk-api';
 import {IPlanningExportTemplate} from 'interfaces';
-import {updateTemplates} from '../../actions/exportTemplates';
 import {ExportTemplateItem} from './ExportTemplateItem';
-import {DataProvider} from 'superdesk-core/scripts/core/helpers/data-provider';
-import {prepareSuperdeskQuery} from 'superdesk-core/scripts/core/helpers/universal-query';
+import {PLANNING_EXPORT_TEMPLATES_RESOURCE} from '../../constants/exportTemplates';
 
 interface IProps {
     closeModal: () => void;
@@ -79,37 +77,13 @@ export class ManageExportTemplatesModal extends React.PureComponent<IProps> {
         super(props);
 
         this.config = getFormConfig();
-
-        new DataProvider<IPlanningExportTemplate>(
-            () => {
-                const {path, urlParams} = prepareSuperdeskQuery(
-                    'planning_export_templates',
-                    {
-                        filter: {},
-                        page: 1,
-                        max_results: 500,
-                        sort: [{_id: 'asc'}],
-                    },
-                );
-
-                return {
-                    method: 'GET',
-                    endpoint: path,
-                    params: urlParams,
-                };
-            },
-            (response) => {
-                planningApi.redux.store.dispatch(updateTemplates(response._items));
-            },
-            {},
-        );
     }
 
     render() {
         const ExportTemplatesView = superdeskApi
             .components
             .getGenericHttpEntityListPageComponent<IPlanningExportTemplate, never>(
-                'planning_export_templates',
+                PLANNING_EXPORT_TEMPLATES_RESOURCE,
                 this.config,
             );
 

--- a/client/components/ExportTemplates/ManageExportTemplates.tsx
+++ b/client/components/ExportTemplates/ManageExportTemplates.tsx
@@ -1,10 +1,13 @@
 import React from 'react';
-import {superdeskApi} from '../../superdeskApi';
+import {planningApi, superdeskApi} from '../../superdeskApi';
 import {Modal} from 'superdesk-ui-framework/react';
 import {gettext} from '../../utils';
 import {IFormField, IFormGroup} from 'superdesk-api';
 import {IPlanningExportTemplate} from 'interfaces';
+import {updateTemplates} from '../../actions/exportTemplates';
 import {ExportTemplateItem} from './ExportTemplateItem';
+import {DataProvider} from 'superdesk-core/scripts/core/helpers/data-provider';
+import {prepareSuperdeskQuery} from 'superdesk-core/scripts/core/helpers/universal-query';
 
 interface IProps {
     closeModal: () => void;
@@ -55,6 +58,10 @@ const getFormConfig = (): IFormGroup<IPlanningExportTemplate> => {
                 type: GenericFormFieldType.plainText,
                 field: 'label',
                 label: gettext('Label'),
+
+                // Required because in the export action modal for events and planning we show
+                // templates by label
+                required: true,
             },
             {
                 type: GenericFormFieldType.checkbox,
@@ -72,6 +79,30 @@ export class ManageExportTemplatesModal extends React.PureComponent<IProps> {
         super(props);
 
         this.config = getFormConfig();
+
+        new DataProvider<IPlanningExportTemplate>(
+            () => {
+                const {path, urlParams} = prepareSuperdeskQuery(
+                    'planning_export_templates',
+                    {
+                        filter: {},
+                        page: 1,
+                        max_results: 500,
+                        sort: [{_id: 'asc'}],
+                    },
+                );
+
+                return {
+                    method: 'GET',
+                    endpoint: path,
+                    params: urlParams,
+                };
+            },
+            (response) => {
+                planningApi.redux.store.dispatch(updateTemplates(response._items));
+            },
+            {},
+        );
     }
 
     render() {

--- a/client/constants/exportTemplates.ts
+++ b/client/constants/exportTemplates.ts
@@ -1,3 +1,3 @@
 export enum ExportTemplatesActions {
-    'UPDATE_EXPORT_TEMPLATES',
+    UPDATE_EXPORT_TEMPLATES = 'UPDATE_EXPORT_TEMPLATES',
 }

--- a/client/constants/exportTemplates.ts
+++ b/client/constants/exportTemplates.ts
@@ -1,3 +1,5 @@
 export enum ExportTemplatesActions {
     UPDATE_EXPORT_TEMPLATES = 'UPDATE_EXPORT_TEMPLATES',
 }
+
+export const PLANNING_EXPORT_TEMPLATES_RESOURCE = 'planning_export_templates';

--- a/client/constants/exportTemplates.ts
+++ b/client/constants/exportTemplates.ts
@@ -1,0 +1,3 @@
+export enum ExportTemplatesActions {
+    'UPDATE_EXPORT_TEMPLATES',
+}

--- a/client/reducers/exportTemplates.ts
+++ b/client/reducers/exportTemplates.ts
@@ -1,0 +1,21 @@
+import {IPlanningExportTemplate} from '../interfaces';
+
+export interface IExportTemplatesState {
+    exportTemplates: Array<IPlanningExportTemplate>;
+}
+
+const initialState: IExportTemplatesState = {
+    exportTemplates: [],
+};
+
+const exportTemplates = (state = initialState, action) => {
+    switch (action.type) {
+    case 'UPDATE_EXPORT_TEMPLATES': {
+        return action.payload;
+    }
+    default:
+        return state;
+    }
+};
+
+export default exportTemplates;

--- a/client/reducers/exportTemplates.ts
+++ b/client/reducers/exportTemplates.ts
@@ -1,3 +1,4 @@
+import {ExportTemplatesActions} from '../constants/exportTemplates';
 import {IPlanningExportTemplate} from '../interfaces';
 
 export interface IExportTemplatesState {
@@ -10,7 +11,7 @@ const initialState: IExportTemplatesState = {
 
 const exportTemplates = (state = initialState, action) => {
     switch (action.type) {
-    case 'UPDATE_EXPORT_TEMPLATES': {
+    case ExportTemplatesActions.UPDATE_EXPORT_TEMPLATES: {
         return action.payload;
     }
     default:

--- a/client/reducers/index.ts
+++ b/client/reducers/index.ts
@@ -19,6 +19,7 @@ import files from './files';
 import contacts from './contacts';
 import locations from './locations';
 import coveragesReducer from './coverageProfiles';
+import exportTemplates from './exportTemplates';
 
 const returnState = (state) => state || {};
 const returnGenreState = (state) => state ?? [];
@@ -43,6 +44,7 @@ const planningApp = combineReducers({
     featuredPlanning: featuredPlanning,
     files: files,
     contacts: contacts,
+    exportTemplates: exportTemplates,
 
     // The following doesn't require reducers as they are loaded using sdPlanningService
     ingest: returnState,
@@ -55,7 +57,6 @@ const planningApp = combineReducers({
     customVocabularies: returnState,
     userDesks: returnState,
     locations: locations,
-    exportTemplates: returnState,
 });
 
 export default planningApp;

--- a/client/services/PlanningStoreService.ts
+++ b/client/services/PlanningStoreService.ts
@@ -5,6 +5,7 @@ import * as selectors from '../selectors';
 import * as actions from '../actions';
 import {planningApi} from '../superdeskApi';
 import {isCustomVocabulary} from '../helpers';
+import {PLANNING_EXPORT_TEMPLATES_RESOURCE} from '../constants/exportTemplates';
 
 export class PlanningStoreService {
     constructor(
@@ -186,7 +187,7 @@ export class PlanningStoreService {
             planningApi.contentProfiles.getAll(),
             planningApi.contentProfiles.coverages.getAll(),
             this.desks.fetchCurrentUserDesks(),
-            this.api('planning_export_templates').query({
+            this.api(PLANNING_EXPORT_TEMPLATES_RESOURCE).query({
                 max_results: 200,
                 page: 1,
             }),


### PR DESCRIPTION
STT-1333

**Purpose:** 
Keep track of changes in the `planning_export_templates` resource. That way views using export templates can have the latest data without re-fetching. 

**What's changed:**
- Enhanced the redux store to also have the ability to get updated data. 
- Removed the template filtering in the export templates modal. 
- Added an event listener that calls a store update once it receives an update. 