### PR TITLE
[STT-1386] fix: Use appConfig.default_language if language field not enabled

### DIFF
--- a/client/api/contentProfiles.ts
+++ b/client/api/contentProfiles.ts
@@ -80,7 +80,7 @@ function getProfile(contentType: string): IPlanningContentProfile {
 }
 
 function getLanguageSchema(profile: IPlanningContentProfile): IProfileSchemaTypeString {
-    if (profile.editor.language?.enabled === true && profile.schema.language != null) {
+    if (profile?.editor?.language?.enabled === true && profile?.schema?.language != null) {
         return profile.schema.language as IProfileSchemaTypeString;
     }
 

--- a/client/api/contentProfiles.ts
+++ b/client/api/contentProfiles.ts
@@ -80,7 +80,11 @@ function getProfile(contentType: string): IPlanningContentProfile {
 }
 
 function getLanguageSchema(profile: IPlanningContentProfile): IProfileSchemaTypeString {
-    return profile?.schema?.language as IProfileSchemaTypeString ?? {
+    if (profile.editor.language?.enabled === true && profile.schema.language != null) {
+        return profile.schema.language as IProfileSchemaTypeString;
+    }
+
+    return {
         type: 'string',
         required: false,
         field_type: 'single_line',


### PR DESCRIPTION
### Purpose
The Event, Planning and Coverages were using the Users language when the language field was not enabled.

### What has changed
Use `appConfig.default_language` if the language field(s) are not enabled.

Resolves: [STT-1386](https://sofab.atlassian.net/browse/STT-1386)



[STT-1386]: https://sofab.atlassian.net/browse/STT-1386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ