### PR TITLE
[STT-1434] - Fix null handling in CustomCV subject field

### DIFF
--- a/client/components/fields/editor/CustomCV.tsx
+++ b/client/components/fields/editor/CustomCV.tsx
@@ -40,7 +40,7 @@ export class EditorFieldCV extends React.PureComponent<ICustomCVFieldProps> {
                     sortable={true}
                     kind="synchronous"
                     allowMultiple={cv.selection_type === 'multi selection'}
-                    value={get(item, storageField ?? 'subject', []).filter((x) => x.scheme === cv._id)}
+                    value={(get(item, storageField ?? 'subject') ?? []).filter((x) => x.scheme === cv._id)}
                     label={cv.translations?.display_name?.[language] ?? cv.display_name}
                     required={this.props.schema.required}
 
@@ -69,7 +69,7 @@ export class EditorFieldCV extends React.PureComponent<ICustomCVFieldProps> {
                     readOnly={disabled}
                     disabled={disabled}
                     onChange={(vocabularyItemsNext) => {
-                        const itemsFromOtherVocabularies = get(item, storageField ?? 'subject', [])
+                        const itemsFromOtherVocabularies = (get(item, storageField ?? 'subject') ?? [])
                             .filter((x) => x.scheme !== cv._id);
 
                         onChange(


### PR DESCRIPTION
### Purpose 
Fix the Assignments view that breaks when clearing custom CV selector in the filters panel. 

### What has changed
- Replaces default empty array with nullish coalescing for subject field value and filtering, ensuring correct behavior when the field is undefined. The problem happened when the user reset the value of the field, the `storageField/subject` remains in the item but with `null` value therefore making the `.filter` function break. 

#### To test, please follow the steps in the ticket as they are pretty clear.

Resolves: [STT-1434]


[STT-1434]: https://sofab.atlassian.net/browse/STT-1434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ