### PR TITLE
[SDESK-7774] - Show event schedule summary for all event types

### DIFF
--- a/client/components/Events/EventEditor/index.tsx
+++ b/client/components/Events/EventEditor/index.tsx
@@ -105,10 +105,6 @@ class EventEditorComponent extends React.PureComponent<IProps> {
     }
 
     renderHeader() {
-        if (appConfig.planning_event_link_method === 'many_secondary') {
-            return null;
-        }
-
         return !this.props.itemExists ? null : (
             <React.Fragment>
                 <EventEditorHeader item={this.props.item} />

--- a/client/components/Events/EventEditor/index.tsx
+++ b/client/components/Events/EventEditor/index.tsx
@@ -17,6 +17,7 @@ import {EditorForm} from '../../Editor/EditorForm';
 import {EventEditorHeader} from './EventEditorHeader';
 import {ContentBlock} from '../../UI/SidePanel';
 import {RepeatEventSummary} from '../RepeatEventSummary';
+import {EventScheduleSummary} from '../EventScheduleSummary';
 import {appConfig} from 'appConfig';
 
 interface IProps {
@@ -105,21 +106,37 @@ class EventEditorComponent extends React.PureComponent<IProps> {
     }
 
     renderHeader() {
-        const eventSchedule: IEventItem['dates'] = this.props.item.dates ?? {};
-        const doesRepeat = eventSchedule.recurring_rule !== null;
+        const {item, itemExists} = this.props;
 
-        return !this.props.itemExists ? null : (
-            <React.Fragment>
-                <EventEditorHeader item={this.props.item} />
-                {doesRepeat && (
-                    <ContentBlock padSmall={true}>
-                        <RepeatEventSummary
-                            schedule={eventSchedule}
-                            noMargin={true}
+        if (!itemExists) {
+            return null;
+        }
+
+        const eventSchedule = item.dates ?? {};
+        const doesRepeat = eventSchedule.recurring_rule !== null;
+        const isManySecondary = appConfig.planning_event_link_method === 'many_secondary';
+
+        return (
+            <>
+                <EventEditorHeader item={item} />
+                {isManySecondary ? (
+                    doesRepeat && (
+                        <ContentBlock padSmall>
+                            <RepeatEventSummary
+                                schedule={eventSchedule}
+                                noMargin
+                            />
+                        </ContentBlock>
+                    )
+                ) : (
+                    <ContentBlock padSmall>
+                        <EventScheduleSummary
+                            event={item}
+                            noPadding
                         />
                     </ContentBlock>
                 )}
-            </React.Fragment>
+            </>
         );
     }
 

--- a/client/components/Events/EventEditor/index.tsx
+++ b/client/components/Events/EventEditor/index.tsx
@@ -16,7 +16,7 @@ import * as actions from '../../../actions';
 import {EditorForm} from '../../Editor/EditorForm';
 import {EventEditorHeader} from './EventEditorHeader';
 import {ContentBlock} from '../../UI/SidePanel';
-import {EventScheduleSummary} from '../EventScheduleSummary';
+import {RepeatEventSummary} from '../RepeatEventSummary';
 import {appConfig} from 'appConfig';
 
 interface IProps {
@@ -105,15 +105,20 @@ class EventEditorComponent extends React.PureComponent<IProps> {
     }
 
     renderHeader() {
+        const eventSchedule: IEventItem['dates'] = this.props.item.dates ?? {};
+        const doesRepeat = eventSchedule.recurring_rule !== null;
+
         return !this.props.itemExists ? null : (
             <React.Fragment>
                 <EventEditorHeader item={this.props.item} />
-                <ContentBlock padSmall={true}>
-                    <EventScheduleSummary
-                        event={this.props.item}
-                        noPadding={true}
-                    />
-                </ContentBlock>
+                {doesRepeat && (
+                    <ContentBlock padSmall={true}>
+                        <RepeatEventSummary
+                            schedule={eventSchedule}
+                            noMargin={true}
+                        />
+                    </ContentBlock>
+                )}
             </React.Fragment>
         );
     }


### PR DESCRIPTION
SDESK-7774

### Purpose
Show event schedule summary after event was created.

### What has changed
Show event schedule summary component regardless of the instance's link config. 

### Steps to test
Create an event. 
You can configure it to be recurring to test if full details render.
Event summary should be rendered at the top of the event after saving it. 

Resolves: #[SDESK-7774](https://sofab.atlassian.net/browse/SDESK-7774)

@MarkLark86 let me know if this needs changes, I'm not sure what the logic behind hiding it was when the changes were made, but now it'll show up always.

[SDESK-7774]: https://sofab.atlassian.net/browse/SDESK-7774?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ