### PR TITLE
[SDESK-7797] fix: Search Planning using date-only

### DIFF
--- a/client/utils/index.ts
+++ b/client/utils/index.ts
@@ -666,9 +666,13 @@ export const onEventCapture = (event) => {
     }
 };
 
-export const isDateInRange = (inputDate, startDate, endDate) => {
+export const isDateInRange = (inputDate, startDate, endDate, allDay = false) => {
     if (!inputDate) {
         return false;
+    }
+
+    if (allDay) {
+        return moment.utc(inputDate).isBetween(startDate, endDate, 'day', '[)');
     }
 
     if (startDate && moment(inputDate).isBefore(startDate, 'millisecond') ||

--- a/client/utils/planning.tsx
+++ b/client/utils/planning.tsx
@@ -1265,10 +1265,12 @@ function getPlanningByDate(
         if (timezone) {
             groupDate.tz(timezone);
         }
+
         return groupDate;
     };
 
     plansInList.forEach((plan) => {
+
         let dates = {};
         let groupDate = null;
         const planningDate = getPlanningDate(plan);
@@ -1301,7 +1303,7 @@ function getPlanningByDate(
 
         if (isEmpty(dates)) {
             groupDate = getGroupDate(planningDate);
-            if (isDateInRange(groupDate, startDate, endDate)) {
+            if (isDateInRange(groupDate, startDate, endDate, plan.all_day)) {
                 dates[groupDate.format('YYYY-MM-DD')] = groupDate;
             }
         }

--- a/client/utils/planning.tsx
+++ b/client/utils/planning.tsx
@@ -1270,7 +1270,6 @@ function getPlanningByDate(
     };
 
     plansInList.forEach((plan) => {
-
         let dates = {};
         let groupDate = null;
         const planningDate = getPlanningDate(plan);

--- a/server/features/search_planning.feature
+++ b/server/features/search_planning.feature
@@ -518,6 +518,73 @@ Feature: Planning Search
         ]}
         """
 
+        # All day
+        Given empty "planning"
+        When we post to "/planning"
+        """
+        [{
+            "guid": "planning_all_day",
+            "slugline": "slug123",
+            "name": "name123",
+            "planning_date": "2025-11-06T00:00:00+0000",
+            "all_day": true
+        }, {
+            "guid": "planning_with_time",
+            "slugline": "slug123",
+            "name": "name123",
+            "planning_date": "2025-11-06T00:00:00+0000"
+        },
+        {
+            "guid": "planning_with_coverage",
+            "slugline": "slug123",
+            "name": "name123",
+            "planning_date": "2025-11-06T00:00:00+0000",
+            "coverages": [
+                {
+                    "coverage_id": "c1",
+                    "planning": {"scheduled": "2025-11-06T08:00:00+0000"}
+                }
+            ]
+        },
+        {
+            "guid": "scheduled_updated",
+            "slugline": "slug123",
+            "name": "name123",
+            "all_day": true,
+            "planning_date": "2025-11-01T00:00:00+0000",
+            "coverages": [
+                {
+                    "coverage_id": "c1",
+                    "planning": {
+                        "scheduled": "2025-11-01T00:00:00+0000"
+                    },
+                    "scheduled_updates": [
+                        {
+                            "coverage_id": "c2",
+                            "planning": {
+                                "scheduled": "2025-11-06T08:00:00+0000"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }]
+        """
+        When we get "/events_planning_search?repo=planning&only_future=false&start_date=2025-11-06T05:00:00%2B0000&time_zone=Europe/Prague"
+        Then we get list with 2 item
+        """
+        {"_items": [{"guid": "planning_all_day"}, {"guid": "planning_with_coverage"}]}
+        """
+        # include scheduled
+        When we get "/events_planning_search?repo=planning&only_future=false&start_date=2025-11-06T05:00:00%2B0000&time_zone=Europe/Prague&include_scheduled_updates=1"
+        Then we get list with 3 items
+        """
+        {"_items": [{"guid": "planning_all_day"}, {"guid": "scheduled_updated"}]}
+        """
+        # default params
+        When we get "/events_planning_search?repo=planning&time_zone=Europe/Prague"
+        Then we get list with 0 items
+
     @auth
     Scenario: Search planning by coverage dates
         Given empty "planning"

--- a/server/planning/search/queries/common.py
+++ b/server/planning/search/queries/common.py
@@ -8,18 +8,14 @@
 # AUTHORS and LICENSE files distributed with this source code, or
 # at https://www.sourcefabric.org/superdesk/license
 
-
-import pytz
-import logging
-
 from typing import Dict, Any, Optional, List, Callable, Union, Awaitable
 from inspect import isawaitable
+import logging
 from datetime import datetime
 
 from eve.utils import str_to_date as _str_to_date, date_to_str
 
 from superdesk import get_resource_service
-from superdesk.core import get_config
 from superdesk.errors import SuperdeskApiError
 from superdesk.default_settings import strtobool as _strtobool
 from superdesk.users.services import current_user_has_privilege
@@ -642,7 +638,3 @@ COMMON_PARAMS = [
     "ednote",
     "internal_note",
 ]
-
-
-def local_now(time_zone: Optional[str] = None) -> datetime:
-    return datetime.now().astimezone(pytz.timezone(time_zone or get_config(str, "DEFAULT_TIMEZONE")))

--- a/server/planning/search/queries/common.py
+++ b/server/planning/search/queries/common.py
@@ -8,14 +8,18 @@
 # AUTHORS and LICENSE files distributed with this source code, or
 # at https://www.sourcefabric.org/superdesk/license
 
+
+import pytz
+import logging
+
 from typing import Dict, Any, Optional, List, Callable, Union, Awaitable
 from inspect import isawaitable
-import logging
 from datetime import datetime
 
 from eve.utils import str_to_date as _str_to_date, date_to_str
 
 from superdesk import get_resource_service
+from superdesk.core import get_config
 from superdesk.errors import SuperdeskApiError
 from superdesk.default_settings import strtobool as _strtobool
 from superdesk.users.services import current_user_has_privilege
@@ -638,3 +642,7 @@ COMMON_PARAMS = [
     "ednote",
     "internal_note",
 ]
+
+
+def local_now(time_zone: Optional[str] = None) -> datetime:
+    return datetime.now().astimezone(pytz.timezone(time_zone or get_config(str, "DEFAULT_TIMEZONE")))

--- a/server/planning/search/queries/elastic.py
+++ b/server/planning/search/queries/elastic.py
@@ -199,7 +199,7 @@ def field_range(query: ElasticRangeParams):
     if query.time_zone:
         params["time_zone"] = query.time_zone
 
-    if query.field in ("dates.start", "dates.end", "_planning_schedule.scheduled"):
+    if query.field in ("dates.start", "dates.end", "_planning_schedule.scheduled", "_updates_schedule.scheduled"):
         # handle also all day events
         # there we get value which is in utc,
         # so we first convert it to local timezone
@@ -267,25 +267,21 @@ def field_range(query: ElasticRangeParams):
                     ],
                 },
             }
-        else:
+        elif query.field == "_planning_schedule.scheduled":
             return {
                 "bool": {
                     "should": [
                         {
                             "bool": {
                                 "must_not": [{"term": {"all_day": True}}],
-                                "must": [{
-                                    "nested": {
-                                        "path": "_planning_schedule",
-                                        "query": {
-                                            "bool": {
-                                                "must": {
-                                                    "range": {"_planning_schedule.scheduled": params}
-                                                }
-                                            }
+                                "must": [
+                                    {
+                                        "nested": {
+                                            "path": "_planning_schedule",
+                                            "query": {"bool": {"must": {"range": {query.field: params}}}},
                                         }
                                     }
-                                }]
+                                ],
                             }
                         },
                         {
@@ -303,31 +299,47 @@ def field_range(query: ElasticRangeParams):
                                                         {
                                                             # Match Planning date using UTC date params
                                                             "bool": {
-                                                                "must_not": {"exists": {"field": "_planning_schedule.coverage_id"}},
-                                                                "must": {"range": {"_planning_schedule.scheduled": local_params}}
+                                                                "must_not": {
+                                                                    "exists": {
+                                                                        "field": "_planning_schedule.coverage_id"
+                                                                    }
+                                                                },
+                                                                "must": {
+                                                                    "range": {
+                                                                        "_planning_schedule.scheduled": local_params
+                                                                    }
+                                                                },
                                                             }
                                                         },
                                                         {
                                                             # Match coverage dates using local date params
                                                             "bool": {
                                                                 "must": [
-                                                                    {"exists": {"field": "_planning_schedule.coverage_id"}},
-                                                                    {"range": {"_planning_schedule.scheduled": params}}
+                                                                    {
+                                                                        "exists": {
+                                                                            "field": "_planning_schedule.coverage_id"
+                                                                        }
+                                                                    },
+                                                                    {"range": {"_planning_schedule.scheduled": params}},
                                                                 ]
                                                             }
                                                         },
                                                     ],
                                                     "minimum_should_match": 1,
                                                 }
-                                            }
+                                            },
                                         }
-                                    }
+                                    },
                                 ]
                             }
-                        }
+                        },
                     ],
                     "minimum_should_match": 1,
                 }
+            }
+        elif query.field == "_updates_schedule.scheduled":
+            return {
+                "nested": {"path": "_updates_schedule", "query": {"bool": {"must": {"range": {query.field: params}}}}}
             }
 
     return {"range": {query.field: params}}

--- a/server/planning/search/queries/elastic.py
+++ b/server/planning/search/queries/elastic.py
@@ -199,7 +199,7 @@ def field_range(query: ElasticRangeParams):
     if query.time_zone:
         params["time_zone"] = query.time_zone
 
-    if query.field in ("dates.start", "dates.end"):
+    if query.field in ("dates.start", "dates.end", "_planning_schedule.scheduled"):
         # handle also all day events
         # there we get value which is in utc,
         # so we first convert it to local timezone
@@ -237,7 +237,7 @@ def field_range(query: ElasticRangeParams):
                     ],
                 },
             }
-        else:
+        elif query.field == "dates.end":
             return {
                 "bool": {
                     "should": [
@@ -266,6 +266,68 @@ def field_range(query: ElasticRangeParams):
                         },
                     ],
                 },
+            }
+        else:
+            return {
+                "bool": {
+                    "should": [
+                        {
+                            "bool": {
+                                "must_not": [{"term": {"all_day": True}}],
+                                "must": [{
+                                    "nested": {
+                                        "path": "_planning_schedule",
+                                        "query": {
+                                            "bool": {
+                                                "must": {
+                                                    "range": {"_planning_schedule.scheduled": params}
+                                                }
+                                            }
+                                        }
+                                    }
+                                }]
+                            }
+                        },
+                        {
+                            "bool": {
+                                "must": [
+                                    {"term": {"all_day": True}},
+                                    {
+                                        "nested": {
+                                            "path": "_planning_schedule",
+                                            "query": {
+                                                "bool": {
+                                                    # Currently, only Planning items can be date-only
+                                                    # So split the search query for Planning and Coverages separately
+                                                    "should": [
+                                                        {
+                                                            # Match Planning date using UTC date params
+                                                            "bool": {
+                                                                "must_not": {"exists": {"field": "_planning_schedule.coverage_id"}},
+                                                                "must": {"range": {"_planning_schedule.scheduled": local_params}}
+                                                            }
+                                                        },
+                                                        {
+                                                            # Match coverage dates using local date params
+                                                            "bool": {
+                                                                "must": [
+                                                                    {"exists": {"field": "_planning_schedule.coverage_id"}},
+                                                                    {"range": {"_planning_schedule.scheduled": params}}
+                                                                ]
+                                                            }
+                                                        },
+                                                    ],
+                                                    "minimum_should_match": 1,
+                                                }
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "minimum_should_match": 1,
+                }
             }
 
     return {"range": {query.field: params}}

--- a/server/planning/search/queries/planning.py
+++ b/server/planning/search/queries/planning.py
@@ -173,47 +173,26 @@ def search_date(params: Dict[str, Any], query: elastic.ElasticQuery):
         if date_filter:
             base_query.date_range = date_filter
             base_query.date = start_date
-
             query_range = elastic.date_range(base_query)
         else:
             base_query.gte = start_date
             base_query.lte = end_date
-
             query_range = elastic.date_range(base_query)
 
-            # TODO-PR: Fix this, as the ``query_range`` format has changed
-            # if not query_range["range"][field_name].get("gte") and not not query_range["range"][field_name].get("lte"):
-            #     query_range["range"][field_name]["gte"] = "now/d"
-
-        # planning_schedule = {
-        #     "nested": {
-        #         "path": "_planning_schedule",
-        #         "query": {"bool": {"filter": query_range}},
-        #     }
-        # }
-
         if strtobool(params.get("include_scheduled_updates", False)):
-            # TODO-PR: Fix this, as the ``query_range`` format has changed
-            pass
-            # updates_range = {"range": {"_updates_schedule.scheduled": deepcopy(query_range["range"][field_name])}}
-            #
-            # query.filter.append(
-            #     elastic.bool_or(
-            #         [
-            #             planning_schedule,
-            #             {
-            #                 "nested": {
-            #                     "path": "_updates_schedule",
-            #                     "query": {"bool": {"filter": updates_range}},
-            #                 }
-            #             },
-            #         ]
-            #     )
-            # )
-            #
-            # query.extra["sort_filter"] = elastic.date_range(
-            #     elastic.ElasticRangeParams(field=field_name, gte="now/d", time_zone=time_zone)
-            # )
+            base_query.field = "_updates_schedule.scheduled"
+            updates_range = elastic.date_range(base_query)
+            query.filter.append(
+                {
+                    "bool": {
+                        "should": [
+                            query_range,
+                            updates_range,
+                        ]
+                    }
+                }
+            )
+            query.extra["sort_filter"] = query_range
         else:
             query.filter.append(query_range)
             query.extra["sort_filter"] = query_range

--- a/server/planning/search/queries/planning.py
+++ b/server/planning/search/queries/planning.py
@@ -181,38 +181,41 @@ def search_date(params: Dict[str, Any], query: elastic.ElasticQuery):
 
             query_range = elastic.date_range(base_query)
 
-            if not query_range["range"][field_name].get("gte") and not not query_range["range"][field_name].get("lte"):
-                query_range["range"][field_name]["gte"] = "now/d"
+            # TODO-PR: Fix this, as the ``query_range`` format has changed
+            # if not query_range["range"][field_name].get("gte") and not not query_range["range"][field_name].get("lte"):
+            #     query_range["range"][field_name]["gte"] = "now/d"
 
-        planning_schedule = {
-            "nested": {
-                "path": "_planning_schedule",
-                "query": {"bool": {"filter": query_range}},
-            }
-        }
+        # planning_schedule = {
+        #     "nested": {
+        #         "path": "_planning_schedule",
+        #         "query": {"bool": {"filter": query_range}},
+        #     }
+        # }
 
         if strtobool(params.get("include_scheduled_updates", False)):
-            updates_range = {"range": {"_updates_schedule.scheduled": deepcopy(query_range["range"][field_name])}}
-
-            query.filter.append(
-                elastic.bool_or(
-                    [
-                        planning_schedule,
-                        {
-                            "nested": {
-                                "path": "_updates_schedule",
-                                "query": {"bool": {"filter": updates_range}},
-                            }
-                        },
-                    ]
-                )
-            )
-
-            query.extra["sort_filter"] = elastic.date_range(
-                elastic.ElasticRangeParams(field=field_name, gte="now/d", time_zone=time_zone)
-            )
+            # TODO-PR: Fix this, as the ``query_range`` format has changed
+            pass
+            # updates_range = {"range": {"_updates_schedule.scheduled": deepcopy(query_range["range"][field_name])}}
+            #
+            # query.filter.append(
+            #     elastic.bool_or(
+            #         [
+            #             planning_schedule,
+            #             {
+            #                 "nested": {
+            #                     "path": "_updates_schedule",
+            #                     "query": {"bool": {"filter": updates_range}},
+            #                 }
+            #             },
+            #         ]
+            #     )
+            # )
+            #
+            # query.extra["sort_filter"] = elastic.date_range(
+            #     elastic.ElasticRangeParams(field=field_name, gte="now/d", time_zone=time_zone)
+            # )
         else:
-            query.filter.append(planning_schedule)
+            query.filter.append(query_range)
             query.extra["sort_filter"] = query_range
 
 
@@ -230,14 +233,7 @@ def search_date_default(params: Dict[str, Any], query: elastic.ElasticQuery):
             )
         )
 
-        query.filter.append(
-            {
-                "nested": {
-                    "path": "_planning_schedule",
-                    "query": {"bool": {"filter": query_range}},
-                }
-            }
-        )
+        query.filter.append(query_range)
 
 
 def search_dates(params: Dict[str, Any], query: elastic.ElasticQuery):


### PR DESCRIPTION
### Purpose
When Planning item's have the `all_day` flag enabled, we're currently not modifying our search to reflect this international all day concept.

### What has changed
* Modify the generated elasticsearch query to include checking UTC date of Planning items with `all_day` flag enabled

Resolves: [SDESK-7797](https://sofab.atlassian.net/browse/SDESK-7797)



[SDESK-7797]: https://sofab.atlassian.net/browse/SDESK-7797?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ