### PR TITLE
[STT-1357] - Fix assignment update logic for multiple content links

### DIFF
--- a/server/planning/assignments/assignments.py
+++ b/server/planning/assignments/assignments.py
@@ -983,10 +983,11 @@ class AssignmentsService(AsyncBaseService):
                 updated_assignment = self._set_user_for_assignment(
                     assignment, None, assignment_update_data.get("item_user_id")
                 )
-                updated_assignment.get("assigned_to")["desk"] = assignment_update_data.get("item_desk_id")
-                updated_assignment.get("assigned_to")["assignor_user"] = assignment_update_data.get("item_user_id")
 
-                if not assignment_allows_multiple_content_linked(assignment):
+                if assignment_allows_multiple_content_linked(assignment):
+                    updated_assignment.get("assigned_to")["desk"] = assignment_update_data.get("item_desk_id")
+                    updated_assignment.get("assigned_to")["assignor_user"] = assignment_update_data.get("item_user_id")
+                else:
                     updated_assignment.get("assigned_to")["state"] = get_next_assignment_status(
                         updated_assignment, ASSIGNMENT_WORKFLOW_STATE.SUBMITTED
                     )

--- a/server/planning/assignments/assignments.py
+++ b/server/planning/assignments/assignments.py
@@ -984,10 +984,9 @@ class AssignmentsService(AsyncBaseService):
                     assignment, None, assignment_update_data.get("item_user_id")
                 )
 
-                if assignment_allows_multiple_content_linked(assignment):
+                if not assignment_allows_multiple_content_linked(assignment):
                     updated_assignment.get("assigned_to")["desk"] = assignment_update_data.get("item_desk_id")
                     updated_assignment.get("assigned_to")["assignor_user"] = assignment_update_data.get("item_user_id")
-                else:
                     updated_assignment.get("assigned_to")["state"] = get_next_assignment_status(
                         updated_assignment, ASSIGNMENT_WORKFLOW_STATE.SUBMITTED
                     )


### PR DESCRIPTION
### Purpose
Corrects the conditional block to update `desk` and `assignor_user` only when assignments allow multiple content links. Previously, these fields were always updated regardless of assignment type.

### How to test
- Create an assignment (allowing multiple content items or just one)
- Start working on the assignment by creating an article and save it
- Send the article to another Desk

**Reported behavior**: The assignment gets also send to another Desk
**Expected behavior**: If the assignment allows multiple content links the assignment should remain in the same desk.

Resolves: [STT-1357]



[STT-1357]: https://sofab.atlassian.net/browse/STT-1357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ