### PR TITLE
[SDBELGA-1000] fix(ingests): Dont set expiry with PLANNING_EXPIRY_MINUTES if config not defined

### DIFF
--- a/server/planning/events/events.py
+++ b/server/planning/events/events.py
@@ -989,9 +989,9 @@ def setRecurringMode(event):
 
 
 def overwrite_event_expiry_date(event):
-    if "expiry" in event:
-        expiry_minutes = app.settings.get("PLANNING_EXPIRY_MINUTES", None)
-        event["expiry"] = event["dates"]["end"] + timedelta(minutes=expiry_minutes or 0)
+    expiry_minutes = app.settings.get("PLANNING_EXPIRY_MINUTES", None)
+    if "expiry" in event and expiry_minutes is not None:
+        event["expiry"] = event["dates"]["end"] + timedelta(minutes=expiry_minutes)
 
 
 def generate_recurring_events(event, recurrence_id=None):


### PR DESCRIPTION
### Purpose
When ingesting Events, and `PLANNING_EXPIRY_MINUTES` config not defined, the `expiry` of the Event was set to the end date/time of the Event.

### What has changed
Only use `PLANNING_EXPIRY_MINUTES` when applying Event expiry if it is set

Resolves: [SDBELGA-1000](https://sofab.atlassian.net/browse/SDBELGA-1000)


[SDBELGA-1000]: https://sofab.atlassian.net/browse/SDBELGA-1000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ