### PR TITLE
[STT-1427] - Fix list reloading on assignments notification

### DIFF
--- a/client/actions/assignments/notifications.ts
+++ b/client/actions/assignments/notifications.ts
@@ -10,7 +10,6 @@ import * as selectors from '../../selectors';
 import assignments from './index';
 import main from '../main';
 import {hideModal, showModal} from '../index';
-import * as actions from '../../actions';
 import planningApis from '../planning/api';
 
 const _notifyAssignmentEdited = (assignmentId) => (
@@ -59,7 +58,7 @@ const onAssignmentCreated = (_e, data) => (
         if (querySearchSettings.deskIds == null || querySearchSettings.deskIds.length > 0 &&
             (currentDesk === data.assigned_desk || currentDesk === data.original_assigned_desk)
         ) {
-            dispatch(assignments.ui.reloadAssignments([data.assignment_state]));
+            dispatch(assignments.ui.reloadAssignments([data.assignment_state], false));
         }
 
         return Promise.resolve();
@@ -103,7 +102,7 @@ const onAssignmentUpdated = (_e, data) => (
             currentDesk === data.original_assigned_desk
         ) {
             dispatch(assignments.api.fetchAssignmentHistory({_id: data.item}));
-            dispatch(assignments.ui.reloadAssignments([data.assignment_state]));
+            dispatch(assignments.ui.reloadAssignments([data.assignment_state], false));
 
             dispatch(assignments.api.fetchAssignmentById(data.item))
                 .then((assignmentInStore) => {
@@ -122,18 +121,20 @@ const onAssignmentUpdated = (_e, data) => (
 
                         if (newGroups[0] !== originalGroups[0]) {
                             dispatch(assignments.ui.reloadAssignments(
-                                [assignmentInStore.assigned_to.state])
-                            );
+                                [assignmentInStore.assigned_to.state],
+                                false,
+                            ));
                         }
                     }
                 });
 
             if (data.assignment_state === ASSIGNMENTS.WORKFLOW_STATE.CANCELLED ||
-                 data.assignment_state === ASSIGNMENTS.WORKFLOW_STATE.IN_PROGRESS) {
+                data.assignment_state === ASSIGNMENTS.WORKFLOW_STATE.IN_PROGRESS) {
                 // If we are in authoring workspace (fulfilment) and assignment is previewed,
                 // close it
-                if (selectors.general.currentWorkspace(getState()) === WORKSPACE.AUTHORING &&
-                        selectors.getCurrentAssignmentId(getState()) === data.item) {
+                if (selectors.general.currentWorkspace(getState()) === WORKSPACE.AUTHORING
+                    && selectors.getCurrentAssignmentId(getState()) === data.item
+                ) {
                     dispatch(assignments.ui.closePreview());
                 }
             }
@@ -201,6 +202,7 @@ function onAssignmentLocked(_e, data: IWebsocketMessageData['ITEM_LOCKED']) {
     return (dispatch) => {
         if (get(data, 'item') && data.clientId !== superdeskApi.session.getUniqueClientId()) {
             planningApi.locks.setItemAsLocked(data);
+
             return dispatch(assignments.api.fetchAssignmentById(data.item, false))
                 .then((assignmentInStore) => {
                     let item = {
@@ -260,8 +262,8 @@ function onAssignmentUnlocked(_e, data: IWebsocketMessageData['ITEM_UNLOCKED']) 
 
                     // If this is the planning item currently being edited, show popup notification
                     if (itemLock !== null &&
-                    data.lock_session !== sessionId &&
-                    itemLock.session === sessionId
+                        data.lock_session !== sessionId &&
+                        itemLock.session === sessionId
                     ) {
                         const user = selectors.general.users(getState()).find((u) => u._id === data.user);
 
@@ -271,7 +273,7 @@ function onAssignmentUnlocked(_e, data: IWebsocketMessageData['ITEM_UNLOCKED']) 
                             modalProps: {
                                 title: 'Item Unlocked',
                                 body: 'The assignment item you were editing was unlocked by "' +
-                                user.display_name + '"',
+                                    user.display_name + '"',
                             },
                         }));
                     }
@@ -322,19 +324,22 @@ const onAssignmentRemoved = (_e, data) => (
 );
 
 const onAssignmentDeleteFailed = (_e, data) => (
-    (dispatch, getState, {notify}) => {
+    (_dispatch, getState, {notify}) => {
         const currentUserId = selectors.general.currentUserId(getState());
         const sessionId = selectors.general.sessionId(getState());
 
-        if (get(data, 'items.length', 0) > 0 &&
-                get(data, 'user') === currentUserId &&
-                get(data, 'session') === sessionId) {
-            const msg = data.items.map((i) => gettext('There is a {{ type }} assignment \'{{ slugline }}\' {{ state }}',
+        if ((data.items?.length ?? 0) > 0 &&
+            data.user === currentUserId &&
+            data.session === sessionId
+        ) {
+            const msg = data.items.map((i) => gettext(
+                'There is a {{ type }} assignment \'{{ slugline }}\' {{ state }}',
                 {
                     state: get(i, 'state'),
                     type: get(i, 'type'),
                     slugline: get(i, 'slugline'),
-                })).join('\n');
+                }
+            )).join('\n');
 
             notify.warning(msg);
         }

--- a/client/actions/assignments/notifications.ts
+++ b/client/actions/assignments/notifications.ts
@@ -128,12 +128,15 @@ const onAssignmentUpdated = (_e, data) => (
                     }
                 });
 
+            const state = getState();
+
             if (data.assignment_state === ASSIGNMENTS.WORKFLOW_STATE.CANCELLED ||
-                data.assignment_state === ASSIGNMENTS.WORKFLOW_STATE.IN_PROGRESS) {
+                data.assignment_state === ASSIGNMENTS.WORKFLOW_STATE.IN_PROGRESS
+            ) {
                 // If we are in authoring workspace (fulfilment) and assignment is previewed,
                 // close it
-                if (selectors.general.currentWorkspace(getState()) === WORKSPACE.AUTHORING
-                    && selectors.getCurrentAssignmentId(getState()) === data.item
+                if (selectors.general.currentWorkspace(state) === WORKSPACE.AUTHORING
+                    && selectors.getCurrentAssignmentId(state) === data.item
                 ) {
                     dispatch(assignments.ui.closePreview());
                 }

--- a/client/actions/assignments/tests/notification_test.ts
+++ b/client/actions/assignments/tests/notification_test.ts
@@ -11,6 +11,7 @@ import main from '../../main';
 import assignmentNotifications from '../notifications';
 import planningApis from '../../planning/api';
 import type {inject} from '../../../globals';
+import {noop} from 'lodash';
 
 describe('actions.assignments.notification', () => {
     let store;
@@ -102,7 +103,7 @@ describe('actions.assignments.notification', () => {
     describe('`assignment:created`', () => {
         beforeEach(() => {
             sinon.stub(assignmentsApi, 'query').callsFake(() => (Promise.resolve({_items: []})));
-            sinon.stub(assignmentsApi, 'receivedAssignments').callsFake(() => { /* no-op */});
+            sinon.stub(assignmentsApi, 'receivedAssignments').callsFake(noop);
             sinon.stub(assignmentUtils, 'getCurrentSelectedDeskId').returns('desk1');
         });
 

--- a/client/actions/assignments/tests/notification_test.ts
+++ b/client/actions/assignments/tests/notification_test.ts
@@ -10,6 +10,7 @@ import assignmentsApi from '../api';
 import main from '../../main';
 import assignmentNotifications from '../notifications';
 import planningApis from '../../planning/api';
+import type {inject} from '../../../globals';
 
 describe('actions.assignments.notification', () => {
     let store;
@@ -101,14 +102,13 @@ describe('actions.assignments.notification', () => {
     describe('`assignment:created`', () => {
         beforeEach(() => {
             sinon.stub(assignmentsApi, 'query').callsFake(() => (Promise.resolve({_items: []})));
-            sinon.stub(assignmentsApi, 'receivedAssignments').callsFake(() => { /* no-op */ });
+            sinon.stub(assignmentsApi, 'receivedAssignments').callsFake(() => { /* no-op */});
             sinon.stub(assignmentUtils, 'getCurrentSelectedDeskId').returns('desk1');
         });
 
         afterEach(() => {
             restoreSinonStub(assignmentsApi.query);
             restoreSinonStub(assignmentsApi.receivedAssignments);
-            restoreSinonStub(assignmentsUi.setInList);
             restoreSinonStub(assignmentUtils.getCurrentSelectedDeskId);
         });
 
@@ -169,10 +169,11 @@ describe('actions.assignments.notification', () => {
                     expect(planningApis.loadPlanningByIds.args).toEqual([
                         [['p1']],
                     ]);
+
                     expect(assignmentsUi.reloadAssignments.callCount).toBe(2);
-                    expect(assignmentsUi.reloadAssignments.args).toEqual([
-                        [['assigned']],
-                        [[undefined]],
+                    expect(assignmentsUi.reloadAssignments.args[0]).toEqual([
+                        ['assigned'],
+                        false,
                     ]);
                     done();
                 })
@@ -358,9 +359,9 @@ describe('actions.assignments.notification', () => {
                         [['p1']],
                     ]);
                     expect(assignmentsUi.reloadAssignments.callCount).toBe(2);
-                    expect(assignmentsUi.reloadAssignments.args).toEqual([
-                        [['completed']],
-                        [[undefined]],
+                    expect(assignmentsUi.reloadAssignments.args[0]).toEqual([
+                        ['completed'],
+                        false,
                     ]);
                     done();
                 })

--- a/client/actions/assignments/tests/ui_test.ts
+++ b/client/actions/assignments/tests/ui_test.ts
@@ -6,6 +6,7 @@ import assignmentsApi from '../api';
 import {getTestActionStore, restoreSinonStub} from '../../../utils/testUtils';
 import * as testData from '../../../utils/testData';
 import {ASSIGNMENTS, ALL_DESKS} from '../../../constants';
+import {noop} from 'lodash';
 
 describe('actions.assignments.ui', () => {
     let store;
@@ -62,7 +63,7 @@ describe('actions.assignments.ui', () => {
             restoreSinonStub(assignmentsApi.link);
             sinon.stub(assignmentsApi, 'link').callsFake(() => (Promise.reject(errorMessage)));
             store.test(done, assignmentsUi.onFulFilAssignment({_id: 'as1'}))
-                .then(() => { /* no-op */}, (error) => {
+                .then(noop, (error) => {
                     expect(assignmentsApi.link.callCount).toBe(1);
                     expect(assignmentsApi.link.args[0]).toEqual([{_id: 'as1'}, {_id: 'item1'}, true]);
                     expect(error).toEqual(errorMessage);
@@ -344,7 +345,7 @@ describe('actions.assignments.ui', () => {
             sinon.stub(assignmentsApi, 'loadArchiveItem').returns(Promise.reject(errorMessage));
             data.assignments[0].item_ids = ['item1'];
             return store.test(done, assignmentsUi.openArchivePreview(data.assignments[0]))
-                .then(() => { /* no-op */}, (error) => {
+                .then(noop, (error) => {
                     expect(error).toEqual(errorMessage);
 
                     expect(assignmentsApi.loadArchiveItem.callCount).toBe(1);

--- a/client/actions/assignments/tests/ui_test.ts
+++ b/client/actions/assignments/tests/ui_test.ts
@@ -62,7 +62,7 @@ describe('actions.assignments.ui', () => {
             restoreSinonStub(assignmentsApi.link);
             sinon.stub(assignmentsApi, 'link').callsFake(() => (Promise.reject(errorMessage)));
             store.test(done, assignmentsUi.onFulFilAssignment({_id: 'as1'}))
-                .then(() => { /* no-op */ }, (error) => {
+                .then(() => { /* no-op */}, (error) => {
                     expect(assignmentsApi.link.callCount).toBe(1);
                     expect(assignmentsApi.link.args[0]).toEqual([{_id: 'as1'}, {_id: 'item1'}, true]);
                     expect(error).toEqual(errorMessage);
@@ -140,7 +140,7 @@ describe('actions.assignments.ui', () => {
         });
 
         it('adds to the list items if the query is for the first page', (done) => {
-            store.test(done, assignmentsUi.queryAndSetAssignmentListGroups('COMPLETED', 2))
+            store.test(done, assignmentsUi.queryAndSetAssignmentListGroups('COMPLETED', false, 2))
                 .then(() => {
                     expect(assignmentsUi.setAssignmentListGroup.callCount).toBe(0);
 
@@ -180,6 +180,7 @@ describe('actions.assignments.ui', () => {
             expect(assignmentsUi.queryAndSetAssignmentListGroups.callCount).toBe(1);
             expect(assignmentsUi.queryAndSetAssignmentListGroups.args[0]).toEqual([
                 'IN_PROGRESS',
+                true,
                 1,
             ]);
         });
@@ -197,6 +198,7 @@ describe('actions.assignments.ui', () => {
             expect(assignmentsUi.queryAndSetAssignmentListGroups.callCount).toBe(1);
             expect(assignmentsUi.queryAndSetAssignmentListGroups.args[0]).toEqual([
                 'TODO',
+                true,
                 2,
             ]);
         });
@@ -228,8 +230,8 @@ describe('actions.assignments.ui', () => {
                     // Updates the lists
                     expect(assignmentsUi.queryAndSetAssignmentListGroups.callCount).toBe(2);
                     expect(assignmentsUi.queryAndSetAssignmentListGroups.args).toEqual([
-                        ['TODAY'],
-                        ['CURRENT'],
+                        ['TODAY', true],
+                        ['CURRENT', true],
                     ]);
 
                     done();
@@ -251,7 +253,7 @@ describe('actions.assignments.ui', () => {
                     // Updates the lists
                     expect(assignmentsUi.queryAndSetAssignmentListGroups.callCount).toBe(1);
                     expect(assignmentsUi.queryAndSetAssignmentListGroups.args).toEqual([
-                        ['TODO'],
+                        ['TODO', true],
                     ]);
 
                     done();
@@ -274,8 +276,8 @@ describe('actions.assignments.ui', () => {
                     // Updates the lists
                     expect(assignmentsUi.queryAndSetAssignmentListGroups.callCount).toBe(2);
                     expect(assignmentsUi.queryAndSetAssignmentListGroups.args).toEqual([
-                        ['TODAY'],
-                        ['CURRENT'],
+                        ['TODAY', true],
+                        ['CURRENT', true],
                     ]);
 
                     done();
@@ -342,7 +344,7 @@ describe('actions.assignments.ui', () => {
             sinon.stub(assignmentsApi, 'loadArchiveItem').returns(Promise.reject(errorMessage));
             data.assignments[0].item_ids = ['item1'];
             return store.test(done, assignmentsUi.openArchivePreview(data.assignments[0]))
-                .then(() => { /* no-op */ }, (error) => {
+                .then(() => { /* no-op */}, (error) => {
                     expect(error).toEqual(errorMessage);
 
                     expect(assignmentsApi.loadArchiveItem.callCount).toBe(1);

--- a/client/actions/assignments/ui.ts
+++ b/client/actions/assignments/ui.ts
@@ -12,6 +12,11 @@ import * as actions from '../../actions';
 import {ASSIGNMENTS, MODALS, WORKSPACE, ALL_DESKS} from '../../constants';
 import {getErrorMessage, assignmentUtils, gettext} from '../../utils';
 
+const COMPLETED_AND_IN_PROGRESS = [
+    ASSIGNMENTS.WORKFLOW_STATE.IN_PROGRESS,
+    ASSIGNMENTS.WORKFLOW_STATE.COMPLETED,
+];
+
 /**
  * Action dispatcher to load the list of assignments for current list settings.
  * @param {String} filterBy - the filter by desk or user ('Desk', 'User')
@@ -45,7 +50,7 @@ const loadAssignments = ({
     );
 
     return dispatch(
-        self.reloadAssignments(null, false)
+        self.reloadAssignments(null)
     );
 };
 
@@ -55,7 +60,7 @@ const loadAssignments = ({
  * @param {Array<String>} groupKeys - Array of keys for the list groups to show
  */
 const loadFulfillModal = (item, groupKeys) => (
-    (dispatch, getState, {desks}) => {
+    (dispatch) => {
         dispatch(self.setListGroups(groupKeys));
 
         const searchQuery = get(item, 'slugline') ?
@@ -147,7 +152,7 @@ const reloadAssignmentList = (list, resetPage = true) => (
             ));
         }
 
-        return dispatch(self.queryAndSetAssignmentListGroups(list));
+        return dispatch(self.queryAndSetAssignmentListGroups(list, resetPage));
     }
 );
 
@@ -161,42 +166,47 @@ const updatePreviewItemOnRouteUpdate = () => (
                 get(selectors.getStoredAssignments(getState()), urlItem);
 
             if (!assignment) {
-                // Fetch it from backend
                 return dispatch(assignments.api.fetchAssignmentById(urlItem, false, false))
                     .then((item) => {
-                        if (item) {
-                            // Preview only if user is a member of that assignment's desk
-                            const currentUserId = selectors.general.currentUserId(getState());
-                            const user = desks.deskMembers[item.assigned_to.desk].find(
-                                (u) => u._id === currentUserId);
-
-                            if (user) {
-                            // For previewing, add it to the store even though it might be from another
-                                dispatch(assignments.api.receivedAssignments([item]));
-                                return dispatch(self.preview(item));
-                            } else {
-                                notify.error('Insufficient privileges to view the assignment');
-                                $location.search('assignment', null);
-                                return dispatch(self.closePreview());
-                            }
+                        if (!item) {
+                            return;
                         }
-                    },
-                    () => {
+
+                        // Preview only if user is a member of that assignment's desk
+                        const currentUserId = selectors.general.currentUserId(getState());
+                        const user = desks.deskMembers[item.assigned_to.desk].find(
+                            (u) => u._id === currentUserId);
+
+                        if (!user) {
+                            notify.error('Insufficient privileges to view the assignment');
+                            $location.search('assignment', null);
+                            return dispatch(self.closePreview());
+                        }
+
+                        // For previewing, add it to the store even though it might be from another
+                        dispatch(assignments.api.receivedAssignments([item]));
+
+                        return dispatch(self.preview(item));
+                    })
+                    .catch(() => {
                         notify.error('Assignment does not exist');
+
                         return dispatch(self.closePreview());
                     });
-            } else {
-                return dispatch(self.preview(assignment));
             }
-        } else {
-            return Promise.resolve();
+
+            return dispatch(self.preview(assignment));
         }
+
+        return Promise.resolve();
     }
 );
 
-const queryAndSetAssignmentListGroups = (groupKey, page = 1) => (
+const queryAndSetAssignmentListGroups = (groupKey, reloadList = false, page = 1) => (
     (dispatch, getState) => {
-        dispatch(assignments.ui.setLoading(groupKey, true));
+        if (reloadList) {
+            dispatch(assignments.ui.setLoading(groupKey, true));
+        }
 
         let querySearchSettings = cloneDeep(selectors.getAssignmentSearch(getState()));
         const assignmentListSelectors = selectors.getAssignmentGroupSelectors[groupKey];
@@ -236,7 +246,9 @@ const queryAndSetAssignmentListGroups = (groupKey, page = 1) => (
                 return Promise.resolve(data._items);
             })
             .finally(() => {
-                dispatch(assignments.ui.setLoading(groupKey, false));
+                if (reloadList) {
+                    dispatch(assignments.ui.setLoading(groupKey, false));
+                }
             });
     }
 );
@@ -260,7 +272,7 @@ const loadMoreAssignments = (groupKey) => (
         const page = lastLoadedPageForListGroup + 1 || 1;
 
         dispatch(self.changeLastAssignmentLoadedPage(listGroup, page));
-        return dispatch(self.queryAndSetAssignmentListGroups(groupKey, page));
+        return dispatch(self.queryAndSetAssignmentListGroups(groupKey, true, page));
     }
 );
 
@@ -337,7 +349,8 @@ function setAssignmentSearchParams(params) {
             type: ASSIGNMENTS.ACTIONS.SET_SEARCH_PARAMS,
             payload: params,
         });
-        return dispatch(self.reloadAssignments(null, false));
+
+        return dispatch(self.reloadAssignments(null, true));
     };
 }
 
@@ -385,7 +398,7 @@ const preview = (
     initialTab?: 'ASSIGNMENT' | 'CONTENT' | 'HISTORY',
     archiveItem?: IArticle,
 ) => (
-    (dispatch, getState, {$timeout, $location}) => (
+    (dispatch, _getState, {$timeout, $location}) => (
         dispatch(assignments.api.loadPlanningAndEvent(assignment))
             .then(() => {
                 $timeout(() => $location.search('assignment', get(assignment, '_id', null)));
@@ -406,7 +419,7 @@ const preview = (
  * @return object
  */
 const closePreview = () => (
-    (dispatch, getState, {$timeout, $location}) => {
+    (dispatch, _getState, {$timeout, $location}) => {
         $timeout(() => $location.search('assignment', null));
         return dispatch({type: ASSIGNMENTS.ACTIONS.CLOSE_PREVIEW_ASSIGNMENT});
     }
@@ -494,7 +507,7 @@ const onFulFilAssignment = (assignment) => (
 );
 
 function complete(item: IAssignmentItem) {
-    return (dispatch, getState, {notify}) => (
+    return (dispatch, _getState, {notify}) => (
         planningApi.locks.lockItem(item, 'complete')
             .then((lockedItem) => {
                 dispatch(assignments.api.complete(lockedItem))
@@ -556,7 +569,7 @@ function revert(item: IAssignmentItem) {
  * @param {object} item
  */
 const onAuthoringMenuClick = (action, type, item) => (
-    (dispatch, getState, {superdesk}) => {
+    (_dispatch, _getState, {superdesk}) => {
         superdesk.intent(action, type, {item: item})
             .then(
                 () => Promise.resolve(item),
@@ -572,16 +585,19 @@ const onAuthoringMenuClick = (action, type, item) => (
  * @param {object} assignment - The Assignment to view content for
  */
 const openArchivePreview = (assignment) => (
-    (dispatch, getState, {authoringWorkspace, notify}) => (
-        assignmentUtils.assignmentHasContent(assignment) ?
-            dispatch(assignments.api.loadArchiveItem(assignment))
-                .then((item) => {
-                    dispatch(self.closePreview());
-                    authoringWorkspace.view(item);
-                    return Promise.resolve(item);
-                }, (error) => Promise.reject(error)) :
-            Promise.resolve()
-    )
+    (dispatch, _getState, {authoringWorkspace}) => {
+        if (!assignmentUtils.assignmentHasContent(assignment)) {
+            return Promise.resolve();
+        }
+
+        return dispatch(assignments.api.loadArchiveItem(assignment))
+            .then((item) => {
+                dispatch(self.closePreview());
+                authoringWorkspace.view(item);
+                return Promise.resolve(item);
+            })
+            .catch((error) => Promise.reject(error));
+    }
 );
 
 /**
@@ -590,13 +606,13 @@ const openArchivePreview = (assignment) => (
  * @param {object} item - The Archive item to preview
  */
 const onArchivePreviewImageClick = (item) => (
-    (dispatch, getState, {superdesk}) => (
+    (_dispatch, _getState, {superdesk}) => (
         superdesk.intent('preview', 'item', item)
     )
 );
 
 const canLinkItem = (item) => (
-    (dispatch, getState, {lock, authoring, archiveService}) => (
+    (_dispatch, _getState, {lock, authoring, archiveService}) => (
         Promise.resolve(
             !item.assignment_id &&
             (!lock.isLocked(item) || lock.isLockedInCurrentSession(item)) &&
@@ -606,11 +622,11 @@ const canLinkItem = (item) => (
 );
 
 function validateStartWorkingOnScheduledUpdate(assignment: IAssignmentItem) {
-    return (dispatch, getState, {notify}) => (
+    return (_dispatch, _getState, {notify}) => (
         // Validate the coverage to see if all preceeding scheduled_updates / coverage
         // is linked to an item
-        planningApi.planning.getById(assignment.planning_item, false).then(
-            (plannings) => {
+        planningApi.planning.getById(assignment.planning_item, false)
+            .then((plannings) => {
                 const planning = get(plannings, '[0]');
 
                 if (!planning) {
@@ -621,7 +637,7 @@ function validateStartWorkingOnScheduledUpdate(assignment: IAssignmentItem) {
                 const coverage = get(planning, 'coverages', []).find((c) =>
                     c.coverage_id === assignment.coverage_item);
 
-                if (![ASSIGNMENTS.WORKFLOW_STATE.IN_PROGRESS, ASSIGNMENTS.WORKFLOW_STATE.COMPLETED].includes(
+                if (!COMPLETED_AND_IN_PROGRESS.includes(
                     get(coverage, 'assigned_to.state'))) {
                     notify.error(gettext('Parent coverage not linked to a news item yet.'));
                     return Promise.reject();
@@ -637,16 +653,17 @@ function validateStartWorkingOnScheduledUpdate(assignment: IAssignmentItem) {
                     return Promise.reject();
                 }) - 1;
 
-                if (previousScheduledUpdateIndex >= 0 && ![ASSIGNMENTS.WORKFLOW_STATE.IN_PROGRESS,
-                    ASSIGNMENTS.WORKFLOW_STATE.COMPLETED].includes(get(
-                    coverage, `scheduled_updates[${previousScheduledUpdateIndex}].assigned_to.state`))) {
+                if (previousScheduledUpdateIndex >= 0
+                    && !COMPLETED_AND_IN_PROGRESS.includes(
+                        get(coverage, `scheduled_updates[${previousScheduledUpdateIndex}].assigned_to.state`)
+                    )
+                ) {
                     notify.error(gettext('Previous scheduled update is not linked to a news item yet.'));
                     return Promise.reject();
                 }
 
                 return Promise.resolve();
-            }
-        )
+            })
     );
 }
 
@@ -659,7 +676,7 @@ function startWorking(assignment: IAssignmentItem) {
         }
 
         promise.then(() =>
-            (planningApi.locks.lockItem(assignment, 'start_working')
+            planningApi.locks.lockItem(assignment, 'start_working')
                 .then((lockedAssignment) => {
                     const defaultTemplateId = assignmentUtils
                         .getCurrentSelectedDesk(desks, getState())?.default_content_template ?? null;
@@ -707,9 +724,9 @@ function startWorking(assignment: IAssignmentItem) {
                             },
                         }));
                     });
-                }, (error) => Promise.reject(error))
-            ), (error) => Promise.resolve()
-        );
+                })
+                .catch((error) => Promise.reject(error))
+        ).catch(() => Promise.resolve());
     };
 }
 

--- a/client/actions/assignments/ui.ts
+++ b/client/actions/assignments/ui.ts
@@ -178,7 +178,7 @@ const updatePreviewItemOnRouteUpdate = () => (
                             (u) => u._id === currentUserId);
 
                         if (!user) {
-                            notify.error('Insufficient privileges to view the assignment');
+                            notify.error(gettext('Insufficient privileges to view the assignment'));
                             $location.search('assignment', null);
                             return dispatch(self.closePreview());
                         }
@@ -189,7 +189,7 @@ const updatePreviewItemOnRouteUpdate = () => (
                         return dispatch(self.preview(item));
                     })
                     .catch(() => {
-                        notify.error('Assignment does not exist');
+                        notify.error(gettext('Assignment does not exist'));
 
                         return dispatch(self.closePreview());
                     });

--- a/client/components/Assignments/AssignmentItem/index.tsx
+++ b/client/components/Assignments/AssignmentItem/index.tsx
@@ -162,7 +162,7 @@ export class AssignmentItem extends React.Component<IAssignmentItemProps, IState
                     firstLine={listViewConfig.firstLine}
                     secondLine={listViewConfig.secondLine}
                     renderFieldsWithProps={(fields) => {
-                        return fields.map((field) => {
+                        return fields.map((field, index) => {
                             const FieldComponent = getComponentForField(field.fieldId as AssignmentViewField);
 
                             const fieldsProps = {
@@ -179,10 +179,16 @@ export class AssignmentItem extends React.Component<IAssignmentItemProps, IState
 
                             return (
                                 <FieldComponent
+
+                                    /**
+                                     * Use index as a key since field.fieldId is not strictly unique,
+                                     * and we won't be sorting fields
+                                     */
+                                    key={index}
+
                                     assignment={this.props.assignment}
                                     fieldsProps={fieldsProps}
                                     fieldOptions={field.fieldOptions}
-                                    key={field.fieldId}
                                 />
                             );
                         });

--- a/client/reducers/assignment.ts
+++ b/client/reducers/assignment.ts
@@ -1,4 +1,4 @@
-import {uniq, keyBy, get, filter} from 'lodash';
+import {uniq, keyBy} from 'lodash';
 import {produce} from 'immer';
 import {ASSIGNMENTS, RESET_STORE, INIT_STORE, SORT_DIRECTION} from '../constants';
 import moment from 'moment';
@@ -70,11 +70,10 @@ const initialState = {
 };
 
 const modifyAssignmentBeingAdded = (payload) => {
-    // payload must be an array. If not, we transform
     const assignments = Array.isArray(payload) ? payload : [payload];
 
     assignments.forEach((assignment) => {
-        if (get(assignment, 'planning.scheduled')) {
+        if (assignment.planning?.scheduled) {
             assignment.planning.scheduled = moment(assignment.planning.scheduled);
         }
     });
@@ -124,11 +123,7 @@ const filterList = (state, listId, assignmentId) => {
         return;
     }
 
-    state.lists[listId].assignmentIds = filter(
-        state.lists[listId].assignmentIds,
-        (aid) => aid !== assignmentId
-    );
-
+    state.lists[listId].assignmentIds = state.lists[listId].assignmentIds.filter((id) => id != assignmentId);
     state.lists[listId].total = state.lists[listId].total - 1;
 };
 
@@ -137,19 +132,15 @@ const assignmentReducer = createReducer(initialState, {
 
     [INIT_STORE]: () => (initialState),
 
-    [ASSIGNMENTS.ACTIONS.RECEIVED_ASSIGNMENTS]: (state, payload) => {
+    [ASSIGNMENTS.ACTIONS.RECEIVED_ASSIGNMENTS]: produce((state, payload) => {
         const receivedAssignments = modifyAssignmentBeingAdded(payload);
 
-        return produce(state, (draftState) => {
-            Object.assign(draftState.assignments, receivedAssignments);
+        Object.assign(state.assignments, receivedAssignments);
 
-            return draftState;
-        });
-    },
+        return state;
+    }),
 
-    [ASSIGNMENTS.ACTIONS.SET_LIST_ITEMS]: (state, payload) => (
-        setList(state, payload)
-    ),
+    [ASSIGNMENTS.ACTIONS.SET_LIST_ITEMS]: setList,
 
     [ASSIGNMENTS.ACTIONS.MY_ASSIGNMENTS_TOTAL]: produce((state, payload) => {
         state.myAssignmentsTotal = payload;
@@ -167,17 +158,11 @@ const assignmentReducer = createReducer(initialState, {
         return state;
     }),
 
-    [ASSIGNMENTS.ACTIONS.SET_LIST_PAGE]: (state, payload) => (
-        setLastPage(state, payload)
-    ),
+    [ASSIGNMENTS.ACTIONS.SET_LIST_PAGE]: setLastPage,
 
-    [ASSIGNMENTS.ACTIONS.SET_GROUP_SORT_ORDER]: (state, payload) => (
-        setListSortOrder(state, payload)
-    ),
+    [ASSIGNMENTS.ACTIONS.SET_GROUP_SORT_ORDER]: setListSortOrder,
 
-    [ASSIGNMENTS.ACTIONS.SET_LOADING]: (state, payload) => (
-        setGroupLoading(state, payload)
-    ),
+    [ASSIGNMENTS.ACTIONS.SET_LOADING]: setGroupLoading,
 
     [ASSIGNMENTS.ACTIONS.SET_SORT_FIELD]: produce((state, payload) => {
         state.orderByField = payload;
@@ -252,7 +237,7 @@ const assignmentReducer = createReducer(initialState, {
         return state;
     }),
 
-    [ASSIGNMENTS.ACTIONS.RECEIVED_ARCHIVE]: (state, payload) => {
+    [ASSIGNMENTS.ACTIONS.RECEIVED_ARCHIVE]: produce((state, payload) => {
         // Store Archive items by their ID
         const newItems = (Array.isArray(payload) ? payload : [payload])
             .reduce((archiveItems, item) => {
@@ -261,25 +246,23 @@ const assignmentReducer = createReducer(initialState, {
                 return archiveItems;
             }, {});
 
-        return produce(state, (draftState) => {
-            Object.assign(draftState.archive, newItems);
+        Object.assign(state.archive, newItems);
 
-            return draftState;
-        });
-    },
+        return state;
+    }),
 
     [ASSIGNMENTS.ACTIONS.REMOVE_ASSIGNMENT]: produce((state, payload) => {
         // Remove the assignment from the stored list of assignments
-        (payload.assignments ?? []).forEach((a) => {
-            if (!(a in state.assignments)) {
+        (payload.assignments ?? []).forEach((itemId) => {
+            if (!(itemId in state.assignments)) {
                 return;
             }
 
-            delete state.assignments[a];
+            delete state.assignments[itemId];
 
             // If this assignment is being viewed,
             // then close the preview and de-select the assignment
-            if (state.currentAssignmentId === a) {
+            if (state.currentAssignmentId === itemId) {
                 state.previewOpened = false;
                 state.currentAssignmentId = null;
                 state.initialTab = null;
@@ -287,12 +270,12 @@ const assignmentReducer = createReducer(initialState, {
             }
 
             // Remove this assignment from any list groups
-            filterList(state, ASSIGNMENTS.LIST_GROUPS.IN_PROGRESS.id, a);
-            filterList(state, ASSIGNMENTS.LIST_GROUPS.TODO.id, a);
-            filterList(state, ASSIGNMENTS.LIST_GROUPS.COMPLETED.id, a);
-            filterList(state, ASSIGNMENTS.LIST_GROUPS.CURRENT.id, a);
-            filterList(state, ASSIGNMENTS.LIST_GROUPS.TODAY.id, a);
-            filterList(state, ASSIGNMENTS.LIST_GROUPS.FUTURE.id, a);
+            filterList(state, ASSIGNMENTS.LIST_GROUPS.IN_PROGRESS.id, itemId);
+            filterList(state, ASSIGNMENTS.LIST_GROUPS.TODO.id, itemId);
+            filterList(state, ASSIGNMENTS.LIST_GROUPS.COMPLETED.id, itemId);
+            filterList(state, ASSIGNMENTS.LIST_GROUPS.CURRENT.id, itemId);
+            filterList(state, ASSIGNMENTS.LIST_GROUPS.TODAY.id, itemId);
+            filterList(state, ASSIGNMENTS.LIST_GROUPS.FUTURE.id, itemId);
         });
 
         return state;

--- a/client/reducers/assignment.ts
+++ b/client/reducers/assignment.ts
@@ -132,30 +132,30 @@ const assignmentReducer = createReducer(initialState, {
 
     [INIT_STORE]: () => (initialState),
 
-    [ASSIGNMENTS.ACTIONS.RECEIVED_ASSIGNMENTS]: produce((state, payload) => {
-        const receivedAssignments = modifyAssignmentBeingAdded(payload);
+    [ASSIGNMENTS.ACTIONS.RECEIVED_ASSIGNMENTS]: produce((draftState, actionPayload) => {
+        const receivedAssignments = modifyAssignmentBeingAdded(actionPayload);
 
-        Object.assign(state.assignments, receivedAssignments);
+        Object.assign(draftState.assignments, receivedAssignments);
 
-        return state;
+        return draftState;
     }),
 
     [ASSIGNMENTS.ACTIONS.SET_LIST_ITEMS]: setList,
 
-    [ASSIGNMENTS.ACTIONS.MY_ASSIGNMENTS_TOTAL]: produce((state, payload) => {
-        state.myAssignmentsTotal = payload;
+    [ASSIGNMENTS.ACTIONS.MY_ASSIGNMENTS_TOTAL]: produce((draftState, actionPayload) => {
+        draftState.myAssignmentsTotal = actionPayload;
 
-        return state;
+        return draftState;
     }),
 
     [ASSIGNMENTS.ACTIONS.ADD_LIST_ITEMS]: (state, payload) => (
         addToList(state, payload)
     ),
 
-    [ASSIGNMENTS.ACTIONS.CHANGE_LIST_VIEW_MODE]: produce((state, payload) => {
-        state.assignmentListSingleGroupView = payload;
+    [ASSIGNMENTS.ACTIONS.CHANGE_LIST_VIEW_MODE]: produce((draftState, actionPayload) => {
+        draftState.assignmentListSingleGroupView = actionPayload;
 
-        return state;
+        return draftState;
     }),
 
     [ASSIGNMENTS.ACTIONS.SET_LIST_PAGE]: setLastPage,
@@ -164,139 +164,139 @@ const assignmentReducer = createReducer(initialState, {
 
     [ASSIGNMENTS.ACTIONS.SET_LOADING]: setGroupLoading,
 
-    [ASSIGNMENTS.ACTIONS.SET_SORT_FIELD]: produce((state, payload) => {
-        state.orderByField = payload;
+    [ASSIGNMENTS.ACTIONS.SET_SORT_FIELD]: produce((draftState, actionPayload) => {
+        draftState.orderByField = actionPayload;
 
-        return state;
+        return draftState;
     }),
 
-    [ASSIGNMENTS.ACTIONS.SET_DAY_FIELD]: produce((state, payload) => {
-        state.dayField = payload;
+    [ASSIGNMENTS.ACTIONS.SET_DAY_FIELD]: produce((draftState, actionPayload) => {
+        draftState.dayField = actionPayload;
 
-        return state;
+        return draftState;
     }),
 
-    [ASSIGNMENTS.ACTIONS.CHANGE_LIST_SETTINGS]: produce((state, payload) => {
-        Object.assign(state, payload);
+    [ASSIGNMENTS.ACTIONS.CHANGE_LIST_SETTINGS]: produce((draftState, actionPayload) => {
+        Object.assign(draftState, actionPayload);
 
-        return state;
+        return draftState;
     }),
 
-    [ASSIGNMENTS.ACTIONS.SET_SEARCH_PARAMS]: produce((state, payload) => {
-        state.searchParams = payload;
+    [ASSIGNMENTS.ACTIONS.SET_SEARCH_PARAMS]: produce((draftState, actionPayload) => {
+        draftState.searchParams = actionPayload;
 
-        return state;
+        return draftState;
     }),
 
-    [ASSIGNMENTS.ACTIONS.PREVIEW_ASSIGNMENT]: produce((state, payload) => {
-        state.previewOpened = true;
-        state.currentAssignmentId = payload.assignmentId;
-        state.initialTab = payload.initialTab;
-        state.selectedArchiveItemId = payload.archiveItemId ?? null;
-        state.readOnly = true;
+    [ASSIGNMENTS.ACTIONS.PREVIEW_ASSIGNMENT]: produce((draftState, actionPayload) => {
+        draftState.previewOpened = true;
+        draftState.currentAssignmentId = actionPayload.assignmentId;
+        draftState.initialTab = actionPayload.initialTab;
+        draftState.selectedArchiveItemId = actionPayload.archiveItemId ?? null;
+        draftState.readOnly = true;
 
-        return state;
+        return draftState;
     }),
 
-    [ASSIGNMENTS.ACTIONS.CLOSE_PREVIEW_ASSIGNMENT]: produce((state) => {
-        state.previewOpened = false;
-        state.currentAssignmentId = null;
-        state.initialTab = null;
-        state.selectedArchiveItemId = null;
-        state.readOnly = true;
+    [ASSIGNMENTS.ACTIONS.CLOSE_PREVIEW_ASSIGNMENT]: produce((draftState) => {
+        draftState.previewOpened = false;
+        draftState.currentAssignmentId = null;
+        draftState.initialTab = null;
+        draftState.selectedArchiveItemId = null;
+        draftState.readOnly = true;
 
-        return state;
+        return draftState;
     }),
 
-    [ASSIGNMENTS.ACTIONS.LOCK_ASSIGNMENT]: produce((state, payload) => {
-        if (!(payload.assignment._id in state.assignments)) return state;
+    [ASSIGNMENTS.ACTIONS.LOCK_ASSIGNMENT]: produce((draftState, actionPayload) => {
+        if (!(actionPayload.assignment._id in draftState.assignments)) return draftState;
 
-        const assignment = state.assignments[payload.assignment._id];
+        const assignment = draftState.assignments[actionPayload.assignment._id];
 
-        assignment.lock_action = payload.assignment.lock_action;
-        assignment.lock_user = payload.assignment.lock_user;
-        assignment.lock_time = payload.assignment.lock_time;
-        assignment.lock_session = payload.assignment.lock_session;
-        assignment._etag = payload.assignment._etag;
+        assignment.lock_action = actionPayload.assignment.lock_action;
+        assignment.lock_user = actionPayload.assignment.lock_user;
+        assignment.lock_time = actionPayload.assignment.lock_time;
+        assignment.lock_session = actionPayload.assignment.lock_session;
+        assignment._etag = actionPayload.assignment._etag;
 
-        return state;
+        return draftState;
     }),
 
-    [ASSIGNMENTS.ACTIONS.UNLOCK_ASSIGNMENT]: produce((state, payload) => {
-        if (!(payload.assignment._id in state.assignments)) return state;
+    [ASSIGNMENTS.ACTIONS.UNLOCK_ASSIGNMENT]: produce((draftState, actionPayload) => {
+        if (!(actionPayload.assignment._id in draftState.assignments)) return draftState;
 
-        const assignment = state.assignments[payload.assignment._id];
+        const assignment = draftState.assignments[actionPayload.assignment._id];
 
         delete assignment.lock_action;
         delete assignment.lock_user;
         delete assignment.lock_time;
         delete assignment.lock_session;
 
-        assignment._etag = payload.assignment._etag;
+        assignment._etag = actionPayload.assignment._etag;
 
-        return state;
+        return draftState;
     }),
 
-    [ASSIGNMENTS.ACTIONS.RECEIVED_ARCHIVE]: produce((state, payload) => {
+    [ASSIGNMENTS.ACTIONS.RECEIVED_ARCHIVE]: produce((draftState, actionPayload) => {
         // Store Archive items by their ID
-        const newItems = (Array.isArray(payload) ? payload : [payload])
+        const newItems = (Array.isArray(actionPayload) ? actionPayload : [actionPayload])
             .reduce((archiveItems, item) => {
                 archiveItems[item._id] = item;
 
                 return archiveItems;
             }, {});
 
-        Object.assign(state.archive, newItems);
+        Object.assign(draftState.archive, newItems);
 
-        return state;
+        return draftState;
     }),
 
-    [ASSIGNMENTS.ACTIONS.REMOVE_ASSIGNMENT]: produce((state, payload) => {
+    [ASSIGNMENTS.ACTIONS.REMOVE_ASSIGNMENT]: produce((draftState, actionPayload) => {
         // Remove the assignment from the stored list of assignments
-        (payload.assignments ?? []).forEach((itemId) => {
-            if (!(itemId in state.assignments)) {
+        (actionPayload.assignments ?? []).forEach((itemId) => {
+            if (!(itemId in draftState.assignments)) {
                 return;
             }
 
-            delete state.assignments[itemId];
+            delete draftState.assignments[itemId];
 
             // If this assignment is being viewed,
             // then close the preview and de-select the assignment
-            if (state.currentAssignmentId === itemId) {
-                state.previewOpened = false;
-                state.currentAssignmentId = null;
-                state.initialTab = null;
-                state.selectedArchiveItemId = null;
+            if (draftState.currentAssignmentId === itemId) {
+                draftState.previewOpened = false;
+                draftState.currentAssignmentId = null;
+                draftState.initialTab = null;
+                draftState.selectedArchiveItemId = null;
             }
 
             // Remove this assignment from any list groups
-            filterList(state, ASSIGNMENTS.LIST_GROUPS.IN_PROGRESS.id, itemId);
-            filterList(state, ASSIGNMENTS.LIST_GROUPS.TODO.id, itemId);
-            filterList(state, ASSIGNMENTS.LIST_GROUPS.COMPLETED.id, itemId);
-            filterList(state, ASSIGNMENTS.LIST_GROUPS.CURRENT.id, itemId);
-            filterList(state, ASSIGNMENTS.LIST_GROUPS.TODAY.id, itemId);
-            filterList(state, ASSIGNMENTS.LIST_GROUPS.FUTURE.id, itemId);
+            filterList(draftState, ASSIGNMENTS.LIST_GROUPS.IN_PROGRESS.id, itemId);
+            filterList(draftState, ASSIGNMENTS.LIST_GROUPS.TODO.id, itemId);
+            filterList(draftState, ASSIGNMENTS.LIST_GROUPS.COMPLETED.id, itemId);
+            filterList(draftState, ASSIGNMENTS.LIST_GROUPS.CURRENT.id, itemId);
+            filterList(draftState, ASSIGNMENTS.LIST_GROUPS.TODAY.id, itemId);
+            filterList(draftState, ASSIGNMENTS.LIST_GROUPS.FUTURE.id, itemId);
         });
 
-        return state;
+        return draftState;
     }),
 
-    [ASSIGNMENTS.ACTIONS.RECEIVE_ASSIGNMENT_HISTORY]: produce((state, payload) => {
-        state.assignmentHistoryItems = payload;
+    [ASSIGNMENTS.ACTIONS.RECEIVE_ASSIGNMENT_HISTORY]: produce((draftState, actionPayload) => {
+        draftState.assignmentHistoryItems = actionPayload;
 
-        return state;
+        return draftState;
     }),
 
-    [ASSIGNMENTS.ACTIONS.SET_BASE_QUERY]: produce((state, payload) => {
-        state.baseQuery = payload;
+    [ASSIGNMENTS.ACTIONS.SET_BASE_QUERY]: produce((draftState, actionPayload) => {
+        draftState.baseQuery = actionPayload;
 
-        return state;
+        return draftState;
     }),
 
-    [ASSIGNMENTS.ACTIONS.SET_GROUP_KEYS]: produce((state, payload) => {
-        state.groupKeys = payload;
+    [ASSIGNMENTS.ACTIONS.SET_GROUP_KEYS]: produce((draftState, actionPayload) => {
+        draftState.groupKeys = actionPayload;
 
-        return state;
+        return draftState;
     }),
 });
 

--- a/client/reducers/assignment.ts
+++ b/client/reducers/assignment.ts
@@ -1,8 +1,8 @@
-import {uniq, keyBy, get, cloneDeep, filter} from 'lodash';
+import {uniq, keyBy, get, filter} from 'lodash';
+import {produce} from 'immer';
 import {ASSIGNMENTS, RESET_STORE, INIT_STORE, SORT_DIRECTION} from '../constants';
 import moment from 'moment';
 import {createReducer} from './createReducer';
-import {getItemId} from '../utils';
 
 const initialState = {
     archive: {},
@@ -78,49 +78,46 @@ const modifyAssignmentBeingAdded = (payload) => {
             assignment.planning.scheduled = moment(assignment.planning.scheduled);
         }
     });
+
     return keyBy(payload, '_id');
 };
 
-const setList = (state, payload) => {
-    state.lists[payload.list] = {
-        ...state.lists[payload.list],
-        assignmentIds: payload.ids,
-        total: payload.total,
-        lastPage: 1,
-    };
+const setList = produce((state, payload) => {
+    state.lists[payload.list].assignmentIds = payload.ids;
+    state.lists[payload.list].total = payload.total;
+    state.lists[payload.list].lastPage = 1;
 
     return state;
-};
+});
 
-const addToList = (state, payload) => {
+const addToList = produce((state, payload) => {
     state.lists[payload.list].assignmentIds = uniq([
         ...state.lists[payload.list].assignmentIds,
         ...payload.ids,
     ]);
+
     state.lists[payload.list].total = payload.total;
 
     return state;
-};
+});
 
-const setLastPage = (state, payload) => {
+const setLastPage = produce((state, payload) => {
     state.lists[payload.list].lastPage = payload.page;
 
     return state;
-};
+});
 
-const setListSortOrder = (state, payload) => {
+const setListSortOrder = produce((state, payload) => {
     state.lists[payload.list].sortOrder = payload.sortOrder;
 
     return state;
-};
+});
 
-const setGroupLoading = (state, payload) => {
-    state.lists[payload.list] = {
-        ...state.lists[payload.list],
-        isLoading: payload.isLoading,
-    };
+const setGroupLoading = produce((state, payload) => {
+    state.lists[payload.list].isLoading = payload.isLoading;
+
     return state;
-};
+});
 
 const filterList = (state, listId, assignmentId) => {
     if (state.lists[listId].assignmentIds.indexOf(assignmentId) < 0) {
@@ -141,101 +138,95 @@ const assignmentReducer = createReducer(initialState, {
     [INIT_STORE]: () => (initialState),
 
     [ASSIGNMENTS.ACTIONS.RECEIVED_ASSIGNMENTS]: (state, payload) => {
-        let receivedAssignments = modifyAssignmentBeingAdded(payload);
+        const receivedAssignments = modifyAssignmentBeingAdded(payload);
 
-        return {
-            ...state,
-            assignments: {
-                ...state.assignments || {},
-                ...receivedAssignments,
-            },
-        };
+        return produce(state, (draftState) => {
+            Object.assign(draftState.assignments, receivedAssignments);
+
+            return draftState;
+        });
     },
 
     [ASSIGNMENTS.ACTIONS.SET_LIST_ITEMS]: (state, payload) => (
-        setList(cloneDeep(state), payload)
+        setList(state, payload)
     ),
 
-    [ASSIGNMENTS.ACTIONS.MY_ASSIGNMENTS_TOTAL]: (state, payload) => (
-        {
-            ...state,
-            myAssignmentsTotal: payload,
-        }
-    ),
+    [ASSIGNMENTS.ACTIONS.MY_ASSIGNMENTS_TOTAL]: produce((state, payload) => {
+        state.myAssignmentsTotal = payload;
+
+        return state;
+    }),
 
     [ASSIGNMENTS.ACTIONS.ADD_LIST_ITEMS]: (state, payload) => (
-        addToList(cloneDeep(state), payload)
+        addToList(state, payload)
     ),
 
-    [ASSIGNMENTS.ACTIONS.CHANGE_LIST_VIEW_MODE]: (state, payload) => (
-        {
-            ...state,
-            assignmentListSingleGroupView: payload,
-        }
-    ),
+    [ASSIGNMENTS.ACTIONS.CHANGE_LIST_VIEW_MODE]: produce((state, payload) => {
+        state.assignmentListSingleGroupView = payload;
+
+        return state;
+    }),
 
     [ASSIGNMENTS.ACTIONS.SET_LIST_PAGE]: (state, payload) => (
-        setLastPage(cloneDeep(state), payload)
+        setLastPage(state, payload)
     ),
 
     [ASSIGNMENTS.ACTIONS.SET_GROUP_SORT_ORDER]: (state, payload) => (
-        setListSortOrder(cloneDeep(state), payload)
+        setListSortOrder(state, payload)
     ),
 
     [ASSIGNMENTS.ACTIONS.SET_LOADING]: (state, payload) => (
         setGroupLoading(state, payload)
     ),
 
-    [ASSIGNMENTS.ACTIONS.SET_SORT_FIELD]: (state, payload) => ({
-        ...state,
-        orderByField: payload,
+    [ASSIGNMENTS.ACTIONS.SET_SORT_FIELD]: produce((state, payload) => {
+        state.orderByField = payload;
+
+        return state;
     }),
 
-    [ASSIGNMENTS.ACTIONS.SET_DAY_FIELD]: (state, payload) => ({
-        ...state,
-        dayField: payload,
+    [ASSIGNMENTS.ACTIONS.SET_DAY_FIELD]: produce((state, payload) => {
+        state.dayField = payload;
+
+        return state;
     }),
 
-    [ASSIGNMENTS.ACTIONS.CHANGE_LIST_SETTINGS]: (state, payload) => (
-        {
-            ...state,
-            ...payload,
-        }
-    ),
-    [ASSIGNMENTS.ACTIONS.SET_SEARCH_PARAMS]: (state, payload) => (
-        {
-            ...state,
-            searchParams: payload,
-        }
-    ),
+    [ASSIGNMENTS.ACTIONS.CHANGE_LIST_SETTINGS]: produce((state, payload) => {
+        Object.assign(state, payload);
 
-    [ASSIGNMENTS.ACTIONS.PREVIEW_ASSIGNMENT]: (state, payload) => (
-        {
-            ...state,
-            previewOpened: true,
-            currentAssignmentId: payload.assignmentId,
-            initialTab: payload.initialTab,
-            selectedArchiveItemId: payload.archiveItemId ?? null,
+        return state;
+    }),
 
-            readOnly: true,
-        }
-    ),
+    [ASSIGNMENTS.ACTIONS.SET_SEARCH_PARAMS]: produce((state, payload) => {
+        state.searchParams = payload;
 
-    [ASSIGNMENTS.ACTIONS.CLOSE_PREVIEW_ASSIGNMENT]: (state) => (
-        {
-            ...state,
-            previewOpened: false,
-            currentAssignmentId: null,
-            initialTab: null,
-            selectedArchiveItemId: null,
-            readOnly: true,
-        }
-    ),
-    [ASSIGNMENTS.ACTIONS.LOCK_ASSIGNMENT]: (state, payload) => {
+        return state;
+    }),
+
+    [ASSIGNMENTS.ACTIONS.PREVIEW_ASSIGNMENT]: produce((state, payload) => {
+        state.previewOpened = true;
+        state.currentAssignmentId = payload.assignmentId;
+        state.initialTab = payload.initialTab;
+        state.selectedArchiveItemId = payload.archiveItemId ?? null;
+        state.readOnly = true;
+
+        return state;
+    }),
+
+    [ASSIGNMENTS.ACTIONS.CLOSE_PREVIEW_ASSIGNMENT]: produce((state) => {
+        state.previewOpened = false;
+        state.currentAssignmentId = null;
+        state.initialTab = null;
+        state.selectedArchiveItemId = null;
+        state.readOnly = true;
+
+        return state;
+    }),
+
+    [ASSIGNMENTS.ACTIONS.LOCK_ASSIGNMENT]: produce((state, payload) => {
         if (!(payload.assignment._id in state.assignments)) return state;
 
-        let assignments = cloneDeep(state.assignments);
-        let assignment = assignments[payload.assignment._id];
+        const assignment = state.assignments[payload.assignment._id];
 
         assignment.lock_action = payload.assignment.lock_action;
         assignment.lock_user = payload.assignment.lock_user;
@@ -243,90 +234,86 @@ const assignmentReducer = createReducer(initialState, {
         assignment.lock_session = payload.assignment.lock_session;
         assignment._etag = payload.assignment._etag;
 
-        return {
-            ...state,
-            assignments,
-        };
-    },
+        return state;
+    }),
 
-    [ASSIGNMENTS.ACTIONS.UNLOCK_ASSIGNMENT]: (state, payload) => {
+    [ASSIGNMENTS.ACTIONS.UNLOCK_ASSIGNMENT]: produce((state, payload) => {
         if (!(payload.assignment._id in state.assignments)) return state;
 
-        let assignments = cloneDeep(state.assignments);
-        let assignment = assignments[payload.assignment._id];
+        const assignment = state.assignments[payload.assignment._id];
 
         delete assignment.lock_action;
         delete assignment.lock_user;
         delete assignment.lock_time;
         delete assignment.lock_session;
+
         assignment._etag = payload.assignment._etag;
 
-        return {
-            ...state,
-            assignments,
-        };
-    },
+        return state;
+    }),
 
     [ASSIGNMENTS.ACTIONS.RECEIVED_ARCHIVE]: (state, payload) => {
         // Store Archive items by their ID
-        return {
-            ...state,
-            archive: {
-                ...state.archive,
-                ...(Array.isArray(payload) ? payload : [payload]).reduce(
-                    (archiveItems, item) => {
-                        archiveItems[item._id] = item;
+        const newItems = (Array.isArray(payload) ? payload : [payload])
+            .reduce((archiveItems, item) => {
+                archiveItems[item._id] = item;
 
-                        return archiveItems;
-                    },
-                    {}
-                ),
-            },
-        };
+                return archiveItems;
+            }, {});
+
+        return produce(state, (draftState) => {
+            Object.assign(draftState.archive, newItems);
+
+            return draftState;
+        });
     },
 
-    [ASSIGNMENTS.ACTIONS.REMOVE_ASSIGNMENT]: (oldState, payload) => {
-        const state = cloneDeep(oldState);
-
+    [ASSIGNMENTS.ACTIONS.REMOVE_ASSIGNMENT]: produce((state, payload) => {
         // Remove the assignment from the stored list of assignments
-        (get(payload, 'assignments') || []).forEach((a) => {
-            if (a in state.assignments) {
-                delete state.assignments[a];
-                // If this assignment is being viewed,
-                // then close the preview and de-select the assignment
-                if (state.currentAssignmentId === a) {
-                    state.previewOpened = false;
-                    state.currentAssignmentId = null;
-                    state.initialTab = null;
-                    state.selectedArchiveItemId = null;
-                }
-
-                // Remove this assignment from any list groups
-                filterList(state, ASSIGNMENTS.LIST_GROUPS.IN_PROGRESS.id, a);
-                filterList(state, ASSIGNMENTS.LIST_GROUPS.TODO.id, a);
-                filterList(state, ASSIGNMENTS.LIST_GROUPS.COMPLETED.id, a);
-                filterList(state, ASSIGNMENTS.LIST_GROUPS.CURRENT.id, a);
-                filterList(state, ASSIGNMENTS.LIST_GROUPS.TODAY.id, a);
-                filterList(state, ASSIGNMENTS.LIST_GROUPS.FUTURE.id, a);
+        (payload.assignments ?? []).forEach((a) => {
+            if (!(a in state.assignments)) {
+                return;
             }
+
+            delete state.assignments[a];
+
+            // If this assignment is being viewed,
+            // then close the preview and de-select the assignment
+            if (state.currentAssignmentId === a) {
+                state.previewOpened = false;
+                state.currentAssignmentId = null;
+                state.initialTab = null;
+                state.selectedArchiveItemId = null;
+            }
+
+            // Remove this assignment from any list groups
+            filterList(state, ASSIGNMENTS.LIST_GROUPS.IN_PROGRESS.id, a);
+            filterList(state, ASSIGNMENTS.LIST_GROUPS.TODO.id, a);
+            filterList(state, ASSIGNMENTS.LIST_GROUPS.COMPLETED.id, a);
+            filterList(state, ASSIGNMENTS.LIST_GROUPS.CURRENT.id, a);
+            filterList(state, ASSIGNMENTS.LIST_GROUPS.TODAY.id, a);
+            filterList(state, ASSIGNMENTS.LIST_GROUPS.FUTURE.id, a);
         });
 
         return state;
-    },
-
-    [ASSIGNMENTS.ACTIONS.RECEIVE_ASSIGNMENT_HISTORY]: (state, payload) => ({
-        ...state,
-        assignmentHistoryItems: payload,
     }),
 
-    [ASSIGNMENTS.ACTIONS.SET_BASE_QUERY]: (state, payload) => ({
-        ...state,
-        baseQuery: payload,
+    [ASSIGNMENTS.ACTIONS.RECEIVE_ASSIGNMENT_HISTORY]: produce((state, payload) => {
+        state.assignmentHistoryItems = payload;
+
+        return state;
     }),
 
-    [ASSIGNMENTS.ACTIONS.SET_GROUP_KEYS]: (state, payload) => ({
-        ...state,
-        groupKeys: payload,
+    [ASSIGNMENTS.ACTIONS.SET_BASE_QUERY]: produce((state, payload) => {
+        state.baseQuery = payload;
+
+        return state;
+    }),
+
+    [ASSIGNMENTS.ACTIONS.SET_GROUP_KEYS]: produce((state, payload) => {
+        state.groupKeys = payload;
+
+        return state;
     }),
 });
 

--- a/client/reducers/tests/assignment_test.ts
+++ b/client/reducers/tests/assignment_test.ts
@@ -405,7 +405,7 @@ describe('assignment', () => {
                 // Checks to see if IN_PROGRESS list is set back to empty
                 let result = assignment(initialState, {
                     type: 'RECEIVED_ASSIGNMENTS',
-                    payload: [assignments[0]],
+                    payload: [cloneDeep(assignments)[0]],
                 });
 
                 result = assignment(result, {
@@ -428,7 +428,7 @@ describe('assignment', () => {
                 // Checks to see if TO_DO list is set back to empty
                 result = assignment(initialState, {
                     type: 'RECEIVED_ASSIGNMENTS',
-                    payload: [assignments[0]],
+                    payload: [cloneDeep(assignments)[0]],
                 });
 
                 result = assignment(result, {
@@ -451,7 +451,7 @@ describe('assignment', () => {
                 // Checks to see if COMPLETED list is set back to empty
                 result = assignment(initialState, {
                     type: 'RECEIVED_ASSIGNMENTS',
-                    payload: [assignments[0]],
+                    payload: [cloneDeep(assignments)[0]],
                 });
 
                 result = assignment(result, {
@@ -475,7 +475,7 @@ describe('assignment', () => {
             it('REMOVE_ASSIGNMENT closes the preview', () => {
                 let result = assignment(initialState, {
                     type: 'RECEIVED_ASSIGNMENTS',
-                    payload: [assignments[0]],
+                    payload: [cloneDeep(assignments)[0]],
                 });
 
                 result = assignment(result, {
@@ -505,7 +505,7 @@ describe('assignment', () => {
             it('REMOVE_ASSIGNMENT doesnt close the preview if not viewing', () => {
                 let result = assignment(initialState, {
                     type: 'RECEIVED_ASSIGNMENTS',
-                    payload: [assignments[0]],
+                    payload: [cloneDeep(assignments)[0]],
                 });
 
                 result = assignment(result, {


### PR DESCRIPTION
### Purpose
Improve the assignments list UI so groups of lists don't rerender completely when there's an assignment change - update an existing one , or on creation of a new one.

### What has changed

**Feature related:**

Logic was introduced to control the triggering of groups UI loaders. 
Reworked the reducer handling assignments actions to use `produce` so we can stop deep copying the entire state in each action, causing unnecessary component re-rendering. 
Trigger the list UI loaders when a search is executed from the advanced search sidebar. Previously that was getting triggered only when user made a query from the top search bar.

**Small improvements:**

I also used the opportunity to just very barely make the code more readable, making conditional logic easier to read in places.

### Steps to test
1. Open two browser windows side by side. 
2. On the first one, go to the assignments page, on the second one open planning.

Case 1:
1. Create a few assignments to the user you're logged in with on the screen with assignments view.
2. Notice the loading mechanism doesn't get triggered, but items count and items in the TODO list view change, with the newly added assignment. 

Case 2:
1. Mark an existing assignment as completed 
2. Notice that the group loaders aren't rendering, rather:
 - marked item should be removed from the "In Progress" group, and get added to the "Completed" one
 - groups' scroll position doesn't change, if you've got enough items so that the 2 groups are overflowing of items and are scrollable. 

### Screenshots
https://github.com/user-attachments/assets/88a12e6f-627e-499c-ab0f-8b69552dd545

Resolves: #[STT-1427](https://sofab.atlassian.net/browse/STT-1427)



[STT-1427]: https://sofab.atlassian.net/browse/STT-1427?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ