### PR TITLE
[SDESK-7779] fix: Unable to update repeating event dates/times from editor

### DIFF
--- a/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx
+++ b/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx
@@ -64,7 +64,7 @@ function eventWasUpdated(original: IEventItem, updates: Partial<IEventItem>): bo
     const originalItem = eventUtils.modifyForServer(cloneDeep(original));
     const eventUpdates = eventUtils.getEventDiff(originalItem, updates);
     const eventFields = Object.keys(eventUpdates).filter(
-        (field) => !['update_method', 'dates', 'associated_plannings'].includes(field)
+        (field) => !['update_method', 'associated_plannings'].includes(field)
     );
 
     return eventFields.length > 0;

--- a/server/features/events_datetime_updates.feature
+++ b/server/features/events_datetime_updates.feature
@@ -1,0 +1,337 @@
+Feature: Updating Event date or time from the editor
+    Background: Setup env
+        Given config update
+        """
+        {"PLANNING_EVENT_LINK_METHOD": "many_secondary"}
+        """
+        Given "events"
+        """
+        [{
+            "guid": "event1",
+            "name": "Test Event",
+            "dates": {
+                "start": "2029-11-21T12:00:00+0000",
+                "end": "2029-11-21T14:00:00+0000",
+                "tz": "Australia/Sydney"
+            },
+            "state": "draft"
+        }]
+        """
+
+    @auth
+    Scenario: Event schedule updates not supported when PLANNING_EVENT_LINK_METHOD is not many_secondary
+        Given config update
+        """
+        {"PLANNING_EVENT_LINK_METHOD": "one_primary"}
+        """
+        When we patch "/events/event1"
+        """
+        {
+            "name": "Test Event 2",
+            "dates": {
+                "start": "2029-11-21T13:00:00+0000",
+                "end": "2029-11-21T15:00:00+0000",
+                "tz": "Australia/Sydney"
+            }
+        }
+        """
+        Then we get OK response
+        Then we get existing resource
+        """
+        {
+            "_id": "event1",
+            "dates": {
+                "start": "2029-11-21T12:00:00+0000",
+                "end": "2029-11-21T14:00:00+0000",
+                "tz": "Australia/Sydney"
+            },
+            "_planning_schedule": [{"scheduled": "2029-11-21T12:00:00+0000"}]
+        }
+        """
+        Given config update
+        """
+        {"PLANNING_EVENT_LINK_METHOD": "one_primary_many_secondary"}
+        """
+        When we patch "/events/event1"
+        """
+        {
+            "name": "Test Event 2",
+            "dates": {
+                "start": "2029-11-21T13:00:00+0000",
+                "end": "2029-11-21T15:00:00+0000",
+                "tz": "Australia/Sydney"
+            }
+        }
+        """
+        Then we get OK response
+        Then we get existing resource
+        """
+        {
+            "_id": "event1",
+            "dates": {
+                "start": "2029-11-21T12:00:00+0000",
+                "end": "2029-11-21T14:00:00+0000",
+                "tz": "Australia/Sydney"
+            },
+            "_planning_schedule": [{"scheduled": "2029-11-21T12:00:00+0000"}]
+        }
+        """
+
+    @auth
+    Scenario: Change time of single Event
+        When we get "/events/event1"
+        Then we get existing resource
+        """
+        {
+            "_id": "event1",
+            "dates": {
+                "start": "2029-11-21T12:00:00+0000",
+                "end": "2029-11-21T14:00:00+0000",
+                "tz": "Australia/Sydney"
+            },
+            "_planning_schedule": [{"scheduled": "2029-11-21T12:00:00+0000"}]
+        }
+        """
+        When we patch "/events/event1"
+        """
+        {
+            "name": "Test Event 2",
+            "dates": {
+                "start": "2029-11-21T13:00:00+0000",
+                "end": "2029-11-21T15:00:00+0000",
+                "tz": "Australia/Sydney"
+            }
+        }
+        """
+        Then we get OK response
+        Then we get existing resource
+        """
+        {
+            "_id": "event1",
+            "dates": {
+                "start": "2029-11-21T13:00:00+0000",
+                "end": "2029-11-21T15:00:00+0000",
+                "tz": "Australia/Sydney"
+            },
+            "_planning_schedule": [{"scheduled": "2029-11-21T13:00:00+0000"}]
+        }
+        """
+
+    @auth
+    Scenario: Change date & time of single Event
+        When we get "/events/event1"
+        Then we get existing resource
+        """
+        {
+            "_id": "event1",
+            "dates": {
+                "start": "2029-11-21T12:00:00+0000",
+                "end": "2029-11-21T14:00:00+0000",
+                "tz": "Australia/Sydney"
+            },
+            "_planning_schedule": [{"scheduled": "2029-11-21T12:00:00+0000"}]
+        }
+        """
+        When we patch "/events/event1"
+        """
+        {
+            "name": "Test Event 2",
+            "dates": {
+                "start": "2029-11-22T13:00:00+0000",
+                "end": "2029-11-22T15:00:00+0000",
+                "tz": "Australia/Sydney"
+            }
+        }
+        """
+        Then we get OK response
+        Then we get existing resource
+        """
+        {
+            "_id": "event1",
+            "dates": {
+                "start": "2029-11-22T13:00:00+0000",
+                "end": "2029-11-22T15:00:00+0000",
+                "tz": "Australia/Sydney"
+            },
+            "_planning_schedule": [{"scheduled": "2029-11-22T13:00:00+0000"}]
+        }
+        """
+
+    @auth
+    Scenario: Change schedule of a series of events
+        Given empty "events"
+        When we post to "/events"
+        """
+        [{
+            "name": "Daily Club",
+            "dates": {
+                "start": "2044-11-21T08:00:00+0000",
+                "end": "2044-11-21T10:00:00+0000",
+                "tz": "Australia/Sydney",
+                "recurring_rule": {
+                    "frequency": "DAILY",
+                    "interval": 1,
+                    "count": 3,
+                    "endRepeatMode": "count"
+                }
+            }
+        }]
+        """
+        Then we get OK response
+        Then we store "EVENT1" with first item
+        Then we store "EVENT2" with 2 item
+        Then we store "EVENT3" with 3 item
+        When we get "/events"
+        Then we get list with 3 items
+        """
+        {"_items": [{
+            "_id": "#EVENT1._id#",
+            "recurrence_id": "#EVENT1.recurrence_id#",
+            "name": "Daily Club",
+            "dates": {"start": "2044-11-21T08:00:00+0000", "end": "2044-11-21T10:00:00+0000"}
+        }, {
+            "_id": "#EVENT2._id#",
+            "recurrence_id": "#EVENT1.recurrence_id#",
+            "name": "Daily Club",
+            "dates": {"start": "2044-11-22T08:00:00+0000", "end": "2044-11-22T10:00:00+0000"}
+        }, {
+            "_id": "#EVENT3._id#",
+            "recurrence_id": "#EVENT1.recurrence_id#",
+            "name": "Daily Club",
+            "dates": {"start": "2044-11-23T08:00:00+0000", "end": "2044-11-23T10:00:00+0000"}
+        }]}
+        """
+        # Update time of 1 Event
+        When we patch "/events/#EVENT2._id#"
+        """
+        {
+            "name": "Daily Club v2",
+            "dates": {
+                "start": "2044-11-22T10:00:00+0000",
+                "end": "2044-11-22T11:00:00+0000"
+            }
+        }
+        """
+        Then we get OK response
+        When we get "/events"
+        Then we get list with 3 items
+        """
+        {"_items": [{
+            "_id": "#EVENT1._id#",
+            "recurrence_id": "#EVENT1.recurrence_id#",
+            "name": "Daily Club",
+            "dates": {"start": "2044-11-21T08:00:00+0000", "end": "2044-11-21T10:00:00+0000"}
+        }, {
+            "_id": "#EVENT2._id#",
+            "recurrence_id": "#EVENT1.recurrence_id#",
+            "name": "Daily Club v2",
+            "dates": {"start": "2044-11-22T10:00:00+0000", "end": "2044-11-22T11:00:00+0000"}
+        }, {
+            "_id": "#EVENT3._id#",
+            "recurrence_id": "#EVENT1.recurrence_id#",
+            "name": "Daily Club",
+            "dates": {"start": "2044-11-23T08:00:00+0000", "end": "2044-11-23T10:00:00+0000"}
+        }]}
+        """
+
+        # Update time of future Events
+        When we patch "/events/#EVENT2._id#"
+        """
+        {
+            "update_method": "future",
+            "name": "Daily Club v3",
+            "dates": {
+                "start": "2044-11-22T11:00:00+0000",
+                "end": "2044-11-22T12:00:00+0000"
+            }
+        }
+        """
+        Then we get OK response
+        When we get "/events"
+        Then we get list with 3 items
+        """
+        {"_items": [{
+            "_id": "#EVENT1._id#",
+            "recurrence_id": "#EVENT1.recurrence_id#",
+            "name": "Daily Club",
+            "dates": {"start": "2044-11-21T08:00:00+0000", "end": "2044-11-21T10:00:00+0000"}
+        }, {
+            "_id": "#EVENT2._id#",
+            "recurrence_id": "#EVENT1.recurrence_id#",
+            "name": "Daily Club v3",
+            "dates": {"start": "2044-11-22T11:00:00+0000", "end": "2044-11-22T12:00:00+0000"}
+        }, {
+            "_id": "#EVENT3._id#",
+            "recurrence_id": "#EVENT1.recurrence_id#",
+            "name": "Daily Club v3",
+            "dates": {"start": "2044-11-23T11:00:00+0000", "end": "2044-11-23T12:00:00+0000"}
+        }]}
+        """
+
+        # Update time of all Events
+        When we patch "/events/#EVENT3._id#"
+        """
+        {
+            "update_method": "all",
+            "name": "Daily Club v4",
+            "dates": {
+                "start": "2044-11-23T07:00:00+0000",
+                "end": "2044-11-23T11:00:00+0000"
+            }
+        }
+        """
+        Then we get OK response
+        When we get "/events"
+        Then we get list with 3 items
+        """
+        {"_items": [{
+            "_id": "#EVENT1._id#",
+            "recurrence_id": "#EVENT1.recurrence_id#",
+            "name": "Daily Club v4",
+            "dates": {"start": "2044-11-21T07:00:00+0000", "end": "2044-11-21T11:00:00+0000"}
+        }, {
+            "_id": "#EVENT2._id#",
+            "recurrence_id": "#EVENT1.recurrence_id#",
+            "name": "Daily Club v4",
+            "dates": {"start": "2044-11-22T07:00:00+0000", "end": "2044-11-22T11:00:00+0000"}
+        }, {
+            "_id": "#EVENT3._id#",
+            "recurrence_id": "#EVENT1.recurrence_id#",
+            "name": "Daily Club v4",
+            "dates": {"start": "2044-11-23T07:00:00+0000", "end": "2044-11-23T11:00:00+0000"}
+        }]}
+        """
+
+        # Update date & time of all Events
+        When we patch "/events/#EVENT1._id#"
+        """
+        {
+            "update_method": "all",
+            "name": "Daily Club v5",
+            "dates": {
+                "start": "2044-12-01T08:00:00+0000",
+                "end": "2044-12-01T12:00:00+0000"
+            }
+        }
+        """
+        Then we get OK response
+        When we get "/events"
+        Then we get list with 3 items
+        """
+        {"_items": [{
+            "_id": "#EVENT1._id#",
+            "recurrence_id": "#EVENT1.recurrence_id#",
+            "name": "Daily Club v5",
+            "dates": {"start": "2044-12-01T08:00:00+0000", "end": "2044-12-01T12:00:00+0000"}
+        }, {
+            "_id": "#EVENT2._id#",
+            "recurrence_id": "#EVENT1.recurrence_id#",
+            "name": "Daily Club v5",
+            "dates": {"start": "2044-12-02T08:00:00+0000", "end": "2044-12-02T12:00:00+0000"}
+        }, {
+            "_id": "#EVENT3._id#",
+            "recurrence_id": "#EVENT1.recurrence_id#",
+            "name": "Daily Club v5",
+            "dates": {"start": "2044-12-03T08:00:00+0000", "end": "2044-12-03T12:00:00+0000"}
+        }]}
+        """

--- a/server/planning/events/events.py
+++ b/server/planning/events/events.py
@@ -18,7 +18,7 @@ import itertools
 
 from copy import deepcopy
 from typing import Dict, Any, Optional, List
-from datetime import timedelta, datetime, timedelta
+from datetime import datetime, timedelta
 from dateutil import parser
 
 from eve.methods.common import resolve_document_etag
@@ -47,7 +47,7 @@ from superdesk.errors import SuperdeskApiError
 from superdesk.metadata.utils import generate_guid
 from superdesk.metadata.item import GUID_NEWSML
 from superdesk.notification import push_notification
-from superdesk.utc import get_date, utcnow
+from superdesk.utc import get_date, utcnow, utc_to_local
 from superdesk.users.services import current_user_has_privilege
 from superdesk.publish_async.utils import get_next_sequence_number
 from apps.auth import get_user, get_user_id
@@ -92,6 +92,7 @@ from planning.utils import (
 )
 from .events_schema import events_schema
 from .events_sync import sync_event_metadata_with_planning_items
+from .events_utils import get_recurring_event_updates_iterator
 
 logger = logging.getLogger(__name__)
 
@@ -681,6 +682,11 @@ class EventsService(AsyncBaseService):
                 recurrence_id=str(generated_events[0]["recurrence_id"]),
             )
         else:
+            if get_planning_event_link_method() == "many_secondary":
+                set_planning_schedule(updates)
+            else:
+                updates.pop("dates", None)
+
             if original.get("lock_action") == "mark_completed" and updates.get("actioned_date"):
                 await self.mark_event_complete(original, updates, original, None)
 
@@ -697,26 +703,12 @@ class EventsService(AsyncBaseService):
         If the recurring_rule has been removed for this event, process
         it separately, otherwise update the event and/or its recurring rules
         """
-        # This method now only handles updating of Event metadata
-        # So make sure to remove any date information that might be in
-        # the updates
-        updates.pop("dates", None)
 
-        if update_method == UPDATE_FUTURE:
-            historic, past, future = await get_recurring_timeline(original, spiked=False, postponed=True)
-            events = future
-        else:
-            historic, past, future = await get_recurring_timeline(original, spiked=False, postponed=True)
-            events = historic + past + future
-
-        events_post_service = get_resource_service("events_post")
-
-        # First we want to validate that all events can be posted
-        for e in events:
-            if post_required(updates, e):
-                merged = deepcopy(e)
-                merged.update(updates)
-                await events_post_service.validate_item(merged)
+        if get_planning_event_link_method() != "many_secondary":
+            # We only support changing Event schedule(s) through the main endpoint
+            # if ``PLANNING_EVENT_LINK_METHOD`` is set to ``many_secondary``
+            # If this is not the case, then we only update the metadata
+            updates.pop("dates", None)
 
         # If this update is from assignToCalendar action
         # Then we only want to update the calendars of each Event
@@ -729,12 +721,18 @@ class EventsService(AsyncBaseService):
 
         mark_completed = original.get("lock_action") == "mark_completed" and updates.get("actioned_date")
         mark_complete_validated = False
-        for e in events:
-            event_id = e[ID_FIELD]
 
-            new_updates = deepcopy(updates)
-            new_updates["skip_on_update"] = True
-            new_updates[ID_FIELD] = event_id
+        events_post_service = get_resource_service("events_post")
+        updates_to_apply: list[tuple[str, dict]] = []
+        async for event, new_updates in get_recurring_event_updates_iterator(original, updates, update_method):
+            event_id = event[ID_FIELD]
+            new_dates = new_updates.get("dates", None)
+            new_updates.update(updates)
+
+            if new_dates:
+                new_updates["dates"] = new_dates
+            else:
+                new_updates.pop("dates", None)
 
             if only_calendars:
                 # Get the original for this item, and add new calendars to it
@@ -747,14 +745,26 @@ class EventsService(AsyncBaseService):
                     [calendar for calendar in updated_calendars if calendar["qcode"] not in original_qcodes]
                 )
             elif mark_completed:
-                await self.mark_event_complete(original, updates, e, mark_complete_validated)
-                # It is validated if the previous funciton did not raise an error
+                await self.mark_event_complete(original, updates, event, mark_complete_validated)
+                # It is validated if the previous function did not raise an error
                 mark_complete_validated = True
 
             # Remove ``embedded_planning`` before updating this event, as this should only be handled
             # by the event provided to this update request
             new_updates.pop("embedded_planning", None)
-            self.patch(event_id, new_updates)
+
+            # If this item is to be posted, make sure it passes validation
+            # before we proceed with updating all the affected Events
+            if post_required(updates, event):
+                merged = deepcopy(event)
+                merged.update(new_updates)
+                await events_post_service.validate_item(merged)
+
+            updates_to_apply.append((event_id, new_updates))
+
+        # Finally, update the affected Events
+        for event_id, new_updates in updates_to_apply:
+            await self.patch_async(event_id, new_updates)
             app = get_current_app().as_any()
             await app.on_updated_events.call_async(new_updates, {"_id": event_id})
 

--- a/server/planning/events/events_reschedule.py
+++ b/server/planning/events/events_reschedule.py
@@ -23,6 +23,7 @@ from planning.common import (
     remove_lock_information,
     set_original_creator,
     set_actioned_date_to_event,
+    get_max_recurrent_events,
 )
 from planning.events.events_utils import (
     get_recurring_timeline,
@@ -54,7 +55,7 @@ def set_next_occurrence(updates: dict[str, Any]):
                 **updates["dates"]["recurring_rule"],
             ),
             0,
-            10,
+            get_max_recurrent_events(),
         )
     ]
     time_delta = updates["dates"]["end"] - updates["dates"]["start"]
@@ -186,6 +187,7 @@ async def reschedule_recurring_event(updates: dict[str, Any], original: dict[str
     time_delta = updates["dates"]["end"] - updates["dates"]["start"]
 
     # Generate the dates for the new event series
+    max_events = get_max_recurrent_events()
     new_dates = [
         date
         for date in islice(
@@ -196,7 +198,7 @@ async def reschedule_recurring_event(updates: dict[str, Any], original: dict[str
                 **updated_rule,
             ),
             0,
-            200,
+            max_events,
         )
     ]
 
@@ -211,7 +213,7 @@ async def reschedule_recurring_event(updates: dict[str, Any], original: dict[str
                 **original_rule,
             ),
             0,
-            200,
+            max_events,
         )
     ]
 

--- a/server/planning/events/events_update_time.py
+++ b/server/planning/events/events_update_time.py
@@ -1,23 +1,16 @@
-from copy import deepcopy
 from typing import Any
-from datetime import date, datetime
 
-from superdesk.utc import local_to_utc, utc_to_local
 from superdesk.resource_fields import ID_FIELD
 from superdesk import get_resource_service
 
 from planning import signals
-from planning.common import (
-    TO_BE_CONFIRMED_FIELD,
-    UPDATE_FUTURE,
-    UPDATE_SINGLE,
-    remove_lock_information,
-)
+from planning.common import UPDATE_SINGLE, remove_lock_information
 from planning.events.events_utils import (
-    get_recurring_timeline,
     get_update_method,
     post_update_event_actions,
     pre_update_event_actions,
+    get_recurring_event_updates_iterator,
+    set_planning_schedule,
 )
 from planning.types import PlanningSchedule
 
@@ -32,64 +25,13 @@ async def update_single_event(updates: dict[str, Any]):
 
 async def update_recurring_events(updates: dict[str, Any], original: dict[str, Any], update_method: str):
     events_service = get_resource_service("events")
-    historic, past, future = await get_recurring_timeline(original)
-
-    # Determine if the selected event is the first one, if so then
-    # act as if we're changing future events
-    if len(historic) == 0 and len(past) == 0:
-        update_method = UPDATE_FUTURE
-
-    if update_method == UPDATE_FUTURE:
-        new_series = [original] + future
-    else:
-        new_series = past + [original] + future
 
     # Release the Lock on the selected Event
     remove_lock_information(updates)
 
-    # Get the timezone from the original Event (as the series was created with that timezone in mind)
-    timezone = original["dates"]["tz"]
-
-    # First find the hour and minute of the start date in local time
-    start_time = utc_to_local(timezone, updates["dates"]["start"]).time()
-
-    # Next convert that to seconds since midnight (which gives us a timedelta instance)
-    delta_since_midnight = datetime.combine(date.min, start_time) - datetime.min
-
-    # And calculate the new duration of the events
-    duration = updates["dates"]["end"] - updates["dates"]["start"]
-
-    for event in new_series:
-        if not event.get(ID_FIELD):
-            continue
-
-        new_updates = {"dates": deepcopy(event["dates"])} if event.get(ID_FIELD) != original.get(ID_FIELD) else updates
-
-        # Calculate midnight in local time for this occurrence
-        if isinstance(event["dates"]["start"], str):
-            event["dates"]["start"] = datetime.fromisoformat(event["dates"]["start"])
-        start_of_day_local = utc_to_local(timezone, event["dates"]["start"]).replace(hour=0, minute=0, second=0)
-
-        # Then convert midnight in local time to UTC
-        start_date_time = local_to_utc(timezone, start_of_day_local)
-
-        # Finally add the delta since midnight
-        start_date_time += delta_since_midnight
-
-        # Set the new start and end times
-        new_updates["dates"]["start"] = start_date_time
-        new_updates["dates"]["end"] = start_date_time + duration
-
-        if event.get(TO_BE_CONFIRMED_FIELD):
-            new_updates[TO_BE_CONFIRMED_FIELD] = False
-
-        # Set '_planning_schedule' on the Event item
-        new_updates["_planning_schedule"] = [PlanningSchedule(scheduled=new_updates["dates"].get("start")).to_dict()]
-
-        if event.get(ID_FIELD) != original.get(ID_FIELD):
-            new_updates["skip_on_update"] = True
-            await events_service.patch_async(event[ID_FIELD], new_updates)
-            await signals.event_time_updated.send(new_updates, {"_id": event[ID_FIELD]})
+    async for event, new_updates in get_recurring_event_updates_iterator(original, updates, update_method):
+        await events_service.patch_async(event[ID_FIELD], new_updates)
+        await signals.event_time_updated.send(new_updates, {"_id": event[ID_FIELD]})
 
 
 async def process_update_time(
@@ -120,6 +62,7 @@ async def process_update_time(
     # Clean updates before persisting change
     updates.pop("update_method", None)
     updates.pop("skip_on_update", None)
+    set_planning_schedule(updates)
 
     # Update the original event in the database
     await events_service.update_async(original[ID_FIELD], updates, original)

--- a/server/planning/events/events_utils.py
+++ b/server/planning/events/events_utils.py
@@ -2,6 +2,7 @@ import arrow
 import re
 from dateutil import parser
 import pytz
+from copy import deepcopy
 
 from datetime import date, datetime
 from dateutil.rrule import rrule, DAILY, WEEKLY, MONTHLY, YEARLY, MO, TU, WE, TH, FR, SA, SU
@@ -15,7 +16,7 @@ from superdesk import get_resource_service, json
 from superdesk.core.types import SortParam, SortListParam
 from superdesk.errors import SuperdeskApiError
 from superdesk.notification import push_notification
-from superdesk.utc import utcnow
+from superdesk.utc import utcnow, utc_to_local, local_to_utc
 from superdesk.resource_fields import ID_FIELD
 from superdesk.metadata.item import GUID_NEWSML
 from superdesk.metadata.utils import generate_guid
@@ -23,7 +24,9 @@ from superdesk.metadata.utils import generate_guid
 from planning.common import (
     TEMP_ID_PREFIX,
     UPDATE_SINGLE,
+    UPDATE_FUTURE,
     WORKFLOW_STATE,
+    TO_BE_CONFIRMED_FIELD,
     get_max_recurrent_events,
     is_valid_event_planning_reason,
     set_ingested_event_state,
@@ -410,3 +413,97 @@ def set_planning_schedule(event: dict[str, Any]):
     """
     if event and event.get("dates") and event["dates"].get("start"):
         event["_planning_schedule"] = [{"scheduled": event["dates"]["start"]}]
+
+
+async def get_recurring_event_updates_iterator(
+    original: dict,
+    updates: dict,
+    update_method: str,
+) -> AsyncGenerator[tuple[dict, dict], None]:
+    """
+    Generate updates for recurring events based on a specified update method.
+
+    This asynchronous generator function determines how a recurring event is
+    updated based on its timeline (historic, past, future occurrences) and an
+    update method provided by the user. This includes the new event schedule, if provided in the updates.
+
+    :param original: The original event data containing details such as dates and timezone.
+    :param updates: The modifications to apply to the recurring events series, including updated dates.
+    :param update_method: Specifies whether updates are applied to all events in the series or limited to future events.
+    :return: An asynchronous generator that yields tuples containing the original event data and the corresponding updated event data.
+    """
+
+    historic, past, future = await get_recurring_timeline(original)
+
+    # Determine if the selected event is the first one, if so then
+    # act as if we're changing future events
+    if len(historic) == 0 and len(past) == 0:
+        update_method = UPDATE_FUTURE
+
+    if update_method == UPDATE_FUTURE:
+        new_series = future
+    else:
+        new_series = historic + past + future
+
+    if "dates" not in updates:
+        # If there are no dates in the updates, there is no need to calculate new schedules
+        # So we provide a simple generator here
+        for event in new_series:
+            if not event.get(ID_FIELD):
+                continue
+
+            yield event, {"skip_on_update": True}
+
+        return
+
+    # Get the timezone from the original Event (as the series was created with that timezone in mind)
+    timezone = original["dates"]["tz"]
+
+    # First get the local date/time for both the original and the updated schedule
+    original_start_local = utc_to_local(timezone, original["dates"]["start"])
+    updated_start_local = utc_to_local(timezone, updates["dates"]["start"])
+
+    # Then calculate the difference between the two dates (ignoring the time values)
+    date_delta = updated_start_local.date() - original_start_local.date()
+
+    # Next convert the updated start time to seconds since midnight (which gives us a timedelta instance)
+    delta_since_midnight = datetime.combine(date.min, updated_start_local.time()) - datetime.min
+
+    # And calculate the new duration of the events
+    duration = updates["dates"]["end"] - updates["dates"]["start"]
+
+    for event in new_series:
+        if not event.get(ID_FIELD):
+            continue
+
+        new_updates = {
+            "dates": deepcopy(event["dates"]),
+            "skip_on_update": True,
+        }
+
+        # Calculate midnight in local time for this occurrence
+        start_of_day_local = utc_to_local(timezone, event["dates"]["start"]).replace(hour=0, minute=0, second=0)
+
+        # Shift the date if needed
+        if date_delta:
+            start_of_day_local += date_delta
+
+        # Then convert midnight in local time to UTC
+        start_date_time = local_to_utc(timezone, start_of_day_local)
+
+        # Finally add the delta since midnight
+        start_date_time += delta_since_midnight
+
+        # Set the new start and end times
+        new_updates["dates"].update(
+            {
+                "start": start_date_time,
+                "end": start_date_time + duration,
+            }
+        )
+        set_planning_schedule(new_updates)
+
+        if event.get(TO_BE_CONFIRMED_FIELD):
+            new_updates[TO_BE_CONFIRMED_FIELD] = False
+
+        yield event, new_updates


### PR DESCRIPTION
### Purpose
If `PLANNING_EVENT_LINK_METHOD` config is set to `many_secondary`, we allow editing of an Event's date and/or time from the editor. This was never supported before this change, and a few bugs were found.

1. The Event's `_planning_schedule` was not updated
2. If updating the date and/or time of an Event in a recurring series, the server ignored the `dates` update

### What has changed
* Create a common generator for use between the `Event patch` and `Event Update Time` endpoints
* Make sure the Event's `_planning_schedule` is updated when the schedule changes
* Add support guard in `Event patch` endpoint to only allow updating `dates` if `PLANNING_EVENT_LINK_METHOD` config is set to `many_secondary`
* When updating only the date or time of an Event, make sure to show the drop-down asking which Events in the series is to be affected

Resolves: [SDESK-7779](https://sofab.atlassian.net/browse/SDESK-7779)



[SDESK-7779]: https://sofab.atlassian.net/browse/SDESK-7779?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ