### PR TITLE
[SDBELGA-1005] fix: SelectUser not updating with Desk selection

### DIFF
--- a/client/components/Assignments/AssignmentEditor.tsx
+++ b/client/components/Assignments/AssignmentEditor.tsx
@@ -327,6 +327,7 @@ export class AssignmentEditorComponent extends React.Component<IProps, IState> {
                     <Row>
                         <div data-test-id={this.FIELDS.USER}>
                             <SelectUser
+                                key={this.props.value.assigned_to?.desk ?? null}
                                 disabled={disableUserSelection}
                                 deskId={this.props.value.assigned_to?.desk ?? null}
                                 selectedUserId={this.state.userId}

--- a/client/components/Coverages/CoverageAddAdvancedModal.tsx
+++ b/client/components/Coverages/CoverageAddAdvancedModal.tsx
@@ -288,6 +288,7 @@ export class CoverageAddAdvancedModal extends React.Component<IProps, IState> {
                                                         }
                                                     >
                                                         <SelectUser
+                                                            key={`${coverage.desk?._id}-${index}`}
                                                             deskId={coverage.desk?._id ?? undefined}
                                                             selectedUserId = {coverage.user?._id}
                                                             onSelect={(user) => {

--- a/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx
+++ b/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx
@@ -64,6 +64,7 @@ export class CoverageFormHeaderComponent extends React.PureComponent<IProps> {
             disableDeskSelection: this.props.addNewsItemToPlanning != null || (
                 this.props.value.assigned_to?.state != null
                 && ![
+                    ASSIGNMENTS.WORKFLOW_STATE.DRAFT,
                     ASSIGNMENTS.WORKFLOW_STATE.ASSIGNED,
                     ASSIGNMENTS.WORKFLOW_STATE.SUBMITTED,
                 ].includes(this.props.value.assigned_to.state)

--- a/client/components/fields/editor/EventRelatedPlannings/EmbeddedCoverageForm.tsx
+++ b/client/components/fields/editor/EventRelatedPlannings/EmbeddedCoverageForm.tsx
@@ -193,6 +193,7 @@ export class EmbeddedCoverageFormComponent extends React.PureComponent<IProps, I
                             style={{padding: '2rem 0'}}
                         >
                             <SelectUser
+                                key={coverage.desk?._id}
                                 deskId={coverage.desk?._id}
                                 onSelect={(user) => {
                                     this.onUserChange(null, user);

--- a/client/constants/assignments.ts
+++ b/client/constants/assignments.ts
@@ -33,6 +33,7 @@ export const ASSIGNMENTS = {
         SET_LOADING: 'SET_LOADING',
     },
     WORKFLOW_STATE: {
+        DRAFT: 'draft',
         ASSIGNED: 'assigned',
         IN_PROGRESS: 'in_progress',
         COMPLETED: 'completed',


### PR DESCRIPTION
### Purpose
The SelectUser input was not updating the list of available users when the DeskId changes.

### What has changed
Force a re-mount of the SelectUser component.

Resolves: [SDBELGA-1005](https://sofab.atlassian.net/browse/SDBELGA-1005)



[SDBELGA-1005]: https://sofab.atlassian.net/browse/SDBELGA-1005?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ