### PR TITLE
[SDESK-7782] - Allow existing non recurring events to be made recurrent

### DIFF
--- a/client/components/Events/EventEditor/index.tsx
+++ b/client/components/Events/EventEditor/index.tsx
@@ -112,30 +112,15 @@ class EventEditorComponent extends React.PureComponent<IProps> {
             return null;
         }
 
-        const eventSchedule = item.dates ?? {};
-        const doesRepeat = eventSchedule.recurring_rule != null;
-        const isManySecondary = appConfig.planning_event_link_method === 'many_secondary';
-
         return (
             <>
                 <EventEditorHeader item={item} />
-                {isManySecondary ? (
-                    doesRepeat && (
-                        <ContentBlock padSmall>
-                            <RepeatEventSummary
-                                schedule={eventSchedule}
-                                noMargin
-                            />
-                        </ContentBlock>
-                    )
-                ) : (
-                    <ContentBlock padSmall>
-                        <EventScheduleSummary
-                            event={item}
-                            noPadding
-                        />
-                    </ContentBlock>
-                )}
+                <ContentBlock padSmall>
+                    <EventScheduleSummary
+                        event={item}
+                        noPadding
+                    />
+                </ContentBlock>
             </>
         );
     }
@@ -169,7 +154,7 @@ class EventEditorComponent extends React.PureComponent<IProps> {
                     recurring_rules: {
                         field: 'dates.recurring_rule',
                         defaultValue: {},
-                        enabled: !this.props.itemExists,
+                        originalItem: this.props.original,
                     },
                     dates: {
                         required: true,

--- a/client/components/Events/EventScheduleSummary/index.tsx
+++ b/client/components/Events/EventScheduleSummary/index.tsx
@@ -122,16 +122,6 @@ export const EventScheduleSummary = ({
                     dataTestId="field-dates_timezone"
                 />
             )}
-
-            {doesRepeat && (
-                <Row noPadding={noPadding} dataTestId="field-dates_repeat">
-                    <RepeatEventSummary
-                        schedule={eventSchedule}
-                        noMargin={noPadding}
-                        forUpdating={forUpdating}
-                    />
-                </Row>
-            )}
         </React.Fragment>
     );
 };

--- a/client/components/editor-standalone/field-definitions/recurring-rules.ts
+++ b/client/components/editor-standalone/field-definitions/recurring-rules.ts
@@ -2,6 +2,7 @@ import {IAuthoringFieldV2, ICommonFieldConfig} from 'superdesk-api';
 import {IFieldDefinition} from './interfaces';
 import {cloneDeep} from 'lodash';
 import moment, {Moment} from 'moment';
+import {IEventItem} from 'globals';
 
 export const getRecurringRulesField = (): IFieldDefinition => {
     return {

--- a/client/components/fields/editor/EventRecurringRules.interface.ts
+++ b/client/components/fields/editor/EventRecurringRules.interface.ts
@@ -1,5 +1,7 @@
-import {IEditorFieldProps} from '../../../interfaces';
+import {IEditorFieldProps, IEventItem} from '../../../interfaces';
 
 export interface IEditorFieldEventRecurringRulesProps extends IEditorFieldProps {
     onlyUpdateRepetitions?: boolean;
+    noPadding?: boolean;
+    originalItem?: IEventItem;
 }

--- a/client/components/fields/editor/EventRecurringRules.tsx
+++ b/client/components/fields/editor/EventRecurringRules.tsx
@@ -7,6 +7,9 @@ import {IEventItem} from '../../../interfaces';
 import {EditorFieldToggle} from './base/toggle';
 import {RecurringRulesInput} from '../../Events/RecurringRulesInput';
 import {IEditorFieldEventRecurringRulesProps} from './EventRecurringRules.interface';
+import {Row} from '../../../components/UI/Form';
+import {RepeatEventSummary} from '../../../components/Events';
+import {isExistingItem} from '../../../utils';
 
 export class EditorFieldEventRecurringRules extends React.PureComponent<IEditorFieldEventRecurringRulesProps> {
     constructor(props) {
@@ -40,19 +43,36 @@ export class EditorFieldEventRecurringRules extends React.PureComponent<IEditorF
         const eventRepeats = Object.keys(value ?? {}).length > 0;
         const recurring = {enabled: eventRepeats};
 
+        const originalRecurringRule = get(this.props.originalItem, field);
+        const originalRuleExists = originalRecurringRule != null
+            && Object.keys(originalRecurringRule).length > 0;
+        const isItemSaved = isExistingItem(this.props.item);
+        const showSummary = eventRepeats && isItemSaved && originalRuleExists;
+        const showInput = eventRepeats && (!isItemSaved || !originalRuleExists);
+
         return (
             <>
-                <EditorFieldToggle
-                    testId={`${this.props.testId}_toggle`}
-                    item={recurring}
-                    field="enabled"
-                    label={gettext('Repeats')}
-                    onChange={(_field, value) => {
-                        this.onRecurringEnableChanged(value);
-                    }}
-                    defaultValue={false}
-                />
-                {!eventRepeats ? null : (
+                {!showSummary && (
+                    <EditorFieldToggle
+                        testId={`${this.props.testId}_toggle`}
+                        item={recurring}
+                        field="enabled"
+                        label={gettext('Repeats')}
+                        onChange={(_field, value) => {
+                            this.onRecurringEnableChanged(value);
+                        }}
+                        defaultValue={false}
+                    />
+                )}
+                {showSummary && (
+                    <Row noPadding={true}>
+                        <RepeatEventSummary
+                            schedule={this.props.item.dates ?? {}}
+                            noMargin={false}
+                        />
+                    </Row>
+                )}
+                {showInput && (
                     <RecurringRulesInput
                         {...this.props}
                         recurring_rule={value}

--- a/client/planning-extension/src/authoring-react-fields/recurring-rules/editor.tsx
+++ b/client/planning-extension/src/authoring-react-fields/recurring-rules/editor.tsx
@@ -37,6 +37,7 @@ export class Editor extends React.PureComponent<IProps> {
                             recurring_rule: this.props.value,
                         }
                     }}
+                    originalItem={this.props.item}
                 />
             </Container>
         );


### PR DESCRIPTION
### Purpose
Allow existing non recurring events to be made into recurring ones.

### What has changed
Event Recurring Rules input. Now if the event is saved but not recurring you can reconfigure it to be one. 

### Steps to test
Case 1:

Open an existing recurring event. 
Recurring summary should be showing in place of the recurring event inline toggle and input.

Case 2:
Open a new event. Save it without making it a recurring one.
Open it again -> you should see the recurring events toggle.
Toggle it on, and configure the recurring settings.
Event should now be turned into a recurring one.

Resolves: #[SDESK-7782](https://sofab.atlassian.net/browse/SDESK-7782)

<img width="593" height="813" alt="image" src="https://github.com/user-attachments/assets/5a53a1c8-6a48-4d0c-bdb1-7ddbc85ccd74" />
<img width="593" height="813" alt="image" src="https://github.com/user-attachments/assets/2977fdde-c0db-40c1-b0c0-623e434aaeed" />
<img width="593" height="813" alt="image" src="https://github.com/user-attachments/assets/88616e2c-00b5-4a5f-bb46-9f500a706276" />
<img width="593" height="813" alt="image" src="https://github.com/user-attachments/assets/1ad1a133-16fa-4c25-bb83-77c1d189afbe" />
<img width="593" height="813" alt="image" src="https://github.com/user-attachments/assets/3aa34f10-1b26-438f-94f8-45c17689be80" />
<img width="593" height="813" alt="image" src="https://github.com/user-attachments/assets/b531b817-0f26-4d11-b65a-8485afc79725" />


[SDESK-7782]: https://sofab.atlassian.net/browse/SDESK-7782?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ