### PR TITLE
Fix the build issue in the client GH Action

### DIFF
--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -28,8 +28,13 @@ jobs:
           cache-dependency-path: 'server/requirements.txt'
       - name: Setup Environment
         run: ./scripts/ci-install.sh
-      - name: Install Planning Client
+      - name: Install Planning Client (Node 14)
+        if: matrix.node-version == '14'
         run: npm ci
+        working-directory: ./
+      - name: Install Planning Client (Node 22)
+        if: matrix.node-version == '22'
+        run: npm install
         working-directory: ./
       - name: Install E2E Client
         run: npm install

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "superdesk-planning",
-  "version": "3.0.0-beta.1",
+  "version": "3.0.0-beta.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5740,6 +5740,11 @@
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
       "dev": true
     },
+    "immer": {
+      "version": "10.1.3",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.3.tgz",
+      "integrity": "sha512-tmjF/k8QDKydUlm3mZU+tjM6zeq9/fFpPqH9SzWmBnVVKsPBg/V66qsMwb3/Bo90cgUN+ghdVBess+hPsxUyRw=="
+    },
     "immutable": {
       "version": "3.8.2",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
@@ -11020,6 +11025,7 @@
         "hls.js": "0.12.4",
         "html-loader": "^1.3.2",
         "htmldiff-js": "github:superdesk/htmldiff-js#master",
+        "immer": "^10.1.1",
         "immutable": "3.8.2",
         "jquery": "3.3.1",
         "jquery-jcrop": "0.9.13",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@sourcefabric/common": "0.0.65",
     "@sourcefabric/draft-js": "^0.11.5",
     "dompurify": "^1.0.11",
+    "immer": "^10.1.1",
     "moment": "^2.30.1",
     "moment-timezone": "^0.5.48",
     "nominatim-browser": "~2.0.2",

--- a/package.json
+++ b/package.json
@@ -87,5 +87,8 @@
     "redux-thunk": "^2.3.0",
     "superdesk-ui-framework": "*",
     "typescript": "*"
+  },
+  "overrides": {
+    "get-intrinsic": "1.2.4"
   }
 }


### PR DESCRIPTION
### Purpose
There is an issue produced by an `ESLint` dependency (`get-intrinsic`) which is no longer compatible with Node 22. The reason it started failing recently is because the version of this dependency has been bumped and it introduces a breaking change. So, in this PR I'm overriding the dependency to the one that do not produce the issue. The change does not affect Node 14 because this dependency is locked in the `package-lock.json` which is not used in Node 22 in the CI Client.

> [!IMPORTANT]  
> - A proper fix for this issue would to upgrade ESLint to v8.x but, we will only be able to do that until we get rid of Node 14.
> - There are some E2E tests broken but those are unrelated to this PR. Those are already broken in branch `release/3.0`. It can be observed in other PRs like this one https://github.com/superdesk/superdesk-planning/actions/runs/18593637450/job/53014251051. We should fix that in a separate ticket/PR.

### What has changed
- Lock the version of `get-intrinsic` using `override` in `package.json` - this only works on Node 22
- Adjust the GH Action to run `npm install` if Node 22 (so it grabs the override) and to run `npm ci` if Node 14 (which grabs the `package-lock.json`)

Relates to [SDCP-969]


[SDCP-969]: https://sofab.atlassian.net/browse/SDCP-969?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ