### PR TITLE
[STT-1380] - Use multiple content default value in add to planning

### DIFF
--- a/client/actions/planning/notifications.ts
+++ b/client/actions/planning/notifications.ts
@@ -1,6 +1,6 @@
 import {get} from 'lodash';
 
-import {IWebsocketMessageData, ITEM_TYPE, IPlanningAppState} from '../../interfaces';
+import {IWebsocketMessageData, ITEM_TYPE, IPlanningAppState, IPlanningItem} from '../../interfaces';
 import {planningApi, superdeskApi} from '../../superdeskApi';
 
 import {gettext, lockUtils} from '../../utils';

--- a/client/api/planning.ts
+++ b/client/api/planning.ts
@@ -201,7 +201,8 @@ function setDefaultValues(
     const newsCoverageStatus = selectors.general.newsCoverageStatus(state);
     const defaultDesk = selectors.general.defaultDesk(state);
     const preferredCoverageDesks = selectors.general.preferredCoverageDesks(state)?.desks ?? {};
-    const coverageProfile = selectors.coverageProfiles.getCoverageProfileByContentType(state, g2contentType);
+    const coverageProfilesMap = selectors.coverageProfiles.getCoverageProfilesMap(state);
+    const coverageProfile = g2contentType ? coverageProfilesMap[g2contentType] : undefined;
 
     return planningUtils.defaultCoverageValues(
         newsCoverageStatus,

--- a/client/api/planning.ts
+++ b/client/api/planning.ts
@@ -12,6 +12,7 @@ import {
     IPlanningRelatedEventLink,
     IPlanningNewsCoverageStatus,
     ICoverageScheduledUpdate,
+    ICoverageType,
 } from '../interfaces';
 import {appConfig} from 'appConfig';
 
@@ -194,12 +195,13 @@ function createFromEvent(event: IEventItem, updates: Partial<IPlanningItem>): Pr
 function setDefaultValues(
     item: DeepPartial<IPlanningItem>,
     event?: IEventItem,
-    g2contentType?: IG2ContentType['qcode']
+    g2contentType?: ICoverageType
 ) {
     const state = planningApi.redux.store.getState();
     const newsCoverageStatus = selectors.general.newsCoverageStatus(state);
     const defaultDesk = selectors.general.defaultDesk(state);
     const preferredCoverageDesks = selectors.general.preferredCoverageDesks(state)?.desks ?? {};
+    const coverageProfile = selectors.coverageProfiles.getCoverageProfileByContentType(state, g2contentType);
 
     return planningUtils.defaultCoverageValues(
         newsCoverageStatus,
@@ -207,7 +209,8 @@ function setDefaultValues(
         event,
         g2contentType,
         defaultDesk,
-        preferredCoverageDesks
+        preferredCoverageDesks,
+        coverageProfile
     );
 }
 

--- a/client/components/Coverages/CoverageArrayInput.tsx
+++ b/client/components/Coverages/CoverageArrayInput.tsx
@@ -5,7 +5,10 @@ import {isEmpty} from 'lodash';
 import {
     EDITOR_TYPE,
     IAssignmentPriority,
-    ICoverageProvider, IEventItem, IFile,
+    ICoverageProvider,
+    ICoverageType,
+    IEventItem,
+    IFile,
     IG2ContentType,
     IGenre,
     IInputArrayHocModeOptions,
@@ -63,6 +66,8 @@ interface IReduxStateProps {
     newsCoverageStatus: Array<IPlanningNewsCoverageStatus>;
     coverageAddAdvancedMode: boolean;
     defaultDesk: IDesk;
+    getCoverageProfile: (coverageType?: ICoverageType) =>
+        ReturnType<typeof selectors.coverageProfiles.getCoverageProfileByContentType>;
 }
 
 interface IReduxDispatchProps {
@@ -76,6 +81,8 @@ interface IState {
 }
 
 const mapStateToProps = (state): IReduxStateProps => ({
+    getCoverageProfile: (contentType: ICoverageType) =>
+        selectors.coverageProfiles.getCoverageProfileByContentType(state, contentType),
     users: selectors.general.users(state),
     desks: selectors.general.desks(state),
     genres: state.genres,
@@ -179,10 +186,12 @@ class CoverageArrayInputComponent extends React.Component<IProps, IState> {
         };
 
         const createCoverage = planningUtils.defaultCoverageValues.bind(
-            null,
             newsCoverageStatus,
             item,
-            event
+            event,
+            null,
+            null,
+            this.props.getCoverageProfile(),
         );
 
         const {desks, users, coverageAddAdvancedMode} = this.props;

--- a/client/components/Coverages/CoverageArrayInput.tsx
+++ b/client/components/Coverages/CoverageArrayInput.tsx
@@ -5,6 +5,7 @@ import {isEmpty} from 'lodash';
 import {
     EDITOR_TYPE,
     IAssignmentPriority,
+    ICoverageContentProfile,
     ICoverageProvider,
     ICoverageType,
     IEventItem,
@@ -66,8 +67,7 @@ interface IReduxStateProps {
     newsCoverageStatus: Array<IPlanningNewsCoverageStatus>;
     coverageAddAdvancedMode: boolean;
     defaultDesk: IDesk;
-    getCoverageProfile: (coverageType?: ICoverageType) =>
-        ReturnType<typeof selectors.coverageProfiles.getCoverageProfileByContentType>;
+    coverageProfilesMap: Record<string, ICoverageContentProfile>;
 }
 
 interface IReduxDispatchProps {
@@ -81,8 +81,7 @@ interface IState {
 }
 
 const mapStateToProps = (state): IReduxStateProps => ({
-    getCoverageProfile: (contentType: ICoverageType) =>
-        selectors.coverageProfiles.getCoverageProfileByContentType(state, contentType),
+    coverageProfilesMap: selectors.coverageProfiles.getCoverageProfilesMap(state),
     users: selectors.general.users(state),
     desks: selectors.general.desks(state),
     genres: state.genres,
@@ -192,7 +191,7 @@ class CoverageArrayInputComponent extends React.Component<IProps, IState> {
             coverageType,
             null,
             null,
-            this.props.getCoverageProfile(coverageType),
+            this.props.coverageProfilesMap[coverageType],
         );
 
         const {desks, users, coverageAddAdvancedMode} = this.props;

--- a/client/components/Coverages/CoverageArrayInput.tsx
+++ b/client/components/Coverages/CoverageArrayInput.tsx
@@ -185,13 +185,14 @@ class CoverageArrayInputComponent extends React.Component<IProps, IState> {
             onItemClose: this.onCoverageClose,
         };
 
-        const createCoverage = planningUtils.defaultCoverageValues.bind(
+        const createCoverage = (coverageType: ICoverageType) => planningUtils.defaultCoverageValues(
             newsCoverageStatus,
             item,
             event,
+            coverageType,
             null,
             null,
-            this.props.getCoverageProfile(),
+            this.props.getCoverageProfile(coverageType),
         );
 
         const {desks, users, coverageAddAdvancedMode} = this.props;
@@ -225,7 +226,7 @@ class CoverageArrayInputComponent extends React.Component<IProps, IState> {
                     editorType,
                 }}
                 element={CoverageEditor}
-                defaultElement={createCoverage}
+                createCoverage={createCoverage}
                 readOnly={readOnly}
                 maxCount={maxCoverageCount}
                 addOnly={addOnly}

--- a/client/components/Coverages/CoverageEditor/index.tsx
+++ b/client/components/Coverages/CoverageEditor/index.tsx
@@ -6,6 +6,7 @@ import {
     EDITOR_TYPE,
     IAssignmentPriority,
     ICoverageProvider,
+    ICoverageType,
     IEventItem,
     IG2ContentType,
     IPlanningAppState,
@@ -82,7 +83,7 @@ function duplicateCoverage({
 }: {
     planning: IPlanningItem;
     coverage: IPlanningCoverageItem;
-    duplicateAs?: IG2ContentType['qcode'];
+    duplicateAs?: ICoverageType;
 }): Array<DeepPartial<IPlanningCoverageItem>> {
     const state: IPlanningAppState = planningApi.redux.store.getState();
 
@@ -96,8 +97,9 @@ function duplicateCoverage({
     const coverages = planningUtils.duplicateCoverage(
         planning,
         coverage,
+        (coverageType) => selectors.coverageProfiles.getCoverageProfileByContentType(state, coverageType),
         duplicateAs,
-        relatedEvent
+        relatedEvent,
     );
 
     return coverages;

--- a/client/components/Coverages/CoverageEditor/index.tsx
+++ b/client/components/Coverages/CoverageEditor/index.tsx
@@ -94,10 +94,12 @@ function duplicateCoverage({
         ? undefined
         : state.events.events[relatedEventId];
 
+    const coverageProfilesMap = selectors.coverageProfiles.getCoverageProfilesMap(state);
+
     const coverages = planningUtils.duplicateCoverage(
         planning,
         coverage,
-        (coverageType) => selectors.coverageProfiles.getCoverageProfileByContentType(state, coverageType),
+        coverageProfilesMap,
         duplicateAs,
         relatedEvent,
     );

--- a/client/components/Main/ItemEditor/ItemManager.ts
+++ b/client/components/Main/ItemEditor/ItemManager.ts
@@ -919,6 +919,7 @@ export class ItemManager {
             g2ContentType,
             this.props.defaultDesk,
             preferredCoverageDesks,
+            selectors.coverageProfiles.getCoverageProfileByContentType(state, g2ContentType),
         );
 
         this.editor.onChangeHandler(

--- a/client/components/Main/ItemEditor/ItemManager.ts
+++ b/client/components/Main/ItemEditor/ItemManager.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {Dispatch} from 'redux';
-import {cloneDeep, get, isEqual, omit, set} from 'lodash';
+import {cloneDeep, get, isEqual, set} from 'lodash';
 
 import {appConfig} from 'appConfig';
 import {
@@ -9,7 +9,6 @@ import {
     IEditorProps,
     IEditorState,
     IEventOrPlanningItem,
-    IPlanningRelatedEventLink
 } from '../../../interfaces';
 import {planningApi} from '../../../superdeskApi';
 import {ITEM_TYPE, POST_STATE, UI, WORKFLOW_STATE, WORKSPACE, EVENTS} from '../../../constants';
@@ -911,6 +910,7 @@ export class ItemManager {
     addCoverage(g2ContentType) {
         const state = planningApi.redux.store.getState();
         const preferredCoverageDesks = selectors.general.preferredCoverageDesks(state)?.desks ?? {};
+        const coverageProfilesMap = selectors.coverageProfiles.getCoverageProfilesMap(state);
 
         const newCoverage = planningUtils.defaultCoverageValues(
             this.props.newsCoverageStatus,
@@ -919,7 +919,7 @@ export class ItemManager {
             g2ContentType,
             this.props.defaultDesk,
             preferredCoverageDesks,
-            selectors.coverageProfiles.getCoverageProfileByContentType(state, g2ContentType),
+            coverageProfilesMap[g2ContentType],
         );
 
         this.editor.onChangeHandler(

--- a/client/components/Planning/PlanningEditor/index.tsx
+++ b/client/components/Planning/PlanningEditor/index.tsx
@@ -6,6 +6,7 @@ import {appConfig} from 'appConfig';
 import {
     EDITOR_TYPE,
     IAgenda,
+    ICoverageContentProfile,
     IEventItem,
     IFile,
     IFormItemManager,
@@ -49,8 +50,7 @@ interface IProps {
     showAllLanguages: boolean;
     language: IVocabularyItem['qcode'];
 
-    getCoverageProfile: (coverageType: ICoverageType) =>
-        ReturnType<typeof selectors.coverageProfiles.getCoverageProfileByContentType>,
+    coverageProfilesMap: Record<ICoverageType, ICoverageContentProfile>;
 
     // State
     newsCoverageStatus: Array<IPlanningNewsCoverageStatus>;
@@ -84,8 +84,7 @@ interface IState {
 }
 
 const mapStateToProps = (state) => ({
-    getCoverageProfile: (coverageType: ICoverageType) =>
-        selectors.coverageProfiles.getCoverageProfileByContentType(state, coverageType),
+    coverageProfilesMap: selectors.coverageProfiles.getCoverageProfilesMap(state),
     events: selectors.events.storedEvents(state),
     newsCoverageStatus: selectors.general.newsCoverageStatus(state),
     currentAgenda: selectors.planning.currentAgenda(state),
@@ -224,7 +223,7 @@ class PlanningEditorComponent extends React.Component<IProps, IState> {
                 this.props.newsCoverageStatus,
                 this.props.desk,
                 this.props.contentTypes,
-                this.props.getCoverageProfile,
+                this.props.coverageProfilesMap,
             );
 
             this.fillCurrentAgenda(updatedPlanning);
@@ -237,7 +236,7 @@ class PlanningEditorComponent extends React.Component<IProps, IState> {
                     this.props.newsCoverageStatus,
                     this.props.desk,
                     this.props.contentTypes,
-                    this.props.getCoverageProfile,
+                    this.props.coverageProfilesMap,
                 )
             );
         }

--- a/client/components/Planning/PlanningEditor/index.tsx
+++ b/client/components/Planning/PlanningEditor/index.tsx
@@ -15,13 +15,14 @@ import {
     IPlanningItem,
     IPlanningNewsCoverageStatus,
     ILockedItems,
+    ICoverageType,
 } from '../../../interfaces';
 import {IArticle, IDesk, IUser, IVocabularyItem} from 'superdesk-api';
 import {planningApi} from '../../../superdeskApi';
 
 import * as actions from '../../../actions';
 import * as selectors from '../../../selectors';
-import {planningUtils, eventUtils, lockUtils, isTemporaryId} from '../../../utils';
+import {planningUtils, eventUtils, lockUtils} from '../../../utils';
 
 import {EditorForm} from '../../Editor/EditorForm';
 import {PlanningEditorHeader} from './PlanningEditorHeader';
@@ -47,6 +48,9 @@ interface IProps {
     editorType: EDITOR_TYPE;
     showAllLanguages: boolean;
     language: IVocabularyItem['qcode'];
+
+    getCoverageProfile: (coverageType: ICoverageType) =>
+        ReturnType<typeof selectors.coverageProfiles.getCoverageProfileByContentType>,
 
     // State
     newsCoverageStatus: Array<IPlanningNewsCoverageStatus>;
@@ -80,6 +84,8 @@ interface IState {
 }
 
 const mapStateToProps = (state) => ({
+    getCoverageProfile: (coverageType: ICoverageType) =>
+        selectors.coverageProfiles.getCoverageProfileByContentType(state, coverageType),
     events: selectors.events.storedEvents(state),
     newsCoverageStatus: selectors.general.newsCoverageStatus(state),
     currentAgenda: selectors.planning.currentAgenda(state),
@@ -217,8 +223,8 @@ class PlanningEditorComponent extends React.Component<IProps, IState> {
                 this.props.addNewsItemToPlanning,
                 this.props.newsCoverageStatus,
                 this.props.desk,
-                this.props.addNewsItemToPlanning?.version_creator,
-                this.props.contentTypes
+                this.props.contentTypes,
+                this.props.getCoverageProfile,
             );
 
             this.fillCurrentAgenda(updatedPlanning);
@@ -230,8 +236,8 @@ class PlanningEditorComponent extends React.Component<IProps, IState> {
                     this.props.addNewsItemToPlanning,
                     this.props.newsCoverageStatus,
                     this.props.desk,
-                    this.props.user,
-                    this.props.contentTypes
+                    this.props.contentTypes,
+                    this.props.getCoverageProfile,
                 )
             );
         }

--- a/client/components/UI/Form/InputArray/index.tsx
+++ b/client/components/UI/Form/InputArray/index.tsx
@@ -8,8 +8,10 @@ import './style.scss';
 import {superdeskApi} from '../../../../superdeskApi';
 import {
     EDITOR_TYPE,
+    ICoverageType,
     IG2ContentType,
     IInputArrayHocModeOptions,
+    IPlanningCoverageItem,
     IPlanningNewsCoverageStatus,
 } from 'interfaces';
 import {IDesk} from 'superdesk-api';
@@ -26,7 +28,7 @@ interface IProps {
     addOnly: boolean;
     originalCount: number;
     element: React.ComponentClass<any>;
-    defaultElement: any;
+    createCoverage: (coverageType: ICoverageType) => DeepPartial<IPlanningCoverageItem>;
     readOnly: boolean;
     message: any;
     invalid: boolean;
@@ -66,13 +68,12 @@ export class InputArray extends React.PureComponent<IProps> {
         this.remove = this.remove.bind(this);
     }
 
-    onAdd(...args) {
-        let currentValue = this.props.value ?? [];
-        const newElement = typeof this.props.defaultElement === 'function' ?
-            this.props.defaultElement(...args) :
-            this.props.defaultElement;
+    onAdd(coverageType: ICoverageType) {
+        const currentValue = this.props.value ?? [];
 
-        this.props.onChange(this.props.field, [...currentValue, newElement]);
+        const newItem = this.props.createCoverage(coverageType);
+
+        this.props.onChange(this.props.field, [...currentValue, newItem]);
     }
 
     remove(index: number) {
@@ -128,7 +129,6 @@ export class InputArray extends React.PureComponent<IProps> {
             addOnly,
             originalCount,
             element,
-            defaultElement = {},
             readOnly,
             message,
             invalid,

--- a/client/components/fields/editor/EventRelatedPlannings/AddNewCoverages.tsx
+++ b/client/components/fields/editor/EventRelatedPlannings/AddNewCoverages.tsx
@@ -34,7 +34,7 @@ interface IProps {
     users: Array<IUser>;
     initiallyExpanded?: boolean;
     updatePlanningItem(updates: DeepPartial<IPlanningItem>): void;
-    getCoverageProfile(coverageType?: ICoverageType): ICoverageContentProfile | undefined;
+    coverageProfilesMap: Record<ICoverageType, ICoverageContentProfile>;
 }
 
 interface IState {
@@ -51,8 +51,7 @@ const mapStateToProps = (state) => ({
     newsCoverageStatus: selectors.general.newsCoverageStatus(state),
     desks: selectors.general.desks(state),
     users: selectors.general.users(state),
-    getCoverageProfile: (contentType?: ICoverageType) =>
-        selectors.coverageProfiles.getCoverageProfileByContentType(state, contentType),
+    coverageProfilesMap: selectors.coverageProfiles.getCoverageProfilesMap(state),
 });
 
 class AddNewCoveragesComponent extends React.Component<IProps, IState> {
@@ -185,10 +184,10 @@ class AddNewCoveragesComponent extends React.Component<IProps, IState> {
                     this.props.newsCoverageStatus,
                     this.props.item,
                     this.props.event,
-                    coverage.type.qcode,
+                    coverage.type.qcode as ICoverageType,
                     null,
                     null,
-                    this.props.getCoverageProfile(coverage.type.qcode),
+                    this.props.coverageProfilesMap[coverage.type.qcode],
                 );
 
                 newCoverage.assigned_to = {

--- a/client/components/fields/editor/EventRelatedPlannings/AddNewCoverages.tsx
+++ b/client/components/fields/editor/EventRelatedPlannings/AddNewCoverages.tsx
@@ -9,9 +9,11 @@ import {
     IPlanningItem,
     IPlanningNewsCoverageStatus,
     IPlanningContentProfile,
-    ISearchProfile
+    ISearchProfile,
+    ICoverageType,
+    ICoverageContentProfile
 } from '../../../../interfaces';
-import {IDesk, IUser} from 'superdesk-api';
+import {Dictionary, IDesk, IUser} from 'superdesk-api';
 
 import * as selectors from '../../../../selectors';
 import {planningUtils, generateTempId} from '../../../../utils';
@@ -30,8 +32,9 @@ interface IProps {
     newsCoverageStatus: Array<IPlanningNewsCoverageStatus>;
     desks: Array<IDesk>;
     users: Array<IUser>;
-    updatePlanningItem(updates: DeepPartial<IPlanningItem>): void;
     initiallyExpanded?: boolean;
+    updatePlanningItem(updates: DeepPartial<IPlanningItem>): void;
+    getCoverageProfile(coverageType?: ICoverageType): ICoverageContentProfile | undefined;
 }
 
 interface IState {
@@ -48,6 +51,8 @@ const mapStateToProps = (state) => ({
     newsCoverageStatus: selectors.general.newsCoverageStatus(state),
     desks: selectors.general.desks(state),
     users: selectors.general.users(state),
+    getCoverageProfile: (contentType?: ICoverageType) =>
+        selectors.coverageProfiles.getCoverageProfileByContentType(state, contentType),
 });
 
 class AddNewCoveragesComponent extends React.Component<IProps, IState> {
@@ -180,7 +185,10 @@ class AddNewCoveragesComponent extends React.Component<IProps, IState> {
                     this.props.newsCoverageStatus,
                     this.props.item,
                     this.props.event,
-                    coverage.type.qcode
+                    coverage.type.qcode,
+                    null,
+                    null,
+                    this.props.getCoverageProfile(coverage.type.qcode),
                 );
 
                 newCoverage.assigned_to = {

--- a/client/interfaces.ts
+++ b/client/interfaces.ts
@@ -2406,7 +2406,6 @@ export interface IPlanningAPI {
                 item: DeepPartial<IPlanningItem>,
                 event?: IEventItem,
                 g2contentType?: IG2ContentType['qcode'],
-                coverageProfile?: ICoverageContentProfile,
             ): DeepPartial<IPlanningCoverageItem>;
             addCoverageToWorkflow(
                 coverages: Array<IPlanningCoverageItem>,

--- a/client/interfaces.ts
+++ b/client/interfaces.ts
@@ -2405,7 +2405,8 @@ export interface IPlanningAPI {
             setDefaultValues(
                 item: DeepPartial<IPlanningItem>,
                 event?: IEventItem,
-                g2contentType?: IG2ContentType['qcode']
+                g2contentType?: IG2ContentType['qcode'],
+                coverageProfile?: ICoverageContentProfile,
             ): DeepPartial<IPlanningCoverageItem>;
             addCoverageToWorkflow(
                 coverages: Array<IPlanningCoverageItem>,

--- a/client/selectors/coverageProfiles.ts
+++ b/client/selectors/coverageProfiles.ts
@@ -1,8 +1,19 @@
-import {ICoverageContentProfile} from 'interfaces';
+import {ICoverageContentProfile, IG2ContentType} from 'interfaces';
 import {get} from 'lodash';
+import {createSelector} from 'reselect';
 
 export const coverageProfiles: (state: any) => Array<ICoverageContentProfile>
     = (state) => (state?.coverageProfiles?.profiles ?? []);
 
 export const oldProfile: (state: any) => ICoverageContentProfile
     = (state) => get(state, 'forms.profiles.coverage', {});
+
+export const getCoverageProfileByContentType = createSelector(
+    [
+        coverageProfiles,
+        (_state: any, contentType: IG2ContentType['qcode']) => contentType,
+    ],
+    (profiles, contentType): ICoverageContentProfile | undefined => {
+        return profiles.find((profile) => profile.content_type === contentType);
+    }
+);

--- a/client/selectors/coverageProfiles.ts
+++ b/client/selectors/coverageProfiles.ts
@@ -1,4 +1,4 @@
-import {ICoverageContentProfile, IG2ContentType} from 'interfaces';
+import {ICoverageContentProfile, ICoverageType, IG2ContentType} from 'interfaces';
 import {get} from 'lodash';
 import {createSelector} from 'reselect';
 
@@ -15,5 +15,18 @@ export const getCoverageProfileByContentType = createSelector(
     ],
     (profiles, contentType): ICoverageContentProfile | undefined => {
         return profiles.find((profile) => profile.content_type === contentType);
+    }
+);
+
+export const getCoverageProfilesMap = createSelector(
+    coverageProfiles,
+    (profiles): Record<ICoverageType, ICoverageContentProfile> => {
+        return profiles.reduce((acc, p) => {
+            if (p?.content_type) {
+                acc[p.content_type] = p;
+            }
+
+            return acc;
+        }, {} as Record<ICoverageType, ICoverageContentProfile>);
     }
 );

--- a/client/selectors/index.ts
+++ b/client/selectors/index.ts
@@ -11,6 +11,7 @@ import * as featuredPlanning from './featuredPlanning';
 import * as locations from './locations';
 import * as editors from './editors';
 import * as workspace from './workspace';
+import * as coverageProfiles from './coverageProfiles';
 
 export * from './assignments';
 
@@ -28,4 +29,5 @@ export {
     locations,
     editors,
     workspace,
+    coverageProfiles,
 };

--- a/client/utils/planning.tsx
+++ b/client/utils/planning.tsx
@@ -1574,7 +1574,7 @@ function defaultCoverageValues(
     const defaultValues = contentProfiles.getDefaultValues(profile) as DeepPartial<IPlanningCoverageItem>;
 
     // if new profile hasn't been created for the type don't set to anything, backend also accepts objectid only
-    const profileId = profile._id ?? undefined;
+    const profileId = profile._id === 'coverage' || profile._id == null ? undefined : profile._id;
 
     let newCoverage: DeepPartial<IPlanningCoverageItem> = {
         coverage_id: generateTempId(),

--- a/client/utils/planning.tsx
+++ b/client/utils/planning.tsx
@@ -2,7 +2,7 @@ import moment from 'moment-timezone';
 import {get, set, uniq, sortBy, isEmpty, cloneDeep, isArray, flatten} from 'lodash';
 
 import {appConfig} from 'appConfig';
-import {IDesk, IArticle, IUser} from 'superdesk-api';
+import {IDesk, IArticle} from 'superdesk-api';
 import {superdeskApi, planningApi} from '../superdeskApi';
 import {
     IPlanningItem,
@@ -1001,14 +1001,14 @@ function createNewPlanningFromNewsItem(
     newsCoverageStatus: Array<IPlanningNewsCoverageStatus>,
     desk: IDesk['_id'],
     contentTypes: Array<IG2ContentType>,
-    getCoverageProfile: (contentType) => null | ICoverageContentProfile,
+    coverageProfilesMap: Record<ICoverageType, ICoverageContentProfile>,
 ) {
     const newCoverage = self.createCoverageFromNewsItem(
         addNewsItemToPlanning,
         newsCoverageStatus,
         desk,
         contentTypes,
-        getCoverageProfile,
+        coverageProfilesMap,
     );
     const {contentProfiles} = planningApi;
     let newPlanning: Partial<IPlanningItem> = {
@@ -1047,7 +1047,7 @@ function createCoverageFromNewsItem(
     newsCoverageStatus: Array<IPlanningNewsCoverageStatus>,
     desk: IDesk['_id'],
     contentTypes: Array<IG2ContentType>,
-    getCoverageProfile: (contentType: ICoverageType) => null | ICoverageContentProfile,
+    coverageProfilesMap: Record<ICoverageType, ICoverageContentProfile>,
 ): Partial<IPlanningCoverageItem> {
     const contentType = contentTypes.find(
         (ctype) => get(ctype, 'content item type') === addNewsItemToPlanning.type
@@ -1060,7 +1060,7 @@ function createCoverageFromNewsItem(
         contentType.qcode as ICoverageType,
         null,
         null,
-        getCoverageProfile(contentType.qcode as ICoverageType),
+        coverageProfilesMap[contentType.qcode],
     );
 
     newCoverage.workflow_status = COVERAGES.WORKFLOW_STATE.ACTIVE;
@@ -1892,7 +1892,7 @@ function showXMPFileUIControl(item: IAssignmentItem | IPlanningCoverageItem): bo
 function duplicateCoverage(
     item: DeepPartial<IPlanningItem>,
     coverage: DeepPartial<IPlanningCoverageItem>,
-    getCoverageProfile: (coverageType?: ICoverageType) => undefined | ICoverageContentProfile,
+    coverageProfilesMap: Record<ICoverageType, ICoverageContentProfile>,
     duplicateAs?: ICoverageType,
     event?: IEventItem, // TAG: MULTIPLE_PRIMARY_EVENTS
 ): DeepPartial<IPlanningItem['coverages']> {
@@ -1916,7 +1916,7 @@ function duplicateCoverage(
         coverageType,
         defaultDesk,
         preferredCoverageDesks,
-        getCoverageProfile(coverageType),
+        coverageType != null ? coverageProfilesMap[coverageType] : undefined,
     );
 
     newCoverage.coverage_id = newCoverage.coverage_id + '-duplicate';

--- a/client/utils/planning.tsx
+++ b/client/utils/planning.tsx
@@ -24,6 +24,7 @@ import {
     IItemAction,
     ICoverageType,
     IAssignmentItem,
+    IProfileSchemaTypeList,
 } from '../interfaces';
 
 import {stripHtmlRaw} from 'superdesk-core/scripts/apps/authoring/authoring/helpers';
@@ -1057,14 +1058,25 @@ function createCoverageFromNewsItem(
         (ctype) => get(ctype, 'content item type') === addNewsItemToPlanning.type
     );
 
+    const contentTypeQcode = (contentType?.qcode ?? PLANNING.G2_CONTENT_TYPE.TEXT) as ICoverageType;
+
     newCoverage.planning = {
         ...newCoverage.planning,
-        g2_content_type: get(contentType, 'qcode', PLANNING.G2_CONTENT_TYPE.TEXT),
+        g2_content_type: contentTypeQcode,
         slugline: get(addNewsItemToPlanning, 'slugline', ''),
         ednote: get(addNewsItemToPlanning, 'ednote', ''),
         scheduled: moment().add(1, 'hour')
             .startOf('hour'),
     };
+
+    const allCoverageProfiles = coverageProfiles(planningApi.redux.store.getState());
+    const coverageProfile = allCoverageProfiles.find((x) => x.content_type === contentTypeQcode);
+    const multipleContentDefaultValue = (coverageProfile?.schema?.['multiple_content'] as IProfileSchemaTypeList)
+        ?.default_value;
+
+    if (multipleContentDefaultValue != null) {
+        newCoverage.planning.multiple_content = multipleContentDefaultValue;
+    }
 
     if (addNewsItemToPlanning.priority != null) {
         newCoverage.planning.priority = addNewsItemToPlanning.priority;

--- a/client/utils/planning.tsx
+++ b/client/utils/planning.tsx
@@ -1057,7 +1057,7 @@ function createCoverageFromNewsItem(
         newsCoverageStatus,
         null,
         null,
-        null,
+        contentType.qcode as ICoverageType,
         null,
         null,
         getCoverageProfile(contentType.qcode as ICoverageType),

--- a/client/utils/planning.tsx
+++ b/client/utils/planning.tsx
@@ -24,7 +24,7 @@ import {
     IItemAction,
     ICoverageType,
     IAssignmentItem,
-    IProfileSchemaTypeList,
+    ICoverageContentProfile,
 } from '../interfaces';
 
 import {stripHtmlRaw} from 'superdesk-core/scripts/apps/authoring/authoring/helpers';
@@ -1000,15 +1000,15 @@ function createNewPlanningFromNewsItem(
     addNewsItemToPlanning: IArticle,
     newsCoverageStatus: Array<IPlanningNewsCoverageStatus>,
     desk: IDesk['_id'],
-    user: IUser['_id'],
-    contentTypes: Array<IG2ContentType>
+    contentTypes: Array<IG2ContentType>,
+    getCoverageProfile: (contentType) => null | ICoverageContentProfile,
 ) {
     const newCoverage = self.createCoverageFromNewsItem(
         addNewsItemToPlanning,
         newsCoverageStatus,
         desk,
-        user,
-        contentTypes
+        contentTypes,
+        getCoverageProfile,
     );
     const {contentProfiles} = planningApi;
     let newPlanning: Partial<IPlanningItem> = {
@@ -1046,17 +1046,24 @@ function createCoverageFromNewsItem(
     addNewsItemToPlanning: IArticle,
     newsCoverageStatus: Array<IPlanningNewsCoverageStatus>,
     desk: IDesk['_id'],
-    user: IUser['_id'],
-    contentTypes: Array<IG2ContentType>
+    contentTypes: Array<IG2ContentType>,
+    getCoverageProfile: (contentType: ICoverageType) => null | ICoverageContentProfile,
 ): Partial<IPlanningCoverageItem> {
-    let newCoverage = self.defaultCoverageValues(newsCoverageStatus);
-
-    newCoverage.workflow_status = COVERAGES.WORKFLOW_STATE.ACTIVE;
-
-    // Add fields from news item to the coverage
     const contentType = contentTypes.find(
         (ctype) => get(ctype, 'content item type') === addNewsItemToPlanning.type
     );
+
+    let newCoverage = self.defaultCoverageValues(
+        newsCoverageStatus,
+        null,
+        null,
+        null,
+        null,
+        null,
+        getCoverageProfile(contentType.qcode as ICoverageType),
+    );
+
+    newCoverage.workflow_status = COVERAGES.WORKFLOW_STATE.ACTIVE;
 
     const contentTypeQcode = (contentType?.qcode ?? PLANNING.G2_CONTENT_TYPE.TEXT) as ICoverageType;
 
@@ -1068,15 +1075,6 @@ function createCoverageFromNewsItem(
         scheduled: moment().add(1, 'hour')
             .startOf('hour'),
     };
-
-    const allCoverageProfiles = coverageProfiles(planningApi.redux.store.getState());
-    const coverageProfile = allCoverageProfiles.find((x) => x.content_type === contentTypeQcode);
-    const multipleContentDefaultValue = (coverageProfile?.schema?.['multiple_content'] as IProfileSchemaTypeList)
-        ?.default_value;
-
-    if (multipleContentDefaultValue != null) {
-        newCoverage.planning.multiple_content = multipleContentDefaultValue;
-    }
 
     if (addNewsItemToPlanning.priority != null) {
         newCoverage.planning.priority = addNewsItemToPlanning.priority;
@@ -1569,15 +1567,14 @@ function defaultCoverageValues(
     g2contentType?: ICoverageType,
     defaultDesk?: IDesk,
     preferredCoverageDesks?: {[key: string]: IDesk['_id']},
+    coverageProfile?: ICoverageContentProfile,
 ): DeepPartial<IPlanningCoverageItem> {
     const {contentProfiles} = planningApi;
-    const allProfiles = coverageProfiles(planningApi.redux.store.getState());
-    const coverageProfile = allProfiles.find((x) => x.content_type === g2contentType)
-        ?? contentProfiles.get('coverage');
-    const defaultValues = (contentProfiles.getDefaultValues(coverageProfile)) as DeepPartial<IPlanningCoverageItem>;
+    const profile = coverageProfile ?? contentProfiles.get('coverage');
+    const defaultValues = contentProfiles.getDefaultValues(profile) as DeepPartial<IPlanningCoverageItem>;
 
     // if new profile hasn't been created for the type don't set to anything, backend also accepts objectid only
-    const profileId = allProfiles.find((x) => x.content_type === g2contentType)?._id ?? undefined;
+    const profileId = profile._id ?? undefined;
 
     let newCoverage: DeepPartial<IPlanningCoverageItem> = {
         coverage_id: generateTempId(),
@@ -1895,7 +1892,8 @@ function showXMPFileUIControl(item: IAssignmentItem | IPlanningCoverageItem): bo
 function duplicateCoverage(
     item: DeepPartial<IPlanningItem>,
     coverage: DeepPartial<IPlanningCoverageItem>,
-    duplicateAs?: IG2ContentType['qcode'],
+    getCoverageProfile: (coverageType?: ICoverageType) => undefined | ICoverageContentProfile,
+    duplicateAs?: ICoverageType,
     event?: IEventItem, // TAG: MULTIPLE_PRIMARY_EVENTS
 ): DeepPartial<IPlanningItem['coverages']> {
     const coveragePlanning: Partial<IPlanningItem> = {
@@ -1909,14 +1907,16 @@ function duplicateCoverage(
     const newsCoverageStatus = selectors.general.newsCoverageStatus(state);
     const defaultDesk = selectors.general.defaultDesk(state);
     const preferredCoverageDesks = get(selectors.general.preferredCoverageDesks(state), 'desks');
+    const coverageType = duplicateAs ?? coverage.planning?.g2_content_type;
 
     let newCoverage = defaultCoverageValues(
         [newsCoverageStatus.find((s) => s.qcode === 'ncostat:int')],
         coveragePlanning,
         event,
-        duplicateAs || coverage.planning?.g2_content_type,
+        coverageType,
         defaultDesk,
-        preferredCoverageDesks
+        preferredCoverageDesks,
+        getCoverageProfile(coverageType),
     );
 
     newCoverage.coverage_id = newCoverage.coverage_id + '-duplicate';

--- a/client/utils/tests/planning_test.ts
+++ b/client/utils/tests/planning_test.ts
@@ -346,7 +346,12 @@ describe('PlanningUtils', () => {
             };
 
             const coverage = planningUtils.createCoverageFromNewsItem(
-                newsItem, newsCoverageStatus, desk, user, contentTypes);
+                newsItem,
+                newsCoverageStatus,
+                desk,
+                contentTypes,
+                () => undefined,
+            );
 
             expect(omit(coverage, ['coverage_id', 'planning._scheduledTime'])).toEqual({
                 planning: {
@@ -385,7 +390,12 @@ describe('PlanningUtils', () => {
             };
 
             const coverage = planningUtils.createCoverageFromNewsItem(
-                newsItem, newsCoverageStatus, desk, user, contentTypes);
+                newsItem,
+                newsCoverageStatus,
+                desk,
+                contentTypes,
+                () => undefined,
+            );
 
             expect(omit(coverage, ['coverage_id', 'planning._scheduledTime'])).toEqual({
                 planning: {
@@ -424,7 +434,12 @@ describe('PlanningUtils', () => {
             };
 
             const coverage = planningUtils.createCoverageFromNewsItem(
-                newsItem, newsCoverageStatus, desk, user, contentTypes);
+                newsItem,
+                newsCoverageStatus,
+                desk,
+                contentTypes,
+                () => undefined,
+            );
 
             expect(omit(coverage, ['coverage_id', 'planning._scheduledTime'])).toEqual({
                 planning: {
@@ -464,7 +479,12 @@ describe('PlanningUtils', () => {
             };
 
             const coverage = planningUtils.createCoverageFromNewsItem(
-                newsItem, newsCoverageStatus, desk, user, contentTypes);
+                newsItem,
+                newsCoverageStatus,
+                desk,
+                contentTypes,
+                () => undefined,
+            );
 
             expect(omit(coverage, ['coverage_id', 'planning._scheduledTime'])).toEqual({
                 planning: {
@@ -1021,10 +1041,12 @@ describe('PlanningUtils', () => {
         it('set coverage time for adhock planning', () => {
             const newsCoverageStatus = [{qcode: 'ncostat:int'}];
             let planned = moment('2119-03-15T09:00:00+11:00');
-            const plan = {slugline: 'Test',
+            const plan = {
+                slugline: 'Test',
                 internal_note: 'Internal Note',
                 ednote: 'Ed note',
-                planning_date: planned};
+                planning_date: planned
+            };
 
             let coverage = planningUtils.defaultCoverageValues(newsCoverageStatus, plan, null);
 

--- a/client/utils/tests/planning_test.ts
+++ b/client/utils/tests/planning_test.ts
@@ -369,7 +369,7 @@ describe('PlanningUtils', () => {
                 newsCoverageStatus,
                 desk,
                 contentTypes,
-                () => undefined,
+                {},
             );
 
             expect(omit(coverage, ['coverage_id', 'planning._scheduledTime'])).toEqual({
@@ -413,7 +413,7 @@ describe('PlanningUtils', () => {
                 newsCoverageStatus,
                 desk,
                 contentTypes,
-                () => undefined,
+                {},
             );
 
             expect(omit(coverage, ['coverage_id', 'planning._scheduledTime'])).toEqual({
@@ -502,7 +502,7 @@ describe('PlanningUtils', () => {
                 newsCoverageStatus,
                 desk,
                 contentTypes,
-                () => COVERAGE_PROFILE_MULTIPLE_CONTENT_TRUE,
+                {text: COVERAGE_PROFILE_MULTIPLE_CONTENT_TRUE},
             );
 
             expect(coverage.planning.multiple_content).toEqual(true);
@@ -529,7 +529,7 @@ describe('PlanningUtils', () => {
                 newsCoverageStatus,
                 desk,
                 contentTypes,
-                () => undefined,
+                {},
             );
 
             expect(omit(coverage, ['coverage_id', 'planning._scheduledTime'])).toEqual({

--- a/client/utils/tests/planning_test.ts
+++ b/client/utils/tests/planning_test.ts
@@ -23,6 +23,25 @@ const contentTypes = [
     },
 ];
 
+const COVERAGE_PROFILE_MULTIPLE_CONTENT_TRUE = {
+    name: 'coverage',
+    editor: {
+        multiple_content: {
+            enabled: true,
+            index: 1,
+        },
+    },
+    schema: {
+        multiple_content: {
+            type: 'boolean',
+            required: false,
+            default_value: true,
+            read_only: false
+        },
+    },
+    content_type: 'text',
+};
+
 describe('PlanningUtils', () => {
     let session;
     let locks;
@@ -460,6 +479,33 @@ describe('PlanningUtils', () => {
                     priority: ASSIGNMENTS.DEFAULT_PRIORITY,
                 },
             });
+        });
+
+        it('coverage multiple content is derived from profile default value', () => {
+            const newsItem = {
+                slugline: 'slug',
+                ednote: 'edit my note',
+                type: 'text',
+                state: 'scheduled',
+                versioncreated: '2017-10-15T14:01:11',
+                version_creator: 'ident2',
+                task: {
+                    desk: 'desk2',
+                    user: 'ident2',
+                },
+                firstpublished: '2017-10-15T16:00:00',
+                schedule_settings: {utc_publish_schedule: '2017-10-15T20:00:00'},
+            };
+
+            const coverage = planningUtils.createCoverageFromNewsItem(
+                newsItem,
+                newsCoverageStatus,
+                desk,
+                contentTypes,
+                () => COVERAGE_PROFILE_MULTIPLE_CONTENT_TRUE,
+            );
+
+            expect(coverage.planning.multiple_content).toEqual(true);
         });
 
         it('coverage time is derived from news item\'s schedule time if item is scheduled for publishing', () => {

--- a/client/utils/tests/planning_test.ts
+++ b/client/utils/tests/planning_test.ts
@@ -535,7 +535,12 @@ describe('PlanningUtils', () => {
             };
 
             const plan = planningUtils.createNewPlanningFromNewsItem(
-                newsItem, newsCoverageStatus, desk, user, contentTypes);
+                newsItem,
+                newsCoverageStatus,
+                desk,
+                contentTypes,
+                () => undefined,
+            );
 
             expect(plan).toEqual(jasmine.objectContaining({
                 type: 'planning',
@@ -590,7 +595,12 @@ describe('PlanningUtils', () => {
             };
 
             const plan = planningUtils.createNewPlanningFromNewsItem(
-                newsItem, newsCoverageStatus, desk, user, contentTypes);
+                newsItem,
+                newsCoverageStatus,
+                desk,
+                contentTypes,
+                () => undefined,
+            );
 
             expect(plan).toEqual(jasmine.objectContaining({
                 type: 'planning',


### PR DESCRIPTION
### Purpose
Use the default value coming from coverage profile for `multiple_content` coverage field when creating a planning with coverage item from "Add to planning" modal

### What has changed
Now the function responsible for creating a planning item that gets triggered from the add to planning modal also reads the default value for `multiple_content` field, and adds it to the newly created coverage item.

### Steps to test
1. Configure `multiple_content` default value to be `true` for text coverage profile. 
2. Create an article
3. Click add to planning in 3 dots menu of the article
4. Create a new planning item, instead of using an existing one
5. The `multiple_content` field of the coverage of the newly created planning item should be set to `true` (toggled on)

Resolves: #[STT-1380](https://sofab.atlassian.net/browse/STT-1380)

[STT-1380]: https://sofab.atlassian.net/browse/STT-1380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ