### PR TITLE
Store multiple_content in planning coverage

### DIFF
--- a/client/components/Coverages/CoverageEditor/CoverageForm.tsx
+++ b/client/components/Coverages/CoverageEditor/CoverageForm.tsx
@@ -500,7 +500,7 @@ export class CoverageFormComponent extends React.Component<IProps, IState> {
                 disabled: this.props.readOnly
                     ?? (coverageProfile?.schema?.['multiple_content'] as IProfileSchemaTypeList)?.read_only
                     ?? false,
-                field: 'multiple_content',
+                field: 'planning.multiple_content',
                 defaultValue: (coverageProfile?.schema?.['multiple_content'] as IProfileSchemaTypeList)?.default_value,
             },
             news_coverage_status: {


### PR DESCRIPTION
### Purpose
Fix coverage saving issues when multiple content is manually toggled on.

### What has changed
Store `multiple_content` field in coverage planning rather than just coverage. 

### Steps to test
Configure coverage profile to have multiple content field with default settings.
Add a coverage to a planning. 
Toggle on multiple content. 
Save the item. 
No errors should be shown and planning item should save

Resolves: #[STT-1348](https://sofab.atlassian.net/browse/STT-1348)



[STT-1348]: https://sofab.atlassian.net/browse/STT-1348?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ