### PR TITLE
[SDCP-969] - Add to Planning not pulling slugline automatically

### DIFF
--- a/client/components/fields/editor/base/text.tsx
+++ b/client/components/fields/editor/base/text.tsx
@@ -24,6 +24,7 @@ interface IState {
     key: string;
     value: string;
     suggestions: string[];
+    userHasModified: boolean;
 }
 
 export class EditorFieldText extends React.Component<IEditorFieldTextProps, IState> {
@@ -45,7 +46,29 @@ export class EditorFieldText extends React.Component<IEditorFieldTextProps, ISta
             key: uniqueId(),
             suggestions: [],
             value: get(props.item, props.field, props.defaultValue || ''),
+            userHasModified: false,
         };
+    }
+
+    /**
+     * Handles scenarios when the field has been initially rendered with empty value
+     * and then the prop value arrives later (like with 'add-to-planning').
+     * It only updates the state if user hasn't started typing to preserve user input
+     * while allowing late-loading data to populate empty fields.
+     */
+    static getDerivedStateFromProps(nextProps: IEditorFieldTextProps, prevState: IState): Partial<IState> | null {
+        const nextValue = get(nextProps.item, nextProps.field, nextProps.defaultValue || '');
+
+        // Only update if:
+        // 1. The prop value is different from current state value, AND
+        // 2. The user hasn't manually modified the field
+        if (nextValue !== prevState.value && !prevState.userHasModified) {
+            return {
+                value: nextValue
+            };
+        }
+
+        return null;
     }
 
     componentDidMount(): void {
@@ -59,7 +82,7 @@ export class EditorFieldText extends React.Component<IEditorFieldTextProps, ISta
     }
 
     onChange(value: string) {
-        this.setState({value}, () => {
+        this.setState({value: value, userHasModified: true}, () => {
             this.propsOnChange(this.state.value);
         });
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5725,6 +5725,11 @@
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
       "dev": true
     },
+    "immer": {
+      "version": "10.1.3",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.3.tgz",
+      "integrity": "sha512-tmjF/k8QDKydUlm3mZU+tjM6zeq9/fFpPqH9SzWmBnVVKsPBg/V66qsMwb3/Bo90cgUN+ghdVBess+hPsxUyRw=="
+    },
     "immutable": {
       "version": "3.8.2",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
@@ -10968,7 +10973,7 @@
       "requires": {
         "@metadata/exif": "github:superdesk/exif#431066d",
         "@popperjs/core": "2.10.2",
-        "@sourcefabric/common": "0.0.64",
+        "@sourcefabric/common": "0.0.69",
         "@sourcefabric/draft-js": "^0.11.5",
         "@superdesk/common": "0.0.17",
         "@types/angular": "~1.6.0",
@@ -10992,7 +10997,7 @@
         "angular-route": "1.6.9",
         "angular-vs-repeat": "1.1.7",
         "bootstrap": "3.3.7",
-        "classnames": "2.2.5",
+        "classnames": "2.5.1",
         "css-loader": "^5.2.7",
         "csstype": "2.6.17",
         "d3": "3.5.17",
@@ -11017,6 +11022,7 @@
         "hls.js": "0.12.4",
         "html-loader": "^1.3.2",
         "htmldiff-js": "github:superdesk/htmldiff-js#master",
+        "immer": "^10.1.1",
         "immutable": "3.8.2",
         "jquery": "3.3.1",
         "jquery-jcrop": "0.9.13",
@@ -11060,7 +11066,7 @@
         "sass-loader": "^10.5.2",
         "shallow-equal": "^3.1.0",
         "shortid": "2.2.8",
-        "superdesk-ui-framework": "4.0.61",
+        "superdesk-ui-framework": "4.0.81",
         "ts-loader": "^8.4.0",
         "typescript": "~4.9.5",
         "uuid": "8.3.1",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@sourcefabric/common": "0.0.65",
     "@sourcefabric/draft-js": "^0.11.5",
     "dompurify": "^1.0.11",
+    "immer": "^10.1.1",
     "moment": "^2.30.1",
     "moment-timezone": "^0.5.48",
     "nominatim-browser": "~2.0.2",


### PR DESCRIPTION
### Purpose
Resolves race condition where field values arrive after component initialization, causing "Add to Planning" to show empty slugline (and other fields) instead of auto-populating from the news item.

### What has changed
- Adds `getDerivedStateFromProps` to sync late-arriving prop values while preserving user input once they start typing.

### To reproduce the issue
- Go to SD CP
- Go to Monitoring menu 
- Click the three dot and then “Add to Planning” and then click + to add a new planning item
- Add to Planning modal dialog does not populate the `slugline`

Resolves: [SDCP-969]


[SDCP-969]: https://sofab.atlassian.net/browse/SDCP-969?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ