### PR TITLE
[STT-1453] - Fix scroll handler to prevent duplicate loading

### DIFF
--- a/client/components/Assignments/AssignmentGroupList.tsx
+++ b/client/components/Assignments/AssignmentGroupList.tsx
@@ -90,20 +90,20 @@ class AssignmentGroupListComponent extends React.Component<IProps, IState> {
         }
     }
 
-    handleScroll(event: React.UIEvent) {
-        if (this.state.isNextPageLoading) {
+    handleScroll(event: React.UIEvent<HTMLUListElement>) {
+        if (this.state.isNextPageLoading || this.props.isLoading) {
             return;
         }
 
-        const node = event.target;
+        const node = event.target as HTMLUListElement;
         const {totalCount, assignments, loadMoreAssignments, groupKey} = this.props;
 
         if (node && totalCount > get(assignments, 'length', 0)) {
             if (node.scrollTop + node.offsetHeight + 200 >= node.scrollHeight) {
-                this.setState({isNextPageLoading: true});
-
-                loadMoreAssignments(groupKey)
-                    .finally(() => this.setState({isNextPageLoading: false}));
+                this.setState({isNextPageLoading: true}, () => {
+                    loadMoreAssignments(groupKey)
+                        .finally(() => this.setState({isNextPageLoading: false}));
+                });
             }
         }
     }


### PR DESCRIPTION
### Purpose
To fix the infinite loading triggered in `onScroll` handler in assignments list

### What has changed
- Updated handleScroll to also check the isLoading prop before triggering loadMoreAssignments, preventing duplicate loading when already in progress. 
- Also improved setState usage to ensure isNextPageLoading is set before loading more assignments.

[STT-1453]


[STT-1453]: https://sofab.atlassian.net/browse/STT-1453?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ