### PR TITLE
inherit location from event to planning to coverage

### DIFF
--- a/server/features/planning.feature
+++ b/server/features/planning.feature
@@ -4365,3 +4365,64 @@ Feature: Planning
         }
         """
         Then we get error 400
+
+    @auth
+    Scenario: Copy location from event to planning and coverages
+        Given "events"
+        """
+        [
+            {
+                "name": "test name",
+                "dates": {
+                    "start": "2016-11-17T12:00:00.000Z",
+                    "end": "2016-11-17T14:00:00.000Z",
+                    "tz": "Europe/Berlin"
+                },
+                "location": [
+                    {"qcode": "test", "name": "Test"}
+                ]
+            }
+        ]
+        """
+        When we post to "/planning"
+        """
+        {
+            "item_class": "item class value",
+            "name": "test name",
+            "slugline": "test slugline",
+            "related_events": [{"_id": "#events._id#"}],
+            "planning_date": "2016-01-02"
+        }
+        """
+        Then we get new resource
+        """
+        {
+            "name": "test name",
+            "headline": "__no_value__",
+            "slugline": "test slugline",
+            "location": [
+                {"qcode": "test", "name": "Test"}
+            ]
+        }
+        """
+        When we patch "/planning/#planning._id#"
+        """
+        {"coverages": [
+                {
+                    "workflow_status": "draft"
+                }
+            ]
+        }
+        """
+        Then we get OK response
+        When we get "/planning"
+        Then we get list with 1 items
+        """
+        {"_items": [
+            {"coverages": [
+                {"planning": {
+                    "location": [{"qcode": "test", "name": "Test"}]
+                }}
+            ]}
+        ]}
+        """

--- a/server/planning/planning/planning.py
+++ b/server/planning/planning/planning.py
@@ -420,6 +420,9 @@ class PlanningService(AsyncBaseService):
         if event.get(TO_BE_CONFIRMED_FIELD):
             doc[TO_BE_CONFIRMED_FIELD] = True
 
+        if event.get("location"):
+            doc.setdefault("location", event["location"])
+
         return event
 
     async def _add_planning_to_event_series(
@@ -654,6 +657,7 @@ class PlanningService(AsyncBaseService):
             return
 
         planning_date = original.get("planning_date") or updates.get("planning_date")
+        planning_location = updates.get("location") or original.get("location")
         original_coverage_ids = [
             coverage["coverage_id"] for coverage in original.get("coverages") or [] if coverage.get("coverage_id")
         ]
@@ -673,6 +677,9 @@ class PlanningService(AsyncBaseService):
                 # If none was supplied, fallback to to ``planning.planning_date``
                 coverage.setdefault("planning", {})
                 coverage["planning"].setdefault("scheduled", planning_date)
+
+                if planning_location:
+                    coverage["planning"].setdefault("location", planning_location)
 
                 set_original_creator(coverage)
                 self.set_coverage_active(coverage, updates)


### PR DESCRIPTION
STT-1317

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

### Front-end checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)

Resolves: #[issue-number]

