### PR TITLE
[SDESK-7792] fix: Process Assignment delete properly from Planning resource

### DIFF
--- a/client/reducers/planning.ts
+++ b/client/reducers/planning.ts
@@ -205,8 +205,7 @@ const planningReducer = createReducer(initialState, {
 
     [ASSIGNMENTS.ACTIONS.REMOVE_ASSIGNMENT]: (state, payload) => {
         // If the planning is not loaded, disregard this action
-        if (!(payload.planning in state.plannings) ||
-            get(state.plannings[payload.planning], 'lock_action') !== ASSIGNMENTS.ITEM_ACTIONS.REMOVE.lock_action) {
+        if (!(payload.planning in state.plannings)) {
             return state;
         }
 

--- a/server/features/assignments_delete.feature
+++ b/server/features/assignments_delete.feature
@@ -1180,3 +1180,101 @@ Feature: Assignments Delete
             "workflow_status": "draft"
         }]}
         """
+
+    @auth
+    @notification
+    Scenario: Remove Coverage assignee also removes the linked Assignment
+        When we post to "/archive"
+        """
+        [{
+            "type": "text",
+            "headline": "test headline",
+            "slugline": "test slugline",
+            "task": {
+                "desk": "#desks._id#",
+                "stage": "#desks.incoming_stage#"
+            }
+        }]
+        """
+        When we post to "assignments/link"
+        """
+        [{"assignment_id": "#assignmentId#", "item_id": "#archive._id#", "reassign": true}]
+        """
+        Then we get OK response
+        When we reset notifications
+        When we patch "/planning/#planning._id#"
+        """
+        {"coverages": [{
+            "coverage_id": "#coverageId#",
+            "planning": {
+                "ednote": "test coverage, I want 250 words",
+                "headline": "test headline",
+                "slugline": "test slugline",
+                "g2_content_type" : "text"
+            },
+            "assigned_to": {},
+            "workflow_status": "draft"
+        }]}
+        """
+        Then we get OK response
+        When we get "/assignments/#assignmentId#"
+        Then we get error 404
+        When we get "/archive/#archive._id#"
+        Then we get existing resource
+        """
+        {"assignment_id": "__none__"}
+        """
+        When we get "/planning/#planning._id#"
+        Then we get existing resource
+        """
+        {"coverages": [{
+            "coverage_id": "#coverageId#",
+            "planning": {
+                "ednote": "test coverage, I want 250 words",
+                "headline": "test headline",
+                "slugline": "test slugline",
+                "g2_content_type" : "text"
+            },
+            "assigned_to": {
+                "desk": "__no_value__",
+                "user": "__no_value__",
+                "state": "__no_value__"
+            },
+            "workflow_status": "draft"
+        }]}
+        """
+        Then we get notifications
+        """
+        [{
+            "event": "assignments:removed",
+            "extra": {
+                "assignments": ["#assignmentId#"],
+                "planning": "#planning._id#",
+                "coverage": "#coverageId#",
+                "planning_etag": "__any_value__"
+            }
+        }]
+        """
+        When we get "/activity"
+        Then we get existing resource
+        """
+        {"_items": [{
+            "data" : {
+                "slugline" : "test slugline",
+                "coverage_type" : "text"
+            },
+            "message" : "The {{coverage_type}} assignment {{slugline}} has been removed",
+            "name":"update",
+            "recipients":[{
+                "user_id":"#CONTEXT_USER_ID#",
+                "read":false
+            }],
+            "resource":"assignments",
+            "user":"#CONTEXT_USER_ID#",
+            "user_name":"test_user"
+        }]}
+        """
+        And we get emails
+        """
+        [{"body": "The text assignment test slugline has been removed"}]
+        """

--- a/server/features/events.feature
+++ b/server/features/events.feature
@@ -1395,7 +1395,7 @@ Feature: Events
         """
         {
             "coverages": [{
-                "workflow_status": "draft",
+                "workflow_status": "assigned",
                 "planning": {
                     "ednote": "test coverage, I want 250 words",
                     "slugline": "test slugline",

--- a/server/planning/assignments/assignments.py
+++ b/server/planning/assignments/assignments.py
@@ -1276,12 +1276,16 @@ class AssignmentsService(AsyncBaseService):
         planning_service = get_resource_service("planning")
         planning_item = await planning_service.find_one_async(req=None, _id=doc.get("planning_item"))
 
-        # Make sure the Assignment is locked by this user and session unless when removing
-        # assignments during spiking/unposting planning items
-        if not is_locked_in_this_session(doc) and planning_item.get("state") not in [
-            WORKFLOW_STATE.KILLED,
-            WORKFLOW_STATE.SPIKED,
-        ]:
+        if not planning_item:
+            raise SuperdeskApiError.badRequestError(message="Failed to find Planning item.")
+
+        # Make sure either the Assignment or Planning item is locked by this user and session
+        assignment_linked_to_coverage = any(
+            True
+            for coverage in planning_item.get("coverages") or []
+            if str((coverage.get("assigned_to") or {}).get("assignment_id")) == str(doc["_id"])
+        )
+        if assignment_linked_to_coverage and not is_locked_in_this_session(doc):
             raise SuperdeskApiError.forbiddenError(message="Lock is not obtained on the Assignment item")
 
         # Make sure the content linked to assignment (if) is also not locked
@@ -1334,7 +1338,7 @@ class AssignmentsService(AsyncBaseService):
             # Now delete all deliveries for that assignment
             await delivery_service.delete_action_async(lookup={"assignment_id": ObjectId(assignment_id)})
 
-    async def on_deleted_async(self, doc):
+    async def on_deleted_async(self, doc, update_planning: bool = True):
         deleted_assignments = [doc.get(ID_FIELD)]
         planning_service = get_resource_service("planning")
         await self.archive_delete_assignment(doc)
@@ -1352,7 +1356,10 @@ class AssignmentsService(AsyncBaseService):
                     marked_for_delete = True
 
         # Remove assignment information from coverage
-        updated_planning = await planning_service.remove_assignment(doc)
+        if update_planning:
+            updated_planning = await planning_service.remove_assignment(doc)
+        else:
+            updated_planning = doc
 
         # Finally send a notification to connected clients that the Assignment
         # has been removed

--- a/server/planning/planning/planning.py
+++ b/server/planning/planning/planning.py
@@ -508,7 +508,46 @@ class PlanningService(AsyncBaseService):
 
         return len(changed_ids) > 0
 
+    async def _process_removed_assignments(self, updates: dict, original: dict) -> None:
+        assignment_service = get_resource_service("assignments")
+        planning_item = deepcopy(original)
+        planning_item.update(deepcopy(updates))
+        updated_coverages = {coverage.get("coverage_id"): coverage for coverage in updates.get("coverages") or []}
+
+        for original_coverage in original.get("coverages") or []:
+            updated_coverage = updated_coverages.get(original_coverage.get("coverage_id")) or {}
+            assignment_id = (original_coverage.get("assigned_to") or {}).get("assignment_id")
+
+            if not assignment_id or (updated_coverage.get("assigned_to") or {}).get("assignment_id"):
+                # Either no Assignment is currently linked, or the updated Coverage is still linked
+                continue
+
+            if original_coverage.get("workflow_status") not in [WORKFLOW_STATE.CANCELLED, WORKFLOW_STATE.DRAFT]:
+                # This Assignment is in workflow, so we need the Assignment service's side-effects
+                cursor = await assignment_service.find_async(
+                    where={"coverage_item": original_coverage.get("coverage_id")}
+                )
+                async for assignment in cursor:
+                    await assignment_service.delete_async(lookup={"_id": assignment_id})
+                    await assignment_service.on_deleted_async(assignment, update_planning=False)
+                    await self.send_remove_assignment_notifications(planning_item, original_coverage, assignment)
+            else:
+                # Otherwise just directly delete the Assignment
+                await assignment_service.delete_async(lookup={"coverage_item": original_coverage.get("coverage_id")})
+
+            assignment = {
+                "planning_item": original.get(ID_FIELD),
+                "coverage_item": updated_coverage.get("coverage_id"),
+            }
+
+            scheduled_update = updated_coverage.get("scheduled_update") or original_coverage.get("scheduled_update")
+            if scheduled_update:
+                assignment["scheduled_update_id"] = scheduled_update
+
+            await AssignmentsHistoryAsyncService().on_item_deleted(assignment)
+
     async def on_updated_async(self, updates, original, from_ingest=False):
+        await self._process_removed_assignments(updates, original)
         added, removed = self._get_added_removed_agendas(updates, original)
         item_id = str(original[ID_FIELD])
         session_id = get_auth().get(ID_FIELD)
@@ -1028,16 +1067,8 @@ class PlanningService(AsyncBaseService):
                     WORKFLOW_STATE.DRAFT,
                 ]:
                     raise SuperdeskApiError.badRequestError("Coverage not in correct state to remove assignment.")
-                # Removing assignment
-                await assignment_service.delete_async(lookup={"_id": assigned_to.get("assignment_id")})
-                assignment = {
-                    "planning_item": planning_original.get(ID_FIELD),
-                    "coverage_item": doc.get("coverage_id"),
-                }
-                if doc.get("scheduled_update"):
-                    assignment["scheduled_update_id"] = doc.get("scheduled_update_id")
 
-                await AssignmentsHistoryAsyncService().on_item_deleted(assignment)
+                # Return now, we will process the assignment after the DB is updated
                 return
 
             # update the assignment using the coverage details
@@ -1268,28 +1299,11 @@ class PlanningService(AsyncBaseService):
             # Assignment was already removed (unposting a planning item scenario)
             return planning_item
 
+        await self.send_remove_assignment_notifications(planning_item, coverage_item, assignment_item)
         for s in coverage_item.get("scheduled_updates"):
-            assigned_to = s.get("assigned_to")
-            await PlanningNotifications().notify_assignment(
-                coverage_status=s.get("workflow_status"),
-                target_desk=assigned_to.get("desk") if assigned_to.get("user") is None else None,
-                target_user=assigned_to.get("user"),
-                message="assignment_removed_msg",
-                coverage_type=get_coverage_type_name(coverage_item.get("planning", {}).get("g2_content_type", "")),
-                slugline=planning_item.get("slugline", ""),
-            )
             del s["assigned_to"]
             s["workflow_status"] = WORKFLOW_STATE.DRAFT
 
-        assigned_to = assignment_item.get("assigned_to")
-        await PlanningNotifications().notify_assignment(
-            coverage_status=coverage_item.get("workflow_status"),
-            target_desk=assigned_to.get("desk") if assigned_to.get("user") is None else None,
-            target_user=assigned_to.get("user"),
-            message="assignment_removed_msg",
-            coverage_type=get_coverage_type_name(coverage_item.get("planning", {}).get("g2_content_type", "")),
-            slugline=planning_item.get("slugline", ""),
-        )
         del coverage_item["assigned_to"]
         coverage_item["workflow_status"] = WORKFLOW_STATE.DRAFT
 
@@ -1302,6 +1316,30 @@ class PlanningService(AsyncBaseService):
         updated_planning["related_events"] = get_related_event_links_for_planning(planning_item)
 
         return updated_planning
+
+    async def send_remove_assignment_notifications(
+        self, planning_item: dict, coverage_item: dict, assignment_item: dict
+    ) -> None:
+        for s in coverage_item.get("scheduled_updates") or []:
+            assigned_to = s.get("assigned_to")
+            await PlanningNotifications().notify_assignment(
+                coverage_status=s.get("workflow_status"),
+                target_desk=assigned_to.get("desk") if assigned_to.get("user") is None else None,
+                target_user=assigned_to.get("user"),
+                message="assignment_removed_msg",
+                coverage_type=get_coverage_type_name(coverage_item.get("planning", {}).get("g2_content_type", "")),
+                slugline=planning_item.get("slugline", ""),
+            )
+
+        assigned_to = assignment_item.get("assigned_to")
+        await PlanningNotifications().notify_assignment(
+            coverage_status=coverage_item.get("workflow_status"),
+            target_desk=assigned_to.get("desk") if assigned_to.get("user") is None else None,
+            target_user=assigned_to.get("user"),
+            message="assignment_removed_msg",
+            coverage_type=get_coverage_type_name(coverage_item.get("planning", {}).get("g2_content_type", "")),
+            slugline=planning_item.get("slugline", ""),
+        )
 
     def is_coverage_planning_modified(self, updates, original):
         for key in updates.get("planning").keys():

--- a/server/planning/planning/planning.py
+++ b/server/planning/planning/planning.py
@@ -1331,7 +1331,7 @@ class PlanningService(AsyncBaseService):
                 slugline=planning_item.get("slugline", ""),
             )
 
-        assigned_to = assignment_item.get("assigned_to")
+        assigned_to = assignment_item.get("assigned_to") or {}
         await PlanningNotifications().notify_assignment(
             coverage_status=coverage_item.get("workflow_status"),
             target_desk=assigned_to.get("desk") if assigned_to.get("user") is None else None,


### PR DESCRIPTION
### Purpose
Removal of an Assignment using the Coverage form did not process the Assignment properly, such as:
* Sending email & slack notifications
* Updating content items to remove `assignment_id`
* Removing the entries for the Assignment from the Delivery resource
* Sending Websocket notifications for the Assignment removal

### What has changed
* Make sure to use the Assignment's on_deleted_async function to process Assignment delete side effects
* Delete the Assignment **after** update of the Planning item
* Fix bug in front-end where `REMOVE_ASSIGNMENT` Redux action was being ignored due to lock_action constraint

Resolves: #[issue-number]

