### PR TITLE
[SDESK-6761] improve: Loading of publish queue preview

### DIFF
--- a/client/apps/PublishQueuePanel.tsx
+++ b/client/apps/PublishQueuePanel.tsx
@@ -1,15 +1,29 @@
-import React from 'react';
+import React, {useState, useEffect} from 'react';
 import {Provider} from 'react-redux';
-import PropTypes from 'prop-types';
-import {PublishQueuePreview} from '../components/PublishQueuePreview';
+import {Store} from 'redux';
+import {Loader} from 'superdesk-ui-framework/react';
+import {PublishQueuePreview} from '../components';
 
-export const PublishQueuePanel = ({store}) => (
-    <Provider store={store}>
-        <PublishQueuePreview />
-    </Provider>
-);
+interface IProps {
+    storePromise: Promise<Store>;
+}
 
+export const PublishQueuePanel: React.FC<IProps> = ({storePromise}) => {
+    const [store, setStore] = useState<Store | null>(null);
 
-PublishQueuePanel.propTypes = {store: PropTypes.object};
+    useEffect(() => {
+        storePromise.then((loadedStore) => {
+            setStore(loadedStore);
+        });
+    }, []); // Empty dependency array ensures it runs only once on mount
 
-
+    return store == null ? (
+        <div className="sd-preview-panel  preview-pane content-item-preview">
+            <Loader />
+        </div>
+    ) : (
+        <Provider store={store}>
+            <PublishQueuePreview />
+        </Provider>
+    );
+};

--- a/client/components/Main/ItemPreview/PreviewPanel.tsx
+++ b/client/components/Main/ItemPreview/PreviewPanel.tsx
@@ -181,6 +181,7 @@ export class PreviewPanelComponent extends React.Component<IPreviewPanelProps, I
                 className="content"
                 shadowRight={true}
                 bg00={true}
+                style={{insetBlockStart: 0}}
             >
                 <Header darkBlue={isEvent} darker={!isEvent}>
                     <Tools tools={this.tools} />

--- a/client/components/PublishQueuePreview.tsx
+++ b/client/components/PublishQueuePreview.tsx
@@ -1,56 +1,79 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
-import {PreviewPanel} from './Main/ItemPreview';
+import {isEqual} from 'lodash';
+import {Loader} from 'superdesk-ui-framework/react';
+
+import {IAssignmentOrPlanningItem} from '../interfaces';
 import * as actions from '../actions';
 import * as selectors from '../selectors';
-import {isEqual} from 'lodash';
+import {PreviewPanel} from './Main';
 
+interface IStateProps {
+    item: IAssignmentOrPlanningItem;
+}
 
-class PublishQueuePreviewComponent extends React.Component {
-    componentDidMount() {
-        const {item} = this.props;
+interface IDispatchProps {
+    fetchQueueItemAndPreview(item: IAssignmentOrPlanningItem): Promise<any>;
+}
 
-        this.props.fetchQueueItemAndPreview(item);
+type IProps = IStateProps & IDispatchProps;
+
+interface IState {
+    loading: boolean;
+}
+
+class PublishQueuePreviewComponent extends React.Component<IProps, IState> {
+    constructor(props: IProps) {
+        super(props);
+        this.state = {loading: true};
     }
 
-    componentWillReceiveProps(nextProps) {
-        const {item} = nextProps;
-        const previousItem = this.props.item;
+    componentDidMount() {
+        this.loadItem();
+    }
 
-        if (item && !isEqual(item, previousItem)) {
-            return this.props.fetchQueueItemAndPreview(item)
-                .then(() => this.props.fetchAgendas());
+    componentDidUpdate(prevProps: Readonly<IProps>) {
+        if (this.props.item && !isEqual(this.props.item, prevProps.item)) {
+            this.loadItem();
         }
+    }
+
+    loadItem() {
+        this.setState({loading: true}, () => {
+            this.props.fetchQueueItemAndPreview(this.props.item)
+                .finally(() => {
+                    setTimeout(() => this.setState({loading: false}), 250);
+                });
+                // .finally(() => this.setState({loading: false}));
+        });
     }
 
     render() {
         return (
             <div className="sd-preview-panel  preview-pane content-item-preview">
-                <PreviewPanel
-                    showUnlock={false}
-                    hideItemActions={true}
-                    hideEditIcon={true}
-                    inPlanning={false}
-                    hideRelatedItems={true}
-                    hideHistory={true}
-                />
+                {this.state.loading ? (
+                    <Loader />
+                ) : (
+                    <PreviewPanel
+                        showUnlock={false}
+                        hideItemActions={true}
+                        hideEditIcon={true}
+                        inPlanning={false}
+                        hideRelatedItems={true}
+                        hideHistory={true}
+                    />
+                )}
             </div>
         );
     }
 }
 
-PublishQueuePreviewComponent.propTypes = {
-    item: PropTypes.object,
-    fetchQueueItemAndPreview: PropTypes.func,
-    fetchAgendas: PropTypes.func,
-};
-
 const mapStateToProps = (state) => ({item: selectors.main.publishQueuePreviewItem(state)});
 
 const mapDispatchToProps = (dispatch) => ({
     fetchQueueItemAndPreview: (item) => dispatch(actions.main.fetchQueueItemAndPreview(item)),
-    fetchAgendas: () => dispatch(actions.fetchAgendas()),
 });
 
-export const PublishQueuePreview = connect(mapStateToProps, mapDispatchToProps)(PublishQueuePreviewComponent);
+export const PublishQueuePreview = connect<IStateProps, IDispatchProps, {}>(
+    mapStateToProps, mapDispatchToProps)(PublishQueuePreviewComponent
+);

--- a/client/components/PublishQueuePreview.tsx
+++ b/client/components/PublishQueuePreview.tsx
@@ -41,10 +41,7 @@ class PublishQueuePreviewComponent extends React.Component<IProps, IState> {
     loadItem() {
         this.setState({loading: true}, () => {
             this.props.fetchQueueItemAndPreview(this.props.item)
-                .finally(() => {
-                    setTimeout(() => this.setState({loading: false}), 250);
-                });
-                // .finally(() => this.setState({loading: false}));
+                .finally(() => this.setState({loading: false}));
         });
     }
 

--- a/client/components/UI/SidePanel/SidePanel.tsx
+++ b/client/components/UI/SidePanel/SidePanel.tsx
@@ -8,6 +8,7 @@ interface IProps {
     transparent?: boolean;
     bg00?: boolean;
     className?: string;
+    style?: React.CSSProperties;
     testId?: string;
 }
 
@@ -23,6 +24,7 @@ export const SidePanel: React.FC<IProps> = ({
     transparent = false,
     bg00 = false,
     className = '',
+    style,
     testId,
 }) => (
     <div
@@ -37,6 +39,7 @@ export const SidePanel: React.FC<IProps> = ({
             className
         )}
         data-test-id={testId}
+        style={style}
     >
         {children}
     </div>

--- a/client/index.ts
+++ b/client/index.ts
@@ -113,7 +113,9 @@ export default angular.module('superdesk-planning', [])
                         scope.$watch('selected.preview', (newValue) => {
                             store.dispatch(actions.main.onQueueItemChange(newValue));
                         });
-                        setTimeout(() => resolve(store), 500);
+
+                        // Use a timeout as resolving the promise straight away causes the app to crash
+                        setTimeout(() => resolve(store));
                     });
                 });
 

--- a/client/index.ts
+++ b/client/index.ts
@@ -105,15 +105,20 @@ export default angular.module('superdesk-planning', [])
 
             ng.register($injector);
 
-            const callback = (extension, scope) => (
-                sdPlanningStore.initWorkspace(WORKSPACE.AUTHORING, (store) => {
-                    store.dispatch(actions.fetchAgendas());
-                    extension.props.store = store;
-                    scope.$watch('selected.preview', (newValue) => {
-                        extension.props.store.dispatch(actions.main.onQueueItemChange(newValue));
+            const callback = (extension, scope) => {
+                extension.props.storePromise = new Promise((resolve) => {
+                    sdPlanningStore.initWorkspace(WORKSPACE.AUTHORING, (store) => {
+                        store.dispatch(actions.fetchAgendas());
+                        actions.main.onQueueItemChange(scope.selected?.preview);
+                        scope.$watch('selected.preview', (newValue) => {
+                            store.dispatch(actions.main.onQueueItemChange(newValue));
+                        });
+                        setTimeout(() => resolve(store), 500);
                     });
-                })
-            );
+                });
+
+                return Promise.resolve();
+            };
 
             ng.waitForServicesToBeAvailable()
                 .then(() => {


### PR DESCRIPTION
### Purpose
When opening the preview of a `Planning` or `Event` item in the Publish Queue page, the preview area would open but show up blank until all data it loaded.

Loading of data includes [many things](https://github.com/superdesk/superdesk-planning/blob/develop/client/services/PlanningStoreService.ts#L178), to ensure all required data is in the redux store.


### What has changed
Improve the user experience by providing a loading animation while the required data is fetched, showing the user that their interaction has started.

There was also a gap at the top of the preview that was caused by css classes in the SidePanel from core. Added a style prop to fix this (should ideally be looked at in the UI-Framework/Superdesk-Client-Core).

### Screenshots
**Previous Experience**
[publish_queue_loading_planning_previous_experience.webm](https://github.com/user-attachments/assets/bb8d09ec-c211-42dc-a4e9-aa8135d75bba)

**New Experience**
[publish_queue_loading_planning_new_experience.webm](https://github.com/user-attachments/assets/b0426c76-9141-400e-aade-58d725adfe08)

### Front-end checklist
- [x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [x] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [x] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [x] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [x] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [x] This pull request is not adding redux based modals
- [x] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [x] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)

Resolves: [SDESK-6761](https://sofab.atlassian.net/browse/SDESK-6761)



[SDESK-6761]: https://sofab.atlassian.net/browse/SDESK-6761?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ