### PR TITLE
[SDESK-7785] fix: Copy Coverage assignee changes to Assignment in workflow

### DIFF
--- a/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx
+++ b/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx
@@ -117,15 +117,78 @@ class CoverageFormHeaderComponent extends React.PureComponent<IProps> {
         }
     }
 
+    renderAssignmentFunctionButtons() {
+        const {
+            value,
+            addNewsItemToPlanning,
+            readOnly,
+            lockedItems,
+        } = this.props;
+
+        if (addNewsItemToPlanning != null
+            || (value as ICoverageScheduledUpdate).scheduled_update_id != null
+            || readOnly === true
+        ) {
+            return null;
+        }
+
+        const assignmentState = value.assigned_to?.state;
+        const isAssignmentLocked = lockedItems?.assignment
+            && value.assigned_to?.assignment_id in lockedItems.assignment;
+        const buttonsDisabled = [
+            ASSIGNMENTS.WORKFLOW_STATE.COMPLETED,
+            ASSIGNMENTS.WORKFLOW_STATE.CANCELLED,
+        ].includes(assignmentState) || isAssignmentLocked;
+
+        let reassignTooltip: string | null = null;
+        let removeTooltip: string | null = null;
+
+        if (assignmentState === ASSIGNMENTS.WORKFLOW_STATE.COMPLETED) {
+            reassignTooltip = gettext('Assignment has been completed, unable to reassign');
+            removeTooltip = gettext('Assignment has been completed, unable to remove');
+        } else if (assignmentState === ASSIGNMENTS.WORKFLOW_STATE.CANCELLED) {
+            reassignTooltip = gettext('Assignment has been cancelled, unable to reassign');
+            removeTooltip = gettext('Assignment has been cancelled, unable to remove');
+        } else if (isAssignmentLocked) {
+            reassignTooltip = gettext('Assignment is locked, unable to reassign');
+            removeTooltip = gettext('Assignment is locked, unable to remove');
+        }
+
+        return (
+            <Column>
+                <ListRow>
+                    <Button
+                        text={gettext('Reassign')}
+                        onClick={this.showAssignmentModal}
+                        style="hollow"
+                        size="small"
+                        expand
+                        disabled={buttonsDisabled}
+                        tooltip={reassignTooltip}
+                    />
+                </ListRow>
+                <ListRow>
+                    <Button
+                        text={gettext('Remove')}
+                        onClick={this.removeAssignment}
+                        style="hollow"
+                        size="small"
+                        expand
+                        disabled={buttonsDisabled}
+                        tooltip={removeTooltip}
+                    />
+                </ListRow>
+            </Column>
+        );
+    }
+
     render() {
         const {
             field,
             value,
             users,
             desks,
-            addNewsItemToPlanning,
             readOnly,
-            lockedItems,
         } = this.props;
 
         const userAssigned = getCreator(value, 'assigned_to.user', users);
@@ -223,62 +286,7 @@ class CoverageFormHeaderComponent extends React.PureComponent<IProps> {
                         </ListRow>
                     )}
                 </Column>
-                {(() => {
-                    if (addNewsItemToPlanning != null
-                        || (value as ICoverageScheduledUpdate).scheduled_update_id != null
-                        || readOnly === true
-                    ) {
-                        return null;
-                    }
-
-                    const isAssignmentLocked = lockedItems?.assignment
-                        && value.assigned_to?.assignment_id in lockedItems.assignment;
-                    const buttonsDisabled = [
-                        ASSIGNMENTS.WORKFLOW_STATE.COMPLETED,
-                        ASSIGNMENTS.WORKFLOW_STATE.CANCELLED,
-                    ].includes(assignmentState) || isAssignmentLocked;
-
-                    let reassignTooltip: string | null = null;
-                    let removeTooltip: string | null = null;
-
-                    if (assignmentState === ASSIGNMENTS.WORKFLOW_STATE.COMPLETED) {
-                        reassignTooltip = gettext('Assignment has been completed, unable to reassign');
-                        removeTooltip = gettext('Assignment has been completed, unable to remove');
-                    } else if (assignmentState === ASSIGNMENTS.WORKFLOW_STATE.CANCELLED) {
-                        reassignTooltip = gettext('Assignment has been cancelled, unable to reassign');
-                        removeTooltip = gettext('Assignment has been cancelled, unable to remove');
-                    } else if (isAssignmentLocked) {
-                        reassignTooltip = gettext('Assignment is locked, unable to reassign');
-                        removeTooltip = gettext('Assignment is locked, unable to remove');
-                    }
-
-                    return (
-                        <Column>
-                            <ListRow>
-                                <Button
-                                    text={gettext('Reassign')}
-                                    onClick={this.showAssignmentModal}
-                                    style="hollow"
-                                    size="small"
-                                    expand
-                                    disabled={buttonsDisabled}
-                                    tooltip={reassignTooltip}
-                                />
-                            </ListRow>
-                            <ListRow>
-                                <Button
-                                    text={gettext('Remove')}
-                                    onClick={this.removeAssignment}
-                                    style="hollow"
-                                    size="small"
-                                    expand
-                                    disabled={buttonsDisabled}
-                                    tooltip={removeTooltip}
-                                />
-                            </ListRow>
-                        </Column>
-                    );
-                })()}
+                {this.renderAssignmentFunctionButtons()}
             </Item>
         );
     }

--- a/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx
+++ b/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx
@@ -53,7 +53,7 @@ const mapStateToProps = (state) => ({
 });
 
 class CoverageFormHeaderComponent extends React.PureComponent<IProps> {
-    constructor(props) {
+    constructor(props: IProps) {
         super(props);
 
         this.showAssignmentModal = this.showAssignmentModal.bind(this);
@@ -67,8 +67,14 @@ class CoverageFormHeaderComponent extends React.PureComponent<IProps> {
             field: this.props.field,
             value: this.props.value,
             onChange: this.props.onChange,
-            disableDeskSelection: !!this.props.addNewsItemToPlanning,
-            disableUserSelection: !!this.props.addNewsItemToPlanning,
+            disableDeskSelection: this.props.addNewsItemToPlanning != null || (
+                this.props.value.assigned_to?.state != null
+                && ![
+                    ASSIGNMENTS.WORKFLOW_STATE.ASSIGNED,
+                    ASSIGNMENTS.WORKFLOW_STATE.SUBMITTED,
+                ].includes(this.props.value.assigned_to.state)
+            ),
+            disableUserSelection: this.props.addNewsItemToPlanning != null,
             priorityPrefix: 'assigned_to.',
         });
     }
@@ -127,11 +133,6 @@ class CoverageFormHeaderComponent extends React.PureComponent<IProps> {
         const coverageProvider = value.assigned_to?.coverage_provider;
         const assignmentState = value.assigned_to?.state;
         const cancelled = value.workflow_status === ASSIGNMENTS.WORKFLOW_STATE.CANCELLED;
-
-        const isAssignmentLocked = lockedItems?.assignment
-            && value.assigned_to?.assignment_id in lockedItems.assignment;
-        const itemIsScheduledUpdate = (value as ICoverageScheduledUpdate).scheduled_update_id;
-        const canEditAssignment = addNewsItemToPlanning == null && !isAssignmentLocked && !itemIsScheduledUpdate;
 
         if (!deskAssigned && !userAssigned && !coverageProvider) {
             return (
@@ -222,28 +223,62 @@ class CoverageFormHeaderComponent extends React.PureComponent<IProps> {
                         </ListRow>
                     )}
                 </Column>
-                {canEditAssignment && !readOnly && (
-                    <Column>
-                        <ListRow>
-                            <Button
-                                text={gettext('Reassign')}
-                                onClick={this.showAssignmentModal}
-                                style="hollow"
-                                size="small"
-                                expand
-                            />
-                        </ListRow>
-                        <ListRow>
-                            <Button
-                                text={gettext('Remove')}
-                                onClick={this.removeAssignment}
-                                style="hollow"
-                                size="small"
-                                expand
-                            />
-                        </ListRow>
-                    </Column>
-                )}
+                {(() => {
+                    if (addNewsItemToPlanning != null
+                        || (value as ICoverageScheduledUpdate).scheduled_update_id != null
+                        || readOnly === true
+                    ) {
+                        return null;
+                    }
+
+                    const isAssignmentLocked = lockedItems?.assignment
+                        && value.assigned_to?.assignment_id in lockedItems.assignment;
+                    const buttonsDisabled = [
+                        ASSIGNMENTS.WORKFLOW_STATE.COMPLETED,
+                        ASSIGNMENTS.WORKFLOW_STATE.CANCELLED,
+                    ].includes(assignmentState) || isAssignmentLocked;
+
+                    let reassignTooltip: string | null = null;
+                    let removeTooltip: string | null = null;
+
+                    if (assignmentState === ASSIGNMENTS.WORKFLOW_STATE.COMPLETED) {
+                        reassignTooltip = gettext('Assignment has been completed, unable to reassign');
+                        removeTooltip = gettext('Assignment has been completed, unable to remove');
+                    } else if (assignmentState === ASSIGNMENTS.WORKFLOW_STATE.CANCELLED) {
+                        reassignTooltip = gettext('Assignment has been cancelled, unable to reassign');
+                        removeTooltip = gettext('Assignment has been cancelled, unable to remove');
+                    } else if (isAssignmentLocked) {
+                        reassignTooltip = gettext('Assignment is locked, unable to reassign');
+                        removeTooltip = gettext('Assignment is locked, unable to remove');
+                    }
+
+                    return (
+                        <Column>
+                            <ListRow>
+                                <Button
+                                    text={gettext('Reassign')}
+                                    onClick={this.showAssignmentModal}
+                                    style="hollow"
+                                    size="small"
+                                    expand
+                                    disabled={buttonsDisabled}
+                                    tooltip={reassignTooltip}
+                                />
+                            </ListRow>
+                            <ListRow>
+                                <Button
+                                    text={gettext('Remove')}
+                                    onClick={this.removeAssignment}
+                                    style="hollow"
+                                    size="small"
+                                    expand
+                                    disabled={buttonsDisabled}
+                                    tooltip={removeTooltip}
+                                />
+                            </ListRow>
+                        </Column>
+                    );
+                })()}
             </Item>
         );
     }

--- a/server/features/assignments.feature
+++ b/server/features/assignments.feature
@@ -2414,3 +2414,172 @@ Feature: Assignments
             }
         }
         """
+
+    @auth
+    @planning_cvs
+    Scenario: Coverage assignee details copied to Assignment
+        When we post to "planning"
+        """
+        [{
+            "slugline": "test slugline",
+            "planning_date": "2042-06-30",
+            "coverages": [{
+                "planning": {
+                    "slugline": "test-cov-1",
+                    "g2_content_type": "text"
+                },
+                "assigned_to": {
+                    "desk": "#desks._id#",
+                    "user": "#CONTEXT_USER_ID#",
+                    "priority": 1
+                },
+                "news_coverage_status": {"qcode": "ncostat:int"},
+                "workflow_status": "assigned"
+            }, {
+                "planning": {
+                    "slugline": "test-cov-2",
+                    "g2_content_type": "text"
+                },
+                "assigned_to": {
+                    "desk": "#desks._id#",
+                    "priority": 3,
+                    "coverage_provider": {
+                        "qcode": "stringer",
+                        "name": "Stringer"
+                    }
+                },
+                "news_coverage_status": {"qcode": "ncostat:int"},
+                "workflow_status": "assigned"
+            }]
+        }]
+        """
+        Then we get OK response
+        And we store coverage id in "COVERAGE_1_ID" from coverage 0
+        And we store coverage id in "COVERAGE_2_ID" from coverage 1
+        And we store assignment id in "ASSIGNMENT_1_ID" from coverage 0
+        And we store assignment id in "ASSIGNMENT_2_ID" from coverage 1
+        When we get "/assignments"
+        Then we get list with 2 items
+        """
+        {"_items": [
+            {
+                "_id": "#ASSIGNMENT_1_ID#",
+                "priority": 1,
+                "assigned_to": {
+                    "desk": "#desks._id#",
+                    "user": "#CONTEXT_USER_ID#",
+                    "coverage_provider": "__no_value__"
+                }
+            },
+            {
+                "_id": "#ASSIGNMENT_2_ID#",
+                "priority": 3,
+                "assigned_to": {
+                    "desk": "#desks._id#",
+                    "user": null,
+                    "coverage_provider": {
+                        "qcode": "stringer",
+                        "name": "Stringer"
+                    }
+                }
+            }
+        ]}
+        """
+        When we patch "/planning/#planning._id#"
+        """
+        {"coverages": [{
+            "coverage_id": "#COVERAGE_1_ID#",
+            "planning": {
+                "slugline": "test-cov-1",
+                "g2_content_type": "text"
+            },
+            "assigned_to": {
+                "assignment_id": "#ASSIGNMENT_1_ID#",
+                "desk": "#desks._id#",
+                "user": null,
+                "coverage_provider": {
+                    "qcode": "stringer",
+                    "name": "Stringer"
+                },
+                "priority": 3
+            },
+            "news_coverage_status": {"qcode": "ncostat:int"},
+            "workflow_status": "assigned"
+        }, {
+            "coverage_id": "#COVERAGE_2_ID#",
+            "planning": {
+                "slugline": "test-cov-2",
+                "g2_content_type": "text"
+            },
+            "assigned_to": {
+                "assignment_id": "#ASSIGNMENT_2_ID#",
+                "desk": "#desks._id#",
+                "user": "#CONTEXT_USER_ID#",
+                "priority": 2
+            },
+            "news_coverage_status": {"qcode": "ncostat:int"},
+            "workflow_status": "assigned"
+        }]}
+        """
+        Then we get OK response
+        When we get "/planning/#planning._id#"
+        Then we get existing resource
+        """
+        {"coverages": [{
+            "coverage_id": "#COVERAGE_1_ID#",
+            "planning": {
+                "slugline": "test-cov-1",
+                "g2_content_type": "text"
+            },
+            "assigned_to": {
+                "assignment_id": "#ASSIGNMENT_1_ID#",
+                "desk": "#desks._id#",
+                "user": null,
+                "coverage_provider": {
+                    "qcode": "stringer",
+                    "name": "Stringer"
+                },
+                "priority": 3
+            },
+            "news_coverage_status": {"qcode": "ncostat:int"},
+            "workflow_status": "assigned"
+        }, {
+            "coverage_id": "#COVERAGE_2_ID#",
+            "planning": {
+                "slugline": "test-cov-2",
+                "g2_content_type": "text"
+            },
+            "assigned_to": {
+                "assignment_id": "#ASSIGNMENT_2_ID#",
+                "desk": "#desks._id#",
+                "user": "#CONTEXT_USER_ID#",
+                "priority": 2
+            },
+            "news_coverage_status": {"qcode": "ncostat:int"},
+            "workflow_status": "assigned"
+        }]}
+        """
+        When we get "/assignments"
+        Then we get list with 2 items
+        """
+        {"_items": [{
+            "_id": "#ASSIGNMENT_1_ID#",
+            "priority": 3,
+            "assigned_to": {
+                "desk": "#desks._id#",
+                "user": null,
+                "coverage_provider": {
+                    "qcode": "stringer",
+                    "name": "Stringer"
+                }
+            }
+        },
+        {
+            "_id": "#ASSIGNMENT_2_ID#",
+            "priority": 2,
+            "assigned_to": {
+                "desk": "#desks._id#",
+                "user": "#CONTEXT_USER_ID#"
+            }
+        }]}
+        """

--- a/server/planning/planning/planning.py
+++ b/server/planning/planning/planning.py
@@ -1070,19 +1070,20 @@ class PlanningService(AsyncBaseService):
                 if TO_BE_CONFIRMED_FIELD in doc:
                     assignment["planning"][TO_BE_CONFIRMED_FIELD] = doc[TO_BE_CONFIRMED_FIELD]
 
+            def _update_assignment_assigned_to():
+                user = get_user()
+                assignment["priority"] = assigned_to.pop("priority", original_assignment.get("priority"))
+                assignment["assigned_to"] = assigned_to
+                if original_assignment.get("assigned_to", {}).get("desk") != assigned_to.get("desk"):
+                    assigned_to["assigned_date_desk"] = utcnow()
+                    assigned_to["assignor_desk"] = user.get(ID_FIELD)
+                if assigned_to.get("user") and original.get("assigned_to", {}).get("user") != assigned_to.get("user"):
+                    assigned_to["assigned_date_user"] = utcnow()
+                    assigned_to["assignor_user"] = user.get(ID_FIELD)
+
             if original_assignment.get("assigned_to").get("state") == ASSIGNMENT_WORKFLOW_STATE.DRAFT:
                 if self.is_coverage_assignment_modified(updates, original_assignment):
-                    user = get_user()
-                    assignment["priority"] = assigned_to.pop("priority", original_assignment.get("priority"))
-                    assignment["assigned_to"] = assigned_to
-                    if original_assignment.get("assigned_to", {}).get("desk") != assigned_to.get("desk"):
-                        assigned_to["assigned_date_desk"] = utcnow()
-                        assigned_to["assignor_desk"] = user.get(ID_FIELD)
-                    if assigned_to.get("user") and original.get("assigned_to", {}).get("user") != assigned_to.get(
-                        "user"
-                    ):
-                        assigned_to["assigned_date_user"] = utcnow()
-                        assigned_to["assignor_user"] = user.get(ID_FIELD)
+                    _update_assignment_assigned_to()
 
             # If we made a coverage 'active' - change assignment status to active
             if original.get("workflow_status") == WORKFLOW_STATE.DRAFT and not is_coverage_draft:
@@ -1102,7 +1103,7 @@ class PlanningService(AsyncBaseService):
                 updates, original_assignment
             ):
                 assigned_to["state"] = ASSIGNMENT_WORKFLOW_STATE.ASSIGNED
-                assignment["assigned_to"] = assigned_to
+                _update_assignment_assigned_to()
 
             # If there has been a change in the planning internal note then notify the assigned users/desk
             if planning_updates.get("internal_note") and planning_original.get("internal_note") != planning_updates.get(
@@ -1126,6 +1127,7 @@ class PlanningService(AsyncBaseService):
                 or "assigned_to" in assignment
                 or "description_text" in assignment
                 or "name" in assignment
+                or "priority" in assignment
             ):
                 await assignment_service.system_update_async(
                     ObjectId(assigned_to.get("assignment_id")),
@@ -1316,7 +1318,7 @@ class PlanningService(AsyncBaseService):
 
     def is_coverage_assignment_modified(self, updates, original):
         if (updates or {}).get("assigned_to"):
-            keys = ["desk", "user", "state", "coverage_provider"]
+            keys = ["desk", "user", "state", "coverage_provider", "contact"]
             for key in keys:
                 if key in updates.get("assigned_to") and updates["assigned_to"][key] != (
                     original.get("assigned_to") or {}


### PR DESCRIPTION
### Purpose
When changing the Coverage assignee details (desk, user, priority, coverage_provider), if the Assignment is already in workflow these changes aren't copied to the Assignment as well.

Additionally there were business logic differences between the `Reassign` button on the Coverage form and the same action in the Assignments page.

### What has changed
* Copy Coverage assignee changes to Assignments already in workflow
* Add tooltips in Coverage form header, as to why the `Reassign` or `Remove` action is not available
* Don't allow re-assign or remove if Assignment is completed or cancelled
* Don't allow re-assigning the desk if the Assignment is in progress

Resolves:
* [SDESK-7785](https://sofab.atlassian.net/browse/SDESK-7785)
* https://sofab.atlassian.net/browse/STT-1384



[SDESK-7785]: https://sofab.atlassian.net/browse/SDESK-7785?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ