### PR TITLE
[SDESK-7783] fix: Autosave race condition on force unlock

### DIFF
--- a/client/components/Main/ItemEditor/ItemManager.ts
+++ b/client/components/Main/ItemEditor/ItemManager.ts
@@ -182,9 +182,7 @@ export class ItemManager {
             if (!this.props.inModalView) {
                 this.clearForm();
             }
-        } else if (actionChanged) {
-            this.onItemActionChanged(prevProps);
-        } else if (idChanged) {
+        } else if (actionChanged || idChanged) {
             this.onItemIDChanged();
         } else if (!this.state.loading &&
             !isTemporaryId(currentId) &&
@@ -193,16 +191,6 @@ export class ItemManager {
         ) {
             this.onItemChanged(this.props);
         }
-    }
-
-    onItemActionChanged(prevProps: IEditorProps) {
-        let promise = Promise.resolve();
-
-        if (prevProps.itemAction && this.props.itemAction === 'read') {
-            promise = this.autoSave.remove();
-        }
-
-        return promise.then(() => this.onItemIDChanged());
     }
 
     onItemIDChanged() {

--- a/client/components/Main/ItemEditor/tests/ItemManager_test.ts
+++ b/client/components/Main/ItemEditor/tests/ItemManager_test.ts
@@ -358,22 +358,6 @@ describe('components.Main.ItemManager', () => {
                 });
         });
 
-        it('calls editor.autoSave.remove on action revert to read', () => {
-            updateProps({
-                itemId: 'e1',
-                itemType: 'event',
-                itemAction: 'read',
-            });
-
-            manager.componentDidUpdate({
-                itemId: 'e1',
-                itemType: 'event',
-                itemAction: 'edit',
-            });
-
-            expect(editor.autoSave.remove.callCount).toBe(1);
-        });
-
         it('calls onItemChanged', () => {
             updateProps({
                 itemId: 'e1',

--- a/server/features/autosave.feature
+++ b/server/features/autosave.feature
@@ -189,3 +189,85 @@ Feature: Events Autosave
             "_message": "Autosave failed, User not supplied"
         }
         """
+
+    @auth
+    Scenario: Event autosave is removed on event unlock
+        Given we have sessions "/sessions"
+        Given "events"
+        """
+        [{
+            "_id": "event1",
+            "guid": "event1",
+            "name": "TestEvent",
+            "dates": {
+                "start": "2029-11-21T12:00:00.000Z",
+                "end": "2029-11-21T14:00:00.000Z",
+                "tz": "Australia/Sydney"
+            },
+            "state": "draft",
+            "lock_user": "#CONTEXT_USER_ID#",
+            "lock_session": "#SESSION_ID#",
+            "lock_action": "edit",
+            "lock_time": "#DATE#"
+        }]
+        """
+        When we post to "event_autosave"
+        """
+        {
+            "_id": "event1",
+            "slugline": "Test Event",
+            "lock_user": "#CONTEXT_USER_ID#",
+            "lock_session": "#SESSION_ID#",
+            "lock_action": "edit",
+            "lock_time": "#DATE#"
+        }
+        """
+        Then we get OK response
+        When we get "/event_autosave/#event_autosave._id#"
+        Then we get OK response
+        When we post to "/events/#events._id#/unlock"
+        """
+        {}
+        """
+        Then we get OK response
+        When we get "/event_autosave/#event_autosave._id#"
+        Then we get error 404
+
+    @auth
+    Scenario: Planning autosave is removed on planning unlock
+        Given we have sessions "/sessions"
+        Given "planning"
+        """
+        [{
+            "_id": "plan1",
+            "guid": "plan1",
+            "name": "TestPlan",
+            "planning_date": "2029-11-21T12:00:00.000Z",
+            "state": "draft",
+            "lock_user": "#CONTEXT_USER_ID#",
+            "lock_session": "#SESSION_ID#",
+            "lock_action": "edit",
+            "lock_time": "#DATE#"
+        }]
+        """
+        When we post to "planning_autosave"
+        """
+        {
+            "_id": "plan1",
+            "slugline": "Test Plan",
+            "lock_user": "#CONTEXT_USER_ID#",
+            "lock_session": "#SESSION_ID#",
+            "lock_action": "edit",
+            "lock_time": "#DATE#"
+        }
+        """
+        Then we get OK response
+        When we get "/planning_autosave/#planning_autosave._id#"
+        Then we get OK response
+        When we post to "/planning/#planning._id#/unlock"
+        """
+        {}
+        """
+        Then we get OK response
+        When we get "/planning_autosave/#planning_autosave._id#"
+        Then we get error 404

--- a/server/planning/autosave_service.py
+++ b/server/planning/autosave_service.py
@@ -1,8 +1,15 @@
+import logging
+
+from bson import ObjectId
+
 from superdesk import get_resource_service
 from superdesk.core.resources import AsyncResourceService
 from superdesk.errors import SuperdeskApiError
 
 from planning.types import EventAutosaveResourceModel, PlanningAutosaveResourceModel
+
+
+logger = logging.getLogger(__name__)
 
 
 class AutosaveAsyncService(AsyncResourceService):
@@ -35,3 +42,19 @@ class AutosaveAsyncService(AsyncResourceService):
 
         if not doc.lock_session:
             raise SuperdeskApiError.badRequestError(message="Autosave failed, User Session not supplied")
+
+
+async def on_item_unlocked(resource: str, item: dict, user_id: ObjectId) -> None:
+    # raise Exception("on_item_unlocked not implemented")
+    if resource == "events":
+        autosave_service = EventAutosaveResourceModel.get_service()
+    elif resource == "planning":
+        autosave_service = PlanningAutosaveResourceModel.get_service()
+    else:
+        return
+
+    try:
+        # Delete any autosave items associated with this item
+        await autosave_service.delete_many(lookup={"_id": item["_id"]})
+    except Exception as err:
+        logger.exception(f"Failed to delete autosave item(s) ({err})")

--- a/server/planning/item_lock.py
+++ b/server/planning/item_lock.py
@@ -23,6 +23,7 @@ from apps.common.components.base_component import BaseComponent
 from apps.item_lock.components.item_lock import LOCK_USER, LOCK_SESSION, LOCK_ACTION, LOCK_TIME
 
 from planning.utils import get_related_event_ids_for_planning, get_first_related_event_id_for_planning
+from planning.signals import item_unlocked
 
 
 logger = logging.getLogger(__name__)
@@ -143,8 +144,9 @@ class LockService(BaseComponent):
         item = await item_service.find_one_async(req=None, _id=item_id)
 
         # following line executes handlers attached to function:
-        # on_unlocked_'resource' - ex. on_unlocked_planning, on_unlocked_event
+        # on_unlocked_'resource' - ex. on_unlocked_planning, on_unlocked_events
         await getattr(self.app, "on_unlocked_%s" % resource).call_async(item, user_id)
+        await item_unlocked.send(resource, item, user_id)
 
         push_notification(
             resource + ":unlock",

--- a/server/planning/module.py
+++ b/server/planning/module.py
@@ -9,6 +9,8 @@ from superdesk.publish_async.signals import on_get_available_filter_params
 from apps.item_lock.components.item_lock import LOCK_SESSION, LOCK_USER
 
 from planning.types import AgendasResourceModel
+from planning.signals import item_unlocked
+from planning.autosave_service import on_item_unlocked
 from planning.agendas_async import agendas_resource_config
 from planning.content_api import (
     content_api_event_resource_config,
@@ -73,6 +75,7 @@ def init_planning(app: SuperdeskAsyncApp):
     wsgi_app = app.wsgi.as_any()
     wsgi_app.on_session_end += cleanup_on_session_end
     on_get_available_filter_params.connect(add_agenda_to_filter_params)
+    item_unlocked.connect(on_item_unlocked)
 
     # register listeners for events planning filters signals
     connect_signals_listeners()

--- a/server/planning/signals.py
+++ b/server/planning/signals.py
@@ -9,6 +9,7 @@
 # at https://www.sourcefabric.org/superdesk/license
 
 import blinker
+from bson import ObjectId
 
 from superdesk.core import AsyncSignal
 
@@ -16,6 +17,7 @@ __all__ = [
     "planning_created",
     "planning_ingested",
     "events_update",
+    "item_unlocked",
 ]
 
 signals = blinker.Namespace()
@@ -79,3 +81,7 @@ assignments_updated = AsyncSignal[dict, dict]("assignments:updated")
 
 #: Signal for when an Assignment is deleted
 assignments_deleted = AsyncSignal[dict]("assignments:delete")
+
+
+#: Signal for when an item has been unlocked
+item_unlocked = AsyncSignal[str, dict, ObjectId]("item:unlocked")


### PR DESCRIPTION
### Purpose
When force unlocking an Event or Planning item, the editor uses the existing autosave _before_ the other user deletes it, which causes an error upon saving the autosave item (with error autosave item not found).

### What has changed
* Move the deletion of autosave items to the back-end, when an item is unlocked
* Add `item_unlocked` async signal

Resolves: [SDESK-7783](https://sofab.atlassian.net/browse/SDESK-7783)



[SDESK-7783]: https://sofab.atlassian.net/browse/SDESK-7783?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ