### PR TITLE
[STT-1343] - Use multiple content field conifg in coverage editor

### DIFF
--- a/client/components/Coverages/CoverageEditor/CoverageForm.tsx
+++ b/client/components/Coverages/CoverageEditor/CoverageForm.tsx
@@ -498,7 +498,7 @@ export class CoverageFormComponent extends React.Component<IProps, IState> {
             },
             multiple_content: {
                 disabled: this.props.readOnly
-                    ?? (coverageProfile?.schema?.['multiple_content'] as IProfileSchemaTypeList).read_only
+                    ?? (coverageProfile?.schema?.['multiple_content'] as IProfileSchemaTypeList)?.read_only
                     ?? false,
                 field: 'multiple_content',
             },

--- a/client/components/Coverages/CoverageEditor/CoverageForm.tsx
+++ b/client/components/Coverages/CoverageEditor/CoverageForm.tsx
@@ -498,7 +498,8 @@ export class CoverageFormComponent extends React.Component<IProps, IState> {
             },
             multiple_content: {
                 disabled: this.props.readOnly
-                    ?? (coverageProfile.schema['multiple_content'] as IProfileSchemaTypeList).read_only,
+                    ?? (coverageProfile?.schema?.['multiple_content'] as IProfileSchemaTypeList).read_only
+                    ?? false,
                 field: 'multiple_content',
             },
             news_coverage_status: {

--- a/client/components/Coverages/CoverageEditor/CoverageForm.tsx
+++ b/client/components/Coverages/CoverageEditor/CoverageForm.tsx
@@ -17,6 +17,7 @@ import {
     IFile,
     ICoverageType,
     IPlanningContentProfile,
+    IProfileSchemaTypeList,
 } from '../../../interfaces';
 import * as selectors from '../../../selectors';
 import {planningUtils, generateTempId, assignmentUtils, isItemExpired} from '../../../utils';
@@ -419,6 +420,9 @@ export class CoverageFormComponent extends React.Component<IProps, IState> {
                 },
             }), {});
 
+        const allProfiles = coverageProfiles(planningApi.redux.store.getState());
+        const coverageProfile = allProfiles.find((x) => x._id === this.props.value.profile);
+
         const fieldProps: Dictionary<keyof IPlanningCoverageItem, any> = {
             ...customCVFields,
             ...textFieldConfigs,
@@ -491,6 +495,11 @@ export class CoverageFormComponent extends React.Component<IProps, IState> {
                 uploadFiles: this.props.uploadFiles,
                 removeFile: this.props.removeFile,
                 files: this.props.files,
+            },
+            multiple_content: {
+                disabled: this.props.readOnly
+                    ?? (coverageProfile.schema['multiple_content'] as IProfileSchemaTypeList).read_only,
+                field: 'multiple_content',
             },
             news_coverage_status: {
                 readOnly: this.props.readOnly || readOnlyFields.newsCoverageStatus,


### PR DESCRIPTION
### Purpose
Use config options from profile for `multiple_content` coverage field. So if `read_only` is `true`, you won't be able to interact with the field through the editor.

### What has changed
Get the full coverage profile, read the config value and pass it to the field.

### Steps to test
1. Configure a coverage profile to have Multiple content field. Set that field to `read_only = true` using the field's side panel. 
2. Open a coverage with this profile.
3. Coverage `multiple_content` field should be disabled.

Resolves: #[STT-1343](https://sofab.atlassian.net/browse/STT-1343)

[STT-1343]: https://sofab.atlassian.net/browse/STT-1343?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ