### PR TITLE
avoid deep copying editor state in reducers

### DIFF
--- a/client/components/Main/ItemEditor/Editor.tsx
+++ b/client/components/Main/ItemEditor/Editor.tsx
@@ -108,48 +108,51 @@ export class EditorComponent extends React.Component<IEditorProps, IEditorState>
         // Use a callback to `this.setState` so we get the state value at the exact point when updating.
         // This allows consecutive updates to the state, while allowing React to batch these updates.
         // Otherwise only the last call to onChangeHandler will be applied to state per React batch update
-        this.setState<'diff'>((prevState: Readonly<IEditorState>) => {
-            // If field (name) is passed, it will replace that field
-            // Else, entire object will be replaced
-            const diff = field ? Object.assign({}, prevState.diff) : cloneDeep(value);
-            const newState: Pick<IEditorState, 'diff' | 'dirty'> = {
-                diff: diff,
-                dirty: prevState.dirty
-            };
+        return new Promise((resolve) => {
+            this.setState<'diff'>((prevState: Readonly<IEditorState>) => {
+                // If field (name) is passed, it will replace that field
+                // Else, entire object will be replaced
+                const diff = field ? Object.assign({}, prevState.diff) : cloneDeep(value);
+                const newState: Pick<IEditorState, 'diff' | 'dirty'> = {
+                    diff: diff,
+                    dirty: prevState.dirty
+                };
 
-            if (field) {
-                updateFormValues(diff, field, value);
-            }
+                if (field) {
+                    updateFormValues(diff, field, value);
+                }
 
-            if (field && typeof field === 'object') {
-                Object.keys(field).forEach((subField) => {
-                    this.editorApi.events.beforeFormUpdates(newState, subField, diff[subField]);
-                });
-            } else {
-                this.editorApi.events.beforeFormUpdates(newState, field, value);
-            }
+                if (field && typeof field === 'object') {
+                    Object.keys(field).forEach((subField) => {
+                        this.editorApi.events.beforeFormUpdates(newState, subField, diff[subField]);
+                    });
+                } else {
+                    this.editorApi.events.beforeFormUpdates(newState, field, value);
+                }
 
-            this.itemManager.validate(this.props, newState, this.state);
+                this.itemManager.validate(this.props, newState, this.state);
 
-            if (updateDirtyFlag) {
-                newState.dirty = this.isDirty(
-                    this.state.initialValues,
-                    diff
-                );
-            }
+                if (updateDirtyFlag) {
+                    newState.dirty = this.isDirty(
+                        this.state.initialValues,
+                        diff
+                    );
+                }
 
-            if (this.props.onChange) {
-                this.props.onChange(diff);
-            }
+                if (this.props.onChange) {
+                    this.props.onChange(diff);
+                }
 
-            return newState;
-        }, () => {
-            if (saveAutosave) {
-                this.autoSave.saveAutosave(this.props, this.state.diff);
-            }
+                return newState;
+            }, resolve);
+        })
+            .then(() => {
+                if (saveAutosave) {
+                    this.autoSave.saveAutosave(this.props, this.state.diff);
+                }
 
-            this.props.saveDiffToStore(this.state.diff);
-        });
+                this.props.saveDiffToStore(this.state.diff);
+            });
     }
 
     isDirty(initialValues, diff) {

--- a/client/components/Main/ItemEditor/Editor.tsx
+++ b/client/components/Main/ItemEditor/Editor.tsx
@@ -108,51 +108,48 @@ export class EditorComponent extends React.Component<IEditorProps, IEditorState>
         // Use a callback to `this.setState` so we get the state value at the exact point when updating.
         // This allows consecutive updates to the state, while allowing React to batch these updates.
         // Otherwise only the last call to onChangeHandler will be applied to state per React batch update
-        return new Promise((resolve) => {
-            this.setState<'diff'>((prevState: Readonly<IEditorState>) => {
-                // If field (name) is passed, it will replace that field
-                // Else, entire object will be replaced
-                const diff = field ? Object.assign({}, prevState.diff) : cloneDeep(value);
-                const newState: Pick<IEditorState, 'diff' | 'dirty'> = {
-                    diff: diff,
-                    dirty: prevState.dirty
-                };
+        this.setState<'diff'>((prevState: Readonly<IEditorState>) => {
+            // If field (name) is passed, it will replace that field
+            // Else, entire object will be replaced
+            const diff = field ? Object.assign({}, prevState.diff) : cloneDeep(value);
+            const newState: Pick<IEditorState, 'diff' | 'dirty'> = {
+                diff: diff,
+                dirty: prevState.dirty
+            };
 
-                if (field) {
-                    updateFormValues(diff, field, value);
-                }
+            if (field) {
+                updateFormValues(diff, field, value);
+            }
 
-                if (field && typeof field === 'object') {
-                    Object.keys(field).forEach((subField) => {
-                        this.editorApi.events.beforeFormUpdates(newState, subField, diff[subField]);
-                    });
-                } else {
-                    this.editorApi.events.beforeFormUpdates(newState, field, value);
-                }
+            if (field && typeof field === 'object') {
+                Object.keys(field).forEach((subField) => {
+                    this.editorApi.events.beforeFormUpdates(newState, subField, diff[subField]);
+                });
+            } else {
+                this.editorApi.events.beforeFormUpdates(newState, field, value);
+            }
 
-                this.itemManager.validate(this.props, newState, this.state);
+            this.itemManager.validate(this.props, newState, this.state);
 
-                if (updateDirtyFlag) {
-                    newState.dirty = this.isDirty(
-                        this.state.initialValues,
-                        diff
-                    );
-                }
+            if (updateDirtyFlag) {
+                newState.dirty = this.isDirty(
+                    this.state.initialValues,
+                    diff
+                );
+            }
 
-                if (this.props.onChange) {
-                    this.props.onChange(diff);
-                }
+            if (this.props.onChange) {
+                this.props.onChange(diff);
+            }
 
-                return newState;
-            }, resolve);
-        })
-            .then(() => {
-                if (saveAutosave) {
-                    this.autoSave.saveAutosave(this.props, this.state.diff);
-                }
+            return newState;
+        }, () => {
+            if (saveAutosave) {
+                this.autoSave.saveAutosave(this.props, this.state.diff);
+            }
 
-                this.props.saveDiffToStore(this.state.diff);
-            });
+            this.props.saveDiffToStore(this.state.diff);
+        });
     }
 
     isDirty(initialValues, diff) {

--- a/client/reducers/forms.ts
+++ b/client/reducers/forms.ts
@@ -5,8 +5,11 @@ import {IPlanningContentProfile} from '../interfaces';
 import {AUTOSAVE, ITEM_TYPE, MAIN, FORMS} from '../constants';
 import {createReducer} from './createReducer';
 import {eventUtils, getItemId, getItemType, planningUtils} from '../utils';
-import {cloneDeep, get, set} from 'lodash';
+import {get, set} from 'lodash';
 import {EDITOR_TYPE, IEditorFormState, IFormState} from '../interfaces';
+import {produce, setAutoFreeze} from 'immer';
+
+setAutoFreeze(false);
 
 const initialState: IFormState = {
     profiles: {},
@@ -47,75 +50,71 @@ function updateEditor(
     modal: boolean,
     updates: DeepPartial<IFormState>['editors']['panel']
 ): IFormState {
-    const newState = cloneDeep(state);
-
-    if (modal) {
-        newState.editors[EDITOR_TYPE.POPUP] = {
-            ...newState.editors[EDITOR_TYPE.POPUP],
-            ...updates,
-        };
-    } else {
-        newState.editors[EDITOR_TYPE.INLINE] = {
-            ...newState.editors[EDITOR_TYPE.INLINE],
-            ...updates,
-        };
-    }
+    const newState = produce(state, (draft) => {
+        if (modal) {
+            Object.assign(draft.editors[EDITOR_TYPE.POPUP], updates);
+        } else {
+            Object.assign(draft.editors[EDITOR_TYPE.INLINE], updates);
+        }
+    });
 
     return newState;
 }
 
 function updateFormGroups(action: string, state: IFormState, payload: any): IFormState {
-    const newState = cloneDeep(state);
-    const editor: IEditorFormState = newState.editors[payload.editor];
+    const newState = produce(state, (draft) => {
+        const editor: IEditorFormState = draft.editors[payload.editor];
 
-    switch (action) {
-    case MAIN.ACTIONS.FORMS_GROUP_SET:
-        editor.groups = payload.groups;
-        break;
-    case MAIN.ACTIONS.FORMS_GROUP_CLEAR:
-        editor.groups = {};
-        break;
-    case MAIN.ACTIONS.FORMS_GROUP_DELETE:
-        delete editor.groups[payload.groupId];
-        break;
-    case MAIN.ACTIONS.FORMS_GROUP_UPDATE:
-        editor.groups[payload.group.id] = {
-            ...editor.groups[payload.group.id],
-            ...payload.updates,
-        };
-        break;
-    }
+        switch (action) {
+        case MAIN.ACTIONS.FORMS_GROUP_SET:
+            editor.groups = payload.groups;
+            break;
+        case MAIN.ACTIONS.FORMS_GROUP_CLEAR:
+            editor.groups = {};
+            break;
+        case MAIN.ACTIONS.FORMS_GROUP_DELETE:
+            delete editor.groups[payload.groupId];
+            break;
+        case MAIN.ACTIONS.FORMS_GROUP_UPDATE:
+            editor.groups[payload.group.id] = {
+                ...editor.groups[payload.group.id],
+                ...payload.updates,
+            };
+            break;
+        }
+    });
 
     return newState;
 }
 
 function updateFormBookmarks(action: string, state: IFormState, payload: any): IFormState {
-    const newState = cloneDeep(state);
-    const editor: IEditorFormState = newState.editors[payload.editor];
+    const newState = produce(state, (draft) => {
+        const editor: IEditorFormState = draft.editors[payload.editor];
 
-    switch (action) {
-    case MAIN.ACTIONS.FORMS_BOOKMARKS_SET:
-        editor.bookmarks = payload.bookmarks;
-        break;
-    case MAIN.ACTIONS.FORMS_BOOKMARKS_CLEAR:
-        editor.bookmarks = {};
-        editor.activeBookmarkId = null;
-        break;
-    case MAIN.ACTIONS.FORMS_BOOKMARKS_DELETE:
-        delete editor.bookmarks[payload.bookmarkId];
-
-        if (payload.bookmarkId === editor.activeBookmarkId) {
+        switch (action) {
+        case MAIN.ACTIONS.FORMS_BOOKMARKS_SET:
+            editor.bookmarks = payload.bookmarks;
+            break;
+        case MAIN.ACTIONS.FORMS_BOOKMARKS_CLEAR:
+            editor.bookmarks = {};
             editor.activeBookmarkId = null;
-        }
+            break;
+        case MAIN.ACTIONS.FORMS_BOOKMARKS_DELETE:
+            delete editor.bookmarks[payload.bookmarkId];
 
-        break;
-    case MAIN.ACTIONS.FORMS_BOOKMARKS_UPDATE:
-        editor.bookmarks[payload.bookmark.id] = {
-            ...editor.bookmarks[payload.bookmark.id],
-            ...payload.updates,
-        };
-        break;
-    }
+            if (payload.bookmarkId === editor.activeBookmarkId) {
+                editor.activeBookmarkId = null;
+            }
+
+            break;
+        case MAIN.ACTIONS.FORMS_BOOKMARKS_UPDATE:
+            editor.bookmarks[payload.bookmark.id] = {
+                ...editor.bookmarks[payload.bookmark.id],
+                ...payload.updates,
+            };
+            break;
+        }
+    });
 
     return newState;
 }
@@ -125,11 +124,12 @@ function setPopupForm(state: IFormState, payload: {
     component: React.ComponentClass,
     props: any,
 }): IFormState {
-    const newState = cloneDeep(state);
-    const editor: IEditorFormState = newState.editors[payload.editor];
+    const newState = produce(state, (draft) => {
+        const editor: IEditorFormState = draft.editors[payload.editor];
 
-    editor.popupFormComponent = payload.component;
-    editor.popupFormProps = payload.props;
+        editor.popupFormComponent = payload.component;
+        editor.popupFormProps = payload.props;
+    });
 
     return newState;
 }
@@ -167,16 +167,17 @@ const formsReducer = createReducer(initialState, {
     ),
 
     [AUTOSAVE.ACTIONS.RECEIVE]: (state, payload) => {
-        const newState = cloneDeep(state);
-        const itemId = getItemId(payload);
-        const itemType = getItemType(payload);
-        const itemPath = `autosaves.${itemType}["${itemId}"]`;
+        const newState = produce(state, (draft) => {
+            const itemId = getItemId(payload);
+            const itemType = getItemType(payload);
+            const itemPath = `autosaves.${itemType}["${itemId}"]`;
 
-        if (itemType === ITEM_TYPE.EVENT) {
-            set(newState, itemPath, eventUtils.modifyForClient(payload, true));
-        } else if (itemType === ITEM_TYPE.PLANNING) {
-            set(newState, itemPath, planningUtils.modifyForClient(payload));
-        }
+            if (itemType === ITEM_TYPE.EVENT) {
+                set(draft, itemPath, eventUtils.modifyForClient(payload, true));
+            } else if (itemType === ITEM_TYPE.PLANNING) {
+                set(draft, itemPath, planningUtils.modifyForClient(payload));
+            }
+        });
 
         return newState;
     },
@@ -189,31 +190,33 @@ const formsReducer = createReducer(initialState, {
             return state;
         }
 
-        const newState = cloneDeep(state);
-        const autosaves = get(newState, `autosaves.${itemType}`);
+        const newState = produce(state, (draft) => {
+            const autosaves = get(draft, `autosaves.${itemType}`);
 
-        if (autosaves[itemId]) {
-            delete autosaves[itemId];
-        }
+            if (autosaves[itemId]) {
+                delete autosaves[itemId];
+            }
+        });
 
         return newState;
     },
 
     [AUTOSAVE.ACTIONS.RECEIVE_ALL]: (state, payload) => {
-        const newState = cloneDeep(state);
-        const items = {};
+        const newState = produce(state, (draft) => {
+            const items = {};
 
-        if (payload.itemType === ITEM_TYPE.EVENT) {
-            payload.autosaves.forEach((item) => {
-                items[getItemId(item)] = eventUtils.modifyForClient(item, true);
-            });
-        } else if (payload.itemType === ITEM_TYPE.PLANNING) {
-            payload.autosaves.forEach((item) => {
-                items[getItemId(item)] = planningUtils.modifyForClient(item);
-            });
-        }
+            if (payload.itemType === ITEM_TYPE.EVENT) {
+                payload.autosaves.forEach((item) => {
+                    items[getItemId(item)] = eventUtils.modifyForClient(item, true);
+                });
+            } else if (payload.itemType === ITEM_TYPE.PLANNING) {
+                payload.autosaves.forEach((item) => {
+                    items[getItemId(item)] = planningUtils.modifyForClient(item);
+                });
+            }
 
-        set(newState, `autosaves.${payload.itemType}`, items);
+            set(draft, `autosaves.${payload.itemType}`, items);
+        });
 
         return newState;
     },
@@ -243,9 +246,9 @@ const formsReducer = createReducer(initialState, {
     [MAIN.ACTIONS.FORMS_BOOKMARKS_CLEAR]: updateFormBookmarks.bind(null, MAIN.ACTIONS.FORMS_BOOKMARKS_CLEAR),
 
     [MAIN.ACTIONS.FORMS_BOOKMARKS_SET_ACTIVE_ID]: (state, payload) => {
-        const newState = cloneDeep(state);
-
-        newState.editors[payload.editor].activeBookmarkId = payload.bookmarkId;
+        const newState = produce(state, (draft) => {
+            draft.editors[payload.editor].activeBookmarkId = payload.bookmarkId;
+        });
 
         return newState;
     },


### PR DESCRIPTION
to avoid editor rerendering on each update

SDCP-1001

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

### Front-end checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)

Resolves: #[issue-number]

