### PR TITLE
[STT-1372] fix: Editing date/times for item in different timezones

### DIFF
--- a/client/api/editor/events.ts
+++ b/client/api/editor/events.ts
@@ -17,6 +17,8 @@ import {planningApi} from '../../superdeskApi';
 
 import * as actions from '../../actions';
 import {editorSelectors} from '../../selectors/editors';
+import {convertEventDatesForTimezone} from '../../utils/events';
+import {convertPlanningDatesForTimezone} from '../../utils/planning';
 
 export function getEventsInstance(type: EDITOR_TYPE): IEditorAPI['events'] {
     function resetDom() {
@@ -116,19 +118,34 @@ export function getEventsInstance(type: EDITOR_TYPE): IEditorAPI['events'] {
         }
     }
 
+    function setDatesAndTimesToItemTimezone(newState: Partial<IEditorState>) {
+        switch (newState.diff.type) {
+        case 'event':
+            // Make sure the Editor is using date/time fields in the timezone of the Event and not the browser
+            convertEventDatesForTimezone(newState.diff, newState.diff.dates.tz);
+            return;
+        case 'planning':
+            // Make sure the Editor is using UTC date/time if the Planning is `all_day`, otherwise leave as is
+            convertPlanningDatesForTimezone(newState.diff);
+        }
+    }
+
     function onOpenForCreate(newState: Partial<IEditorState>) {
         registerFormComponents(newState);
         setEventsPlanningsToAdd(newState);
+        setDatesAndTimesToItemTimezone(newState);
     }
 
     function onOpenForEdit(newState: Partial<IEditorState>) {
         registerFormComponents(newState);
         setEventsPlanningsToAdd(newState);
+        setDatesAndTimesToItemTimezone(newState);
     }
 
     function onOpenForRead(newState: Partial<IEditorState>) {
         registerFormComponents(newState);
         setEventsPlanningsToAdd(newState);
+        setDatesAndTimesToItemTimezone(newState);
     }
 
     function onOriginalChanged(item: IEventOrPlanningItem) {

--- a/client/components/Main/ItemEditor/tests/ItemManager_test.ts
+++ b/client/components/Main/ItemEditor/tests/ItemManager_test.ts
@@ -6,6 +6,7 @@ import {planningApi} from '../../../../superdeskApi';
 import {main} from '../../../../actions';
 import {EVENTS} from '../../../../constants';
 import {getItemInArrayById, itemsEqual, timeUtils, updateFormValues, removeAutosaveFields} from '../../../../utils';
+import {convertEventDatesForTimezone} from '../../../../utils/events';
 import {restoreSinonStub, waitFor} from '../../../../utils/testUtils';
 import * as testData from '../../../../utils/testData';
 import {ItemManager} from '../ItemManager';
@@ -526,11 +527,13 @@ describe('components.Main.ItemManager', () => {
                         editor.props,
                         testData.events[0],
                     ]);
+                    const expectedDiff = cloneDeep(testData.events[0]);
 
+                    convertEventDatesForTimezone(expectedDiff);
                     expectState({
                         initialValues: testData.events[0],
                         diff: {
-                            ...testData.events[0],
+                            ...expectedDiff,
                             associated_plannings: [testData.plannings[1]],
                         },
                         dirty: false,
@@ -1265,7 +1268,7 @@ describe('components.Main.ItemManager', () => {
                             _etag: 'e789',
                             state: 'scheduled',
                             pubstatus: 'usable',
-                        })
+                        }, true, true)
                     );
                     expect(editor.autoSave.flushAutosave.callCount).toBe(2);
 
@@ -1333,7 +1336,7 @@ describe('components.Main.ItemManager', () => {
                             _etag: 'e789',
                             state: 'killed',
                             pubstatus: 'cancelled',
-                        })
+                        }, true, true)
                     );
                     expect(editor.autoSave.flushAutosave.callCount).toBe(2);
 

--- a/client/components/fields/editor/EventSchedule.tsx
+++ b/client/components/fields/editor/EventSchedule.tsx
@@ -68,7 +68,6 @@ export class EditorFieldEventSchedule extends React.PureComponent<IEventSchedule
 
     changeStartTime(value?: moment.Moment) {
         const startDate = this.props.item?.dates?.start;
-        const endDate = this.props.item?.dates?.end;
 
         if (!value) {
             const changes = {
@@ -83,7 +82,6 @@ export class EditorFieldEventSchedule extends React.PureComponent<IEventSchedule
             this.props.onChange(changes);
             return;
         }
-
         const newStartDate = !startDate ? value : combineDateTime(startDate, value, this.props.item.dates?.tz);
         const changes = {
             'dates.start': newStartDate,
@@ -127,6 +125,8 @@ export class EditorFieldEventSchedule extends React.PureComponent<IEventSchedule
     }
 
     changeEndTime(value?: moment.Moment) {
+        const endDate = this.props.item?.dates?.end;
+
         if (!value) {
             const changes = {
                 _endTime: null,
@@ -141,10 +141,7 @@ export class EditorFieldEventSchedule extends React.PureComponent<IEventSchedule
             return;
         }
 
-        const endDate = this.props.item?.dates?.end != null ?
-            moment(this.props.item.dates.end) :
-            null;
-        const newEndDate = endDate ? combineDateTime(endDate, value, this.props.item.dates?.tz) : value;
+        const newEndDate = !endDate ? value : combineDateTime(endDate, value, this.props.item.dates?.tz);
 
         const changes = {
             _endTime: newEndDate,

--- a/client/components/fields/editor/PlanningDateTime.tsx
+++ b/client/components/fields/editor/PlanningDateTime.tsx
@@ -44,7 +44,7 @@ export class EditorFieldPlanningDateTime extends React.PureComponent<IProps> {
     }
 
     formatValue(value: moment.Moment) : moment.MomentInput {
-        return this.allDay ? value.format('YYYY-MM-DD') : value;
+        return this.allDay ? moment.utc(value.format('YYYY-MM-DD')) : value;
     }
 
     render() {

--- a/client/components/fields/editor/base/dateTime.tsx
+++ b/client/components/fields/editor/base/dateTime.tsx
@@ -51,27 +51,12 @@ export class EditorFieldDateTime extends React.PureComponent<IProps> {
         const value = get(this.props.item, field, this.props.defaultValue);
         const error = get(this.props.errors ?? {}, field);
 
-        let momentValue : moment.Moment;
-
-        if (value != null) {
-            if (this.props.allDay) {
-                const dateStr = moment(value).format('YYYY-MM-DD');
-                const tz = this.props.remoteTimeZone || moment.tz.guess();
-
-                momentValue = moment.tz(dateStr, tz);
-            } else {
-                momentValue = moment(value);
-            }
-        } else {
-            momentValue = undefined;
-        }
-
         return (
             <DateTimeInput
                 {...this.props}
                 diff={this.props.item}
                 field={field}
-                value={momentValue}
+                value={value}
                 message={error}
                 invalid={error?.length > 0 && this.props.invalid}
                 testId={this.props.testId}

--- a/client/utils/events.tsx
+++ b/client/utils/events.tsx
@@ -1146,6 +1146,32 @@ function normalizeSortDate(event: IEventItem) {
     return localStart.toISOString();
 }
 
+export function convertEventDatesForTimezone(event: IEventItem | Partial<IEventItem>, tz?: string) {
+    const timezone_string = tz ?? timeUtils.localTimeZone();
+
+    if (event.dates?.start != null) {
+        if (event.dates.all_day === true) {
+            // All day Events do not have a timezone attached
+            event.dates.start = moment.utc(event.dates.start);
+            event._startTime = null;
+        } else {
+            event.dates.start = timeUtils.getDateInRemoteTimeZone(event.dates.start, timezone_string);
+            event._startTime = timeUtils.getDateInRemoteTimeZone(event.dates.start, timezone_string);
+        }
+    }
+
+    if (event.dates?.end != null) {
+        if (event.dates.all_day === true || event.dates.no_end_time === true) {
+            // All day Events do not have a timezone attached
+            event.dates.end = moment.utc(event.dates.end);
+            event._endTime = null;
+        } else {
+            event.dates.end = timeUtils.getDateInRemoteTimeZone(event.dates.end, timezone_string);
+            event._endTime = timeUtils.getDateInRemoteTimeZone(event.dates.end, timezone_string);
+        }
+    }
+}
+
 function modifyForClient(event: IEventItem): IEventItem; // overload
 
 // eslint-disable-next-line no-redeclare
@@ -1157,11 +1183,7 @@ function modifyForClient(event: Partial<IEventItem>): Partial<IEventItem> {
         delete event._status;
     }
 
-    if (event.dates?.start != null) {
-        event.dates.start = timeUtils.getDateInRemoteTimeZone(event.dates.start, timeUtils.localTimeZone());
-        event._startTime = event.dates.all_day ? null
-            : timeUtils.getDateInRemoteTimeZone(event.dates.start, timeUtils.localTimeZone());
-    }
+    convertEventDatesForTimezone(event);
 
     if (event.dates?.end != null) {
         event.dates.end = timeUtils.getDateInRemoteTimeZone(event.dates.end, timeUtils.localTimeZone());

--- a/client/utils/planning.tsx
+++ b/client/utils/planning.tsx
@@ -896,6 +896,13 @@ function getPlanningActionsForUiFrameworkMenu(data: IGetPlanningActionArgs): Arr
     return toUIFrameworkInterface(planningUtils.getPlanningActions(data));
 }
 
+export function convertPlanningDatesForTimezone(plan: IPlanningItem | Partial<IPlanningItem>) {
+    if (plan.planning_date != null) {
+        // All day Planning items do not have a timezone attached
+        plan.planning_date = plan.all_day === true ? moment.utc(plan.planning_date) : moment(plan.planning_date);
+    }
+}
+
 export function modifyForClient<T extends IPlanningItem | Partial<IPlanningItem>>(plan: T): T {
     sanitizeItemFields(plan);
 
@@ -904,9 +911,7 @@ export function modifyForClient<T extends IPlanningItem | Partial<IPlanningItem>
         delete plan._status;
     }
 
-    if (get(plan, 'planning_date')) {
-        plan.planning_date = moment(plan.planning_date);
-    }
+    convertPlanningDatesForTimezone(plan);
 
     const defaults = {
         'flags.marked_for_not_publication': false,


### PR DESCRIPTION
### Purpose
There were a couple issues with the previous implementation. It all stemmed from the Editor not using the correct timezone with the moment instance (either all_day, or separate timezone from current browser/os settings).

### What has changed
* When loading into Redux, store either in UTC (for all day) or users browser/os timezone (events only)
* When loading into Editor, store either in UTC (for all day) or item timezone (events only)
* For Planning all_day editor field, store using moment instance in UTC (was previously storing as string, and required creating moment instance on every render)

Resolves: [STT-1372](https://sofab.atlassian.net/browse/STT-1372)



[STT-1372]: https://sofab.atlassian.net/browse/STT-1372?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ