### PR TITLE
[STT-1326] - Fix default enabled state for new editor fields

### DIFF
--- a/server/planning/content_profiles/service.py
+++ b/server/planning/content_profiles/service.py
@@ -165,11 +165,14 @@ class ContentProfilesService(AsyncBaseService):
             db_content_profile.setdefault(config_type, {})
             for field, options in updated_content_profile[config_type].items():
                 # if this field exists in default but not in database, add it
-                # but make sure new fields are disabled by default
                 if field not in db_content_profile[config_type]:
-                    new_field_options = deepcopy(options)
-                    new_field_options["enabled"] = False
-                    db_content_profile[config_type][field] = new_field_options
+                    if config_type == "editor" and isinstance(options, dict):
+                        # make sure new fields are disabled by default
+                        new_field_options = deepcopy(options)
+                        new_field_options["enabled"] = False
+                        db_content_profile[config_type][field] = new_field_options
+                    else:
+                        db_content_profile[config_type][field] = options
 
                 # if field exists in both, merge the options (database take precedence)
                 elif updated_content_profile[config_type][field]:


### PR DESCRIPTION
### Purpose
Following up on this https://github.com/superdesk/superdesk-planning/pull/2522#discussion_r2386876914 I realized it should only be for `editor` and not the scheme. This PR ensures that new fields added to the `editor` config type are disabled by default.

[STT-1326]


[STT-1326]: https://sofab.atlassian.net/browse/STT-1326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ