### PR TITLE
[STT-1365] - Planning filters: Users cannot select more items for "single selection" CVs

### DIFF
--- a/client/components/AdvancedSearch/index.tsx
+++ b/client/components/AdvancedSearch/index.tsx
@@ -164,6 +164,7 @@ export class AdvancedSearch extends React.PureComponent<IProps> {
                 },
                 anpa_category: {
                     field: this.props.type === 'assignments' ? 'anpaCategory' : 'anpa_category',
+                    singleSelect: false,
                 },
                 start_date: {
                     canClear: true,

--- a/client/components/fields/editor/Categories.tsx
+++ b/client/components/fields/editor/Categories.tsx
@@ -25,7 +25,7 @@ export class EditorFieldCategoriesComponent extends React.PureComponent<IProps> 
                 field={this.props.field ?? 'anpa_category'}
                 label={vocabulary.display_name ?? gettext('ANPA Category')}
                 options={this.props.categories}
-                singleSelect={vocabulary.selection_type !== 'multi selection'}
+                singleSelect={this.props.singleSelect ?? (vocabulary.selection_type !== 'multi selection')}
             />
         );
     }


### PR DESCRIPTION
### Purpose
This PR allows for ANPA Category filters like Osasto in the advanced search to accept multiple selections even when the CV is set as single selection.

### What has changed
- Added `singleSelect: false` for anpa_category in the AdvancedSearch config
- Updated `EditorFieldCategories` to check passed-in `singleSelect` override before using the one in the CV

### Steps to test
1. Open the Planning module and show Advanced Filters.
2. Under “Vocabularies → Osasto”, test that you can select more than one value. Also check that the search query sends the selected filters in the API
3. Open the editor form and confirm ANPA Category like Osasto remains single-select there as defined in their CV configs.

### Screenshots
#### Before
<img width="359" height="531" alt="2025-10-10_12-55-13" src="https://github.com/user-attachments/assets/798898e4-2b71-4d10-ae73-77b4233bc9d8" />

#### After
<img width="355" height="457" alt="2025-10-10_12-55-35" src="https://github.com/user-attachments/assets/93690c41-7102-4b98-89b4-553b6635ee31" />


Resolves: #[STT-1365](https://sofab.atlassian.net/browse/STT-1365)


[STT-1365]: https://sofab.atlassian.net/browse/STT-1365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ