### PR TITLE
[STT-1407] fix: Dont re-assign Assignment on content link

### DIFF
--- a/server/features/assignments_multi_content.feature
+++ b/server/features/assignments_multi_content.feature
@@ -15,6 +15,11 @@ Feature: Assignment with multiple linked content
             "members": [{"user": "#CONTEXT_USER_ID#"}],
             "default_content_template": "#content_templates._id#",
             "default_content_profile": "#content_types._id#"
+        }, {
+            "name": "Finance Desk",
+            "members": [{"user": "#CONTEXT_USER_ID#"}],
+            "default_content_template": "#content_templates._id#",
+            "default_content_profile": "#content_types._id#"
         }]
         """
         When we post to "planning"
@@ -564,4 +569,83 @@ Feature: Assignment with multiple linked content
         Then we get existing resource
         """
         {"assigned_to": {"state": "in_progress"}}
+        """
+
+    @auth
+    Scenario: Linking a published article to assignment does not complete it
+        When we configure content for publishing
+        When we post to "/archive"
+        """
+        [{
+            "type": "text",
+            "headline": "test headline 1",
+            "slugline": "test slugline",
+            "state": "in_progress",
+            "task": {"desk": "#desks._id#", "stage": "#desks.incoming_stage#"}
+        }]
+        """
+        Then we get OK response
+        And we store "CONTENT_1_ID" with value "#archive._id#" to context
+        When we publish "#CONTENT_1_ID#" with "publish" type and "published" state
+        Then we get OK response
+        When we post to "assignments/link"
+        """
+        [{
+            "assignment_id": "#ASSIGNMENT_ID#",
+            "item_id": "#CONTENT_1_ID#",
+            "reassign": true
+        }]
+        """
+        Then we get OK response
+        When we get "/archive/#CONTENT_1_ID#"
+        Then we get existing resource
+        """
+        {"_id": "#CONTENT_1_ID#", "assignment_id": "#ASSIGNMENT_ID#"}
+        """
+        When we get "/assignments/#ASSIGNMENT_ID#"
+        Then we get existing resource
+        """
+        {"assigned_to": {"state": "in_progress"}}
+        """
+
+    @auth
+    Scenario: Updating article to different desk does not re-assign the assignment
+        When we configure content for publishing
+        When we post to "/assignments/content"
+        """
+        [{"assignment_id": "#ASSIGNMENT_ID#"}]
+        """
+        Then we get OK response
+        And we store "CONTENT_1_ID" with value "#content._id#" to context
+        When we patch "/archive/#CONTENT_1_ID#"
+        """
+        {"headline": "test content 1"}
+        """
+        Then we get OK response
+        When we publish "#CONTENT_1_ID#" with "publish" type and "published" state
+        Then we get OK response
+        When we get "/assignments/#ASSIGNMENT_ID#"
+        Then we get existing resource
+        """
+        {"assigned_to": {"state": "in_progress", "desk": "#desks_1._id#"}}
+        """
+        When we rewrite "#CONTENT_1_ID#"
+        """
+        {"desk_id": "#desks_0._id#"}
+        """
+        Then we get OK response
+        When we get "/assignments/#ASSIGNMENT_ID#"
+        Then we get existing resource
+        """
+        {"assigned_to": {"state": "in_progress", "desk": "#desks_1._id#"}}
+        """
+        When we get "/archive/#CONTENT_1_ID#"
+        Then we get existing resource
+        """
+        {"task": {"desk": "#desks_1._id#"}}
+        """
+        When we get "/archive/#REWRITE_ID#"
+        Then we get existing resource
+        """
+        {"task": {"desk": "#desks_0._id#"}}
         """

--- a/server/planning/assignments/assignments_link.py
+++ b/server/planning/assignments/assignments_link.py
@@ -66,7 +66,8 @@ class AssignmentsLinkService(AsyncBaseService):
         deliveries = []
         published_updated_items = []
         updates = {"assigned_to": deepcopy(assignment.get("assigned_to"))}
-        need_complete = None
+        need_complete = False
+        multiple_content_enabled = assignment_allows_multiple_content_linked(assignment)
         for item in related_items:
             if not item.get("assignment_id") or (item["_id"] == actioned_item.get("_id") and doc.get("force")):
                 # Update the delivery for the item if one exists
@@ -102,7 +103,8 @@ class AssignmentsLinkService(AsyncBaseService):
                 items.append(item)
 
                 if (
-                    item.get(ITEM_STATE) in [CONTENT_STATE.PUBLISHED, CONTENT_STATE.CORRECTED]
+                    not multiple_content_enabled
+                    and item.get(ITEM_STATE) in [CONTENT_STATE.PUBLISHED, CONTENT_STATE.CORRECTED]
                     and not assignment.get("scheduled_update_id")
                     and assignment["assigned_to"]["state"] != ASSIGNMENT_WORKFLOW_STATE.COMPLETED
                 ):
@@ -120,6 +122,7 @@ class AssignmentsLinkService(AsyncBaseService):
             doc.pop("reassign", None),
             already_completed,
             need_complete,
+            multiple_content_enabled,
         )
         actioned_item["assignment_id"] = assignment[ID_FIELD]
         doc.update(actioned_item)
@@ -218,6 +221,7 @@ class AssignmentsLinkService(AsyncBaseService):
         reassign,
         already_completed,
         need_complete,
+        multiple_content_enabled,
     ):
         # Update assignments, assignment history and publish planning
         # set the state to in progress if no item in the updates chain has ever been published
@@ -227,14 +231,17 @@ class AssignmentsLinkService(AsyncBaseService):
         elif not already_completed:
             new_state = (
                 ASSIGNMENT_WORKFLOW_STATE.COMPLETED
-                if actioned_item.get(ITEM_STATE) in [CONTENT_STATE.PUBLISHED, CONTENT_STATE.CORRECTED]
+                if (
+                    not multiple_content_enabled
+                    and actioned_item.get(ITEM_STATE) in [CONTENT_STATE.PUBLISHED, CONTENT_STATE.CORRECTED]
+                )
                 else ASSIGNMENT_WORKFLOW_STATE.IN_PROGRESS
             )
             updates["assigned_to"]["state"] = get_next_assignment_status(updates, new_state)
             updated = True
 
         # on fulfiling the assignment the user is assigned the assignment, for add to planning it is not
-        if reassign:
+        if reassign and not multiple_content_enabled:
             user = get_user()
             if user and str(user.get(ID_FIELD)) != (assignment.get("assigned_to") or {}).get("user"):
                 updates["assigned_to"]["user"] = str(user.get(ID_FIELD))


### PR DESCRIPTION
### Purpose
There were 2 bugs discovered with an Assignment with multi-content enabled:
* linking a published article to an Assignment marks the Assignment as completed
* Updating a published article to a different desk attempts to re-assign the Assignment to the new desk

### What has changed
If Assignment has multi-content enabled:
* Don't mark Assignment as completed when linking content to it
* Don't re-assign Assignment Desk when linking content to it

Resolves: [STT-1407](https://sofab.atlassian.net/browse/STT-1407)



[STT-1407]: https://sofab.atlassian.net/browse/STT-1407?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ