### PR TITLE
Enhance test runner with file and reporter options

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ Below sections include the config options that can be defined in settings.py.
 The search filters in the Planning module can be configured using the `planning_types` resource, using a document
 with an `_id` of `advanced_search`.
 
-Managing this config is currently not available from the front-end, but instead can be managed using the 
+Managing this config is currently not available from the front-end, but instead can be managed using the
 `data/planning_types.json` file in the application github repo.
 
 Extract of an example `data/planning_types.json` file:
@@ -400,7 +400,7 @@ Example: Add a custom text field with `_id` of `sttregistrationinfo` to Assignme
 ```
 
 > [!NOTE]
-> Custom text field filters is currently only supported in the Assignments filters panel. 
+> Custom text field filters is currently only supported in the Assignments filters panel.
 
 ### Development tools config
 
@@ -506,7 +506,6 @@ To run the same tests that is used in Travis, run the following:
 ```
 cd superdesk-planning
 make test
-cd ..
 ```
 
 Or you can run them individually as below.
@@ -516,21 +515,37 @@ Code Style
 ```
 cd superdesk-planning
 npm run hint
-cd ..
 ```
 
 Unit Tests
 ```
 cd superdesk-planning
-npm run unit_test
+npm test
+```
+
+Run tests with verbose output
+```
+cd superdesk-planning
+npm test --reporter=verbose
+```
+
+Run tests for specific files
+```
+cd superdesk-planning
+npm test --file=AddToPlanningController
 cd ..
 ```
 
-Coverage Report
+Combine options (verbose + specific file)
 ```
 cd superdesk-planning
-npm run coveralls
-cd ..
+npm test --reporter=verbose --file=AddToPlanningController
+```
+
+Debug tests in Chrome browser
+```
+cd superdesk-planning
+npm run debug_unit_tests
 ```
 
 ### Tests: Server

--- a/client/tests.ts
+++ b/client/tests.ts
@@ -26,6 +26,16 @@ beforeEach(() => {
     moment.tz.setDefault('Australia/Sydney');
 });
 
-var testsContext = require.context('client', true, /_test.[j|t]sx?$/);
+var testsContext = require.context('.', true, /_test\.[jt]sx?$/);
 
-testsContext.keys().forEach(testsContext);
+if (process.env.TEST_FILE_PATTERN) {
+    // Allow running specific test files via TEST_FILE_PATTERN env variable
+    // Usage: npm run test:file --file=AddToPlanningController
+    const testPattern = new RegExp(process.env.TEST_FILE_PATTERN + '_test\\.[jt]sx?$');
+
+    testsContext.keys()
+        .filter((path) => testPattern.test(path))
+        .forEach(testsContext);
+} else {
+    testsContext.keys().forEach(testsContext);
+}

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -4,9 +4,24 @@ var webpackConfig = require('./webpack.config.js')
 
 module.exports = function(config) {
     // in karma, entry is read from files prop
-    webpackConfig.entry = {}
+    webpackConfig.entry = {};
     webpackConfig.devtool = 'eval';
     webpackConfig.mode = 'development';
+
+    // Pass test file pattern to webpack via environment variable
+    if (process.env.TEST_FILE_PATTERN) {
+        webpackConfig.plugins = webpackConfig.plugins || [];
+        webpackConfig.plugins.push(
+            new (require('webpack')).DefinePlugin({
+                'process.env.TEST_FILE_PATTERN': JSON.stringify(process.env.TEST_FILE_PATTERN),
+            })
+        );
+    }
+
+    // Allow choosing reporter via KARMA_REPORTER env variable
+    // Options: 'dots' (default), 'verbose', 'progress'
+    const reporter = process.env.KARMA_REPORTER || 'dots';
+
     config.set({
 
         // base path that will be used to resolve all patterns (eg. files, exclude)
@@ -27,9 +42,11 @@ module.exports = function(config) {
             'tests.ts': ['webpack', 'sourcemap'],
         },
         // test results reporter to use
-        // possible values: 'dots', 'progress'
+        // possible values: 'dots', 'progress', 'verbose'
         // available reporters: https://npmjs.org/browse/keyword/karma-reporter
-        reporters: ['dots'],
+        // 'verbose' shows detailed test info including file paths
+        // Can be set via KARMA_REPORTER env variable
+        reporters: [reporter],
         // web server port
         port: 9876,
         // enable / disable colors in the output (reporters and logs)

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "fix": "eslint client --ext=jsx --ext=js --ext=tsx --ext=ts --ext=spec --fix",
     "hint": "eslint client --ext=jsx --ext=js --ext=tsx --ext=ts --ext=spec",
     "lint": "eslint client --ext=jsx --ext=js --ext=tsx --ext=ts --ext=spec --quiet",
-    "test": "karma start karma.conf.js --log-level debug --display-error-details --single-run",
+    "test": "KARMA_REPORTER=$npm_config_reporter TEST_FILE_PATTERN=$npm_config_file karma start karma.conf.js --log-level error --display-error-details --single-run",
     "karma": "karma start karma.conf.js",
     "debug_unit_tests": "karma start karma.conf.js --browsers=Chrome"
   },


### PR DESCRIPTION
### Purpose
To enhance test runner to allow running specific test files and also use a different reporter in case more information is needed.

### What has changed
- Added support for running specific test files and selecting test reporters via environment variables. 
- Updated test scripts, Karma configuration, and documentation to reflect these new options.

### Examples:
```bash
  npm test                                    # run all tests
  npm test --reporter=verbose                 # verbose output
  npm test --file=AddToPlanningController     # specific file
  npm test --reporter=verbose --file=pattern  # combined
```
