### PR TITLE
[STT-1343, SDESK-7774] - Fix repeat summary and multiple content default value

### DIFF
--- a/client/components/Coverages/CoverageEditor/CoverageForm.tsx
+++ b/client/components/Coverages/CoverageEditor/CoverageForm.tsx
@@ -501,6 +501,7 @@ export class CoverageFormComponent extends React.Component<IProps, IState> {
                     ?? (coverageProfile?.schema?.['multiple_content'] as IProfileSchemaTypeList)?.read_only
                     ?? false,
                 field: 'multiple_content',
+                defaultValue: (coverageProfile?.schema?.['multiple_content'] as IProfileSchemaTypeList)?.default_value,
             },
             news_coverage_status: {
                 readOnly: this.props.readOnly || readOnlyFields.newsCoverageStatus,

--- a/client/components/Events/EventEditor/index.tsx
+++ b/client/components/Events/EventEditor/index.tsx
@@ -113,7 +113,7 @@ class EventEditorComponent extends React.PureComponent<IProps> {
         }
 
         const eventSchedule = item.dates ?? {};
-        const doesRepeat = eventSchedule.recurring_rule !== null;
+        const doesRepeat = eventSchedule.recurring_rule != null;
         const isManySecondary = appConfig.planning_event_link_method === 'many_secondary';
 
         return (


### PR DESCRIPTION
STT-1343
SDESK-7774

### Purpose
Fix `null` check to use type conversion so `undefined` and `null` values both work. Pass default value from content profile config to `multiple_content` field.

Resolves: 
#[SDESK-7774](https://sofab.atlassian.net/browse/SDESK-7774)
#[STT-1343](https://sofab.atlassian.net/browse/STT-1343)



[SDESK-7774]: https://sofab.atlassian.net/browse/SDESK-7774?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[STT-1343]: https://sofab.atlassian.net/browse/STT-1343?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ