### PR TITLE
[SDCP-986] fix: Use ObjectIds for ids of filters

### DIFF
--- a/server/features/search.feature
+++ b/server/features/search.feature
@@ -193,11 +193,11 @@ Feature: Search Feature
     Scenario: Search events and planning using calendars and agenda
         Given "agenda"
         """
-            [
-                {"name": "sports", "_id": "sports", "is_enabled": true},
-                {"name": "finance", "_id": "finance", "is_enabled": true},
-                {"name": "entertainment", "_id": "entertainment", "is_enabled": true}
-            ]
+        [
+            {"name": "sports", "_id": "68e5df45ac0f6c8b678c17b1", "is_enabled": true},
+            {"name": "finance", "_id": "68e5df45ac0f6c8b678c17b2", "is_enabled": true},
+            {"name": "entertainment", "_id": "68e5df45ac0f6c8b678c17b3", "is_enabled": true}
+        ]
         """
         And "events"
             """
@@ -268,7 +268,7 @@ Feature: Search Feature
                 "headline": "test headline",
                 "slugline": "slug123",
                 "planning_date": "2016-01-02T12:00:00+0000",
-                "agendas": ["sports"]
+                "agendas": ["68e5df45ac0f6c8b678c17b1"]
             },
             {
                 "guid": "planning_2",
@@ -277,7 +277,7 @@ Feature: Search Feature
                 "slugline": "slug123",
                 "related_events": [{"_id": "event_123", "link_type": "primary"}],
                 "planning_date": "2016-01-02T13:00:00+0000",
-                "agendas": ["sports"]
+                "agendas": ["68e5df45ac0f6c8b678c17b1"]
             },
             {
                 "guid": "planning_3",
@@ -286,7 +286,7 @@ Feature: Search Feature
                 "slugline": "slug456",
                 "related_events": [{"_id": "event_456", "link_type": "primary"}],
                 "planning_date": "2016-01-02T14:00:00+0000",
-                "agendas": ["finance"]
+                "agendas": ["68e5df45ac0f6c8b678c17b2"]
             },
             {
                 "guid": "planning_4",
@@ -295,7 +295,7 @@ Feature: Search Feature
                 "slugline": "slug456",
                 "related_events": [{"_id": "event_456", "link_type": "primary"}],
                 "planning_date": "2016-01-02T14:00:00+0000",
-                "agendas": ["entertainment"]
+                "agendas": ["68e5df45ac0f6c8b678c17b3"]
             },
             {
                 "guid": "planning_5",
@@ -304,7 +304,7 @@ Feature: Search Feature
                 "slugline": "slug456",
                 "related_events": [{"_id": "event_786", "link_type": "primary"}],
                 "planning_date": "2016-01-02T14:00:00+0000",
-                "agendas": ["sports", "finance"]
+                "agendas": ["68e5df45ac0f6c8b678c17b1", "68e5df45ac0f6c8b678c17b2"]
             },
             {
                 "guid": "planning_6",
@@ -312,7 +312,7 @@ Feature: Search Feature
                 "headline": "test headline",
                 "slugline": "slug456",
                 "planning_date": "2016-01-02T14:00:00+0000",
-                "agendas": ["entertainment"]
+                "agendas": ["68e5df45ac0f6c8b678c17b3"]
             }
         ]
         """
@@ -343,7 +343,7 @@ Feature: Search Feature
             ]
         }
         """
-        When we get "/events_planning_search?agendas=sports&calendars=sports&start_date=2016-01-02T00:00:00%2B0000"
+        When we get "/events_planning_search?agendas=68e5df45ac0f6c8b678c17b1&calendars=sports&start_date=2016-01-02T00:00:00%2B0000"
         Then we get list with 5 items
         """
         {
@@ -356,7 +356,7 @@ Feature: Search Feature
             ]
         }
         """
-        When we get "/events_planning_search?agendas=sports&calendars=sports,finance&start_date=2016-01-02T00:00:00%2B0000"
+        When we get "/events_planning_search?agendas=68e5df45ac0f6c8b678c17b1&calendars=sports,finance&start_date=2016-01-02T00:00:00%2B0000"
         Then we get list with 5 items
         """
         {
@@ -369,7 +369,7 @@ Feature: Search Feature
             ]
         }
         """
-        When we get "/events_planning_search?agendas=sports,finance&calendars=sports,finance&start_date=2016-01-02T00:00:00%2B0000"
+        When we get "/events_planning_search?agendas=68e5df45ac0f6c8b678c17b1,68e5df45ac0f6c8b678c17b2&calendars=sports,finance&start_date=2016-01-02T00:00:00%2B0000"
         Then we get list with 6 items
         """
         {
@@ -383,7 +383,7 @@ Feature: Search Feature
             ]
         }
         """
-        When we get "/events_planning_search?agendas=entertainment&start_date=2016-01-02T00:00:00%2B0000"
+        When we get "/events_planning_search?agendas=68e5df45ac0f6c8b678c17b3&start_date=2016-01-02T00:00:00%2B0000"
         Then we get list with 2 items
         """
         {
@@ -393,7 +393,7 @@ Feature: Search Feature
             ]
         }
         """
-        When we get "/events_planning_search?agendas=sports&start_date=2016-01-02T00:00:00%2B0000"
+        When we get "/events_planning_search?agendas=68e5df45ac0f6c8b678c17b1&start_date=2016-01-02T00:00:00%2B0000"
         Then we get list with 3 items
         """
         {

--- a/server/features/search_combined.feature
+++ b/server/features/search_combined.feature
@@ -2,11 +2,11 @@ Feature: Search Events and Planning
     Background: Initial setup
         Given "agenda"
         """
-            [
-                {"name": "sports", "_id": "sports", "is_enabled": true},
-                {"name": "finance", "_id": "finance", "is_enabled": true},
-                {"name": "entertainment", "_id": "entertainment", "is_enabled": true}
-            ]
+        [
+            {"name": "sports", "_id": "68e5df45ac0f6c8b678c17b1", "is_enabled": true},
+            {"name": "finance", "_id": "68e5df45ac0f6c8b678c17b2", "is_enabled": true},
+            {"name": "entertainment", "_id": "68e5df45ac0f6c8b678c17b3", "is_enabled": true}
+        ]
         """
         And "events"
             """

--- a/server/features/search_events.feature
+++ b/server/features/search_events.feature
@@ -2,11 +2,11 @@ Feature: Event Search
     Background: Initial setup
         Given "agenda"
         """
-            [
-                {"name": "sports", "_id": "sports", "is_enabled": true},
-                {"name": "finance", "_id": "finance", "is_enabled": true},
-                {"name": "entertainment", "_id": "entertainment", "is_enabled": true}
-            ]
+        [
+            {"name": "sports", "_id": "68e5df45ac0f6c8b678c17b1", "is_enabled": true},
+            {"name": "finance", "_id": "68e5df45ac0f6c8b678c17b2", "is_enabled": true},
+            {"name": "entertainment", "_id": "68e5df45ac0f6c8b678c17b3", "is_enabled": true}
+        ]
         """
         And "events"
             """
@@ -102,7 +102,7 @@ Feature: Event Search
                 "headline": "test headline",
                 "slugline": "slug123",
                 "planning_date": "2016-01-02T12:00:00+0000",
-                "agendas": ["sports"]
+                "agendas": ["68e5df45ac0f6c8b678c17b1"]
             }
         ]
         """

--- a/server/features/search_planning.feature
+++ b/server/features/search_planning.feature
@@ -2,11 +2,11 @@ Feature: Planning Search
     Background: Initial setup
         Given "agenda"
         """
-            [
-                {"name": "sports", "_id": "sports", "is_enabled": true},
-                {"name": "finance", "_id": "finance", "is_enabled": true},
-                {"name": "entertainment", "_id": "entertainment", "is_enabled": true}
-            ]
+        [
+            {"name": "sports", "_id": "68e5df45ac0f6c8b678c17b1", "is_enabled": true},
+            {"name": "finance", "_id": "68e5df45ac0f6c8b678c17b2", "is_enabled": true},
+            {"name": "entertainment", "_id": "68e5df45ac0f6c8b678c17b3", "is_enabled": true}
+        ]
         """
         And "events"
             """
@@ -316,7 +316,7 @@ Feature: Planning Search
 
     @auth
     Scenario: Search by planning specific parameters
-        When we get "/events_planning_search?repo=planning&only_future=false&agendas=sports,finance"
+        When we get "/events_planning_search?repo=planning&only_future=false&agendas=68e5df45ac0f6c8b678c17b1,68e5df45ac0f6c8b678c17b2"
         Then we get list with 3 items
         """
         {"_items": [

--- a/server/planning/types/agendas.py
+++ b/server/planning/types/agendas.py
@@ -1,11 +1,11 @@
 from typing import Annotated
 
-from .base import BasePlanningModel
+from .base import BasePlanningModelWithObjectId
 from superdesk.core.resources import fields, Dataclass
 from superdesk.core.resources.validators import validate_iunique_value_async
 
 
-class AgendasResourceModel(BasePlanningModel):
+class AgendasResourceModel(BasePlanningModelWithObjectId):
     name: Annotated[fields.Keyword, validate_iunique_value_async("agenda", "name")]
     is_enabled: bool = True
 

--- a/server/planning/types/assignment.py
+++ b/server/planning/types/assignment.py
@@ -6,7 +6,7 @@ from superdesk.utc import utcnow
 from superdesk.core.resources import fields, dataclass
 from superdesk.core.resources.validators import validate_data_relation_async
 
-from .base import BasePlanningModel
+from .base import BasePlanningModelWithObjectId
 from .common import LockFieldsMixin, AssignmentCoverage
 from .enums import AssignmentPublishedState, AssignmentWorkflowState
 
@@ -32,9 +32,7 @@ class AssignedTo:
     coverage_provider: CoverageProvider | None = None
 
 
-class AssignmentResourceModel(BasePlanningModel, LockFieldsMixin):
-    id: Annotated[fields.ObjectId, Field(alias="_id", default_factory=fields.ObjectId)]
-
+class AssignmentResourceModel(BasePlanningModelWithObjectId, LockFieldsMixin):
     firstcreated: datetime = Field(default_factory=utcnow)
     versioncreated: datetime = Field(default_factory=utcnow)
 

--- a/server/planning/types/base.py
+++ b/server/planning/types/base.py
@@ -1,9 +1,18 @@
 from typing import Annotated
-from superdesk.core.resources import ResourceModel
+
+from superdesk.core.resources import ResourceModel, ResourceModelWithObjectId
 from superdesk.core.resources.fields import ObjectId
 from superdesk.core.resources.validators import validate_data_relation_async
 
 
-class BasePlanningModel(ResourceModel):
+class VersionCreatorMixin:
     original_creator: Annotated[ObjectId | None, validate_data_relation_async("users")] = None
     version_creator: Annotated[ObjectId | None, validate_data_relation_async("users")] = None
+
+
+class BasePlanningModel(ResourceModel, VersionCreatorMixin):
+    pass
+
+
+class BasePlanningModelWithObjectId(ResourceModelWithObjectId, VersionCreatorMixin):
+    pass

--- a/server/planning/types/filters.py
+++ b/server/planning/types/filters.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from superdesk.core.resources import fields, Dataclass
 from superdesk.core.resources.validators import validate_data_relation_async, validate_iunique_value_async
 
-from .base import BasePlanningModel
+from .base import BasePlanningModelWithObjectId
 from .enums import LockState, SpikedState, SearchItemType, SearchScheduleFrequency, SearchWeekDay, SearchDateRange
 
 
@@ -85,7 +85,7 @@ class FilterParams(Dataclass):
     coverage_assignment_status: str | None = None
 
 
-class EventPlanningFilter(BasePlanningModel):
+class EventPlanningFilter(BasePlanningModelWithObjectId):
     name: Annotated[str, validate_iunique_value_async("events_planning_filters", "name")]
     item_type: SearchItemType = Field(default=SearchItemType.COMBINED)
     params: FilterParams = Field(default_factory=FilterParams)

--- a/server/planning/types/locations.py
+++ b/server/planning/types/locations.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import Any, Annotated
 from pydantic import Field
 
-from planning.types.base import BasePlanningModel
+from planning.types.base import BasePlanningModelWithObjectId
 
 from superdesk.utc import utcnow
 from superdesk.core.resources import fields, dataclass
@@ -34,7 +34,7 @@ class Address:
     address_type: str | None = Field(alias="type", default=None)
 
 
-class LocationResourceModel(BasePlanningModel):
+class LocationResourceModel(BasePlanningModelWithObjectId):
     guid: Annotated[
         fields.Keyword,
         validate_iunique_value_async("locations", "guid"),


### PR DESCRIPTION
### Purpose
Using Events or Planning filters was not working, regardless of the filter params used. It turns out the new async model was using a urn format for the IDs and not ObjectIds, which led the back-end not search the ids by strings.

### What has changed
Update the following resources to use ObjectIds:
* AgendasResourceModel
* AssignmentResourceModel (was already ObjectId, but now uses common base class)
* EventPlanningFilter
* LocationResourceModel

Resolves: [SDCP-986](https://sofab.atlassian.net/browse/SDCP-986)



[SDCP-986]: https://sofab.atlassian.net/browse/SDCP-986?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ