### PR TITLE
fix ui crash when editing planning filters

### DIFF
--- a/client/components/EventsPlanningFilters/EditFilter.tsx
+++ b/client/components/EventsPlanningFilters/EditFilter.tsx
@@ -116,7 +116,7 @@ export class EditFilter extends React.Component<IEventsPlanningContentPanelProps
                 newValue = null;
             }
         } else if (Array.isArray(value) && value.length === 0) {
-            newValue = null;
+            newValue = [];
         }
 
         this.onFilterChange(`params.${field}`, newValue);
@@ -129,7 +129,7 @@ export class EditFilter extends React.Component<IEventsPlanningContentPanelProps
             const value = get(updates, field);
 
             if (Array.isArray(value) && value.length === 0) {
-                set(filter.params, field, null);
+                set(filter.params, field, []);
             } else {
                 set(filter.params, field, value);
             }

--- a/client/components/fields/index.tsx
+++ b/client/components/fields/index.tsx
@@ -172,7 +172,7 @@ export function renderFieldsForPanel(
         }
 
         if (newField.component == null) {
-            console.error(`Component for field ${fieldName} not registered`);
+            console.warn(`Component for field ${fieldName} not registered`);
         } else if (
             profile[fieldName].enabled &&
             profile[fieldName][enabledField] &&


### PR DESCRIPTION
when removing value from list it was setting the field to null which would crash later when reading using filter on it.

STT-1390

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

### Front-end checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)

Resolves: #[issue-number]

