### PR TITLE
[STT-1401] fix: Reverted Assignment should be InProgress if content linked

### DIFF
--- a/server/features/assignments_revert.feature
+++ b/server/features/assignments_revert.feature
@@ -1,156 +1,274 @@
 Feature: Assignment Revert
-
-  @auth
-  @notification
-  Scenario: Assignment State goes back to revert_state
-    Given "desks"
-    """
-    [{"_id": "desk123", "name": "Politic Desk"}]
-    """
-    When we post to "planning" with success
-    """
-    [{
-        "guid": "plan1",
-        "headline": "test headline",
-        "slugline": "test slugline",
-        "state": "scheduled",
-        "planning_date": "2016-01-02"
-    }]
-    """
-    Given "assignments"
-    """
-    [{
-        "_id": "aaaaaaaaaaaaaaaaaaaaaaaa",
-        "planning_item": "plan1",
-        "planning": {
-            "ednote": "test coverage, I want 250 words",
-            "headline": "test headline",
-            "slugline": "test slugline",
-            "g2_content_type": "live_video",
-            "scheduled": "2016-01-02T14:00:00+0000"
-        },
-        "assigned_to": {
-            "desk": "desk123",
-            "user": "#CONTEXT_USER_ID#",
-            "state": "completed",
-            "revert_state": "assigned"
-        }
-    }]
-    """
-    When we post to "/assignments/#assignments._id#/lock"
-    """
-    {"lock_action": "revert"}
-    """
-    Then we get OK response
-    When we perform revert on assignments "#assignments._id#"
-    """
-    { }
-    """
-    Then we get OK response
-    When we get "/assignments/#assignments._id#"
-    Then we get OK response
-    Then we get existing resource
-    """
-    {
-        "_id": "aaaaaaaaaaaaaaaaaaaaaaaa",
-        "planning": {
-            "ednote": "test coverage, I want 250 words",
-            "headline": "test headline",
-            "slugline": "test slugline",
-            "g2_content_type": "live_video",
-            "scheduled": "2016-01-02T14:00:00+0000"
-        },
-        "assigned_to": {
-            "desk": "desk123",
-            "user": "#CONTEXT_USER_ID#",
-            "state": "assigned"
-        }
-    }
-    """
-    
-  @auth
-  @notification
-  @vocabularies
-  Scenario: Text Assignments cannot be reverted
-    Given "vocabularies"
-    """
+    Background: Setup data
+        Given "content_types"
+        """
+        [{"schema": {"body_html": {}, "slugline": {}, "headline": {}, "ednote": null }}]
+        """
+        Given "content_templates"
+        """
+        [{"template_name": "Default", "template_type": "create", "data": {}}]
+        """
+        Given "desks"
+        """
         [{
-          "_id": "g2_content_type",
-          "display_name": "Coverage content types",
-          "type": "manageable",
-          "unique_field": "qcode",
-          "selection_type": "do not show",
-          "items": [
-              {"is_active": true, "name": "Text", "qcode": "text", "content item type": "text"}
-          ]
+            "name": "Sports Desk",
+            "members": [{"user": "#CONTEXT_USER_ID#"}],
+            "default_content_template": "#content_templates._id#",
+            "default_content_profile": "#content_types._id#"
         }]
-    """
-    Given "assignments"
-    """
-    [{
-        "_id": "aaaaaaaaaaaaaaaaaaaaaaaa",
-        "planning_item": "plan1",
-        "planning": {
-            "ednote": "test coverage, I want 250 words",
+        """
+        And "planning"
+        """
+        [{
+            "guid": "plan1",
             "headline": "test headline",
             "slugline": "test slugline",
-            "g2_content_type": "text",
-            "scheduled": "2016-01-02T14:00:00+0000"
-        },
-        "assigned_to": {
-            "desk": "desk123",
-            "user": "#CONTEXT_USER_ID#",
-            "state": "completed",
-            "revert_state": "assigned"
-        }
-    }]
-    """
-    When we post to "/assignments/#assignments._id#/lock"
-    """
-    {"lock_action": "revert"}
-    """
-    Then we get OK response
-    When we perform revert on assignments "#assignments._id#"
-    """
-    { }
-    """
-    Then we get error 400
-    """
-    {"_issues": {"validator exception": "403: Cannot revert text assignments."}}
-    """
+            "state": "scheduled",
+            "planning_date": "2016-01-02"
+        }]
+        """
 
-  @auth
-  @notification
-  Scenario: Non-Text Assignments should be in completed status for revert action
-    Given "assignments"
-    """
-    [{
-        "_id": "aaaaaaaaaaaaaaaaaaaaaaaa",
-        "planning_item": "plan1",
-        "planning": {
-            "ednote": "test coverage, I want 250 words",
-            "headline": "test headline",
-            "slugline": "test slugline",
-            "g2_content_type": "live_video",
-            "scheduled": "2016-01-02T14:00:00+0000"
-        },
-        "assigned_to": {
-            "desk": "desk123",
-            "user": "#CONTEXT_USER_ID#",
-            "state": "assigned"
+    @auth
+    Scenario: Assignment State goes back to revert_state
+        When we patch "/planning/#planning._id#"
+        """
+        {"coverages": [{
+            "planning": {
+                "ednote": "test coverage, I want 250 words",
+                "headline": "test headline",
+                "slugline": "test slugline",
+                "g2_content_type": "live_video",
+                "scheduled": "2016-01-02T14:00:00+0000"
+            },
+            "assigned_to": {
+                "desk": "#desks._id#",
+                "user": "#CONTEXT_USER_ID#",
+                "state": "completed",
+                "revert_state": "assigned"
+            }
+        }]}
+        """
+        Then we get OK response
+        And we store coverage id in "COVERAGE_ID" from coverage 0
+        And we store assignment id in "ASSIGNMENT_ID" from coverage 0
+        When we post to "/assignments/#ASSIGNMENT_ID#/lock"
+        """
+        {"lock_action": "revert"}
+        """
+        Then we get OK response
+        When we perform revert on assignments "#ASSIGNMENT_ID#"
+        """
+        {}
+        """
+        Then we get OK response
+        When we get "/assignments/#ASSIGNMENT_ID#"
+        Then we get OK response
+        Then we get existing resource
+        """
+        {
+            "coverage_item": "#COVERAGE_ID#",
+            "assigned_to": {
+                "desk": "#desks._id#",
+                "user": "#CONTEXT_USER_ID#",
+                "state": "assigned"
+            }
         }
-    }]
-    """
-    When we post to "/assignments/#assignments._id#/lock"
-    """
-    {"lock_action": "revert"}
-    """
-    Then we get OK response
-    When we perform revert on assignments "#assignments._id#"
-    """
-    { }
-    """
-    Then we get error 400
-    """
-    {"_issues": {"validator exception": "403: Cannot revert an assignment which is not yet confirmed."}}
-    """
+        """
+
+    @auth
+    @planning_cvs
+    Scenario: Text Assignments cannot be reverted
+        When we patch "/planning/#planning._id#"
+        """
+        {"coverages": [{
+            "planning": {
+                "ednote": "test coverage, I want 250 words",
+                "headline": "test headline",
+                "slugline": "test slugline",
+                "g2_content_type": "text",
+                "scheduled": "2016-01-02T14:00:00+0000"
+            },
+            "assigned_to": {
+                "desk": "#desks._id#",
+                "user": "#CONTEXT_USER_ID#",
+                "state": "completed",
+                "revert_state": "assigned"
+            }
+        }]}
+        """
+        Then we get OK response
+        And we store assignment id in "ASSIGNMENT_ID" from coverage 0
+        When we post to "/assignments/#ASSIGNMENT_ID#/lock"
+        """
+        {"lock_action": "revert"}
+        """
+        Then we get OK response
+        When we perform revert on assignments "#ASSIGNMENT_ID#"
+        """
+        {}
+        """
+        Then we get error 400
+        """
+        {"_issues": {"validator exception": "403: Cannot revert text assignments."}}
+        """
+
+    @auth
+    @planning_cvs
+    Scenario: Text Assignments with multi-content enabled can be reverted
+        When we patch "/planning/#planning._id#"
+        """
+        {"coverages": [{
+            "planning": {
+                "ednote": "test coverage, I want 250 words",
+                "headline": "test headline",
+                "slugline": "test slugline",
+                "g2_content_type": "text",
+                "scheduled": "2016-01-02T14:00:00+0000",
+                    "multiple_content": true
+            },
+            "assigned_to": {
+                "desk": "#desks._id#",
+                "user": "#CONTEXT_USER_ID#",
+                "state": "completed",
+                "revert_state": "assigned"
+            }
+        }]}
+        """
+        Then we get OK response
+        And we store coverage id in "COVERAGE_ID" from coverage 0
+        And we store assignment id in "ASSIGNMENT_ID" from coverage 0
+        When we post to "/assignments/#ASSIGNMENT_ID#/lock"
+        """
+        {"lock_action": "revert"}
+        """
+        Then we get OK response
+        When we perform revert on assignments "#ASSIGNMENT_ID#"
+        """
+        {}
+        """
+        Then we get OK response
+        Then we get existing resource
+        """
+        {
+            "coverage_item": "#COVERAGE_ID#",
+            "assigned_to": {
+                "desk": "#desks._id#",
+                "user": "#CONTEXT_USER_ID#",
+                "state": "assigned"
+            }
+        }
+        """
+
+    @auth
+    Scenario: Non-Text Assignments should be in completed status for revert action
+        When we patch "/planning/#planning._id#"
+        """
+        {"coverages": [{
+            "planning": {
+                "ednote": "test coverage, I want 250 words",
+                "headline": "test headline",
+                "slugline": "test slugline",
+                "g2_content_type": "live_video",
+                "scheduled": "2016-01-02T14:00:00+0000"
+            },
+            "assigned_to": {
+                "desk": "#desks._id#",
+                "user": "#CONTEXT_USER_ID#",
+                "state": "assigned"
+            }
+        }]}
+        """
+        Then we get OK response
+        And we store assignment id in "ASSIGNMENT_ID" from coverage 0
+        When we post to "/assignments/#ASSIGNMENT_ID#/lock"
+        """
+        {"lock_action": "revert"}
+        """
+        Then we get OK response
+        When we perform revert on assignments "#ASSIGNMENT_ID#"
+        """
+        {}
+        """
+        Then we get error 400
+        """
+        {"_issues": {"validator exception": "403: Cannot revert an assignment which is not yet confirmed."}}
+        """
+
+    @auth
+    @planning_cvs
+    Scenario: Text Assignments with multi-content should be in_progress when reverted with content
+        When we patch "/planning/#planning._id#"
+        """
+        {"coverages": [{
+            "planning": {
+                "ednote": "test coverage, I want 250 words",
+                "headline": "test headline",
+                "slugline": "test slugline",
+                "g2_content_type": "text",
+                "scheduled": "2016-01-02T14:00:00+0000",
+                "multiple_content": true
+            },
+            "assigned_to": {
+                "desk": "#desks._id#",
+                "user": "#CONTEXT_USER_ID#",
+                "state": "assigned"
+            }
+        }]}
+        """
+        Then we get OK response
+        And we store coverage id in "COVERAGE_ID" from coverage 0
+        And we store assignment id in "ASSIGNMENT_ID" from coverage 0
+
+        # Create the Content from the Assignment
+        When we post to "/assignments/content"
+        """
+        [{"assignment_id": "#ASSIGNMENT_ID#"}]
+        """
+        Then we get OK response
+        Then we store "CONTENT_1_ID" with value "#content._id#" to context
+        When we get "/assignments/#ASSIGNMENT_ID#"
+        Then we get existing resource
+        """
+        {"assigned_to": {"state": "in_progress"}}
+        """
+
+        # Next mark Assignment as completed
+        When we post to "/assignments/#ASSIGNMENT_ID#/lock"
+        """
+        {"lock_action": "complete"}
+        """
+        Then we get OK response
+        When we perform complete on assignments "#ASSIGNMENT_ID#"
+        """
+        {}
+        """
+        Then we get OK response
+        When we get "/assignments/#ASSIGNMENT_ID#"
+        Then we get existing resource
+        """
+        {"assigned_to": {"state": "completed"}}
+        """
+
+        # Finally revert the Assignment
+        When we post to "/assignments/#ASSIGNMENT_ID#/lock"
+        """
+        {"lock_action": "revert"}
+        """
+        Then we get OK response
+        When we perform revert on assignments "#ASSIGNMENT_ID#"
+        """
+        {}
+        """
+        Then we get OK response
+        When we get "/assignments/#ASSIGNMENT_ID#"
+        Then we get existing resource
+        """
+        {
+            "coverage_item": "#COVERAGE_ID#",
+            "assigned_to": {
+                "desk": "#desks._id#",
+                "user": "#CONTEXT_USER_ID#",
+                "state": "in_progress"
+            }
+        }
+        """

--- a/server/planning/assignments/assignments_revert.py
+++ b/server/planning/assignments/assignments_revert.py
@@ -57,8 +57,15 @@ class AssignmentsRevertService(AsyncBaseService):
             raise SuperdeskApiError.forbiddenError("Cannot revert an assignment which is not yet confirmed.")
 
         updates["assigned_to"] = deepcopy(original).get("assigned_to")
-        updates["assigned_to"]["state"] = updates["assigned_to"].get("revert_state", ASSIGNMENT_WORKFLOW_STATE.ASSIGNED)
         updates["assigned_to"]["revert_state"] = None
+
+        if await get_resource_service("delivery").count_async({"assignment_id": original["_id"]}) > 0:
+            # If there is content linked to this Assignment, then we should change the state to ``In Progress``
+            updated_state = ASSIGNMENT_WORKFLOW_STATE.IN_PROGRESS
+        else:
+            # Otherwise we use the previously known state, or ``Assigned`` if it was never confirmed
+            updated_state = updates["assigned_to"].get("revert_state") or ASSIGNMENT_WORKFLOW_STATE.ASSIGNED
+        updates["assigned_to"]["state"] = updated_state
 
         remove_lock_information(updates)
 


### PR DESCRIPTION
### Purpose
When reverting an Assignment, it was being moved to the `ToDo` state, regardless if content is still linked or not.

### What has changed
* When reverting an Assignment, move it to the `In Progress` state if there is still content linked.
* Improve formatting for feature file, add new scenarios

Resolves: [STT-1401](https://sofab.atlassian.net/browse/STT-1401)



[STT-1401]: https://sofab.atlassian.net/browse/STT-1401?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ