### PR TITLE
Scheduled creation of advisories fails for all times other than the full hour [STT-1341]

### DIFF
--- a/server/planning/commands/export_scheduled_filters_test.py
+++ b/server/planning/commands/export_scheduled_filters_test.py
@@ -17,6 +17,7 @@ from superdesk.utc import local_to_utc
 
 from planning.tests import TestCase
 from planning.commands.export_scheduled_filters import ExportScheduledFilters
+from planning.search.eventsplanning_filters_service import EventsPlanningFiltersAsyncService
 
 
 def to_naive(date_str):
@@ -298,3 +299,28 @@ class ExportScheduledFiltersTestCase(TestCase):
             end="2018-06-30T23",
             expected_hits=expected_hits,
         )
+
+    def test_set_schedule_daily_preserves_hours(self):
+        svc = EventsPlanningFiltersAsyncService()
+        updates = {
+            "schedules": [
+                {
+                    "frequency": "daily",
+                    "hours": ["14:30", "08:05"],
+                    "hour": 14,
+                    "day": 10,
+                    "week_days": ["Monday"],
+                    "desk": "desk1",
+                }
+            ]
+        }
+
+        svc.set_schedule(updates)
+        schedule = updates["schedules"][0]
+
+        self.assertEqual(schedule["frequency"], "daily")
+        self.assertIn("hours", schedule)
+        self.assertListEqual(schedule["hours"], ["14:30", "08:05"])
+        self.assertEqual(schedule.get("day"), -1)
+        self.assertEqual(schedule.get("week_days"), [])
+        self.assertEqual(schedule.get("hour"), 14)

--- a/server/planning/common.py
+++ b/server/planning/common.py
@@ -688,23 +688,43 @@ def get_next_assignment_status(assignment, next_state):
 
 
 def get_first_paragraph_text(input_string):
+    # handle empty/None inputs
+    if not input_string:
+        return ""
     try:
         elem = parse_html(input_string, content="html")
-    except ValueError as e:
+    except Exception as e:
         logger.warning(e)
-    else:
-        # all non-empty paragraphs: ignores <p><br></p> sections
-        return get_text_from_elem(elem) or get_text_from_elem(elem, tag=None)
+        return ""
+    if elem is None:
+        return ""
+
+    # all non-empty paragraphs: ignores <p><br></p> sections
+    text = get_text_from_elem(elem)
+    if text:
+        return text
+
+    # Fallback to any text fragment if no <p> found
+    return get_text_from_elem(elem, tag=None) or ""
 
 
 def get_text_from_elem(elem, tag=".//p"):
+    # Ensure element is valid
+    if elem is None:
+        return None
+
+    # When tag is None, return first available text fragment
     if not tag:
         for t in elem.itertext():
-            return t  # Return first text item
+            if t:
+                return t  # Return first non-empty text item
+        return None
 
     for p in elem.iterfind(tag):
         if p.text:
             return p.text
+
+    return None
 
 
 def get_delivery_publish_time(updates, original=None):

--- a/server/planning/search/eventsplanning_filters_service.py
+++ b/server/planning/search/eventsplanning_filters_service.py
@@ -61,7 +61,15 @@ class EventsPlanningFiltersAsyncService(BasePlanningAsyncService[EventPlanningFi
             if frequency == "hourly":
                 schedule.update({"frequency": "hourly", "hour": -1, "day": -1, "week_days": []})
             elif frequency == "daily":
-                schedule.update({"frequency": "daily", "hour": hour, "day": -1, "week_days": []})
+                schedule.update(
+                    {
+                        "frequency": "daily",
+                        "hours": schedule.get("hours", []),
+                        "hour": hour,
+                        "day": -1,
+                        "week_days": [],
+                    }
+                )
             elif frequency == "weekly":
                 schedule.update(
                     {


### PR DESCRIPTION
Fix scheduling to run at specific times and prevent export crashes by handling `archive_text` parsing to avoid `NoneType` errors.