### PR TITLE
[STT-1334] - Fix planning going blank after clearing due date in coverage

### DIFF
--- a/client/validators/planning.ts
+++ b/client/validators/planning.ts
@@ -227,7 +227,7 @@ const validateCoverageScheduleDate = ({
     errors,
     messages,
 }) => {
-    if (get(profile, 'schema.scheduled.required') && (value as moment.Moment).isValid() === false) {
+    if (profile?.schema?.scheduled?.required && (!moment.isMoment(value) || !value.isValid())) {
         set(errors, 'planning.scheduled.date', gettext('Required'));
         messages.push(gettext('COVERAGE SCHEDULE is required'));
 
@@ -326,12 +326,9 @@ const validateScheduledUpdatesDate = ({
     }
 };
 
-// eslint-disable-next-line consistent-this
-const self = {
+export default {
     validatePlanningScheduleDate,
     validateCoverages,
     validateScheduledUpdatesDate,
     validateCoverageScheduleDate,
 };
-
-export default self;

--- a/client/validators/tests/planning_test.ts
+++ b/client/validators/tests/planning_test.ts
@@ -75,7 +75,9 @@ describe('planningValidators', () => {
             field: 'coverages[0].planning.scheduled',
             value: planningDiff.coverages[0].planning.scheduled,
             errors: errors,
-            messages: errorMessages});
+            profile: {},
+            messages: errorMessages
+        });
         expect(errorMessages).toEqual(['COVERAGE SCHEDULED DATE cannot be in the past']);
         expect(errors).toEqual({
             coverages: [{
@@ -88,6 +90,33 @@ describe('planningValidators', () => {
         });
     });
 
+    it('fails if coverage schedule is required but value is invalid', () => {
+        const profile = {
+            schema: {
+                scheduled: {
+                    required: true
+                }
+            }
+        };
+
+        planningValidators.validateCoverageScheduleDate({
+            getState: getState,
+            field: 'coverages[0].planning.scheduled',
+            value: 'invalid_date',
+            profile: profile,
+            errors: errors,
+            messages: errorMessages
+        });
+        expect(errorMessages).toEqual(['COVERAGE SCHEDULE is required']);
+        expect(errors).toEqual({
+            planning: {
+                scheduled: {
+                    date: 'Required',
+                },
+            },
+        });
+    });
+
     it('Fails if scheduled updates are not ahead of each other in the sequential order', () => {
         const planningDiff = cloneDeep(planning);
 
@@ -97,6 +126,7 @@ describe('planningValidators', () => {
             getState: getState,
             field: 'planningDiff.coverages[0].scheduled_updates',
             value: planningDiff.coverages[0].scheduled_updates,
+            profile: {},
             errors: errors,
             messages: errorMessages,
             diff: planningDiff,
@@ -124,6 +154,7 @@ describe('planningValidators', () => {
             getState: getState,
             field: 'planningDiff.coverages[0].scheduled_updates',
             value: planningDiff.coverages[0].scheduled_updates,
+            profile: {},
             errors: errors,
             messages: errorMessages,
             diff: planningDiff,


### PR DESCRIPTION
### Purpose
To fix an issue that makes the Planning page to go blank when clearing the due date of a coverage item and trying to save the planning item. 

### What has changed
- Improved the validation for required coverage schedule dates by checking for valid moment objects and their validity.
- Updated tests to cover the new validation logic and ensure correct error handling when required dates are invalid.

### Steps to test
- Go to Planning and create a Planning item
- Save it and create a Coverage with due time set as a mandatory field
- Remove the time and click to save the Planning item

Resolves: [STT-1334]


[STT-1334]: https://sofab.atlassian.net/browse/STT-1334?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ