### PR TITLE
[SDESK-7782] - Persist new recurring rules from editor

### DIFF
--- a/server/planning/events/events.py
+++ b/server/planning/events/events.py
@@ -657,12 +657,11 @@ class EventsService(AsyncBaseService):
             merged.update(updates)
             await get_resource_service("events_post").validate_item(merged)
 
-        # Determine if we're to convert this single event to a recurring
-        #  of events
-        if (
-            original.get(LOCK_ACTION) == "convert_recurring"
-            and updates.get("dates", {}).get("recurring_rule", None) is not None
-        ):
+        # Determine if we're to convert this single event to a recurring of events, either through
+        # conversion from recurring form or from within the event editor
+        if (original.get(LOCK_ACTION) == "convert_recurring" or original.get(LOCK_ACTION) == "edit") and updates.get(
+            "dates", {}
+        ).get("recurring_rule", None) is not None:
             generated_events = await self._convert_to_recurring_event(updates, original)
 
             # if the original event was "posted" then post all the generated events


### PR DESCRIPTION
### Purpose
Allow conversion of a single day event to recurring when rules are edited through the editor and not the convert to recurring event form.

### What has changed
On the backend we now allow changes of recurring rules if lock action is `edit` - thus done from the editor.

### Steps to test
Create a single day event. Save it. Edit the recurring rules. Event should now be recurring and you should see the repetitions of that event in the list view.


Resolves: #[SDESK-7782](https://sofab.atlassian.net/browse/SDESK-7782)



[SDESK-7782]: https://sofab.atlassian.net/browse/SDESK-7782?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ