### PR TITLE
[SDESK-7783] fix: Change locks in redux by api request OR websocket

### DIFF
--- a/client/actions/assignments/notifications.ts
+++ b/client/actions/assignments/notifications.ts
@@ -2,7 +2,7 @@ import {get, cloneDeep} from 'lodash';
 
 import {IWebsocketMessageData} from '../../interfaces';
 
-import {planningApi} from '../../superdeskApi';
+import {planningApi, superdeskApi} from '../../superdeskApi';
 import {ASSIGNMENTS, WORKSPACE, MODALS} from '../../constants';
 import {lockUtils, assignmentUtils, gettext, isExistingItem} from '../../utils';
 
@@ -199,7 +199,7 @@ const _updatePlannigRelatedToAssignment = (data) => (
 
 function onAssignmentLocked(_e, data: IWebsocketMessageData['ITEM_LOCKED']) {
     return (dispatch) => {
-        if (get(data, 'item')) {
+        if (get(data, 'item') && data.clientId !== superdeskApi.session.getUniqueClientId()) {
             planningApi.locks.setItemAsLocked(data);
             return dispatch(assignments.api.fetchAssignmentById(data.item, false))
                 .then((assignmentInStore) => {
@@ -235,7 +235,7 @@ function onAssignmentLocked(_e, data: IWebsocketMessageData['ITEM_LOCKED']) {
  */
 function onAssignmentUnlocked(_e, data: IWebsocketMessageData['ITEM_UNLOCKED']) {
     return (dispatch, getState) => {
-        if (get(data, 'item')) {
+        if (get(data, 'item') && data.clientId !== superdeskApi.session.getUniqueClientId()) {
             planningApi.locks.setItemAsUnlocked(data);
             return dispatch(assignments.api.fetchAssignmentById(data.item, false))
                 .then((assignmentInStore) => {

--- a/client/actions/events/notifications.ts
+++ b/client/actions/events/notifications.ts
@@ -1,6 +1,6 @@
 import {get} from 'lodash';
 
-import {planningApi} from '../../superdeskApi';
+import {planningApi, superdeskApi} from '../../superdeskApi';
 import {IWebsocketMessageData, ITEM_TYPE} from '../../interfaces';
 import * as selectors from '../../selectors';
 import {WORKFLOW_STATE, EVENTS, LOCKS} from '../../constants';
@@ -33,7 +33,7 @@ const onEventCreated = (_e, data) => (
  */
 function onEventUnlocked(_e: {}, data: IWebsocketMessageData['ITEM_UNLOCKED']) {
     return (dispatch, getState) => {
-        if (data?.item != null) {
+        if (data?.item != null && data.clientId !== superdeskApi.session.getUniqueClientId()) {
             const state = getState();
             const events = selectors.events.storedEvents(state);
             let eventInStore = get(events, data.item, {});
@@ -71,7 +71,7 @@ function onEventUnlocked(_e: {}, data: IWebsocketMessageData['ITEM_UNLOCKED']) {
 
 const onEventLocked = (_e, data) => (
     (dispatch, getState) => {
-        if (data && data.item) {
+        if (data && data.item && data?.clientId !== superdeskApi.session.getUniqueClientId()) {
             planningApi.locks.setItemAsLocked(data);
 
             const sessionId = selectors.general.session(getState()).sessionId;

--- a/client/actions/main.ts
+++ b/client/actions/main.ts
@@ -1237,18 +1237,30 @@ const openFromURLOrRedux = (action) => (
         }
 
         if (item.id && item.type) {
+            const isNewItem = isTemporaryId(item.id);
+
             // Make sure the item is loaded into the redux store
             // before loading the preview or editor
-            return dispatch(self.fetchById(item.id, item.type))
-                .then((loadedItem) => {
-                    if (action === MAIN.EDIT) {
-                        dispatch(self.openForEdit(loadedItem));
-                    } else if (action === MAIN.PREVIEW) {
-                        dispatch(self.openPreview(loadedItem));
-                    }
+            if (isNewItem && action === MAIN.EDIT) {
+                const baseItem = {
+                    _id: item.id,
+                    type: item.type,
+                };
 
-                    return Promise.resolve(loadedItem);
-                });
+                dispatch(self.openForEdit(baseItem));
+                return Promise.resolve(baseItem);
+            } else if (!isNewItem) {
+                return dispatch(self.fetchById(item.id, item.type))
+                    .then((loadedItem) => {
+                        if (action === MAIN.EDIT) {
+                            dispatch(self.openForEdit(loadedItem));
+                        } else if (action === MAIN.PREVIEW) {
+                            dispatch(self.openPreview(loadedItem));
+                        }
+
+                        return Promise.resolve(loadedItem);
+                    });
+            }
         }
 
         // Remove the item from the URL

--- a/client/actions/main.ts
+++ b/client/actions/main.ts
@@ -1237,25 +1237,18 @@ const openFromURLOrRedux = (action) => (
         }
 
         if (item.id && item.type) {
-            const baseItem = {
-                _id: item.id,
-                type: item.type,
-            };
+            // Make sure the item is loaded into the redux store
+            // before loading the preview or editor
+            return dispatch(self.fetchById(item.id, item.type))
+                .then((loadedItem) => {
+                    if (action === MAIN.EDIT) {
+                        dispatch(self.openForEdit(loadedItem));
+                    } else if (action === MAIN.PREVIEW) {
+                        dispatch(self.openPreview(loadedItem));
+                    }
 
-            if (action === MAIN.EDIT) {
-                dispatch(self.openForEdit(baseItem));
-
-                return Promise.resolve(baseItem);
-            } else if (action === MAIN.PREVIEW) {
-                // Make sure the item is loaded into the redux store
-                // and store the entire item in the forms initialValues
-                return dispatch(self.fetchById(item.id, item.type))
-                    .then((loadedItem) => {
-                        dispatch(self.openPreview(loadedItem || baseItem));
-
-                        return Promise.resolve(loadedItem || baseItem);
-                    });
-            }
+                    return Promise.resolve(loadedItem);
+                });
         }
 
         // Remove the item from the URL

--- a/client/actions/planning/notifications.ts
+++ b/client/actions/planning/notifications.ts
@@ -1,7 +1,7 @@
 import {get} from 'lodash';
 
 import {IWebsocketMessageData, ITEM_TYPE, IPlanningAppState} from '../../interfaces';
-import {planningApi} from '../../superdeskApi';
+import {planningApi, superdeskApi} from '../../superdeskApi';
 
 import {gettext, lockUtils} from '../../utils';
 import {PLANNING, MODALS, WORKFLOW_STATE, WORKSPACE} from '../../constants';
@@ -105,7 +105,7 @@ const onPlanningUpdated = (_e: {}, data: IWebsocketMessageData['PLANNING_UPDATED
 
 const onPlanningLocked = (e: {}, data: IWebsocketMessageData['ITEM_LOCKED']) => (
     (dispatch, getState) => {
-        if (data.item != null) {
+        if (data.item != null && data.clientId !== superdeskApi.session.getUniqueClientId()) {
             planningApi.locks.setItemAsLocked(data);
 
             const sessionId = selectors.general.session(getState()).sessionId;
@@ -151,7 +151,7 @@ const onPlanningLocked = (e: {}, data: IWebsocketMessageData['ITEM_LOCKED']) => 
  */
 function onPlanningUnlocked(_e: {}, data: IWebsocketMessageData['ITEM_UNLOCKED']) {
     return (dispatch, getState) => {
-        if (data?.item != null) {
+        if (data?.item != null && data.clientId !== superdeskApi.session.getUniqueClientId()) {
             const state = getState();
             let planningItem = selectors.planning.storedPlannings(state)[data.item];
             const isCurrentlyLocked = lockUtils.isItemLocked(planningItem, selectors.locks.getLockedItems(state));

--- a/client/actions/tests/main_test.ts
+++ b/client/actions/tests/main_test.ts
@@ -488,8 +488,13 @@ describe('actions.main', () => {
                 .then(() => {
                     expect(main.openForEdit.callCount).toBe(1);
                     expect(main.openForEdit.args[0]).toEqual([{
-                        _id: 'e1',
-                        type: 'event',
+                        ...data.events[0],
+                        associated_plannings: [],
+                        dates: {
+                            ...data.events[0].dates,
+                            start: moment(data.events[0].dates.start),
+                            end: moment(data.events[0].dates.end),
+                        },
                     }]);
 
                     done();
@@ -504,8 +509,13 @@ describe('actions.main', () => {
                 .then(() => {
                     expect(main.openForEdit.callCount).toBe(1);
                     expect(main.openForEdit.args[0]).toEqual([{
-                        _id: 'e1',
-                        type: 'event',
+                        ...data.events[0],
+                        associated_plannings: [],
+                        dates: {
+                            ...data.events[0].dates,
+                            start: moment(data.events[0].dates.start),
+                            end: moment(data.events[0].dates.end),
+                        },
                     }]);
 
                     done();

--- a/client/api/locks.ts
+++ b/client/api/locks.ts
@@ -166,7 +166,11 @@ function lockItem<T extends IAssignmentOrPlanningItem>(item: T, action?: string)
     }
 
     // @ts-ignore
-    return superdeskApi.dataApi.create<T>(endpoint, {lock_action: lockAction})
+    return superdeskApi.dataApi.create<T>(
+        endpoint,
+        {lock_action: lockAction},
+        {clientId: superdeskApi.session.getUniqueClientId()}
+    )
         .then((lockedItem) => {
             // On lock, file object in the item is lost, so replace it from original item
             if (lockedItem.type !== 'assignment' && item.type !== 'assignment') {
@@ -288,7 +292,7 @@ function unlockItem<T extends IAssignmentOrPlanningItem>(
     let lockedItemId: string;
 
     if (item.type === 'event' && item.recurrence_id === currentLock.item_id) {
-        lockedItemId = item._id;
+        lockedItemId = item.recurrence_id;
     } else if (item.type === 'planning' && item.recurrence_id === currentLock.item_id) {
         const relatedEventIds = getRelatedEventIdsForPlanning(item, 'primary');
 
@@ -304,7 +308,7 @@ function unlockItem<T extends IAssignmentOrPlanningItem>(
     const resource = getLockResourceName(currentLock.item_type);
     const endpoint = `${resource}/${lockedItemId}/unlock`;
 
-    return superdeskApi.dataApi.create<T>(endpoint, {})
+    return superdeskApi.dataApi.create<T>(endpoint, {}, {clientId: superdeskApi.session.getUniqueClientId()})
         .then((unlockedItem) => {
             if (unlockedItem.type === 'event') {
                 eventUtils.modifyForClient(unlockedItem);

--- a/client/api/tests/api_locks_test.ts
+++ b/client/api/tests/api_locks_test.ts
@@ -153,6 +153,7 @@ describe('planningApi.locks', () => {
                     expect(superdeskApi.dataApi.create.args[0]).toEqual([
                         'events/e1/lock',
                         {lock_action: 'edit'},
+                        {clientId: 'abcd123'},
                     ]);
 
                     // Lock is added to the store
@@ -205,6 +206,7 @@ describe('planningApi.locks', () => {
                     expect(superdeskApi.dataApi.create.args[0]).toEqual([
                         'planning/p1/lock',
                         {lock_action: 'cancel'},
+                        {clientId: 'abcd123'},
                     ]);
 
                     // Lock is added to the store
@@ -260,6 +262,7 @@ describe('planningApi.locks', () => {
                     expect(superdeskApi.dataApi.create.args[0]).toEqual([
                         'assignments/as1/lock',
                         {lock_action: 'reassign'},
+                        {clientId: 'abcd123'},
                     ]);
 
                     // Lock is added to the store

--- a/client/interfaces.ts
+++ b/client/interfaces.ts
@@ -2229,6 +2229,7 @@ export interface IWebsocketMessageData {
         lock_session?: IEventOrPlanningItem['lock_session'];
         recurrence_id?: IEventItem['recurrence_id'];
         type: IEventOrPlanningItem['type'] | IAssignmentItem['type'];
+        clientId?: string;
     };
     ITEM_LOCKED: {
         item: IEventOrPlanningItem['_id'];
@@ -2241,6 +2242,7 @@ export interface IWebsocketMessageData {
         lock_time: IEventOrPlanningItem['lock_time'];
         recurrence_id?: IEventOrPlanningItem['recurrence_id'];
         type: IEventOrPlanningItem['type'] | IAssignmentItem['type'];
+        clientId?: string;
     };
 
     PLANNING_CREATED: {

--- a/client/utils/testApi.ts
+++ b/client/utils/testApi.ts
@@ -19,6 +19,9 @@ Object.assign(superdeskApi, {
         findOne: sinon.stub().returns(Promise.resolve({})),
         create: sinon.stub().callsFake((resource, item) => Promise.resolve({...item}))
     },
+    session: {
+        getUniqueClientId: () => 'abcd123',
+    },
     browser: {
         location: {
             urlParams: {

--- a/e2e/cypress/e2e/item_locks.cy.ts
+++ b/e2e/cypress/e2e/item_locks.cy.ts
@@ -51,7 +51,7 @@ describe('Planning: item locks', () => {
         modal.waitTillClosed();
     }
 
-    function testCancelActionFromEditPanel(actionLabel, ignoreCancelSavedShown = false) {
+    function testCancelActionFromEditPanel(actionLabel) {
         // Open the Event for editing, and make sure the form is not disabled
         list.item(0).dblclick();
         editor.waitTillOpen();
@@ -90,13 +90,6 @@ describe('Planning: item locks', () => {
             .should('exist')
             .click()
 
-        // TODO[BUG]: This should not be happening
-        if (ignoreCancelSavedShown) {
-            modal.waitTillOpen();
-            modal.getFooterButton('Ignore')
-                .should('exist')
-                .click();
-        }
         editor.waitTillClosed();
         list.item(0)
             .find('.sd-list-item__border--locked')
@@ -165,7 +158,7 @@ describe('Planning: item locks', () => {
         it('cancel action', () => {
             testCancelActionFromModal('Cancel');
             testUnlockedFromModal('Cancel', 'events', 'event1');
-            testCancelActionFromEditPanel('Cancel', true);
+            testCancelActionFromEditPanel('Cancel');
             testUnlockedFromEditPanel('Cancel', 'events', 'event1');
         });
 
@@ -173,29 +166,28 @@ describe('Planning: item locks', () => {
             testCancelActionFromModal('Spike');
             testUnlockedFromModal('Spike', 'events', 'event1');
 
-            // TODO: Fix cancel action modal from editor, not returning to Edit state
-            testCancelActionFromEditPanel('Cancel', true);
+            testCancelActionFromEditPanel('Cancel');
             testUnlockedFromEditPanel('Cancel', 'events', 'event1');
         });
 
         it('update time action', () => {
             testCancelActionFromModal('Update time');
             testUnlockedFromModal('Update time', 'events', 'event1');
-            testCancelActionFromEditPanel('Update time', true);
+            testCancelActionFromEditPanel('Update time');
             testUnlockedFromEditPanel('Update time', 'events', 'event1');
         });
 
         it('mark as postponed action', () => {
             testCancelActionFromModal('Mark as Postponed');
             testUnlockedFromModal('Mark as Postponed', 'events', 'event1');
-            testCancelActionFromEditPanel('Mark as Postponed', true);
+            testCancelActionFromEditPanel('Mark as Postponed');
             testUnlockedFromEditPanel('Mark as Postponed', 'events', 'event1');
         });
 
         it('reschedule action', () => {
             testCancelActionFromModal('Reschedule');
             testUnlockedFromModal('Reschedule', 'events', 'event1');
-            testCancelActionFromEditPanel('Reschedule', true);
+            testCancelActionFromEditPanel('Reschedule');
             testUnlockedFromEditPanel('Reschedule', 'events', 'event1');
         });
 

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -2,7 +2,7 @@
   "name": "superdesk",
   "license": "GPL-3.0",
   "dependencies": {
-    "superdesk-core": "github:superdesk/superdesk-client-core#develop",
+    "superdesk-core": "github:superdesk/superdesk-client-core#release/3.1",
     "superdesk-planning": "file:../"
   },
   "devDependencies": {

--- a/e2e/server/core-requirements.in
+++ b/e2e/server/core-requirements.in
@@ -1,2 +1,2 @@
 honcho==1.0.1
-git+https://github.com/superdesk/superdesk-core.git@develop#egg=superdesk-core
+git+https://github.com/superdesk/superdesk-core.git@release/3.1#egg=superdesk-core

--- a/e2e/server/core-requirements.txt
+++ b/e2e/server/core-requirements.txt
@@ -8,13 +8,13 @@ aioboto3==14.3.0
     # via superdesk-core
 aiobotocore[boto3]==2.22.0
     # via aioboto3
-aiofiles==24.1.0
+aiofiles==25.1.0
     # via
     #   aioboto3
     #   quart
 aiohappyeyeballs==2.6.1
     # via aiohttp
-aiohttp==3.12.15
+aiohttp==3.13.0
     # via
     #   aiobotocore
     #   elasticsearch
@@ -30,13 +30,13 @@ arrow==1.3.0
     # via
     #   eve-elastic
     #   superdesk-core
-asgiref==3.9.1
+asgiref==3.10.0
     # via superdesk-core
 async-timeout==5.0.1
     # via
     #   aiohttp
     #   redis
-attrs==25.3.0
+attrs==25.4.0
     # via aiohttp
 authlib==1.4.1
     # via superdesk-core
@@ -44,7 +44,7 @@ babel==2.17.0
     # via quart-babel
 bcrypt==4.3.0
     # via superdesk-core
-billiard==4.2.1
+billiard==4.2.2
     # via celery
 blinker==1.9.0
     # via
@@ -63,7 +63,7 @@ botocore==1.37.3
     #   aiobotocore
     #   boto3
     #   s3transfer
-cachetools==6.2.0
+cachetools==6.2.1
     # via flask-oidc-ex
 celery[redis]==5.4.0
     # via superdesk-core
@@ -71,23 +71,23 @@ cerberus==1.3.7
     # via
     #   eve
     #   superdesk-core
-certifi==2025.8.3
+certifi==2025.10.5
     # via
     #   elastic-apm
     #   elasticsearch
     #   requests
     #   sentry-sdk
-cffi==1.17.1
+cffi==2.0.0
     # via cryptography
 chardet==5.2.0
     # via superdesk-core
-charset-normalizer==3.4.3
+charset-normalizer==3.4.4
     # via
     #   reportlab
     #   requests
 ciso8601==2.3.3
     # via eve-elastic
-click==8.2.1
+click==8.3.0
     # via
     #   celery
     #   click-didyoumean
@@ -103,11 +103,11 @@ click-repl==0.3.0
     # via celery
 croniter==6.0.0
     # via superdesk-core
-cryptography==45.0.6
+cryptography==46.0.3
     # via
     #   authlib
     #   jwcrypto
-dnspython==2.7.0
+dnspython==2.8.0
     # via pymongo
 draftjs-exporter[lxml]==5.1.0
     # via superdesk-core
@@ -127,7 +127,7 @@ exceptiongroup==1.3.0
     # via
     #   hypercorn
     #   taskgroup
-feedparser==6.0.11
+feedparser==6.0.12
     # via superdesk-core
 flask==3.1.2
     # via
@@ -138,14 +138,12 @@ flask-mail==0.10.0
     # via superdesk-core
 flask-oidc-ex==0.6.2
     # via superdesk-core
-frozenlist==1.7.0
+frozenlist==1.8.0
     # via
     #   aiohttp
     #   aiosignal
 future==1.0.0
     # via python-twitter
-gunicorn==22.0.0
-    # via -r core-requirements.in
 h11==0.16.0
     # via
     #   hypercorn
@@ -160,13 +158,13 @@ honcho==1.0.1
     # via -r core-requirements.in
 hpack==4.1.0
     # via h2
-httplib2==0.22.0
+httplib2==0.31.0
     # via oauth2client
 hypercorn==0.17.3
     # via quart
 hyperframe==6.1.0
     # via h2
-idna==3.10
+idna==3.11
     # via
     #   requests
     #   yarl
@@ -200,9 +198,9 @@ lxml==5.3.2
     #   lxml-html-clean
     #   superdesk-core
     #   xmlsec
-lxml-html-clean==0.4.2
+lxml-html-clean==0.4.3
     # via superdesk-core
-markupsafe==3.0.2
+markupsafe==3.0.3
     # via
     #   flask
     #   jinja2
@@ -211,7 +209,7 @@ markupsafe==3.0.2
     #   werkzeug
 motor==3.7.1
     # via superdesk-core
-multidict==6.6.4
+multidict==6.7.0
     # via
     #   aiobotocore
     #   aiohttp
@@ -221,18 +219,16 @@ oauth2client==4.1.3
 oauthlib==3.3.1
     # via requests-oauthlib
 packaging==25.0
-    # via
-    #   gunicorn
-    #   kombu
-pillow==11.1.0
+    # via kombu
+pillow==11.2.1
     # via
     #   reportlab
     #   superdesk-core
 priority==2.0.0
     # via hypercorn
-prompt-toolkit==3.0.51
+prompt-toolkit==3.0.52
     # via click-repl
-propcache==0.3.2
+propcache==0.4.1
     # via
     #   aiohttp
     #   yarl
@@ -244,11 +240,11 @@ pyasn1==0.6.1
     #   rsa
 pyasn1-modules==0.4.2
     # via oauth2client
-pycparser==2.22
+pycparser==2.23
     # via cffi
-pydantic==2.11.7
+pydantic==2.12.2
     # via superdesk-core
-pydantic-core==2.33.2
+pydantic-core==2.41.4
     # via pydantic
 pyjwt==2.10.1
     # via superdesk-core
@@ -259,7 +255,7 @@ pymongo==4.9.2
     #   eve
     #   motor
     #   superdesk-core
-pyparsing==3.2.3
+pyparsing==3.2.5
     # via httplib2
 python-dateutil==2.9.0.post0
     # via
@@ -281,7 +277,7 @@ pytz==2025.2
     #   eve-elastic
     #   quart-babel
     #   superdesk-core
-pyyaml==6.0.2
+pyyaml==6.0.3
     # via superdesk-core
 quart @ git+https://github.com/MarkLark86/quart@fix-test-client-with-utf8-url
     # via
@@ -300,7 +296,7 @@ redis==5.2.1
     #   superdesk-core
 regex==2024.11.6
     # via superdesk-core
-reportlab==4.4.3
+reportlab==4.4.4
     # via superdesk-core
 requests==2.32.5
     # via
@@ -313,24 +309,24 @@ rsa==4.9.1
     # via oauth2client
 s3transfer==0.11.3
     # via boto3
-sentry-sdk[quart]==2.35.0
+sentry-sdk[quart]==2.42.0
     # via superdesk-core
 sgmllib3k==1.0.0
     # via feedparser
-simplejson==3.20.1
+simplejson==3.20.2
     # via eve
 six==1.17.0
     # via
     #   flask-oidc-ex
     #   oauth2client
     #   python-dateutil
-superdesk-core @ git+https://github.com/superdesk/superdesk-core.git@develop-async
+superdesk-core @ git+https://github.com/superdesk/superdesk-core.git@release/3.1
     # via -r core-requirements.in
 taskgroup==0.2.2
     # via hypercorn
-tomli==2.2.1
+tomli==2.3.0
     # via hypercorn
-types-python-dateutil==2.9.0.20250822
+types-python-dateutil==2.9.0.20251008
     # via arrow
 types-pytz==2025.2.0.20250809
     # via quart-babel
@@ -338,6 +334,7 @@ typing-extensions==4.15.0
     # via
     #   aiosignal
     #   asgiref
+    #   cryptography
     #   exceptiongroup
     #   hypercorn
     #   jwcrypto
@@ -346,7 +343,7 @@ typing-extensions==4.15.0
     #   pydantic-core
     #   taskgroup
     #   typing-inspection
-typing-inspection==0.4.1
+typing-inspection==0.4.2
     # via pydantic
 tzdata==2025.2
     # via
@@ -354,7 +351,7 @@ tzdata==2025.2
     #   kombu
 tzlocal==5.3.1
     # via superdesk-core
-unidecode==1.3.8
+unidecode==1.4.0
     # via superdesk-core
 urllib3==1.26.20
     # via
@@ -369,7 +366,7 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-wcwidth==0.2.13
+wcwidth==0.2.14
     # via prompt-toolkit
 websockets==15.0.1
     # via superdesk-core
@@ -385,5 +382,5 @@ wsproto==1.2.0
     # via hypercorn
 xmlsec==1.3.14
     # via superdesk-core
-yarl==1.20.1
+yarl==1.22.0
     # via aiohttp

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "superdesk-planning",
-  "version": "3.0.0-dev.0",
+  "version": "3.1.0-dev.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -37,9 +37,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.3.tgz",
-      "integrity": "sha512-9uIQ10o0WGdpP6GDhXcdOJPJuDgFtIDtN/9+ArJQ2NAfAmiuhTQdzkaTGR33v43GYS2UrSA0eX2pPPHoFVvpxA=="
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ=="
     },
     "@babel/types": {
       "version": "7.28.4",
@@ -198,9 +198,9 @@
       }
     },
     "@superdesk/primereact": {
-      "version": "5.0.2-13",
-      "resolved": "https://registry.npmjs.org/@superdesk/primereact/-/primereact-5.0.2-13.tgz",
-      "integrity": "sha512-v/Vzwo20voLTH+3pqhRepe3ZeOurrgOZ1wA+g9WtjMCmQGUD0eIJLS7p7bxYM60zVWHB/JWNqpPiVpf7hVck5Q==",
+      "version": "5.0.2-15",
+      "resolved": "https://registry.npmjs.org/@superdesk/primereact/-/primereact-5.0.2-15.tgz",
+      "integrity": "sha512-DN7nsoznoXVEUB3EmI85NQNb1h5AY4OxxbvlsUN6QpeuwBabDxym74oS7UN1MAj/PKPOkmyU8uCv4tMHO2PEOw==",
       "dev": true,
       "requires": {
         "react-transition-group": "^4.4.1"
@@ -445,12 +445,12 @@
       "dev": true
     },
     "@types/node": {
-      "version": "24.3.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
-      "integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
+      "version": "24.8.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.8.0.tgz",
+      "integrity": "sha512-5x08bUtU8hfboMTrJ7mEO4CpepS9yBwAqcL52y86SWNmbPX8LVbNs3EP4cNrIZgdjk2NAlP2ahNihozpoZIxSg==",
       "dev": true,
       "requires": {
-        "undici-types": "~7.10.0"
+        "undici-types": "~7.14.0"
       }
     },
     "@types/node-forge": {
@@ -613,9 +613,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.4.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-          "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+          "version": "4.4.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+          "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
           "dev": true,
           "requires": {
             "ms": "^2.1.3"
@@ -661,9 +661,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.4.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-          "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+          "version": "4.4.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+          "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
           "dev": true,
           "requires": {
             "ms": "^2.1.3"
@@ -3331,9 +3331,9 @@
       "dev": true
     },
     "envinfo": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.17.0.tgz",
-      "integrity": "sha512-GpfViocsFM7viwClFgxK26OtjMlKN67GCR5v6ASFkotxtpBWd9d+vNy+AH7F2E1TUkMDZ8P/dDPZX71/NG8xnQ==",
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.18.0.tgz",
+      "integrity": "sha512-02QGCLRW+Jb8PC270ic02lat+N57iBaWsvHjcJViqp6UVupRB+Vsg7brYPTqEFXvsdTql3KnSczv5ModZFpl8Q==",
       "dev": true
     },
     "enzyme": {
@@ -3618,9 +3618,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.4.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-          "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+          "version": "4.4.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+          "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
           "dev": true,
           "requires": {
             "ms": "^2.1.3"
@@ -4542,6 +4542,12 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
       "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true
+    },
+    "generator-function": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
       "dev": true
     },
     "get-caller-file": {
@@ -5718,9 +5724,9 @@
       "dev": true
     },
     "immer": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.1.tgz",
-      "integrity": "sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw=="
+      "version": "10.1.3",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.3.tgz",
+      "integrity": "sha512-tmjF/k8QDKydUlm3mZU+tjM6zeq9/fFpPqH9SzWmBnVVKsPBg/V66qsMwb3/Bo90cgUN+ghdVBess+hPsxUyRw=="
     },
     "immutable": {
       "version": "3.8.2",
@@ -6114,13 +6120,14 @@
       "dev": true
     },
     "is-generator-function": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.0.tgz",
-      "integrity": "sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
       "dev": true,
       "requires": {
-        "call-bound": "^1.0.3",
-        "get-proto": "^1.0.0",
+        "call-bound": "^1.0.4",
+        "generator-function": "^2.0.0",
+        "get-proto": "^1.0.1",
         "has-tostringtag": "^1.0.2",
         "safe-regex-test": "^1.1.0"
       }
@@ -6977,9 +6984,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.4.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-          "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+          "version": "4.4.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+          "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
           "dev": true,
           "requires": {
             "ms": "^2.1.3"
@@ -9593,9 +9600,9 @@
       }
     },
     "semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
       "dev": true
     },
     "send": {
@@ -10407,9 +10414,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.4.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-          "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+          "version": "4.4.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+          "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
           "dev": true,
           "requires": {
             "ms": "^2.1.3"
@@ -10947,8 +10954,8 @@
       }
     },
     "superdesk-core": {
-      "version": "github:superdesk/superdesk-client-core#5a1173b3ef88dda0812ce956dcafb8f1879725c2",
-      "from": "github:superdesk/superdesk-client-core#develop",
+      "version": "github:superdesk/superdesk-client-core#0d6c39a771b28dc0997a5c1cd4811bc636930056",
+      "from": "github:superdesk/superdesk-client-core#release/3.1",
       "dev": true,
       "requires": {
         "@popperjs/core": "2.10.2",
@@ -11062,15 +11069,6 @@
           "integrity": "sha512-IXf3XA7+XyN7CP9gGh/XB0UxVMlvARGEgGXLubFICsUMGz6Q+DU+i4gGlpOxTjKvXjkJDJC8YdqdKkDj9qZHEQ==",
           "dev": true
         },
-        "@superdesk/primereact": {
-          "version": "5.0.2-15",
-          "resolved": "https://registry.npmjs.org/@superdesk/primereact/-/primereact-5.0.2-15.tgz",
-          "integrity": "sha512-DN7nsoznoXVEUB3EmI85NQNb1h5AY4OxxbvlsUN6QpeuwBabDxym74oS7UN1MAj/PKPOkmyU8uCv4tMHO2PEOw==",
-          "dev": true,
-          "requires": {
-            "react-transition-group": "^4.4.1"
-          }
-        },
         "@types/lodash": {
           "version": "4.14.117",
           "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.117.tgz",
@@ -11088,24 +11086,6 @@
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
           "integrity": "sha512-ZiPp9pZlgxpWRu0M+YWbm6+aQ84XEfH1JRXvfOc/fILWI0VKhLC2LX13X1NYq4fULzLMq7Hfh43CSo2/aIaUPA==",
           "dev": true
-        },
-        "dom-helpers": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
-          "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.8.7",
-            "csstype": "^3.0.2"
-          },
-          "dependencies": {
-            "csstype": {
-              "version": "3.1.3",
-              "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-              "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-              "dev": true
-            }
-          }
         },
         "fbjs": {
           "version": "0.8.18",
@@ -11178,31 +11158,6 @@
             "prop-types": "^15.5.7"
           }
         },
-        "react-transition-group": {
-          "version": "4.4.5",
-          "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
-          "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.5.5",
-            "dom-helpers": "^5.0.1",
-            "loose-envify": "^1.4.0",
-            "prop-types": "^15.6.2"
-          },
-          "dependencies": {
-            "prop-types": {
-              "version": "15.8.1",
-              "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-              "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-              "dev": true,
-              "requires": {
-                "loose-envify": "^1.4.0",
-                "object-assign": "^4.1.1",
-                "react-is": "^16.13.1"
-              }
-            }
-          }
-        },
         "superdesk-ui-framework": {
           "version": "4.0.94",
           "resolved": "https://registry.npmjs.org/superdesk-ui-framework/-/superdesk-ui-framework-4.0.94.tgz",
@@ -11244,14 +11199,14 @@
       }
     },
     "superdesk-ui-framework": {
-      "version": "4.0.91",
-      "resolved": "https://registry.npmjs.org/superdesk-ui-framework/-/superdesk-ui-framework-4.0.91.tgz",
-      "integrity": "sha512-DswRB2CgUkUy0h2az3DKIN/K9thhLC7RItOWvbKoTmOkBJu0xV3FUA6gDfjO+0mG++jEgB4Zl01xb9St2nY0nw==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/superdesk-ui-framework/-/superdesk-ui-framework-4.1.2.tgz",
+      "integrity": "sha512-9z1v1A2CRsf9Hde6MqxzD0/EP2PY+ZmQnXnQJDiX1KCHwQE7FeUSRubaCm6Vd3jrTe1BLqiT/ElkMdwo6VCPyg==",
       "dev": true,
       "requires": {
         "@popperjs/core": "^2.4.0",
         "@sourcefabric/common": "0.0.66",
-        "@superdesk/primereact": "^5.0.2-13",
+        "@superdesk/primereact": "^5.0.2-16",
         "@superdesk/react-resizable-panels": "0.0.39",
         "chart.js": "^2.9.3",
         "date-fns": "^4.1.0",
@@ -11261,6 +11216,7 @@
         "react-beautiful-dnd": "^13.0.0",
         "react-id-generator": "^3.0.0",
         "react-scrollspy": "^3.4.3",
+        "tippy.js": "^6.3.7",
         "weekstart": "^2.0.0"
       },
       "dependencies": {
@@ -11279,6 +11235,31 @@
             "tippy.js": "^6.3.7"
           }
         },
+        "@superdesk/primereact": {
+          "version": "5.0.2-16",
+          "resolved": "https://registry.npmjs.org/@superdesk/primereact/-/primereact-5.0.2-16.tgz",
+          "integrity": "sha512-abKaxIPphR9Y7y6Mq4iPjV/ocvl7EoGPLfPpMvDs3cu8RvPeWREsaJptjuDOarTiggsYz88Mo+8CoEjqYhWKnQ==",
+          "dev": true,
+          "requires": {
+            "react-transition-group": "^4.4.1"
+          }
+        },
+        "csstype": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+          "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+          "dev": true
+        },
+        "dom-helpers": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+          "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.8.7",
+            "csstype": "^3.0.2"
+          }
+        },
         "react-sortable-hoc": {
           "version": "1.11.0",
           "resolved": "https://registry.npmjs.org/react-sortable-hoc/-/react-sortable-hoc-1.11.0.tgz",
@@ -11288,6 +11269,18 @@
             "@babel/runtime": "^7.2.0",
             "invariant": "^2.2.4",
             "prop-types": "^15.5.7"
+          }
+        },
+        "react-transition-group": {
+          "version": "4.4.5",
+          "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+          "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.5.5",
+            "dom-helpers": "^5.0.1",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.6.2"
           }
         }
       }
@@ -11926,9 +11919,9 @@
       }
     },
     "undici-types": {
-      "version": "7.10.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
-      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.14.0.tgz",
+      "integrity": "sha512-QQiYxHuyZ9gQUIrmPo3IA+hUl4KYk8uSA7cHrcKd/l3p1OTpZcM0Tbp9x7FAtXdAYhlasd60ncPpgu6ihG6TOA==",
       "dev": true
     },
     "union-value": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superdesk-planning",
-  "version": "3.2.0-dev.0",
+  "version": "3.1.0-dev.0",
   "license": "AGPL-3.0",
   "description": "",
   "repository": {
@@ -71,7 +71,7 @@
     "sinon": "^4.5.0",
     "style-loader": "^2.0.0",
     "superdesk-code-style": "1.5.0",
-    "superdesk-core": "github:superdesk/superdesk-client-core#develop",
+    "superdesk-core": "github:superdesk/superdesk-client-core#release/3.1",
     "superdesk-ui-framework": "^4.0.91",
     "ts-loader": "^8.4.0",
     "ts-node": "~7.0.1",

--- a/server/planning/__init__.py
+++ b/server/planning/__init__.py
@@ -69,7 +69,7 @@ from planning.search.planning_autocomplete import init_app as init_planning_auto
 
 from .module import module  # noqa
 
-__version__ = "3.2.0-dev.0"
+__version__ = "3.1.0-dev.0"
 
 _SERVER_PATH = os.path.dirname(os.path.realpath(__file__))
 

--- a/server/planning/item_lock.py
+++ b/server/planning/item_lock.py
@@ -18,6 +18,7 @@ from superdesk.users.services import current_user_has_privilege
 from superdesk.utc import utcnow
 from superdesk.lock import lock, unlock
 from superdesk import get_resource_service, get_resource_privileges
+from superdesk.flask import request
 from apps.common.components.base_component import BaseComponent
 from apps.item_lock.components.item_lock import LOCK_USER, LOCK_SESSION, LOCK_ACTION, LOCK_TIME
 
@@ -97,6 +98,7 @@ class LockService(BaseComponent):
                     event_ids=get_related_event_ids_for_planning(item),
                     recurrence_id=item.get("recurrence_id") or None,
                     type=item.get("type"),
+                    clientId=request.args.get("clientId") if request else None,
                 )
             else:
                 raise SuperdeskApiError.forbiddenError(message=error_message)
@@ -153,6 +155,7 @@ class LockService(BaseComponent):
             event_ids=get_related_event_ids_for_planning(item),
             recurrence_id=item.get("recurrence_id") or None,
             type=item.get("type"),
+            clientId=request.args.get("clientId") if request else None,
         )
 
         return item

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ package_data = {
 
 setup(
     name="superdesk-planning",
-    version="3.2.0-dev.0",
+    version="3.1.0-dev.0",
     description=DESCRIPTION,
     long_description=DESCRIPTION,
     package_dir={"": "server"},


### PR DESCRIPTION
### Purpose
Lock information in the redux store was being updated by both api requests and websocket notifications.

Additionally, this PR fixes the following bugs:
* Unlocking a recurring series of items using the incorrect lock ID
* On page load, item was not loaded before loading the editor (cased some logic issues)

### What has changed
Only change item locks either by api request OR a websocket notification, not both. Making the locking and redux updates predictable.
* Send a client ID when locking an item
* Send client ID with lock websocket messages
* Ignore lock websocket message if it came from the same browser tab instance
* On page load, make sure to load the item before dispatching redux request to preview/edit the item
* Fix logic when getting recurring event ID to unlock

Resolves:
* [SDESK-7783](https://sofab.atlassian.net/browse/SDESK-7783)
* [SDESK-7784](https://sofab.atlassian.net/browse/SDESK-7784)

Depends on: https://github.com/superdesk/superdesk-client-core/pull/4980



[SDESK-7783]: https://sofab.atlassian.net/browse/SDESK-7783?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SDESK-7784]: https://sofab.atlassian.net/browse/SDESK-7784?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ