### PR TITLE
[STT-1399] - Bugfix: embedded planning coverages saving

### DIFF
--- a/client/components/Main/ItemEditor/ItemManager.ts
+++ b/client/components/Main/ItemEditor/ItemManager.ts
@@ -29,7 +29,7 @@ import {AutoSave} from './AutoSave';
 import {EditorGroup} from '../../Editor/EditorGroup';
 import * as selectors from '../../../selectors';
 import {handleEmbeddedItems} from '../../../components/editor-standalone/save-handling';
-import {IPlanningItem} from 'globals';
+import {IPlanningItem} from '../../../interfaces';
 
 
 export class ItemManager {

--- a/client/components/Main/ItemEditor/ItemManager.ts
+++ b/client/components/Main/ItemEditor/ItemManager.ts
@@ -9,7 +9,6 @@ import {
     IEditorProps,
     IEditorState,
     IEventOrPlanningItem,
-    IPlanningRelatedEventLink
 } from '../../../interfaces';
 import {planningApi} from '../../../superdeskApi';
 import {ITEM_TYPE, POST_STATE, UI, WORKFLOW_STATE, WORKSPACE, EVENTS} from '../../../constants';
@@ -30,6 +29,7 @@ import {AutoSave} from './AutoSave';
 import {EditorGroup} from '../../Editor/EditorGroup';
 import * as selectors from '../../../selectors';
 import {handleEmbeddedItems} from '../../../components/editor-standalone/save-handling';
+import {IPlanningItem} from 'globals';
 
 
 export class ItemManager {
@@ -219,13 +219,13 @@ export class ItemManager {
                 );
 
                 switch (this.props.itemAction) {
-                case 'create':
-                    return this.createNew(this.props);
-                case 'edit':
-                    return this.loadItem(this.props);
-                case 'read':
-                default:
-                    return this.loadReadOnlyItem(this.props);
+                    case 'create':
+                        return this.createNew(this.props);
+                    case 'edit':
+                        return this.loadItem(this.props);
+                    case 'read':
+                    default:
+                        return this.loadReadOnlyItem(this.props);
                 }
             });
     }
@@ -680,15 +680,16 @@ export class ItemManager {
         /**
          * Calls internal save of each embedded item - the one of the storage adapter, then returns the saved items.
          */
-        const promise = handleEmbeddedItems(this.props.editorType, 'SAVE', this.props.itemType)
-            .then((res) =>
-                Promise.all([
-                    Promise.resolve(res),
-                    !updateStates ? Promise.resolve({}) : this.setState({submitting: true, submitFailed: false})
-                ])
-            );
+        const saveEmbeddedItemsChanges = handleEmbeddedItems(this.props.editorType, 'SAVE', this.props.itemType)
+            .then((res) => {
+                if (updateStates) {
+                    this.setState({submitting: true, submitFailed: false});
+                }
 
-        return promise.then(() => {
+                return res;
+            });
+
+        return saveEmbeddedItemsChanges.then((updatedEmbeddedItems) => {
             if (this.props.addNewsItemToPlanning) {
                 return this._saveFromAuthoring({post, unpost});
             }
@@ -713,6 +714,8 @@ export class ItemManager {
 
             if (updates.type === 'event') {
                 updates.update_method = updateMethod;
+
+                updates.associated_plannings = updatedEmbeddedItems as Array<IPlanningItem>;
 
                 if (Object.keys(planningUpdateMethods).length > 0) {
                     updates.associated_plannings?.forEach((planningItem) => {

--- a/client/components/Main/ItemEditor/ItemManager.ts
+++ b/client/components/Main/ItemEditor/ItemManager.ts
@@ -219,13 +219,13 @@ export class ItemManager {
                 );
 
                 switch (this.props.itemAction) {
-                    case 'create':
-                        return this.createNew(this.props);
-                    case 'edit':
-                        return this.loadItem(this.props);
-                    case 'read':
-                    default:
-                        return this.loadReadOnlyItem(this.props);
+                case 'create':
+                    return this.createNew(this.props);
+                case 'edit':
+                    return this.loadItem(this.props);
+                case 'read':
+                default:
+                    return this.loadReadOnlyItem(this.props);
                 }
             });
     }

--- a/client/components/Main/ItemEditor/tests/ItemManager_test.ts
+++ b/client/components/Main/ItemEditor/tests/ItemManager_test.ts
@@ -10,6 +10,7 @@ import {restoreSinonStub, waitFor} from '../../../../utils/testUtils';
 import * as testData from '../../../../utils/testData';
 import {ItemManager} from '../ItemManager';
 import {EDITOR_TYPE} from 'interfaces';
+import * as saveHandling from '../../../../components/editor-standalone/save-handling';
 
 describe('components.Main.ItemManager', () => {
     let editor;
@@ -1167,6 +1168,8 @@ describe('components.Main.ItemManager', () => {
                 diff: item,
             });
 
+            sinon.stub(saveHandling, 'handleEmbeddedItems').returns(Promise.resolve([testData.plannings[1]]));
+
             manager._save()
                 .then(() => {
                     expect(main.save.callCount).toBe(1);
@@ -1199,7 +1202,10 @@ describe('components.Main.ItemManager', () => {
 
                     done();
                 })
-                .catch(done.fail);
+                .catch(done.fail)
+                .finally(() => {
+                    restoreSinonStub(saveHandling.handleEmbeddedItems);
+                });
         });
 
         it('sets submitting to false if main.save fails', (done) => {

--- a/client/components/editor-standalone/authoring-autosave.ts
+++ b/client/components/editor-standalone/authoring-autosave.ts
@@ -1,10 +1,10 @@
+import type {IAuthoringAutoSave, IBaseRestApiResponse} from 'superdesk-api';
+import type {IEventOrPlanningItem} from '../../interfaces';
 import moment from 'moment';
-import {IAuthoringAutoSave, IBaseRestApiResponse} from 'superdesk-api';
 import * as selectors from '../../selectors';
 import {throttle, DebouncedFunc} from 'lodash';
 import {planningApi, superdeskApi} from '../../superdeskApi';
 import {omitFields} from './utils';
-import {IEventOrPlanningItem} from '../../interfaces';
 
 export class AutoSaveHttp<T extends IBaseRestApiResponse & IEventOrPlanningItem> implements IAuthoringAutoSave<T> {
     private autoSaveThrottled: DebouncedFunc<typeof this.autosave>;

--- a/client/components/editor-standalone/authoring-autosave.ts
+++ b/client/components/editor-standalone/authoring-autosave.ts
@@ -4,8 +4,9 @@ import * as selectors from '../../selectors';
 import {throttle, DebouncedFunc} from 'lodash';
 import {planningApi, superdeskApi} from '../../superdeskApi';
 import {omitFields} from './utils';
+import {IEventOrPlanningItem} from '../../interfaces';
 
-export class AutoSaveHttp<T extends IBaseRestApiResponse> implements IAuthoringAutoSave<T> {
+export class AutoSaveHttp<T extends IBaseRestApiResponse & IEventOrPlanningItem> implements IAuthoringAutoSave<T> {
     private autoSaveThrottled: DebouncedFunc<typeof this.autosave>;
 
     private autosavePromise: Promise<void> | null;
@@ -31,52 +32,51 @@ export class AutoSaveHttp<T extends IBaseRestApiResponse> implements IAuthoringA
         const {httpRequestJsonLocal} = superdeskApi;
 
         const item: T = this.modifyForServer(getItem());
+        let result: Promise<T>;
 
-        const autosaveRequest = (() => {
-            if (previousAutosavedItem != null) {
-                const {
+        if (previousAutosavedItem != null) {
+            const {
+                lock_action,
+                lock_user,
+                lock_session,
+                lock_time,
+            } = previousAutosavedItem;
+
+            result = httpRequestJsonLocal<T>({
+                method: 'PATCH',
+                path: `/${this.resource}/${item._id}`,
+                payload: {
+                    ...omitFields(item, true),
                     lock_action,
                     lock_user,
                     lock_session,
                     lock_time,
-                } = previousAutosavedItem;
+                },
+                headers: {
+                    'If-Match': previousAutosavedItem._etag,
+                },
+            });
+        } else {
+            const {getState} = planningApi.redux.store;
 
-                return httpRequestJsonLocal<T>({
-                    method: 'PATCH',
-                    path: `/${this.resource}/${item._id}`,
-                    payload: {
-                        ...omitFields(item, true),
-                        lock_action,
-                        lock_user,
-                        lock_session,
-                        lock_time,
-                    },
-                    headers: {
-                        'If-Match': previousAutosavedItem._etag,
-                    },
-                });
-            } else {
-                const {getState} = planningApi.redux.store;
+            const lockInfo = {
+                lock_action: 'edit',
+                lock_user: selectors.general.currentUserId(getState()),
+                lock_session: selectors.general.sessionId(getState()),
+                lock_time: moment(),
+            };
 
-                const lockInfo = {
-                    lock_action: 'edit',
-                    lock_user: selectors.general.currentUserId(getState()),
-                    lock_session: selectors.general.sessionId(getState()),
-                    lock_time: moment(),
-                };
+            result = httpRequestJsonLocal<T>({
+                method: 'POST',
+                path: `/${this.resource}`,
+                payload: omitFields({
+                    ...item,
+                    ...lockInfo,
+                }),
+            });
+        }
 
-                return httpRequestJsonLocal<T>({
-                    method: 'POST',
-                    path: `/${this.resource}`,
-                    payload: omitFields({
-                        ...item,
-                        ...lockInfo,
-                    }),
-                });
-            }
-        })();
-
-        this.autosavePromise = autosaveRequest.then((res) => {
+        result.then((res) => {
             this.autosavePromise = null;
 
             const result = this.modifyForClient(res);
@@ -91,11 +91,7 @@ export class AutoSaveHttp<T extends IBaseRestApiResponse> implements IAuthoringA
         return httpRequestJsonLocal<T>({
             method: 'GET',
             path: `/${this.resource}/${id}`,
-        }).then((res) => {
-            const result = this.modifyForClient(res);
-
-            return result;
-        });
+        }).then(this.modifyForClient);
     }
 
     public delete(id: T['_id'], etag: T['_etag']) {

--- a/client/components/editor-standalone/authoring-autosave.ts
+++ b/client/components/editor-standalone/authoring-autosave.ts
@@ -91,7 +91,7 @@ export class AutoSaveHttp<T extends IBaseRestApiResponse & IEventOrPlanningItem>
         return httpRequestJsonLocal<T>({
             method: 'GET',
             path: `/${this.resource}/${id}`,
-        }).then(this.modifyForClient);
+        }).then((res) => this.modifyForClient(res));
     }
 
     public delete(id: T['_id'], etag: T['_etag']) {

--- a/client/components/editor-standalone/authoring-autosave.ts
+++ b/client/components/editor-standalone/authoring-autosave.ts
@@ -76,7 +76,7 @@ export class AutoSaveHttp<T extends IBaseRestApiResponse & IEventOrPlanningItem>
             });
         }
 
-        result.then((res) => {
+        this.autosavePromise = result.then((res) => {
             this.autosavePromise = null;
 
             const result = this.modifyForClient(res);

--- a/client/components/editor-standalone/authoring-storage-event-http.ts
+++ b/client/components/editor-standalone/authoring-storage-event-http.ts
@@ -4,7 +4,8 @@ import {superdeskApi} from '../../superdeskApi';
 import {getProfile} from './profile';
 import {omitFields} from './utils';
 import {AutoSaveHttp} from './authoring-autosave';
-import {eventUtils, getErrorMessage, gettext, notifyError} from '../../utils';
+import {eventUtils, getErrorMessage, gettext} from '../../utils';
+import {IEventItem} from '../../interfaces';
 
 export const authoringStorageEventItemHttp: IAuthoringStorage<IEventItem> = {
     autosave: new AutoSaveHttp<IEventItem>(
@@ -52,11 +53,14 @@ export const authoringStorageEventItemHttp: IAuthoringStorage<IEventItem> = {
             return original;
         });
     },
+
     getContentProfile: (item) => {
         return Promise.resolve(getProfile('event', item.language));
     },
+
     closeAuthoring: (_current, original, hasUnsavedChanges, _cancelAutosave, doClose) => {
-        return Promise.resolve();
+        return Promise.resolve({cancelled: false});
     },
+
     getUserPreferences: () => ng.get('preferencesService').get()
 };

--- a/client/components/editor-standalone/authoring-storage-in-memory.ts
+++ b/client/components/editor-standalone/authoring-storage-in-memory.ts
@@ -3,7 +3,7 @@ import {IAuthoringAutoSave, IAuthoringStorage} from 'superdesk-api';
 import {getProfile} from './profile';
 import {autosave} from '../../api/autosave';
 import {superdeskApi} from '../../superdeskApi';
-import {IEventOrPlanningItem} from 'interfaces';
+import {IEventOrPlanningItem} from '../../interfaces';
 
 export function getAuthoringStorageInMemory<T extends IEventOrPlanningItem>(
     profile: 'event' | 'planning',
@@ -90,7 +90,7 @@ export function getAuthoringStorageInMemory<T extends IEventOrPlanningItem>(
         },
 
         closeAuthoring: (_current, original, hasUnsavedChanges, _cancelAutosave, doClose) => {
-            return Promise.resolve();
+            return Promise.resolve({cancelled: false});
         },
 
         getUserPreferences: () => ng.get('preferencesService').get()

--- a/client/components/editor-standalone/authoring-storage-planning-http.ts
+++ b/client/components/editor-standalone/authoring-storage-planning-http.ts
@@ -14,6 +14,7 @@ export const authoringStoragePlanningItemHttp: IAuthoringStorage<IPlanningItem> 
         (item) => planningUtils.modifyForClient(item) as IPlanningItem,
         1000,
     ),
+
     getEntity: (id) => {
         const {httpRequestJsonLocal} = superdeskApi;
 
@@ -32,26 +33,30 @@ export const authoringStoragePlanningItemHttp: IAuthoringStorage<IPlanningItem> 
     saveEntity: (current, original) => {
         const {httpRequestJsonLocal} = superdeskApi;
         const {generatePatch} = superdeskApi.utilities;
+        const patchData = omitFields(
+            generatePatch(
+                planningUtils.modifyForServer(original),
+                planningUtils.modifyForServer(current, original),
+            ),
+        );
 
         return httpRequestJsonLocal<IPlanningItem>({
             method: 'PATCH',
             path: `/planning/${original._id}`,
-            payload: omitFields(
-                generatePatch(
-                    planningUtils.modifyForServer(original),
-                    planningUtils.modifyForServer(current, original),
-                ),
-            ),
+            payload: patchData,
             headers: {
                 'If-Match': original._etag,
             },
         }).then(planningUtils.modifyForClient);
     },
+
     getContentProfile: (item) => {
         return Promise.resolve(getProfile('planning', item.language));
     },
+
     closeAuthoring: (_current, _original, _hasUnsavedChanges, _cancelAutosave, _doClose) => {
-        return Promise.resolve();
+        return Promise.resolve({cancelled: false});
     },
+
     getUserPreferences: () => ng.get('preferencesService').get()
 };

--- a/client/components/editor-standalone/authoring-storage-planning-http.ts
+++ b/client/components/editor-standalone/authoring-storage-planning-http.ts
@@ -36,7 +36,7 @@ export const authoringStoragePlanningItemHttp: IAuthoringStorage<IPlanningItem> 
         const patchData = omitFields(
             generatePatch(
                 planningUtils.modifyForServer(original),
-                planningUtils.modifyForServer(current, original),
+                planningUtils.modifyForServer(current),
             ),
         );
 

--- a/client/components/editor-standalone/save-handling.ts
+++ b/client/components/editor-standalone/save-handling.ts
@@ -41,12 +41,12 @@ const getEmbeddedItemsExposed = <T extends IPlanningItem | IEventItem | void>(
  * Will stop on first error.
  * User will be prompted about the issue in the UI and is expected to try again.
  */
-export const handleEmbeddedItems = async<T extends IEventItem | IPlanningItem>(
+export const handleEmbeddedItems = <T extends IEventItem | IPlanningItem>(
     editorType: EDITOR_TYPE,
     action: IEmbeddedPlanningsActionType,
     itemType: ItemType,
 ): Promise<Array<T>> => {
-    const updatedItems: Array<T> = [];
+    const updatedItems: Array<Promise<T>> = [];
     const itemsExposed = getEmbeddedItemsExposed<T>(editorType, itemType);
 
     for (const exposed of itemsExposed) {
@@ -54,21 +54,21 @@ export const handleEmbeddedItems = async<T extends IEventItem | IPlanningItem>(
         const areAllChangesSaved = !exposed.hasUnsavedChanges();
 
         if (areAllChangesSaved) {
-            updatedItems.push(latestItem);
+            updatedItems.push(Promise.resolve(latestItem));
             continue;
         }
 
         if (action === 'SAVE') {
-            updatedItems.push(await exposed.save());
+            updatedItems.push(exposed.save());
         } else if (action === 'DISCARD') {
-            await exposed.discardUnsavedChanges();
-            updatedItems.push(latestItem);
+            exposed.discardUnsavedChanges();
+            updatedItems.push(Promise.resolve(latestItem));
         } else {
-            updatedItems.push(await exposed.handleUnsavedChanges());
+            updatedItems.push(exposed.handleUnsavedChanges());
         }
     }
 
-    return updatedItems;
+    return Promise.all(updatedItems);
 };
 
 export const embeddedItemHasUnsavedChanges = (itemType: ItemType) => {

--- a/client/components/editor-standalone/save-handling.ts
+++ b/client/components/editor-standalone/save-handling.ts
@@ -46,7 +46,7 @@ export const handleEmbeddedItems = async<T extends IEventItem | IPlanningItem>(
     action: IEmbeddedPlanningsActionType,
     itemType: ItemType,
 ): Promise<Array<T>> => {
-    const updatedItems: Array<Promise<T>> = [];
+    const updatedItems: Array<T> = [];
     const itemsExposed = getEmbeddedItemsExposed<T>(editorType, itemType);
 
     for (const exposed of itemsExposed) {
@@ -54,21 +54,21 @@ export const handleEmbeddedItems = async<T extends IEventItem | IPlanningItem>(
         const areAllChangesSaved = !exposed.hasUnsavedChanges();
 
         if (areAllChangesSaved) {
-            updatedItems.push(Promise.resolve(latestItem));
+            updatedItems.push(latestItem);
             continue;
         }
 
         if (action === 'SAVE') {
-            updatedItems.push(exposed.save());
+            updatedItems.push(await exposed.save());
         } else if (action === 'DISCARD') {
             await exposed.discardUnsavedChanges();
-            updatedItems.push(Promise.resolve(latestItem));
+            updatedItems.push(latestItem);
         } else {
-            updatedItems.push(exposed.handleUnsavedChanges());
+            updatedItems.push(await exposed.handleUnsavedChanges());
         }
     }
 
-    return Promise.all(updatedItems);
+    return updatedItems;
 };
 
 export const embeddedItemHasUnsavedChanges = (itemType: ItemType) => {

--- a/client/components/editor-standalone/utils.ts
+++ b/client/components/editor-standalone/utils.ts
@@ -1,6 +1,6 @@
-import {IEventOrPlanningItem, IPlanningItem, IProfileSchemaType, IProfileSchemaTypeString} from 'interfaces';
+import type {IEventOrPlanningItem, IPlanningItem, IProfileSchemaType, IProfileSchemaTypeString} from 'interfaces';
+import type {IBaseRestApiResponse} from 'superdesk-api';
 import {isEqual, omit} from 'lodash';
-import {IBaseRestApiResponse} from 'superdesk-api';
 
 export function omitFields<T extends IBaseRestApiResponse>(
     item: Partial<T> | T,

--- a/client/components/editor-standalone/utils.ts
+++ b/client/components/editor-standalone/utils.ts
@@ -1,10 +1,9 @@
-import {IEventOrPlanningItem, IProfileSchemaType, IProfileSchemaTypeString} from 'interfaces';
+import {IEventOrPlanningItem, IPlanningItem, IProfileSchemaType, IProfileSchemaTypeString} from 'interfaces';
 import {isEqual, omit} from 'lodash';
-import {isMoment} from 'moment';
 import {IBaseRestApiResponse} from 'superdesk-api';
 
 export function omitFields<T extends IBaseRestApiResponse>(
-    item: Partial<T>,
+    item: Partial<T> | T,
     omitId: boolean = false, // useful when patching
 ): Partial<T> {
     const baseApiFields = [

--- a/client/components/fields/editor/EventRelatedPlannings/EventRelatedPlanningWrapper.tsx
+++ b/client/components/fields/editor/EventRelatedPlannings/EventRelatedPlanningWrapper.tsx
@@ -1,6 +1,13 @@
 import React from 'react';
 import {EditorFieldEventRelatedPlanningsComponent} from './EventRelatedPlannings';
-import {IEditorFieldProps, ILockedItems, IProfileSchemaTypeList, ISearchProfile} from 'interfaces';
+import {
+    IEditorFieldProps,
+    IEventItem,
+    ILockedItems,
+    IPlanningItem,
+    IProfileSchemaTypeList,
+    ISearchProfile,
+} from 'interfaces';
 import * as selectors from '../../../../selectors';
 import {connect} from 'react-redux';
 

--- a/client/components/fields/editor/EventRelatedPlannings/RelatedPlanningItem.tsx
+++ b/client/components/fields/editor/EventRelatedPlannings/RelatedPlanningItem.tsx
@@ -131,10 +131,12 @@ export class RelatedPlanningItem extends React.PureComponent<IProps> {
                                     'planning',
                                     item as IPlanningItem,
                                     (item) => {
-                                        // Remove fields responsible for creating a link, so that item can be
-                                        // standalone until user decides to link it through main editor "Save"
+                                        /**
+                                         * When adding a new embedded planning, this save call will come from
+                                         * ItemManager via handleEmbeddedItems in save-handling.ts
+                                         */
                                         const fieldsToOmit = [
-                                            '_temporary', 'related_events', '_created', '_etag', '_links', '_updated',
+                                            '_temporary', '_created', '_etag', '_links', '_updated',
                                         ] satisfies Array<keyof IPlanningItem>;
                                         const itemClean = omit(
                                             modifyForServer(item, true),

--- a/client/utils/planning.tsx
+++ b/client/utils/planning.tsx
@@ -927,7 +927,7 @@ export function modifyForClient<T extends IPlanningItem | Partial<IPlanningItem>
     return plan;
 }
 
-function modifyForServer(plan: Partial<IPlanningItem>, original?: Partial<IPlanningItem>): Partial<IPlanningItem> {
+function modifyForServer(plan: Partial<IPlanningItem>): Partial<IPlanningItem> {
     delete plan?.event;
 
     const modifyGenre = (coverage) => {

--- a/client/utils/testData.ts
+++ b/client/utils/testData.ts
@@ -596,7 +596,7 @@ export const templates = {templates: []};
 
 export const form = {};
 
-export const plannings = [
+export const plannings: Array<IPlanningItem> = [
     {
         _id: 'p1',
         type: 'planning',


### PR DESCRIPTION
### Purpose
Fix a saving bug where when you add a coverage to an embedded planning, then also make changes to the event and then save all changes from the event header, the embedded planning item wouldn't have. 

### What has changed
Now after changes occur in the embedded planning items after they're saved via `handleEmbeddedItems`, they are synced to the event's `associated_plannings` so that the endpoint that saves all the data for the event, doesn't override the newly saved changes, and also cause `_etag`s of the embedded planning items to be out of sync.

### Steps to test
Add an event and save it.
Add an embedded planning item to it and save it.
Add a coverage inside the embedded planning item and make a change in the event.
Click the save from the event header. All changes should save now.

Resolves: #[STT-1399](https://sofab.atlassian.net/browse/STT-1399)

[STT-1399]: https://sofab.atlassian.net/browse/STT-1399?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ