### PR TITLE
[STT-1405] fix: EventRelatedPlanning crashes on update when disabled

### DIFF
--- a/client/components/fields/editor/EventRelatedPlannings/EventRelatedPlannings.tsx
+++ b/client/components/fields/editor/EventRelatedPlannings/EventRelatedPlannings.tsx
@@ -39,18 +39,22 @@ export class EditorFieldEventRelatedPlanningsComponent extends React.PureCompone
     }
 
     componentDidUpdate(prevProps: Readonly<IRelatedPlanningProps>): void {
-        const prevPlanIds = prevProps.item.associated_plannings.map((x) => x._id);
-        const currentPlanIds = this.props.item.associated_plannings.map((x) => x._id);
+        if (this.props.disabled !== true) {
+            const prevPlanIds = prevProps.item.associated_plannings.map((x) => x._id);
+            const currentPlanIds = this.props.item.associated_plannings.map((x) => x._id);
 
-        if (isEqual(prevPlanIds, currentPlanIds) === false) {
-            this.softLockPlannings();
+            if (isEqual(prevPlanIds, currentPlanIds) === false) {
+                this.softLockPlannings();
+            }
         }
     }
 
     componentWillUnmount(): void {
-        this.props.item.associated_plannings
-            .filter((x) => x._temporary != null)
-            .forEach((x) => planningApi.locks.unlockEmbeddedItem(x as IPlanningItem));
+        if (this.props.disabled !== true) {
+            this.props.item.associated_plannings
+                .filter((x) => x._temporary != null)
+                .forEach((x) => planningApi.locks.unlockEmbeddedItem(x as IPlanningItem));
+        }
     }
 
     render() {


### PR DESCRIPTION
### Purpose
The `EventRelatedPlanning` component crashes on update or unmount if the component is in a read-only state.

### What has changed
* Only process associated items if the component is not disabled

Resolves: [STT-1405](https://sofab.atlassian.net/browse/STT-1405)



[STT-1405]: https://sofab.atlassian.net/browse/STT-1405?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ