### PR TITLE
[STT-1373] fix: Revert availability not sending item id

### DIFF
--- a/client/actions/assignments/api.ts
+++ b/client/actions/assignments/api.ts
@@ -360,10 +360,11 @@ function unlink(assignment: IAssignmentItem, itemId: IArticle['_id']) {
         })
             .then(() => {
                 notify.success(gettext('Assignment reverted.'));
-                return planningApi.locks.unlockItem(assignment);
             }, (error) => {
                 notify.error(get(error, 'data._message') || gettext('Could not unlock the assignment.'));
-                throw error;
+            })
+            .finally(() => {
+                return planningApi.locks.unlockItem(assignment);
             })
     );
 }

--- a/client/actions/assignments/ui.ts
+++ b/client/actions/assignments/ui.ts
@@ -516,8 +516,13 @@ function revert(item: IAssignmentItem) {
         planningApi.locks.lockItem(item, 'revert')
             .then((lockedItem) => {
                 const contentTypes = selectors.general.contentTypes(getState());
+                const itemIds = item.item_ids ?? [];
 
-                if (!assignmentUtils.isTextAssignment(item, contentTypes) || item.planning?.multiple_content) {
+                if (
+                    !assignmentUtils.isTextAssignment(item, contentTypes)
+                    || item.planning?.multiple_content
+                    || itemIds.length === 0
+                ) {
                     return dispatch(assignments.api.revert(lockedItem))
                         .then((updatedItem) => {
                             notify.success(gettext('The assignment has been reverted.'));
@@ -528,12 +533,12 @@ function revert(item: IAssignmentItem) {
                         });
                 }
 
-                lockedItem.item_ids = get(item, 'item_ids', []);
+                lockedItem.item_ids = itemIds;
                 dispatch(showModal({
                     modalType: MODALS.CONFIRMATION,
                     modalProps: {
                         body: gettext('This will unlink the text item associated with the assignment. Are you sure ?'),
-                        action: () => dispatch(assignments.api.unlink(lockedItem)),
+                        action: () => dispatch(assignments.api.unlink(lockedItem, itemIds[0])),
                         onCancel: () => planningApi.locks.unlockItem(lockedItem),
                         autoClose: true,
                     },


### PR DESCRIPTION
### Purpose
When reverting the Assignment availability, and archive item ID was not sent.

### What has changed
* Send archive item ID when reverting Assignment availability
* Make sure to always unlock the Assignment, regardless of request response status.

Resolves:
[STT-1373](https://sofab.atlassian.net/browse/STT-1373)
[STT-1378](https://sofab.atlassian.net/browse/STT-1378)



[STT-1373]: https://sofab.atlassian.net/browse/STT-1373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[STT-1378]: https://sofab.atlassian.net/browse/STT-1378?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ