### PR TITLE
[STT-1453] Track fetched assignment count in AssignmentGroupList

### DIFF
--- a/client/components/Assignments/AssignmentGroupList.tsx
+++ b/client/components/Assignments/AssignmentGroupList.tsx
@@ -37,7 +37,6 @@ interface IProps {
     hideItemActions?: boolean;
     privileges?: any;
     startWorking?: () => any;
-    totalCount?: number;
     changeAssignmentListSingleGroupView?: (groupKey: string) => any;
     assignmentListSingleGroupView?: string;
     preview?: () => any;
@@ -58,6 +57,16 @@ interface IProps {
     isLoading?: boolean;
     dayField?: string;
     archiveItems: {[itemId: string]: IArticle};
+
+    /**
+     * Total number of assignments in the current group as reported by the server
+     */
+    totalCount?: number;
+
+    /**
+     * The actual count of assignments that have been fetched from the server for the current group
+     */
+    groupAssignmentsFetchedCount: number;
 }
 
 interface IState {
@@ -96,9 +105,9 @@ class AssignmentGroupListComponent extends React.Component<IProps, IState> {
         }
 
         const node = event.target as HTMLUListElement;
-        const {totalCount, assignments, loadMoreAssignments, groupKey} = this.props;
+        const {totalCount, groupAssignmentsFetchedCount, loadMoreAssignments, groupKey} = this.props;
 
-        if (node && totalCount > get(assignments, 'length', 0)) {
+        if (node && totalCount > groupAssignmentsFetchedCount) {
             if (node.scrollTop + node.offsetHeight + 200 >= node.scrollHeight) {
                 this.setState({isNextPageLoading: true}, () => {
                     loadMoreAssignments(groupKey)
@@ -380,6 +389,7 @@ const mapStateToProps = (state, ownProps) => {
         isLoading: assignmentDataSelector.isLoading(state),
         archiveItems: selectors.getStoredArchiveItems(state),
         totalCount: assignmentDataSelector.countSelector(state),
+        groupAssignmentsFetchedCount: assignmentDataSelector.assignmentIds(state).length,
     };
 };
 


### PR DESCRIPTION
### Purpose
To fix the issue with infinite loading in scroll handler in Assignments Group. The problem was that when the assignments are filter by day, the total count of filtered assignments in that day will never be the same as the total count reported by the server, therefore triggering infinite fetching when handling the scroll in the assignment group list

### What has changed
- Added groupAssignmentsFetchedCount prop to distinguish between total assignments reported by the server and the number actually fetched. 
- Updated scroll loading logic to use the fetched count, improving accuracy when loading more assignments.

[STT-1453]


[STT-1453]: https://sofab.atlassian.net/browse/STT-1453?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ