### PR TITLE
[STT-1453] - Fix assignment's date filtering logic

### DIFF
--- a/client/components/Assignments/AssignmentGroupList.tsx
+++ b/client/components/Assignments/AssignmentGroupList.tsx
@@ -14,7 +14,6 @@ import {AssignmentMultiTextItem} from './AssignmentItem/AssignmentMultiTextItem'
 import {Header, Group} from '../UI/List';
 import {OrderDirectionIcon} from '../OrderBar';
 import {ListItemLoader, LoadMoreIndicator} from 'superdesk-ui-framework/react';
-import moment from 'moment';
 
 const focusElement = throttle((element: HTMLElement) => {
     element.focus();
@@ -283,11 +282,7 @@ class AssignmentGroupListComponent extends React.Component<IProps, IState> {
         } = this.props;
         const listStyle = setMaxHeight ? {maxHeight: this.getListMaxHeight() + 'px'} : {};
         const headingId = `heading--${this.props.groupKey}`;
-        const filteredAssignments = this.props.dayField == null
-            ? assignments
-            : assignments.filter((assignment) =>
-                moment(assignment.planning.scheduled).isSameOrAfter(moment(this.props.dayField)),
-            );
+        const assignmentsCount = assignments?.length ?? 0;
 
         return (
             <div data-test-id="assignment-group__list">
@@ -310,9 +305,9 @@ class AssignmentGroupListComponent extends React.Component<IProps, IState> {
                             <div className="sd-list-header__number sd-flex-grow">
                                 <span className="a11y-only">{gettext(
                                     'Number of Assignments: ',
-                                    {count: (totalCount ?? 0)}
+                                    {count: (assignmentsCount)}
                                 )}</span>
-                                <span className="badge">{(totalCount ?? 0)}</span>
+                                <span className="badge">{(assignmentsCount)}</span>
                             </div>
                         )}
 
@@ -342,15 +337,15 @@ class AssignmentGroupListComponent extends React.Component<IProps, IState> {
                     tabIndex={-1}
                 >
                     {/* only show this loader when no items exist yet */}
-                    {isLoading === true && (filteredAssignments?.length ?? 0) === 0 && <ListItemLoader />}
+                    {isLoading === true && (assignmentsCount) === 0 && <ListItemLoader />}
 
-                    {filteredAssignments?.length > 0 && (
+                    {assignmentsCount > 0 && (
                         <>
-                            {filteredAssignments.map((assignment) => this.rowRenderer(assignment))}
+                            {assignments.map((assignment) => this.rowRenderer(assignment))}
 
                             <LoadMoreIndicator
                                 loading={this.state.isNextPageLoading}
-                                currentCount={filteredAssignments.length}
+                                currentCount={assignmentsCount}
                                 totalCount={totalCount}
                                 loadingText={gettext('Loading more...')}
                             />
@@ -358,7 +353,7 @@ class AssignmentGroupListComponent extends React.Component<IProps, IState> {
                     )}
 
                     {/* only when not loading and no items */}
-                    {!isLoading && (filteredAssignments?.length ?? 0) === 0 && (
+                    {!isLoading && (assignmentsCount) === 0 && (
                         <li className="sd-list-item-group__empty-msg">{groupEmptyMessage}</li>
                     )}
                 </Group>

--- a/client/selectors/assignments.ts
+++ b/client/selectors/assignments.ts
@@ -17,6 +17,7 @@ import {currentUserId} from './general';
 import {coverageProfiles} from './coverageProfiles';
 import {getItemsById} from '../utils';
 import {ASSIGNMENTS, SORT_DIRECTION, ALL_DESKS} from '../constants';
+import moment from 'moment';
 
 export const getStoredAssignments = (state) => get(state, 'assignment.assignments', {});
 export const getStoredArchiveItems = (state) => get(state, 'assignment.archive', {});
@@ -45,12 +46,10 @@ const filterBySelectedDay = (
 ) => {
     if (selectedDate == null) return assignments;
 
-    const targetDay = new Date(selectedDate).toDateString();
-
     return assignments.filter((assignment) => {
         const scheduled = assignment?.planning?.scheduled;
 
-        return scheduled != null && new Date(scheduled).toDateString() === targetDay;
+        return scheduled != null && moment(scheduled).isSame(selectedDate, 'day');
     });
 };
 


### PR DESCRIPTION
### What has changed
- (Re)moved assignment date filtering from `AssignmentGroupList` component to the assignments selector
- Replaced manual date comparison with moment.js's `isSame` method for improved accuracy with timezones.
- Fix counter badge to display the right value (after filtering)

Resolves: [STT-1453]


[STT-1453]: https://sofab.atlassian.net/browse/STT-1453?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ