### PR TITLE
[SDESK-7769] Remove slugline required field validation

### DIFF
--- a/client/controllers/FulfilAssignmentController.tsx
+++ b/client/controllers/FulfilAssignmentController.tsx
@@ -72,12 +72,6 @@ export class FulFilAssignmentController {
             this.item = this.item.archive_item;
         }
 
-        if (!this.item?.slugline) {
-            this.notify.error(this.gettext('[SLUGLINE] is a required field'));
-            this.$scope.resolve();
-            return;
-        }
-
         return sdPlanningStore.initWorkspace(WORKSPACE.AUTHORING, this.loadWorkspace)
             .then(
                 this.render,


### PR DESCRIPTION
### Purpose
Eliminates the check for a required slugline field in Fulfil Assignment. This allows assignments to proceed even if the slugline is missing.

### To test
Please see the description in the ticket. Is basically creating an item without slug, and then clicking "Fulfil Assignment" from the tree dots menu

<img width="1227" height="847" alt="image" src="https://github.com/user-attachments/assets/8d397f88-8ac7-4ec4-bfdb-3b367cc24e98" />

Thanks for checking!

Resolves: [SDESK-7769]



[SDESK-7769]: https://sofab.atlassian.net/browse/SDESK-7769?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ