### PR TITLE
[STT-1424] - Improve and fix update time

### DIFF
--- a/client/actions/events/api.ts
+++ b/client/actions/events/api.ts
@@ -449,7 +449,10 @@ const updateEventTime = (original, updates) => (
             original,
             {
                 update_method: get(updates, 'update_method.value', EVENTS.UPDATE_METHODS[0].value),
-                dates: updates.dates,
+                dates: {
+                    ...updates.dates,
+                    no_end_time: false,
+                },
                 [TO_BE_CONFIRMED_FIELD]: false,
             }
         );

--- a/client/utils/events.tsx
+++ b/client/utils/events.tsx
@@ -973,7 +973,8 @@ function getEventActions(
 
     let actions = [];
     const isExpired = isItemExpired(item);
-    let alllowedCallBacks = [
+
+    let allowedCallBacks = [
         EVENTS.ITEM_ACTIONS.PREVIEW.actionName,
         EVENTS.ITEM_ACTIONS.EDIT_EVENT.actionName,
         EVENTS.ITEM_ACTIONS.EDIT_EVENT_MODAL.actionName,
@@ -982,7 +983,6 @@ function getEventActions(
         EVENTS.ITEM_ACTIONS.CANCEL_EVENT.actionName,
         EVENTS.ITEM_ACTIONS.SPIKE.actionName,
         EVENTS.ITEM_ACTIONS.UNSPIKE.actionName,
-        EVENTS.ITEM_ACTIONS.UPDATE_TIME.actionName,
         EVENTS.ITEM_ACTIONS.POSTPONE_EVENT.actionName,
         EVENTS.ITEM_ACTIONS.RESCHEDULE_EVENT.actionName,
         EVENTS.ITEM_ACTIONS.UPDATE_REPETITIONS.actionName,
@@ -990,19 +990,23 @@ function getEventActions(
         EVENTS.ITEM_ACTIONS.MARK_AS_COMPLETED.actionName,
     ];
 
+    if (appConfig.planning_event_link_method !== 'many_secondary') {
+        allowedCallBacks.push(EVENTS.ITEM_ACTIONS.UPDATE_TIME.actionName);
+    }
+
     if (appConfig.event_templates_enabled === true) {
-        alllowedCallBacks.push(EVENTS.ITEM_ACTIONS.SAVE_AS_TEMPLATE.actionName);
+        allowedCallBacks.push(EVENTS.ITEM_ACTIONS.SAVE_AS_TEMPLATE.actionName);
     }
 
     if (isExpired && !privileges[PRIVILEGES.EDIT_EXPIRED]) {
-        alllowedCallBacks = [EVENTS.ITEM_ACTIONS.DUPLICATE.actionName];
+        allowedCallBacks = [EVENTS.ITEM_ACTIONS.DUPLICATE.actionName];
     }
 
     if (isItemSpiked(item)) {
-        alllowedCallBacks = [EVENTS.ITEM_ACTIONS.UNSPIKE.actionName];
+        allowedCallBacks = [EVENTS.ITEM_ACTIONS.UNSPIKE.actionName];
     }
 
-    alllowedCallBacks.forEach((callbackName) => {
+    allowedCallBacks.forEach((callbackName) => {
         const action = find(EVENTS.ITEM_ACTIONS, (action) => action.actionName === callbackName);
 
         if (callBacks[action.actionName]) {


### PR DESCRIPTION
### Purpose
If event link is set to `many_secondary` hide the Update time action since we can update time via the editor field. 

In the case it's not, fix the update time action.

### What has changed
Conditionally add update time action. 
Set `no_end_time` flag to `false` since it's always required to have and end time in the update time modal, and also to allow the updates to be properly rendered in the UI.

Resolves: #[STT-1424](https://sofab.atlassian.net/browse/STT-1424)



[STT-1424]: https://sofab.atlassian.net/browse/STT-1424?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ