### PR TITLE
Remove add to workflow from coverage profile

### DIFF
--- a/client/api/utils/constants.ts
+++ b/client/api/utils/constants.ts
@@ -1,3 +1,3 @@
-export const COVERAGE_SYSTEM_REQUIRED_FIELDS = ['g2_content_type', 'scheduled', 'add_coverage_to_workflow'];
+export const COVERAGE_SYSTEM_REQUIRED_FIELDS = ['g2_content_type', 'scheduled'];
 export const PLANNING_ITEM_SYSTEM_REQUIRED_FIELDS = ['planning_date', 'coverages'];
 export const EVENT_ITEM_SYSTEM_REQUIRED_FIELDS = ['dates'];

--- a/client/components/ContentProfiles/CoverageProfileModal.tsx
+++ b/client/components/ContentProfiles/CoverageProfileModal.tsx
@@ -170,14 +170,10 @@ export class CoverageProfilesModal extends React.Component<IProps, IState> {
     updateFields(fields: Array<IProfileFieldEntry>) {
         const profileCloned = cloneDeep(this.state.profile);
 
-        // Make sure `add_to_workflow is always first so
-        // it renders first in the editor
-        profileCloned.editor.add_coverage_to_workflow.index = 0;
-
         fields.forEach((item, index) => {
             profileCloned.editor[item.name] = {...item.field};
             profileCloned.schema[item.name] = {...item.schema};
-            profileCloned.editor[item.name].index = index + 1;
+            profileCloned.editor[item.name].index = index;
         });
 
         this.setState({

--- a/client/components/Coverages/CoverageEditor/CoverageForm.tsx
+++ b/client/components/Coverages/CoverageEditor/CoverageForm.tsx
@@ -574,8 +574,14 @@ export class CoverageFormComponent extends React.Component<IProps, IState> {
          */
         const editorDomFields = {};
 
-        if (isAutoAddToWorkflowOn) {
-            delete searchProfile['add_coverage_to_workflow'];
+        /**
+         * If auto add to workflow is off, show the field, and make sure it's always first in the editor
+         */
+        if (!isAutoAddToWorkflowOn) {
+            searchProfile['add_coverage_to_workflow'] = {
+                enabled: true,
+                index: -1,
+            };
         }
 
         return (

--- a/server/features/content_profiles_coverage.feature
+++ b/server/features/content_profiles_coverage.feature
@@ -8,41 +8,37 @@ Feature: Coverage Content Profiles
     {"_items": [{
         "name": "coverage",
         "editor": {
-            "add_coverage_to_workflow": {
+            "g2_content_type": {
                 "enabled": true,
                 "index": 1
             },
-            "g2_content_type": {
+            "genre": {
                 "enabled": true,
                 "index": 2
             },
-            "genre": {
+            "slugline": {
                 "enabled": true,
                 "index": 3
             },
-            "slugline": {
+            "ednote": {
                 "enabled": true,
                 "index": 4
             },
-            "ednote": {
+            "internal_note": {
                 "enabled": true,
                 "index": 5
             },
-            "internal_note": {
+            "news_coverage_status": {
                 "enabled": true,
                 "index": 6
             },
-            "news_coverage_status": {
+            "scheduled": {
                 "enabled": true,
                 "index": 7
             },
-            "scheduled": {
-                "enabled": true,
-                "index": 8
-            },
             "scheduled_updates": {
                 "enabled": true,
-                "index": 9
+                "index": 8
             },
             "contact_info": {"enabled": false},
             "language": {"enabled": false},

--- a/server/features/content_profiles_coverage.feature
+++ b/server/features/content_profiles_coverage.feature
@@ -141,10 +141,10 @@ Feature: Coverage Content Profiles
         }
     }]
     """
-    When we get "/planning_types"
+    When we get "/planning_types/coverage"
     Then we get existing resource
     """
-    {"_items": [{
+    {
         "name": "coverage",
         "editor": {
             "language": {
@@ -152,16 +152,14 @@ Feature: Coverage Content Profiles
                 "index": 1
             },
             "g2_content_type": {
-                "enabled": true,
-                "index": 2
+                "enabled": true
             },
             "headline": {
                 "enabled": true,
                 "index": 3
             },
             "slugline": {
-                "enabled": false,
-                "index": 4
+                "enabled": false
             }
         },
         "schema": {
@@ -174,7 +172,7 @@ Feature: Coverage Content Profiles
                 "required": true
             }
         }
-    }]}
+    }
     """
 
     @auth

--- a/server/planning/content_profiles/profiles/coverage.py
+++ b/server/planning/content_profiles/profiles/coverage.py
@@ -42,39 +42,39 @@ DEFAULT_COVERAGE_PROFILE = {
     "editor": {
         "g2_content_type": {
             "enabled": True,
-            "index": 2,
+            "index": 1,
         },
         "genre": {
             "enabled": True,
-            "index": 3,
+            "index": 2,
         },
         "slugline": {
             "enabled": True,
-            "index": 4,
+            "index": 3,
         },
         "ednote": {
             "enabled": True,
-            "index": 5,
+            "index": 4,
         },
         "internal_note": {
             "enabled": True,
-            "index": 6,
+            "index": 5,
         },
         "news_coverage_status": {
             "enabled": True,
-            "index": 7,
+            "index": 6,
         },
         "scheduled": {
             "enabled": True,
-            "index": 8,
+            "index": 7,
         },
         "scheduled_updates": {
             "enabled": True,
-            "index": 9,
+            "index": 8,
         },
         "multiple_content": {
             "enabled": False,
-            "index": 10,
+            "index": 9,
         },
         "location": {"enabled": False},
         "anpa_category": {"enabled": False},

--- a/server/planning/content_profiles/profiles/coverage.py
+++ b/server/planning/content_profiles/profiles/coverage.py
@@ -40,10 +40,6 @@ class CoverageSchema(BaseSchema):
 DEFAULT_COVERAGE_PROFILE = {
     "name": "coverage",
     "editor": {
-        "add_coverage_to_workflow": {
-            "enabled": True,
-            "index": 1,
-        },
         "g2_content_type": {
             "enabled": True,
             "index": 2,


### PR DESCRIPTION
### Purpose
Remove add to workflow field from coverage profile, because we don't need it; also because existing instances might get in a bad state because we no longer allow users to configure it but was a system required field

Resolves: #[SDESK-7781](https://sofab.atlassian.net/browse/SDESK-7781)



[SDESK-7781]: https://sofab.atlassian.net/browse/SDESK-7781?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ