### PR TITLE
[STT-1394] fix(select): Send null value in onChange callback when value cleared

### DIFF
--- a/client/components/fields/editor/base/select.tsx
+++ b/client/components/fields/editor/base/select.tsx
@@ -49,7 +49,7 @@ export class EditorFieldSelect extends React.PureComponent<IProps> {
 
     onChange(newValue: string) {
         if (this.props.valueAsString) {
-            this.props.onChange(this.props.field, newValue);
+            this.props.onChange(this.props.field, newValue || null);
         } else {
             this.props.onChange(this.props.field, this.props.options.find(
                 (option) => option[this.props.keyField ?? 'qcode'] === newValue


### PR DESCRIPTION
### Purpose
When clearing the value from a Select input element, an empty string was sent to the `onChange` method.

`null` makes more sense here and is valid for the back-end, where as an empty string is still a value and is invalid for the backend.

This only affects when the `valueAsString` prop is `true`, which makes the behaviour the same as if this is off (sending `null` as the value).

### What has changed
Send `null` to `onChange` when the value is falsy

Resolves: [STT-1394](https://sofab.atlassian.net/browse/STT-1394)
Note: Replaces https://github.com/superdesk/superdesk-planning/pull/2564



[STT-1394]: https://sofab.atlassian.net/browse/STT-1394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ