### PR TITLE
[STT-1397] - Assignments view: Filtering by ANPA category (Osasto)

### DIFF
--- a/server/planning/assignments/assignments_content.py
+++ b/server/planning/assignments/assignments_content.py
@@ -94,7 +94,14 @@ async def get_item_from_assignment(assignment, template=None):
 
                 await merge_subject(item, planning)
                 merge_list("place", item, planning)
-                merge_list("anpa_category", item, planning)
+
+                # Inherit anpa_category from coverage first, then fallback to planning item
+                coverage = await get_coverage_for_assignment(assignment) or {}
+                coverage_anpa_category = (coverage.get("planning") or {}).get("anpa_category")
+                if coverage_anpa_category:
+                    item["anpa_category"] = deepcopy(coverage_anpa_category)
+                else:
+                    merge_list("anpa_category", item, planning)
 
             if assignment.get("description_text"):
                 item["abstract"] = "<p>{}</p>".format(assignment["description_text"])

--- a/server/planning/assignments/assignments_content.py
+++ b/server/planning/assignments/assignments_content.py
@@ -95,11 +95,9 @@ async def get_item_from_assignment(assignment, template=None):
                 await merge_subject(item, planning)
                 merge_list("place", item, planning)
 
-                # Inherit anpa_category from coverage first, then fallback to planning item
-                coverage = await get_coverage_for_assignment(assignment) or {}
-                coverage_anpa_category = (coverage.get("planning") or {}).get("anpa_category")
-                if coverage_anpa_category:
-                    item["anpa_category"] = deepcopy(coverage_anpa_category)
+                anpa_category = planning_data.get("anpa_category")
+                if anpa_category:
+                    item["anpa_category"] = deepcopy(anpa_category)
                 else:
                     merge_list("anpa_category", item, planning)
 

--- a/server/planning/assignments/assignments_content.py
+++ b/server/planning/assignments/assignments_content.py
@@ -95,8 +95,7 @@ async def get_item_from_assignment(assignment, template=None):
                 await merge_subject(item, planning)
                 merge_list("place", item, planning)
 
-                anpa_category = planning_data.get("anpa_category")
-                if anpa_category:
+                if anpa_category := planning_data.get("anpa_category"):
                     item["anpa_category"] = deepcopy(anpa_category)
                 else:
                     merge_list("anpa_category", item, planning)

--- a/server/planning/planning/planning.py
+++ b/server/planning/planning/planning.py
@@ -674,9 +674,7 @@ class PlanningService(AsyncBaseService):
                 coverage.setdefault("planning", {})
                 coverage["planning"].setdefault("scheduled", planning_date)
 
-                # Inherit anpa category from planning item if not explicitly set/missing in coverage profile
-                if not coverage["planning"].get("anpa_category"):
-                    coverage["planning"]["anpa_category"] = updates.get("anpa_category", [])
+                self.inherit_anpa_category(coverage, updates)
 
                 set_original_creator(coverage)
                 self.set_coverage_active(coverage, updates)
@@ -764,9 +762,7 @@ class PlanningService(AsyncBaseService):
             coverage.setdefault("planning", {})
             coverage["planning"].setdefault("scheduled", (original_coverage.get("planning") or {}).get("scheduled"))
 
-            # Inherit anpa category from planning item if not explicitly set/missing in coverage profile
-            if not coverage["planning"].get("anpa_category"):
-                coverage["planning"]["anpa_category"] = updates.get("anpa_category", [])
+            self.inherit_anpa_category(coverage, updates)
 
             self.set_coverage_active(coverage, updates)
             await self.set_slugline_from_xmp(coverage, original_coverage)
@@ -1783,6 +1779,10 @@ class PlanningService(AsyncBaseService):
                 continue
             yield plan
 
+    def inherit_anpa_category(self, coverage, updates):
+        # Inherit anpa category from planning item if not explicitly set/missing in coverage profile
+        if not coverage["planning"].get("anpa_category"):
+            coverage["planning"]["anpa_category"] = updates.get("anpa_category", [])
 
 class PlanningResource(Resource):
     """Resource for planning data model

--- a/server/planning/planning/planning.py
+++ b/server/planning/planning/planning.py
@@ -674,6 +674,10 @@ class PlanningService(AsyncBaseService):
                 coverage.setdefault("planning", {})
                 coverage["planning"].setdefault("scheduled", planning_date)
 
+                # Inherit anpa category from planning item if not explicitly set/missing in coverage profile
+                if not coverage["planning"].get("anpa_category"):
+                    coverage["planning"]["anpa_category"] = updates.get("anpa_category", [])
+
                 set_original_creator(coverage)
                 self.set_coverage_active(coverage, updates)
                 await self.set_slugline_from_xmp(coverage, None)
@@ -759,6 +763,11 @@ class PlanningService(AsyncBaseService):
             # If none was supplied, fallback to ``original.planning.scheduled``
             coverage.setdefault("planning", {})
             coverage["planning"].setdefault("scheduled", (original_coverage.get("planning") or {}).get("scheduled"))
+
+            # Inherit anpa category from planning item if not explicitly set/missing in coverage profile
+            if not coverage["planning"].get("anpa_category"):
+                coverage["planning"]["anpa_category"] = updates.get("anpa_category", [])
+
             self.set_coverage_active(coverage, updates)
             await self.set_slugline_from_xmp(coverage, original_coverage)
             if self.coverage_changed(coverage, original_coverage):

--- a/server/planning/planning/planning.py
+++ b/server/planning/planning/planning.py
@@ -674,7 +674,7 @@ class PlanningService(AsyncBaseService):
                 coverage.setdefault("planning", {})
                 coverage["planning"].setdefault("scheduled", planning_date)
 
-                self.inherit_anpa_category(coverage, updates)
+                self.inherit_planning_metadata(coverage, updates)
 
                 set_original_creator(coverage)
                 self.set_coverage_active(coverage, updates)
@@ -762,7 +762,7 @@ class PlanningService(AsyncBaseService):
             coverage.setdefault("planning", {})
             coverage["planning"].setdefault("scheduled", (original_coverage.get("planning") or {}).get("scheduled"))
 
-            self.inherit_anpa_category(coverage, updates)
+            self.inherit_planning_metadata(coverage, updates)
 
             self.set_coverage_active(coverage, updates)
             await self.set_slugline_from_xmp(coverage, original_coverage)
@@ -1779,10 +1779,16 @@ class PlanningService(AsyncBaseService):
                 continue
             yield plan
 
-    def inherit_anpa_category(self, coverage, updates):
-        # Inherit anpa category from planning item if not explicitly set/missing in coverage profile
-        if not coverage["planning"].get("anpa_category"):
-            coverage["planning"]["anpa_category"] = updates.get("anpa_category", [])
+    def inherit_planning_metadata(self, coverage, updates):
+        """
+        Inherit planning metadata fields to coverage if not explicitly set in coverage profile.
+        The fields inherited are those overlapping metadata fields from the planning schema and coverage schema
+        """
+        fields_to_inherit = ["anpa_category", "subject", "genre", "priority", "location"]
+        for field in fields_to_inherit:
+            if updates.get(field):
+                coverage["planning"].setdefault(field, updates[field])
+
 
 class PlanningResource(Resource):
     """Resource for planning data model


### PR DESCRIPTION
### Purpose
This PR adds some changes to the planning -> coverage flow whereby now : 
- Coverages now inherit the Planning’s category if none is provided explicitly . They can both be different.
- Newly created stories from assignments inherit from the coverage first then fall back to the planning item if coverage is null.

### What has changed
- In the planning service, added logic so a coverage without its own `anpa_category` now inherits from the parent planning item.
- Updated merge logic to pull `anpa_category` from the coverage if it set before falling back to the planning item’s category.

### Steps to test
1. Create a Planning item and set its anpa category.
2. Add a Coverage to the planning item without anpa category. 
3. In the Assignments list, filter by that category → the assignment must appear. It should also show the anpa category inherited from the planning item in the list view.
4. Click “Start working” on that assignment → the new story’s anpa category should match the Coverage’s one.
6. Repeat with a Coverage that has its own anpa category. Observe it retains its own category even if different from the planning item. Filtering on Assignments list should also work. Also story must inherit the Coverage’s category as expected.

Resolves: #[STT-1379](https://sofab.atlassian.net/browse/STT-1379)


[STT-1379]: https://sofab.atlassian.net/browse/STT-1379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ