### PR TITLE
[SDESK-7775] fix: Only call softLockItem if form isn't disabled

### DIFF
--- a/client/components/fields/editor/AssociatedEvent.tsx
+++ b/client/components/fields/editor/AssociatedEvent.tsx
@@ -68,11 +68,13 @@ export class EditorFieldAssociatedEventComponent extends React.PureComponent<IAs
     }
 
     private lockRelatedItemsOnFrontEnd() {
-        planningApi.locks.softLockItem({
-            type: 'planning',
-            item: this.props.item,
-            event_ids: this.props.events.map((x) => x._id)
-        });
+        if (this.props.disabled !== true) {
+            planningApi.locks.softLockItem({
+                type: 'planning',
+                item: this.props.item,
+                event_ids: this.props.events.map((x) => x._id)
+            });
+        }
     }
 
     componentDidUpdate(prevProps: Readonly<IAssociatedEventFieldProps>): void {

--- a/client/components/fields/editor/EventRelatedPlannings/EventRelatedPlannings.tsx
+++ b/client/components/fields/editor/EventRelatedPlannings/EventRelatedPlannings.tsx
@@ -25,11 +25,13 @@ export class EditorFieldEventRelatedPlanningsComponent extends React.PureCompone
     }
 
     private softLockPlannings() {
-        planningApi.locks.softLockItem({
-            type: 'event',
-            item: this.props.item,
-            plan_ids: this.props.item.associated_plannings.map((x) => x._id),
-        });
+        if (this.props.disabled !== true) {
+            planningApi.locks.softLockItem({
+                type: 'event',
+                item: this.props.item,
+                plan_ids: this.props.item.associated_plannings.map((x) => x._id),
+            });
+        }
     }
 
     componentDidMount(): void {


### PR DESCRIPTION
### Purpose
Unlock button in editor header is not visible in recurring series other than the direct event that is locked.

### What has changed
Call softLockItem only if the form isn't disabled (keeping current lock in redux store)

Resolves: [SDESK-7775](https://sofab.atlassian.net/browse/SDESK-7775)



[SDESK-7775]: https://sofab.atlassian.net/browse/SDESK-7775?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ