### PR TITLE
[SDESK-7790] - Fix event unlock notification payload

### DIFF
--- a/server/planning/events/events.py
+++ b/server/planning/events/events.py
@@ -627,6 +627,7 @@ class EventsService(AsyncBaseService):
                 etag=updates["_etag"],
                 recurrence_id=original.get("recurrence_id") or None,
                 from_ingest=from_ingest,
+                type=original.get("type"),
             )
 
         await self.delete_event_files(updates, original)

--- a/server/planning/events/events_service.py
+++ b/server/planning/events/events_service.py
@@ -352,6 +352,7 @@ class EventsAsyncService(BasePlanningAsyncService[EventResourceModel]):
                 etag=updates["_etag"],
                 recurrence_id=original.recurrence_id or None,
                 from_ingest=from_ingest,
+                type=original.get("type"),
             )
 
         await self.delete_event_files(updates, original.files)

--- a/server/planning/planning/planning.py
+++ b/server/planning/planning/planning.py
@@ -542,6 +542,7 @@ class PlanningService(AsyncBaseService):
                 event_ids=get_related_event_ids_for_planning(doc, "primary"),  # Event IDs for primary events,
                 recurrence_id=original.get("recurrence_id") or None,
                 from_ingest=from_ingest,
+                type=original.get("type"),
             )
 
         posted = await update_post_item(updates, original)

--- a/server/planning/planning/planning_service.py
+++ b/server/planning/planning/planning_service.py
@@ -235,6 +235,7 @@ class PlanningAsyncService(BasePlanningAsyncService[PlanningResourceModel]):
                 event_ids=get_related_event_ids_for_planning(doc, "primary"),  # Event IDs for primary events,
                 recurrence_id=original.get("recurrence_id") or None,
                 from_ingest=False,
+                type=original.get("type"),
                 # from_ingest=from_ingest, # TODO-ASYNC: adjust when we know how to tackle this
             )
 


### PR DESCRIPTION
### Purpose
Unlock the original event that was converted to a recurring one, via the "Convert to recurring event" action modal. 

### What has changed
Add `item_type` to the payload of `event:unlock` notification, so that the notification handler on the frontend can remove the item lock


Resolves: #[SDESK-7790](https://sofab.atlassian.net/browse/SDESK-7790)



[SDESK-7790]: https://sofab.atlassian.net/browse/SDESK-7790?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ