### PR TITLE
[STT-1403] Remove required field validation from `Add to Planning`

### DIFF
--- a/client/controllers/AddToPlanningController.tsx
+++ b/client/controllers/AddToPlanningController.tsx
@@ -5,21 +5,12 @@ import ReactDOM from 'react-dom';
 import {Provider} from 'react-redux';
 import {ModalsContainer} from '../components';
 import {planning} from '../actions';
-import {isEmpty, isNumber, noop} from 'lodash';
 import {registerNotifications, getErrorMessage, isExistingItem} from '../utils';
 import {WORKSPACE, MODALS, PLANNING} from '../constants';
-import {GET_LABEL_MAP} from 'superdesk-core/scripts/apps/workspace/content/constants';
 import {IArticle, IContentProfile} from 'superdesk-api';
 import {authoringReactViewEnabled} from 'appConfig';
 import {planningApi, superdeskApi} from '../superdeskApi';
 import {PLANNING_VIEW} from '../interfaces';
-
-const DEFAULT_PLANNING_SCHEMA = {
-    anpa_category: {required: true},
-    subject: {required: true},
-    slugline: {required: true},
-    urgency: {required: true},
-};
 
 const ADD_TO_PLANNING_LOCK = PLANNING.ITEM_ACTIONS.ADD_TO_PLANNING.lock_action;
 
@@ -248,28 +239,13 @@ export class AddToPlanningController {
 
     loadArchiveItem() {
         return this.getArchiveItemAndProfile()
-            .then(({newsItem, contentProfile}) => {
+            .then(({newsItem}) => {
                 const errMessages = [];
                 const profile = planningProfile(this.store.getState());
-                const planningSchema = profile.schema || DEFAULT_PLANNING_SCHEMA;
-                const requiredError = (field) => this.gettext('[{{ field }}] is a required field')
-                    .replace('{{ field }}', field);
-                const labels = GET_LABEL_MAP();
 
                 if (newsItem.assignment_id) {
                     errMessages.push(this.gettext('Item already linked to a Planning item'));
                 }
-
-                Object.keys(planningSchema)
-                    .filter((field) => (
-                        contentProfile.schema?.[field] != null &&
-                        planningSchema[field]?.required === true &&
-                        isEmpty(newsItem[field]) &&
-                        !isNumber(newsItem[field])
-                    ))
-                    .forEach((field) => {
-                        errMessages.push(requiredError(labels[field] || field));
-                    });
 
                 if (errMessages.length) {
                     errMessages.forEach((err) => {

--- a/client/controllers/AddToPlanningController.tsx
+++ b/client/controllers/AddToPlanningController.tsx
@@ -1,5 +1,5 @@
 import * as actions from '../actions';
-import {currentItem, currentItemType, planningProfile} from '../selectors/forms';
+import {currentItem, currentItemType} from '../selectors/forms';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import {Provider} from 'react-redux';
@@ -7,9 +7,9 @@ import {ModalsContainer} from '../components';
 import {planning} from '../actions';
 import {registerNotifications, getErrorMessage, isExistingItem} from '../utils';
 import {WORKSPACE, MODALS, PLANNING} from '../constants';
-import {IArticle, IContentProfile} from 'superdesk-api';
+import {IArticle} from 'superdesk-api';
 import {authoringReactViewEnabled} from 'appConfig';
-import {planningApi, superdeskApi} from '../superdeskApi';
+import {planningApi} from '../superdeskApi';
 import {PLANNING_VIEW} from '../interfaces';
 
 const ADD_TO_PLANNING_LOCK = PLANNING.ITEM_ACTIONS.ADD_TO_PLANNING.lock_action;
@@ -217,16 +217,12 @@ export class AddToPlanningController {
     }
 
     getArchiveItemAndProfile(): Promise<{
-        newsItem: IArticle,
-        contentProfile: IContentProfile
+        newsItem: IArticle
     }> {
         return this.api.find('archive', this.item._id)
             .then((newsItem: IArticle) => {
-                const contentProfile = superdeskApi.entities.contentProfile.get(newsItem.profile);
-
                 return {
-                    newsItem,
-                    contentProfile
+                    newsItem
                 };
             }, (error) => {
                 this.notify.error(
@@ -241,7 +237,6 @@ export class AddToPlanningController {
         return this.getArchiveItemAndProfile()
             .then(({newsItem}) => {
                 const errMessages = [];
-                const profile = planningProfile(this.store.getState());
 
                 if (newsItem.assignment_id) {
                     errMessages.push(this.gettext('Item already linked to a Planning item'));

--- a/client/controllers/AddToPlanningController_test.ts
+++ b/client/controllers/AddToPlanningController_test.ts
@@ -71,46 +71,21 @@ describe('AddToPlanningController', () => {
         api,
         lock,
         session,
-        userList
+        userList,
+        $timeout
     ) => {
         api.find = sinon.stub().returns($q.reject({}));
-        return new AddToPlanningController(null,
+        return (new AddToPlanningController(null,
             scope, sdPlanningStore, notify,
-            gettext, api, lock, session, userList
-        )
+            gettext, api, lock, session, userList,
+            $timeout, {}
+        ) as any)
             .then(() => { /* no-op */ }, () => {
                 expect(api.find.callCount).toBe(1);
                 expect(api.find.args[0]).toEqual(['archive', 'item1']);
 
                 expect(notify.error.callCount).toBe(2);
                 expect(notify.error.args[0]).toEqual(['Failed to load the item.']);
-            });
-    }));
-
-    it('notifies the user if the item fails data validation', inject((
-        sdPlanningStore,
-        notify,
-        gettext,
-        api,
-        lock,
-        session,
-        userList
-    ) => {
-        delete newsItem.slugline;
-        delete newsItem.urgency;
-        delete newsItem.subject;
-        delete newsItem.anpa_category;
-
-        return new AddToPlanningController(null,
-            scope, sdPlanningStore, notify,
-            gettext, api, lock, session, userList
-        )
-            .then(() => { /* no-op */ }, () => {
-                expect(notify.error.callCount).toBe(4);
-                expect(notify.error.args).toContain(['[Slugline] is a required field']);
-                expect(notify.error.args).toContain(['[Urgency] is a required field']);
-                expect(notify.error.args).toContain(['[Subject] is a required field']);
-                expect(notify.error.args).toContain(['[ANPA Category] is a required field']);
             });
     }));
 
@@ -121,13 +96,15 @@ describe('AddToPlanningController', () => {
         api,
         lock,
         session,
-        userList
+        userList,
+        $timeout
     ) => {
         newsItem.assignment_id = 'as1';
-        return new AddToPlanningController(null,
+        return (new AddToPlanningController(null,
             scope, sdPlanningStore, notify,
-            gettext, api, lock, session, userList
-        )
+            gettext, api, lock, session, userList,
+            $timeout, {}
+        ) as any)
             .then(() => {
                 expect(notify.error.callCount).toBe(1);
                 expect(notify.error.args[0]).toEqual(['Item already linked to a Planning item']);
@@ -142,12 +119,14 @@ describe('AddToPlanningController', () => {
             api,
             lock,
             session,
-            userList
+            userList,
+            $timeout
         ) => (
-            new AddToPlanningController(null,
+            (new AddToPlanningController(null,
                 scope, sdPlanningStore, notify,
-                gettext, api, lock, session, userList
-            )
+                gettext, api, lock, session, userList,
+                $timeout, {}
+            ) as any)
                 .then(() => {
                     expect(lock.isLockedInCurrentSession.callCount).toBe(1);
                     expect(lock.isLockedInCurrentSession.args[0]).toEqual([newsItem]);


### PR DESCRIPTION
### Purpose
"Add to planning" action should be executed without the topic/slugline field being present or filled in. So in this PR we're removing any validation when the user "clicks" the add to planning button as the required field will still be there in the editor form.

### What has changed
- Eliminated logic enforcing required fields when adding to planning
- Remove related test cases

Resolves: [STT-1403]


[STT-1403]: https://sofab.atlassian.net/browse/STT-1403?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ