### PR TITLE
fix ingested events state after manual editing

### DIFF
--- a/server/planning/common.py
+++ b/server/planning/common.py
@@ -498,20 +498,6 @@ def list_uniq_with_order(list):
     return [x for x in list if not (x in seen or seen_add(x))]
 
 
-def set_ingested_event_state(updates, original):
-    """Set the ingested event state to draft"""
-    if not updates.get("version_creator"):
-        return
-
-    # don't change status to draft when event was duplicated
-    if (
-        original.get(ITEM_STATE) == WORKFLOW_STATE.INGESTED
-        and not updates.get("duplicate_to")
-        and not updates.get(ITEM_STATE)
-    ):
-        updates[ITEM_STATE] = WORKFLOW_STATE.DRAFT
-
-
 def set_actioned_date_to_event(updates, original):
     # If event lasts more than a day, set actioned_date
     if type(updates) is dict and ((original["dates"]["end"] - original["dates"]["start"]).total_seconds() / 60) >= (
@@ -859,7 +845,8 @@ def update_ingest_on_patch(updates: Dict[str, Any], original: Dict[str, Any]):
     elif original.get("pubstatus") == updates.get("ingest_pubstatus"):
         # The local version has been published
         # and no change to ``pubstatus`` on ingested item
-        updates.pop("state")
+        if original.get("state") not in {WORKFLOW_STATE.DRAFT}:  # item was manually edited after ingesting
+            updates.pop("state")
 
 
 def get_coverage_from_planning(planning_item: Planning, coverage_id: str) -> Optional[Coverage]:

--- a/server/planning/events/events.py
+++ b/server/planning/events/events.py
@@ -62,7 +62,6 @@ from planning.common import (
     POST_STATE,
     get_event_max_multi_day_duration,
     set_original_creator,
-    set_ingested_event_state,
     LOCK_ACTION,
     sanitize_input_data,
     set_ingest_version_datetime,
@@ -531,7 +530,6 @@ class EventsService(superdesk.Service):
 
         if user_id:
             updates["version_creator"] = user_id
-            set_ingested_event_state(updates, original)
 
         lock_user = original.get("lock_user", None)
         str_user_id = str(user.get(config.ID_FIELD)) if user_id else None

--- a/server/planning/events/events_base_service.py
+++ b/server/planning/events/events_base_service.py
@@ -25,7 +25,6 @@ from planning.common import (
     WORKFLOW_STATE,
     get_max_recurrent_events,
     update_post_item,
-    set_ingested_event_state,
     is_valid_event_planning_reason,
 )
 from planning.item_lock import LOCK_USER, LOCK_SESSION, LOCK_ACTION
@@ -53,7 +52,6 @@ class EventsBaseService(BaseService):
         user_id = get_user_id()
         if user_id:
             updates["version_creator"] = user_id
-            set_ingested_event_state(updates, original)
 
         # If `skip_on_update` is provided in the updates
         # Then return here so no further processing is performed on this event.

--- a/server/planning/io/ingest_rule_handler_test.py
+++ b/server/planning/io/ingest_rule_handler_test.py
@@ -9,7 +9,7 @@
 # at https://www.sourcefabric.org/superdesk/license
 
 from bson import ObjectId
-from datetime import datetime
+from datetime import datetime, timedelta
 from superdesk import get_resource_service
 from superdesk.metadata.item import ITEM_TYPE, CONTENT_TYPE
 from .ingest_rule_handler import PlanningRoutingRuleHandler
@@ -240,3 +240,23 @@ class IngestRuleHandlerTestCase(TestCase):
         original = events_service.find_one(req=None, _id=event["_id"])
         assert original["pubstatus"] == "usable"
         assert original["state"] == "scheduled"
+
+    def test_autopost_draft_event(self):
+        event = self.event_items[0].copy()
+        event["versioncreated"] = datetime.now() - timedelta(minutes=10)
+        events_service = get_resource_service("events")
+        events_service.post([event])
+
+        original = events_service.find_one(req=None, _id=event["_id"])
+        assert original["pubstatus"] == "usable"
+        assert original["state"] == "draft"
+
+        event.pop("state")
+        event["name"] = "updated name"
+        event["pubstatus"] = "usable"
+        event["versioncreated"] = datetime.now()
+        events_service.patch_in_mongo(event["_id"], event, original)
+
+        original = events_service.find_one(req=None, _id=event["_id"])
+        assert original["pubstatus"] == "usable"
+        assert original["state"] == "ingested"


### PR DESCRIPTION
- avoid setting `draft` state when editing ingested events
- if it's already set update it on next update

CPCN-1155

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

### Front-end checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)

Resolves: #[issue-number]

