### PR TITLE
[STT-1453] - Fix `Assignement` view being jumpy when filtered by date

### DIFF
--- a/client/components/Assignments/AssignmentGroupList.tsx
+++ b/client/components/Assignments/AssignmentGroupList.tsx
@@ -13,7 +13,7 @@ import {assignmentUtils} from '../../utils';
 import {AssignmentMultiTextItem} from './AssignmentItem/AssignmentMultiTextItem';
 import {Header, Group} from '../UI/List';
 import {OrderDirectionIcon} from '../OrderBar';
-import {ListItemLoader} from 'superdesk-ui-framework/react/components/ListItemLoader';
+import {ListItemLoader, LoadMoreIndicator} from 'superdesk-ui-framework/react';
 import moment from 'moment';
 
 const focusElement = throttle((element: HTMLElement) => {
@@ -207,7 +207,7 @@ class AssignmentGroupListComponent extends React.Component<IProps, IState> {
         }
     }
 
-    rowRenderer(index) {
+    rowRenderer(assignment) {
         const {
             users,
             session,
@@ -219,7 +219,6 @@ class AssignmentGroupListComponent extends React.Component<IProps, IState> {
             archiveItems,
         } = this.props;
 
-        const assignment = this.props.assignments[index];
         const assignedUser = users.find((user) => get(assignment, 'assigned_to.user') === user._id);
         const isCurrentUser = assignedUser && assignedUser._id === session.identity._id;
         const onDoubleClick = assignmentUtils.assignmentHasContent(assignment) ?
@@ -333,15 +332,25 @@ class AssignmentGroupListComponent extends React.Component<IProps, IState> {
                     refNode={(assignmentsList) => this.dom.list = assignmentsList}
                     tabIndex={-1}
                 >
-                    {isLoading === true && (
-                        <ListItemLoader />
+                    {/* only show this loader when no items exist yet */}
+                    {isLoading === true && (filteredAssignments?.length ?? 0) === 0 && <ListItemLoader />}
+
+                    {filteredAssignments?.length > 0 && (
+                        <>
+                            {filteredAssignments.map((assignment) => this.rowRenderer(assignment))}
+
+                            <LoadMoreIndicator
+                                loading={this.state.isNextPageLoading}
+                                currentCount={filteredAssignments.length}
+                                totalCount={totalCount}
+                                loadingText={gettext('Loading more...')}
+                            />
+                        </>
                     )}
-                    {isLoading !== true && (
-                        (filteredAssignments?.length ?? 0) > 0 ? (
-                            filteredAssignments.map((_assignment, index) => this.rowRenderer(index))
-                        ) : (
-                            <li className="sd-list-item-group__empty-msg">{groupEmptyMessage}</li>
-                        )
+
+                    {/* only when not loading and no items */}
+                    {!isLoading && (filteredAssignments?.length ?? 0) === 0 && (
+                        <li className="sd-list-item-group__empty-msg">{groupEmptyMessage}</li>
                     )}
                 </Group>
             </div>

--- a/client/styles/index.scss
+++ b/client/styles/index.scss
@@ -122,3 +122,7 @@
         word-break: break-word;
     }
 }
+
+[class="icon-dots-vertical"], [class="icon-pencil"] {
+    pointer-events: unset !important;
+}

--- a/e2e/cypress/support/common/inputs/coverageUserSelectInput.ts
+++ b/e2e/cypress/support/common/inputs/coverageUserSelectInput.ts
@@ -15,7 +15,7 @@ export class CoverageUserSelectInput extends Input {
 
         popup.element.find('[data-test-id="filter-input"]', {timeout: 2000})
             .should('be.enabled')
-            .type(value);
+            .type(value, {force: true});
 
         popup.element.find('li')
             .first()

--- a/e2e/cypress/support/common/ui/actionMenu.ts
+++ b/e2e/cypress/support/common/ui/actionMenu.ts
@@ -38,8 +38,8 @@ export class ActionMenu {
      */
     open() {
         cy.log('Common.UI.ActionMenu.open');
-        // force click in case of `pointer-events: none`
-        this.menuButton.click({force: true});
+        this.menuButton.click();
+        // this.menuButton.click({force: true});
         this.popup.waitTillOpen();
         return this;
     }

--- a/e2e/cypress/support/common/ui/actionMenu.ts
+++ b/e2e/cypress/support/common/ui/actionMenu.ts
@@ -38,8 +38,8 @@ export class ActionMenu {
      */
     open() {
         cy.log('Common.UI.ActionMenu.open');
-        this.menuButton.click();
-        // this.menuButton.click({force: true});
+        // force click in case of `pointer-events: none`
+        this.menuButton.click({force: true});
         this.popup.waitTillOpen();
         return this;
     }


### PR DESCRIPTION
### What has changed
- Updated AssignmentGroupList to pass assignment objects directly to rowRenderer instead of indices.
- Improved loading and empty state handling: ListItemLoader now only shows when no items are loaded, and LoadMoreIndicator is added for paginated loading.

Resolves: [STT-1453]



[STT-1453]: https://sofab.atlassian.net/browse/STT-1453?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ