### PR TITLE
[STT-1363] - Fix HTML tags rendering in Assignment view

### DIFF
--- a/client/components/Assignments/AssignmentItem/fields/DescriptionText.tsx
+++ b/client/components/Assignments/AssignmentItem/fields/DescriptionText.tsx
@@ -1,10 +1,15 @@
 import React from 'react';
 import {IAssignmentListItemField} from '../../../../components/Assignments/interfaces';
+import {stringUtils} from '../../../../utils';
 
 type IProps = IAssignmentListItemField;
 
 export const DescriptionTextComponent = ({assignment}: IProps) => {
     const descriptionText = assignment.description_text;
 
-    return <span>{descriptionText}</span>;
+    if (!descriptionText) return null;
+
+    const plainText = stringUtils.convertHtmlToPlainText(descriptionText);
+
+    return <span>{plainText}</span>;
 };

--- a/client/components/Assignments/AssignmentPreviewContainer/AssignmentPreview.tsx
+++ b/client/components/Assignments/AssignmentPreviewContainer/AssignmentPreview.tsx
@@ -73,6 +73,7 @@ export class AssignmentPreview extends React.PureComponent<IProps> {
                             planning: planningItem,
                         },
                         language: planning.language,
+                        schema: assignmentCoverageProfile?.schema,
                     },
                     {
                         contact_info: {field: 'coverage'},
@@ -86,12 +87,7 @@ export class AssignmentPreview extends React.PureComponent<IProps> {
                         ednote: {field: 'coverage.ednote', renderEmpty: true},
                         internal_note: {field: 'coverage.internal_note', renderEmpty: true},
                         location: {field: 'planning.location'},
-                    },
-                    undefined,
-                    undefined,
-                    'enabled',
-                    {},
-                    assignmentCoverageProfile?.schema
+                    }
                 )}
 
                 <Row

--- a/client/components/Assignments/AssignmentPreviewContainer/AssignmentPreview.tsx
+++ b/client/components/Assignments/AssignmentPreviewContainer/AssignmentPreview.tsx
@@ -4,6 +4,7 @@ import {get} from 'lodash';
 import {superdeskApi} from '../../../superdeskApi';
 import {
     IAssignmentItem,
+    ICoverageContentProfile,
     ICoverageFormProfile,
     ICoveragePlanningDetails,
     IFile,
@@ -26,6 +27,11 @@ interface IProps {
     planningItem: IPlanningItem;
     files: Array<IFile>;
     createLink(file: IFile): string;
+
+    /**
+     * The coverage profile used when creating the assignment
+     */
+    assignmentCoverageProfile: ICoverageContentProfile;
 }
 
 export class AssignmentPreview extends React.PureComponent<IProps> {
@@ -35,6 +41,7 @@ export class AssignmentPreview extends React.PureComponent<IProps> {
             assignment,
             coverageFormProfile,
             planningFormProfile,
+            assignmentCoverageProfile,
             planningItem,
             files,
             createLink,
@@ -80,6 +87,11 @@ export class AssignmentPreview extends React.PureComponent<IProps> {
                         internal_note: {field: 'coverage.internal_note', renderEmpty: true},
                         location: {field: 'planning.location'},
                     },
+                    undefined,
+                    undefined,
+                    'enabled',
+                    {},
+                    assignmentCoverageProfile?.schema
                 )}
 
                 <Row

--- a/client/components/Assignments/AssignmentPreviewContainer/index.tsx
+++ b/client/components/Assignments/AssignmentPreviewContainer/index.tsx
@@ -6,6 +6,7 @@ import {IDesk, IUser, IArticle} from 'superdesk-api';
 import {
     IAssignmentItem,
     IAssignmentPriority,
+    ICoverageContentProfile,
     IEventItem, IFile,
     IFormProfiles,
     IG2ContentType,
@@ -54,6 +55,8 @@ interface IStateProps {
     contentTypes: Array<IG2ContentType>;
     files: Array<IFile>;
     archiveItems: {[itemId: string]: IArticle};
+
+    assignmentCoverageProfile: ICoverageContentProfile;
 }
 
 interface IDispatchProps {
@@ -137,6 +140,7 @@ class AssignmentPreviewContainerComponent extends React.Component<IProps> {
             planningItem,
             priorities,
             formProfile,
+            assignmentCoverageProfile,
             hideAvatar,
             currentWorkspace,
             contentTypes,
@@ -193,6 +197,7 @@ class AssignmentPreviewContainerComponent extends React.Component<IProps> {
                         assignment={assignment}
                         coverageFormProfile={formProfile.coverage}
                         planningFormProfile={formProfile.planning}
+                        assignmentCoverageProfile={assignmentCoverageProfile}
                         planningItem={planningItem}
                         createLink={getFileDownloadURL}
                         files={files}
@@ -274,6 +279,8 @@ const mapStateToProps = (state) => ({
     contentTypes: selectors.general.contentTypes(state),
     files: selectors.general.files(state),
     archiveItems: selectors.getStoredArchiveItems(state),
+
+    assignmentCoverageProfile: selectors.getCurrentAssignmentCoverageProfile(state),
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/client/components/Coverages/CoveragePreview/index.tsx
+++ b/client/components/Coverages/CoveragePreview/index.tsx
@@ -130,6 +130,7 @@ export class CoveragePreview extends React.PureComponent<IProps> {
                         item: coverage,
                         language: coverage.planning.language ?? getUserInterfaceLanguageFromCV(),
                         renderEmpty: true,
+                        schema: formProfile?.schema,
                     },
                     {
                         language: {field: 'planning.language', enabled: false},

--- a/client/components/fields/preview/base/PreviewHoc.tsx
+++ b/client/components/fields/preview/base/PreviewHoc.tsx
@@ -18,7 +18,7 @@ export interface IBasePreviewProps {
     style?: 'normal' | 'strong' | 'light' | 'italic' | 'serif' | 'slugline'; // defaults to normal
     convertNewlineToBreak?: boolean;
     expandable?: boolean;
-    schema?: IProfileSchemaType;
+    schema?: {[key: string]: IProfileSchemaType};
 }
 
 export interface IPreviewHocOptions<S = {}> {
@@ -56,6 +56,8 @@ export function previewHoc<S = {}>(
             }
 
             const props = options.props == undefined ? {} : options.props();
+            const {schema} = this.props;
+            const fieldSchema = schema?.[field] || schema?.[fieldName];
 
             return (
                 <Component
@@ -63,7 +65,7 @@ export function previewHoc<S = {}>(
                     light={true}
                     {...props}
                     {...this.props}
-                    schema={this.props.schema}
+                    schema={fieldSchema}
                     translations={translations}
                 />
             );

--- a/client/components/fields/preview/base/PreviewHoc.tsx
+++ b/client/components/fields/preview/base/PreviewHoc.tsx
@@ -63,7 +63,7 @@ export function previewHoc<S = {}>(
                     light={true}
                     {...props}
                     {...this.props}
-                    schema={this.props.schema?.[field]}
+                    schema={this.props.schema}
                     translations={translations}
                 />
             );

--- a/client/selectors/assignments.ts
+++ b/client/selectors/assignments.ts
@@ -14,6 +14,7 @@ import {
 import {storedEvents} from './events';
 import {storedPlannings} from './planning';
 import {currentUserId} from './general';
+import {coverageProfiles} from './coverageProfiles';
 import {getItemsById} from '../utils';
 import {ASSIGNMENTS, SORT_DIRECTION, ALL_DESKS} from '../constants';
 
@@ -244,6 +245,29 @@ export const getCurrentAssignmentPlanningItem = createSelector(
             get(plannings, assignment.planning_item) :
             null
     )
+);
+
+/**
+ * Returns the coverage profile that was used when creating the assignment.
+ * This profile would include any user modifications to the schema not just
+ * the default values
+ */
+export const getCurrentAssignmentCoverageProfile = createSelector(
+    [getCurrentAssignment, getCurrentAssignmentPlanningItem, coverageProfiles],
+    (assignment, planningItem, profiles) => {
+        if (!assignment || !planningItem || !profiles.length) {
+            return null;
+        }
+
+        const coverageItem = planningItem.coverages?.find(
+            (coverage) => coverage.coverage_id === assignment.coverage_item
+        );
+
+        if (!coverageItem?.profile)
+            return null;
+
+        return profiles.find((profile) => profile._id === coverageItem.profile) || null;
+    }
 );
 
 export const getRelatedEventsForCurrentAssignment = createSelector<

--- a/client/selectors/assignments.ts
+++ b/client/selectors/assignments.ts
@@ -255,7 +255,7 @@ export const getCurrentAssignmentPlanningItem = createSelector(
 export const getCurrentAssignmentCoverageProfile = createSelector(
     [getCurrentAssignment, getCurrentAssignmentPlanningItem, coverageProfiles],
     (assignment, planningItem, profiles) => {
-        if (!assignment || !planningItem || !profiles.length) {
+        if (assignment == null || planningItem == null || profiles.length === 0) {
             return null;
         }
 
@@ -263,10 +263,10 @@ export const getCurrentAssignmentCoverageProfile = createSelector(
             (coverage) => coverage.coverage_id === assignment.coverage_item
         );
 
-        if (!coverageItem?.profile)
+        if (coverageItem?.profile == null)
             return null;
 
-        return profiles.find((profile) => profile._id === coverageItem.profile) || null;
+        return profiles.find((profile) => profile._id === coverageItem.profile) ?? null;
     }
 );
 

--- a/client/selectors/tests/assignments_test.ts
+++ b/client/selectors/tests/assignments_test.ts
@@ -347,45 +347,5 @@ describe('selectors', () => {
 
             expect(coverageProfile).toBeNull();
         });
-
-        it('returns null when profile ID does not match any coverage profile', () => {
-            const stateWithNonMatchingProfile = {
-                ...state,
-                planning: {
-                    ...state.planning,
-                    plannings: {
-                        ...state.planning.plannings,
-                        a: {
-                            ...state.planning.plannings.a,
-                            coverages: [{
-                                coverage_id: 'coverage1',
-                                profile: 'nonexistent_profile',
-                            }],
-                        },
-                    },
-                },
-            };
-
-            const coverageProfile = selectors.getCurrentAssignmentCoverageProfile(stateWithNonMatchingProfile);
-
-            expect(coverageProfile).toBeNull();
-        });
-
-        it('returns correct profile for different assignment', () => {
-            const stateWithDifferentAssignment = {
-                ...state,
-                assignment: {
-                    ...state.assignment,
-                    currentAssignmentId: 2,
-                },
-            };
-
-            const coverageProfile = selectors.getCurrentAssignmentCoverageProfile(stateWithDifferentAssignment);
-
-            expect(coverageProfile).toBeTruthy();
-            expect(coverageProfile._id).toBe('profile2');
-            expect(coverageProfile.name).toBe('Photo Profile');
-            expect(coverageProfile.content_type).toBe('picture');
-        });
     });
 });

--- a/client/selectors/tests/assignments_test.ts
+++ b/client/selectors/tests/assignments_test.ts
@@ -14,6 +14,8 @@ describe('selectors', () => {
                         desk: 'desk1',
                         user: 'user1',
                     },
+                    coverage_item: 'coverage1',
+                    planning_item: 'a',
                 },
                 2: {
                     _id: 2,
@@ -23,6 +25,8 @@ describe('selectors', () => {
                         assigned_date: '2017-07-28T13:16:36+0000',
                         desk: 'desk2',
                     },
+                    coverage_item: 'coverage2',
+                    planning_item: 'b',
                 },
             },
             assignmentsInTodoList: [1, 2],
@@ -70,13 +74,27 @@ describe('selectors', () => {
                         link_type: 'primary',
                     }],
                     agendas: ['1', '2'],
+                    coverages: [{
+                        coverage_id: 'coverage1',
+                        profile: 'profile1',
+                    }],
                 },
                 b: {
                     name: 'name b',
                     state: 'draft',
                     agendas: ['1', '2'],
+                    coverages: [{
+                        coverage_id: 'coverage2',
+                        profile: 'profile2',
+                    }],
                 },
-                c: {name: 'plan c'},
+                c: {
+                    name: 'plan c',
+                    coverages: [{
+                        coverage_id: 'coverage3',
+                        // No profile - this should test null case
+                    }],
+                },
                 d: {
                     name: 'plan d',
                     state: 'spiked',
@@ -106,6 +124,25 @@ describe('selectors', () => {
                 is_enabled: false,
             }],
             currentAgendaId: '1',
+        },
+        coverageProfiles: {
+            profiles: [
+                {
+                    _id: 'profile1',
+                    name: 'Text Profile',
+                    content_type: 'text',
+                },
+                {
+                    _id: 'profile2',
+                    name: 'Photo Profile',
+                    content_type: 'picture',
+                },
+                {
+                    _id: 'profile3',
+                    name: 'Video Profile',
+                    content_type: 'video',
+                },
+            ],
         },
         session: {identity: {_id: 'user1'}},
     };
@@ -175,6 +212,8 @@ describe('selectors', () => {
                 desk: 'desk1',
                 user: 'user1',
             },
+            coverage_item: 'coverage1',
+            planning_item: 'a',
         });
     });
 
@@ -228,6 +267,125 @@ describe('selectors', () => {
             filterByPriority: null,
             selectedDeskId: '',
             ignoreScheduledUpdates: false,
+        });
+    });
+
+    describe('getCurrentAssignmentCoverageProfile', () => {
+        it('returns coverage profile when assignment, planning item and profile exist', () => {
+            const coverageProfile = selectors.getCurrentAssignmentCoverageProfile(state);
+
+            expect(coverageProfile).toBeTruthy();
+            expect(coverageProfile._id).toBe('profile1');
+            expect(coverageProfile.name).toBe('Text Profile');
+            expect(coverageProfile.content_type).toBe('text');
+        });
+
+        it('returns null when no current assignment', () => {
+            const stateWithoutCurrentAssignment = {
+                ...state,
+                assignment: {
+                    ...state.assignment,
+                    currentAssignmentId: null,
+                },
+            };
+
+            const coverageProfile = selectors.getCurrentAssignmentCoverageProfile(stateWithoutCurrentAssignment);
+
+            expect(coverageProfile).toBeNull();
+        });
+
+        it('returns null when planning item does not exist', () => {
+            const stateWithoutPlanningItem = {
+                ...state,
+                assignment: {
+                    ...state.assignment,
+                    assignments: {
+                        ...state.assignment.assignments,
+                        1: {
+                            ...state.assignment.assignments[1],
+                            planning_item: 'nonexistent',
+                        },
+                    },
+                },
+            };
+
+            const coverageProfile = selectors.getCurrentAssignmentCoverageProfile(stateWithoutPlanningItem);
+
+            expect(coverageProfile).toBeNull();
+        });
+
+        it('returns null when coverage item has no profile', () => {
+            const stateWithoutProfile = {
+                ...state,
+                assignment: {
+                    ...state.assignment,
+                    assignments: {
+                        ...state.assignment.assignments,
+                        1: {
+                            ...state.assignment.assignments[1],
+                            coverage_item: 'coverage3',
+                            planning_item: 'c',
+                        },
+                    },
+                },
+            };
+
+            const coverageProfile = selectors.getCurrentAssignmentCoverageProfile(stateWithoutProfile);
+
+            expect(coverageProfile).toBeNull();
+        });
+
+        it('returns null when coverage profiles array is empty', () => {
+            const stateWithoutProfiles = {
+                ...state,
+                coverageProfiles: {
+                    profiles: [],
+                },
+            };
+
+            const coverageProfile = selectors.getCurrentAssignmentCoverageProfile(stateWithoutProfiles);
+
+            expect(coverageProfile).toBeNull();
+        });
+
+        it('returns null when profile ID does not match any coverage profile', () => {
+            const stateWithNonMatchingProfile = {
+                ...state,
+                planning: {
+                    ...state.planning,
+                    plannings: {
+                        ...state.planning.plannings,
+                        a: {
+                            ...state.planning.plannings.a,
+                            coverages: [{
+                                coverage_id: 'coverage1',
+                                profile: 'nonexistent_profile',
+                            }],
+                        },
+                    },
+                },
+            };
+
+            const coverageProfile = selectors.getCurrentAssignmentCoverageProfile(stateWithNonMatchingProfile);
+
+            expect(coverageProfile).toBeNull();
+        });
+
+        it('returns correct profile for different assignment', () => {
+            const stateWithDifferentAssignment = {
+                ...state,
+                assignment: {
+                    ...state.assignment,
+                    currentAssignmentId: 2,
+                },
+            };
+
+            const coverageProfile = selectors.getCurrentAssignmentCoverageProfile(stateWithDifferentAssignment);
+
+            expect(coverageProfile).toBeTruthy();
+            expect(coverageProfile._id).toBe('profile2');
+            expect(coverageProfile.name).toBe('Photo Profile');
+            expect(coverageProfile.content_type).toBe('picture');
         });
     });
 });


### PR DESCRIPTION
### Purpose

This PR fixes  the rendering of HTML tags in assignment descriptions and improving the assignment preview functionality. The changes ensure that HTML content in assignment descriptions is properly sanitized to display as plain text instead of rendering raw HTML tags, while also enhancing the assignment preview system with better coverage profile handling.

### What has changed

**HTML Sanitization:**
- Modified `DescriptionTextComponent` in `client/components/Assignments/AssignmentItem/fields/DescriptionText.tsx` to convert HTML content to plain text using `stringUtils.convertHtmlToPlainText()`, preventing raw HTML from being displayed in assignment descriptions

**Assignment Coverage Profile Enhancement:**
- Added new selector `getCurrentAssignmentCoverageProfile` in `client/selectors/assignments.ts` to properly retrieve coverage profiles used when creating assignments, including user modifications
- Updated `AssignmentPreview.tsx` and `AssignmentPreviewContainer/index.tsx` to utilize the new coverage profile selector
- Added tests in `client/selectors/tests/assignments_test.ts` to verify the new selector functionality

### How to test
Please follow the steps in the ticket 

### Screenshots
#### before
<img width="1000" alt="image" src="https://github.com/user-attachments/assets/ed7d326f-f13d-4118-acb1-c18bc6e76085" />

#### with 
<img width="1000" alt="image" src="https://github.com/user-attachments/assets/73c6b5a7-b577-4dc1-844c-99470fd96fec" />


Resolves: [STT-1363]


[STT-1363]: https://sofab.atlassian.net/browse/STT-1363?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ