### PR TITLE
[STT-1364] - Fix internal note tooltip

### DIFF
--- a/client/components/InternalNoteLabel/index.tsx
+++ b/client/components/InternalNoteLabel/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {get} from 'lodash';
 import classNames from 'classnames';
-import {Popover} from 'superdesk-ui-framework/react';
+import {Text, Tooltip} from 'superdesk-ui-framework/react';
 import {gettext, getItemWorkflowStateLabel} from '../../utils';
 
 import './style.scss';
@@ -31,11 +31,18 @@ export const InternalNoteLabel: React.FC<IInternalNoteLabelProps> = ({
     marginLeft = false,
     showHeaderText = true,
 }) => {
-    const internalNote = get(item, `${prefix}${noteField}`);
+    const internalNoteRaw = get(item, `${prefix}${noteField}`);
 
-    if ((internalNote ?? '').length < 1) {
+    if ((internalNoteRaw ?? '').length < 1) {
         return null;
     }
+
+    // Strip out any existing HTML tags and convert \n to <br> tags for HTML rendering
+    const internalNoteHtml = internalNoteRaw
+        .replace(/<[^>]*>/g, '')
+        .split('\n')
+        .map((line) => line)
+        .join('<br>');
 
     const iconColor = stateField ? get(getItemWorkflowStateLabel(item, stateField), 'iconType') : 'red';
 
@@ -58,21 +65,24 @@ export const InternalNoteLabel: React.FC<IInternalNoteLabelProps> = ({
         return (
             <div className={className}>
                 {icon}
-                {showText && internalNote}
+                {showText && <span dangerouslySetInnerHTML={{__html: internalNoteHtml}} />}
             </div>
         );
     }
 
     return (
         <>
-            <Popover
+            <Tooltip
                 placement="auto"
-                triggerSelector="#internal-note-icon"
-                title={showHeaderText ? gettext('Internal Note:') : ''}
+                content={() => (
+                    <div>
+                        {showHeaderText && <Text weight="strong">{gettext('Internal Note:')}</Text>}
+                        <div dangerouslySetInnerHTML={{__html: internalNoteHtml}} />
+                    </div>
+                )}
             >
-                {internalNote}
-            </Popover>
-            {icon}
+                {icon}
+            </Tooltip>
         </>
     );
 };

--- a/client/components/InternalNoteLabel/index.tsx
+++ b/client/components/InternalNoteLabel/index.tsx
@@ -75,7 +75,14 @@ export const InternalNoteLabel: React.FC<IInternalNoteLabelProps> = ({
             <Tooltip
                 placement="auto"
                 content={() => (
-                    <div>
+                    <div
+                        style={{
+                            boxShadow: 'var(--sd-shadow--z3)',
+                            padding: 'var(--space--1-5)',
+                            fontSize: 'var(--text-size-small)',
+                            lineHeight: 1.4
+                        }}
+                    >
                         {showHeaderText && <Text weight="strong">{gettext('Internal Note:')}</Text>}
                         <div dangerouslySetInnerHTML={{__html: internalNoteHtml}} />
                     </div>


### PR DESCRIPTION
### Purpose
Rework internal note, while still making it show on hover.

### What has changed
Clean up styles from the internal note. Drop usage of old component and use the new `Tooltip`.

Resolves: #[STT-1364](https://sofab.atlassian.net/browse/STT-1364)

<img width="723" height="314" alt="image" src="https://github.com/user-attachments/assets/b166a007-bd5a-4b71-9bb8-b5f3631bc5ef" />


[STT-1364]: https://sofab.atlassian.net/browse/STT-1364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ