### PR TITLE
add location to planning profile and to all previews

### DIFF
--- a/client/actions/agenda.ts
+++ b/client/actions/agenda.ts
@@ -271,6 +271,10 @@ export function convertEventToPlanningItem(event: IEventItem): Partial<IPlanning
         languages: event.languages || defaultValues.languages,
     };
 
+    if (event.location) {
+        newPlanningItem.location = event.location;
+    }
+
     newPlanningItem = convertStringFields(
         event,
         newPlanningItem,

--- a/client/api/planning.ts
+++ b/client/api/planning.ts
@@ -184,6 +184,7 @@ function createFromEvent(event: IEventItem, updates: Partial<IPlanningItem>): Pr
             description_text: event.definition_short,
             ednote: event.ednote,
             language: event.language,
+            location: event.location,
             ...updates,
             related_events: [eventLink],
         }),

--- a/client/components/Assignments/AssignmentPreviewContainer/AssignmentPreview.tsx
+++ b/client/components/Assignments/AssignmentPreviewContainer/AssignmentPreview.tsx
@@ -78,6 +78,7 @@ export class AssignmentPreview extends React.PureComponent<IProps> {
                         keyword: {field: 'coverage.keyword'},
                         ednote: {field: 'coverage.ednote', renderEmpty: true},
                         internal_note: {field: 'coverage.internal_note', renderEmpty: true},
+                        location: {field: 'planning.location'},
                     },
                 )}
 

--- a/client/components/Coverages/CoveragePreview/index.tsx
+++ b/client/components/Coverages/CoveragePreview/index.tsx
@@ -140,6 +140,7 @@ export class CoveragePreview extends React.PureComponent<IProps> {
                         g2_content_type: {field: 'planning.g2_content_type'},
                         genre: {field: 'planning.genre'},
                         flags: {field: 'planning.flags'},
+                        location: {field: 'planning.location'},
                     }
                 )}
 

--- a/client/components/Events/EventMetadata/EventMetadata_test.tsx
+++ b/client/components/Events/EventMetadata/EventMetadata_test.tsx
@@ -14,10 +14,10 @@ describe('<EventMetadata />', () => {
                 tz: moment.tz.guess(),
             },
             definition_short: 'definition_short 1',
-            location: {
+            location: [{
                 name: 'location1',
                 formatted_address: 'address1',
-            },
+            }],
             name: 'name1',
             occur_status: {
                 name: 'Planned, occurs certainly',

--- a/client/components/Events/tests/EventPreviewContent_test.tsx
+++ b/client/components/Events/tests/EventPreviewContent_test.tsx
@@ -39,10 +39,10 @@ describe('<EventPreviewContent />', () => {
             name: 'Planned, occurs certainly',
             qcode: 'eocstat:eos5',
         },
-        location: {
+        location: [{
             name: 'location',
             formatted_address: 'address',
-        },
+        }],
         calendars: [{
             name: 'Sport',
             qcode: 'sport',

--- a/client/components/Planning/PlanningEditor/index.tsx
+++ b/client/components/Planning/PlanningEditor/index.tsx
@@ -363,6 +363,10 @@ class PlanningEditorComponent extends React.Component<IProps, IState> {
                         field: 'related_events',
                         events: fullEvents,
                     },
+                    location: {
+                        enableExternalSearch: true,
+                        storeAsArray: true,
+                    },
                     coverages: {
                         onChange: this.onCoverageChange,
                         addNewsItemToPlanning: this.props.addNewsItemToPlanning,

--- a/client/components/editor-standalone/field-definitions/locations-field.ts
+++ b/client/components/editor-standalone/field-definitions/locations-field.ts
@@ -1,17 +1,24 @@
-import {IAuthoringFieldV2} from 'superdesk-api';
+import {IAuthoringFieldV2, ICommonFieldConfig} from 'superdesk-api';
 import {superdeskApi} from '../../../superdeskApi';
 import {IFieldDefinition} from './interfaces';
+
+interface ILocationFieldConfig extends ICommonFieldConfig {
+    storeAsArray: boolean;
+}
 
 export const getLocationsField = (): IFieldDefinition => ({
     fieldId: 'location',
     getField: ({id, required}) => {
+        const fieldConfig: ILocationFieldConfig = {
+            required: required,
+            storeAsArray: true,
+        };
+
         const field: IAuthoringFieldV2 = {
             id: id,
             name: superdeskApi.localization.gettext('Location'),
             fieldType: 'location',
-            fieldConfig: {
-                required: required,
-            },
+            fieldConfig: fieldConfig,
         };
 
         return field;

--- a/client/components/fields/index.tsx
+++ b/client/components/fields/index.tsx
@@ -326,6 +326,7 @@ const PREVIEW_GROUPS: IPreviewGroups = {
             'description_text',
             'internal_note',
             'place',
+            'location',
             'agendas',
         ],
     }, {
@@ -352,6 +353,7 @@ const PREVIEW_GROUPS: IPreviewGroups = {
             'news_coverage_status',
             'scheduled',
             'flags',
+            'location',
         ],
     }],
     [PREVIEW_PANEL.ASSOCIATED_EVENT]: [{
@@ -378,6 +380,7 @@ const PREVIEW_GROUPS: IPreviewGroups = {
             'keyword',
             'ednote',
             'internal_note',
+            'location',
         ],
     }],
     [PREVIEW_PANEL.SCHEDULED_COVERAGE_UPDATE]: [{

--- a/client/components/fields/location.tsx
+++ b/client/components/fields/location.tsx
@@ -7,12 +7,14 @@ import {get} from 'lodash';
 import {Location} from '../';
 
 export const location = ({item, fieldsProps}) => {
-    const hasLocation = !!get(item, 'location.name') || !!get(item, 'location.formatted_address');
-    const locationProps = get(fieldsProps, 'location');
+    const locations = Array.isArray(item.location) ? item.location : [item.location];
 
-    if (!hasLocation) {
+    if (locations.length === 0 || locations[0] == null) {
         return null;
     }
+
+    const location = locations[0];
+    const locationProps = fieldsProps?.location ?? {};
 
     return (
         <span
@@ -20,8 +22,8 @@ export const location = ({item, fieldsProps}) => {
                 {'sd-list-item__element-lm-10': !get(locationProps, 'noMargin')})}
         >
             <Location
-                name={get(item, 'location.name')}
-                address={get(item, 'location.formatted_address')}
+                name={location.name}
+                address={location.formatted_address}
             />
         </span>
     );

--- a/client/components/fields/preview/Location.tsx
+++ b/client/components/fields/preview/Location.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import {get} from 'lodash';
 
 import {superdeskApi} from '../../../superdeskApi';
-import {IListFieldProps, ILocation} from '../../../interfaces';
+import {IEventLocation, IListFieldProps} from '../../../interfaces';
 
 import {PreviewFormItem} from './base/PreviewFormItem';
 import {Location} from '../../Location';
@@ -11,23 +11,26 @@ import {eventUtils} from '../../../utils';
 export class PreviewFieldLocation extends React.PureComponent<IListFieldProps> {
     render() {
         const field = this.props.field ?? 'location';
-        const location = get(this.props.item, field) as ILocation;
+        const locations = get(this.props.item, field, []) as Array<IEventLocation>;
 
         return (
             <div>
                 <PreviewFormItem
                     label={superdeskApi.localization.gettext('Location')}
                     light={true}
+                    value={locations.length ? '' : undefined} // otherwise it won't render in preview
                     {...this.props}
                 >
-                    <div>
-                        <Location
-                            name={location?.name}
-                            address={location?.formatted_address}
-                            multiLine={true}
-                            details={eventUtils.normalizeLocationDetails(location?.details)}
-                        />
-                    </div>
+                    {locations.map((location) => (
+                        <div key={location.qcode}>
+                            <Location
+                                name={location.name}
+                                address={location.formatted_address}
+                                multiLine={true}
+                                details={eventUtils.normalizeLocationDetails(location.details)}
+                            />
+                        </div>
+                    ))}
                 </PreviewFormItem>
             </div>
         );

--- a/client/interfaces.ts
+++ b/client/interfaces.ts
@@ -515,7 +515,7 @@ export interface IEventItem extends IBaseRestApiResponse {
     }>;
     subject?: Array<ISubject>;
     slugline?: string;
-    location?: IEventLocation;
+    location?: Array<IEventLocation>;
     participant?: Array<{
         qcode?: string;
         name?: string;

--- a/client/interfaces.ts
+++ b/client/interfaces.ts
@@ -635,6 +635,7 @@ export interface ICoveragePlanningDetails {
     subject?: Array<{name: string; qcode: string; scheme: string}>;
     anpa_category?: Array<{name: string; qcode: string}>;
     fields: Array<{field: string; value: string}>;
+    location?: Array<IEventLocation>;
 }
 
 export interface ICoverageScheduledUpdate {
@@ -761,6 +762,7 @@ export interface IPlanningItem extends IBaseRestApiResponse {
     reason: string;
     _time_to_be_confirmed: boolean;
     _cancelAllCoverage: boolean;
+    location: Array<IEventLocation>;
 
     // Used when showing Associated Planning item for Events
     _agendas: Array<IAgenda>;

--- a/client/planning-extension/src/authoring-react-fields/location/editor.tsx
+++ b/client/planning-extension/src/authoring-react-fields/location/editor.tsx
@@ -12,6 +12,7 @@ export class Editor extends React.PureComponent<IProps> {
         return (
             <EditorFieldLocation
                 field="location"
+                storeAsArray
                 enableExternalSearch
                 item={{location: this.props.value}}
                 required={this.props.config.required}

--- a/client/utils/planning.tsx
+++ b/client/utils/planning.tsx
@@ -1611,6 +1611,10 @@ function defaultCoverageValues(
         newCoverage._time_to_be_confirmed = planningItem._time_to_be_confirmed;
     }
 
+    if (planningItem?.location || eventItem?.location) {
+        newCoverage.planning.location = planningItem?.location ?? eventItem?.location;
+    }
+
     if (planningItem) {
         const getCoverageDueDateStrategy = appConfig.coverage?.getDueDateStrategy || getDefaultCoverageDueDate;
         const coverageTime = getCoverageDueDateStrategy(planningItem as IPlanningItem, eventItem);

--- a/server/planning/content_profiles/profiles/planning.py
+++ b/server/planning/content_profiles/profiles/planning.py
@@ -138,6 +138,10 @@ DEFAULT_PLANNING_PROFILE = {
             "index": 1,
         },
         "priority": {"enabled": False, "group": "details", "index": 8},
+        "location": {
+            "enabled": False,
+            "group": "details",
+        },
     },
     "schema": dict(PlanningSchema),  # type: ignore
     "groups": {


### PR DESCRIPTION
STT-1317

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

### Front-end checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)

Resolves: #[issue-number]

