### PR TITLE
[STT-1376] fix: Add to planning changes planning lock to edit

### DIFF
--- a/client/components/Main/ItemEditor/ItemManager.ts
+++ b/client/components/Main/ItemEditor/ItemManager.ts
@@ -357,7 +357,12 @@ export class ItemManager {
                 .then((original: IEventOrPlanningItem) => {
                     initialValues = cloneDeep(original);
 
-                    return planningApi.locks.lockItem(original, 'edit');
+                    if (original.lock_action == null) {
+                        // Only lock the item if it's not already locked
+                        return planningApi.locks.lockItem(original, 'edit');
+                    } else {
+                        return original;
+                    }
                 });
         } else {
             // Fetch the latest item from the API to view in read-only mode


### PR DESCRIPTION
### Purpose
When attempting to add a story to an existing Planning item, the item is first locked for `add_to_planning` but later the editor re-locks the item in the DB to `edit`. This changes the context in which the item is being edited for.

### What has changed
When loading the item for the editor, if the item is already locked then don't attempt to lock it again.

Resolves: STT-1376

