### PR TITLE
[STT-1462] - Replace `react-bootstrap` tooltips with `superdesk-ui-framework`

### DIFF
--- a/client/components/Agendas/AgendaNameList.tsx
+++ b/client/components/Agendas/AgendaNameList.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {get, sortBy} from 'lodash';
 import {gettext} from '../../utils';
-import {OverlayTrigger, Tooltip} from 'react-bootstrap';
+import {Tooltip} from 'superdesk-ui-framework/react';
 
 export const AgendaNameList = ({agendas}) => {
     let tooltipElem = (agendas || []).map((a) =>
@@ -13,14 +13,7 @@ export const AgendaNameList = ({agendas}) => {
         <span>
             {get(agendas, 'length', 0) === 0 ? gettext('No Agenda Assigned.') :
                 (
-                    <OverlayTrigger
-                        placement="left"
-                        overlay={(
-                            <Tooltip id="agenda_tooltip" className="tooltip--text-left">
-                                {tooltipElem}
-                            </Tooltip>
-                        )}
-                    >
+                    <Tooltip content={tooltipElem} placement="left">
                         <span>
                             {sortBy(agendas.filter((a) => a), [(a) => get(a, 'name', '').toLowerCase()])
                                 .map((a, index, arr) => (
@@ -30,8 +23,9 @@ export const AgendaNameList = ({agendas}) => {
                                     >
                                         {a.name}{index === arr.length - 1 ? '' : ', '}
                                     </span>
-                                ))}</span>
-                    </OverlayTrigger>
+                                ))}
+                        </span>
+                    </Tooltip>
                 )
             }
         </span>

--- a/client/components/Assignments/AssignmentItem/index.tsx
+++ b/client/components/Assignments/AssignmentItem/index.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import moment from 'moment';
 import {get, debounce, Cancelable} from 'lodash';
-import {OverlayTrigger, Tooltip} from 'react-bootstrap';
 
 import {superdeskApi} from '../../../superdeskApi';
 import {IUser, IDesk, IArticle} from 'superdesk-api';
@@ -19,7 +18,7 @@ import {assignmentUtils, planningUtils} from '../../../utils';
 import {ASSIGNMENTS, CLICK_DELAY} from '../../../constants';
 import {editPlanningInNewTab, getAssignmentTypeInfo} from '../../../utils/assignments';
 
-import {Menu} from 'superdesk-ui-framework/react';
+import {Menu, Tooltip} from 'superdesk-ui-framework/react';
 import {UserAvatar} from '../../../components/UserAvatar';
 import {Item, Border, Column} from '../../UI/List';
 
@@ -143,12 +142,12 @@ export class AssignmentItem extends React.Component<IAssignmentItemProps, IState
         return (
             <Column>
                 <span className="a11y-only">{tooltip}</span>
-                <OverlayTrigger
+                <Tooltip
+                    content={tooltip}
                     placement="right"
-                    overlay={<Tooltip id="content_type">{tooltip}</Tooltip>}
                 >
                     <i className={className} />
-                </OverlayTrigger>
+                </Tooltip>
             </Column>
         );
     }

--- a/client/components/Editor/bookmarks/AddCoverageBookmark.tsx
+++ b/client/components/Editor/bookmarks/AddCoverageBookmark.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {OverlayTrigger, Tooltip} from 'react-bootstrap';
+import {Tooltip} from 'superdesk-ui-framework/react';
 import classNames from 'classnames';
 
 import {EDITOR_TYPE, IBookmarkProps, IG2ContentType, IPlanningCoverageItem, IPlanningItem} from '../../../interfaces';
@@ -52,13 +52,9 @@ export class AddCoverageBookmark extends React.PureComponent<IProps> {
                 target="icon-plus-sign"
                 language={this.props.item.language}
                 button={({toggleMenu}) => (
-                    <OverlayTrigger
+                    <Tooltip
+                        content={gettext('Add Coverage')}
                         placement="right"
-                        overlay={(
-                            <Tooltip id="coverage_links">
-                                {gettext('Add Coverage')}
-                            </Tooltip>
-                        )}
                     >
                         <button
                             data-test-id={`editor--bookmarks__${this.props.bookmark.id}`}
@@ -74,7 +70,7 @@ export class AddCoverageBookmark extends React.PureComponent<IProps> {
                         >
                             <Icon name="plus-sign" />
                         </button>
-                    </OverlayTrigger>
+                    </Tooltip>
                 )}
             />
         );

--- a/client/components/Editor/bookmarks/AddPlanningBookmark.tsx
+++ b/client/components/Editor/bookmarks/AddPlanningBookmark.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {OverlayTrigger, Tooltip} from 'react-bootstrap';
+import {Tooltip} from 'superdesk-ui-framework/react';
 import classNames from 'classnames';
 
 import {EDITOR_TYPE, IBookmarkProps} from '../../../interfaces';
@@ -26,13 +26,9 @@ export class AddPlanningBookmark extends React.PureComponent<IBookmarkProps> {
         const {gettext} = superdeskApi.localization;
 
         return (
-            <OverlayTrigger
+            <Tooltip
+                content={gettext('Add Planning Item')}
                 placement="right"
-                overlay={(
-                    <Tooltip id="add_planning_item">
-                        {gettext('Add Planning Item')}
-                    </Tooltip>
-                )}
             >
                 <button
                     data-test-id={`editor--bookmarks__${this.props.bookmark.id}`}
@@ -48,7 +44,7 @@ export class AddPlanningBookmark extends React.PureComponent<IBookmarkProps> {
                 >
                     <Icon name="plus-large" />
                 </button>
-            </OverlayTrigger>
+            </Tooltip>
         );
     }
 }

--- a/client/components/Editor/bookmarks/AssociatedPlanningsBookmark.tsx
+++ b/client/components/Editor/bookmarks/AssociatedPlanningsBookmark.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {OverlayTrigger, Tooltip} from 'react-bootstrap';
+import {Tooltip} from 'superdesk-ui-framework/react';
 import classNames from 'classnames';
 
 import {EDITOR_TYPE, IBookmarkProps, IEventItem, IPlanningItem} from '../../../interfaces';
@@ -50,16 +50,12 @@ export class AssociatedPlanningsBookmark extends React.Component<IProps, IState>
         const {gettext} = superdeskApi.localization;
 
         return this.props.item.associated_plannings.map((plan, index) => (
-            <OverlayTrigger
+            <Tooltip
                 key={plan._id}
+                content={gettext('Planning: {{ name }}', {
+                    name: plan.slugline || plan.headline || plan.name,
+                })}
                 placement="right"
-                overlay={(
-                    <Tooltip id="associated_plannings">
-                        {gettext('Planning: {{ name }}', {
-                            name: plan.slugline || plan.headline || plan.name,
-                        })}
-                    </Tooltip>
-                )}
             >
                 <button
                     data-test-id={`editor--bookmarks__planning-${index}`}
@@ -77,7 +73,7 @@ export class AssociatedPlanningsBookmark extends React.Component<IProps, IState>
                 >
                     <Icon name="calendar" />
                 </button>
-            </OverlayTrigger>
+            </Tooltip>
         ));
     }
 

--- a/client/components/Editor/bookmarks/FormGroupBookmark.tsx
+++ b/client/components/Editor/bookmarks/FormGroupBookmark.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {OverlayTrigger, Tooltip} from 'react-bootstrap';
+import {Tooltip} from 'superdesk-ui-framework/react';
 import classNames from 'classnames';
 
 import {EDITOR_TYPE, IBookmarkProps, IEditorBookmarkGroup} from '../../../interfaces';
@@ -29,13 +29,9 @@ export class FormGroupBookmark extends React.PureComponent<IProps> {
 
     renderForPanel() {
         return (
-            <OverlayTrigger
+            <Tooltip
+                content={this.props.bookmark.tooltip}
                 placement="right"
-                overlay={(
-                    <Tooltip id={this.props.bookmark.id}>
-                        {this.props.bookmark.tooltip}
-                    </Tooltip>
-                )}
             >
                 <button
                     data-test-id={`editor--bookmarks__${this.props.bookmark.id}`}
@@ -51,7 +47,7 @@ export class FormGroupBookmark extends React.PureComponent<IProps> {
                 >
                     <Icon name={this.props.bookmark.icon} />
                 </button>
-            </OverlayTrigger>
+            </Tooltip>
         );
     }
 

--- a/client/components/Events/tests/EventPreviewContent_test.tsx
+++ b/client/components/Events/tests/EventPreviewContent_test.tsx
@@ -100,7 +100,7 @@ describe('<EventPreviewContent />', () => {
         restoreSinonStub(timeUtils.localTimeZone);
     });
 
-    it('renders an event with all its details', () => {
+    fit('renders an event with all its details', () => {
         const wrapper = getWrapper();
 
         const dateString = eventUtils.getDateStringForEvent(
@@ -165,7 +165,7 @@ describe('<EventPreviewContent />', () => {
 
         let relatedPlannings = wrapper.find('.related-plannings');
 
-        const relPlan = relatedPlannings.find('span').first();
+        const relPlan = relatedPlannings.find('span.sd-list-item__slugline').first();
 
         expect(relPlan.text()).toBe('Planning2'); // expect to display slugline (i.e. Planning2)
     });

--- a/client/components/Location/Location_test.tsx
+++ b/client/components/Location/Location_test.tsx
@@ -28,7 +28,9 @@ describe('<Location />', () => {
         );
 
         expect(wrapper.text()).toBe(name);
-        expect(wrapper.html()).toBe('<span class="sd-list-item__location">location_name</span>');
+        expect(wrapper.html()).toBe(
+            '<span style="display: contents;"><span class="sd-list-item__location">location_name</span></span>',
+        );
         wrapper = mount(
             <Provider store={store}>
                 <Location address={address} />
@@ -36,7 +38,9 @@ describe('<Location />', () => {
         );
 
         expect(wrapper.text()).toBe(address);
-        expect(wrapper.html()).toBe('<span class="sd-list-item__location">location_address</span>');
+        expect(wrapper.html()).toBe(
+            '<span style="display: contents;"><span class="sd-list-item__location">location_address</span></span>',
+        );
     });
 
     it('render single line with map', () => {

--- a/client/components/Location/index.tsx
+++ b/client/components/Location/index.tsx
@@ -14,7 +14,7 @@ export const Location = ({name, address, multiLine, details}) => {
     // eslint-disable-next-line react/no-multi-comp
     const renderSingleline = () => (
         <Tooltip
-            content={
+            content={() => (
                 <>
                     {name && <div className="sd-line-input__label">{name}</div>}
                     {address && (
@@ -23,7 +23,7 @@ export const Location = ({name, address, multiLine, details}) => {
                         </div>
                     )}
                 </>
-            }
+            )}
         >
             <span className="sd-list-item__location">
                 {name || address}

--- a/client/components/Location/index.tsx
+++ b/client/components/Location/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {OverlayTrigger, Tooltip} from 'react-bootstrap';
+import {Tooltip} from 'superdesk-ui-framework/react';
 
 import {appConfig} from 'appConfig';
 
@@ -13,22 +13,22 @@ export const Location = ({name, address, multiLine, details}) => {
 
     // eslint-disable-next-line react/no-multi-comp
     const renderSingleline = () => (
-        <OverlayTrigger
-            overlay={(
-                <Tooltip id="location_tooltip" className="tooltip--text-left">
+        <Tooltip
+            content={
+                <>
                     {name && <div className="sd-line-input__label">{name}</div>}
                     {address && (
                         <div className="sd-line-input__input--address">
                             {address}
                         </div>
                     )}
-                </Tooltip>
-            )}
+                </>
+            }
         >
             <span className="sd-list-item__location">
                 {name || address}
             </span>
-        </OverlayTrigger>
+        </Tooltip>
     );
 
     // eslint-disable-next-line react/no-multi-comp

--- a/client/components/Planning/PlanningItem.tsx
+++ b/client/components/Planning/PlanningItem.tsx
@@ -2,8 +2,7 @@ import React from 'react';
 import {connect} from 'react-redux';
 import {get, isEqual} from 'lodash';
 import moment from 'moment';
-import {OverlayTrigger, Tooltip} from 'react-bootstrap';
-import {Menu} from 'superdesk-ui-framework/react';
+import {Menu, Tooltip} from 'superdesk-ui-framework/react';
 
 import {superdeskApi} from '../../superdeskApi';
 import {
@@ -314,13 +313,9 @@ class PlanningItemComponent extends React.Component<IProps, IState> {
                 )}
                 {showAddCoverage && !isItemLocked && (
                     <Column border={false}>
-                        <OverlayTrigger
+                        <Tooltip
+                            content={gettext('Add as coverage')}
                             placement="left"
-                            overlay={(
-                                <Tooltip id={getItemId(item)}>
-                                    {gettext('Add as coverage')}
-                                </Tooltip>
-                            )}
                         >
                             <NavButton
                                 className="dropdown sd-create-btn"
@@ -330,7 +325,7 @@ class PlanningItemComponent extends React.Component<IProps, IState> {
                             >
                                 <span className="circle" />
                             </NavButton>
-                        </OverlayTrigger>
+                        </Tooltip>
                     </Column>
                 )}
                 {this.renderItemActions()}

--- a/client/components/UI/Icon.tsx
+++ b/client/components/UI/Icon.tsx
@@ -2,8 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import {values} from 'lodash';
-
-import {OverlayTrigger, Tooltip} from 'react-bootstrap';
+import {Tooltip} from 'superdesk-ui-framework/react';
 
 import {ICON_COLORS} from './constants';
 
@@ -28,13 +27,9 @@ const Icon = ({icon, doubleSize, big, className, tooltip, color}) => {
     );
 
     return tooltip ? (
-        <OverlayTrigger
-            overlay={
-                <Tooltip id="icon_list_item">{tooltip}</Tooltip>
-            }
-        >
+        <Tooltip content={tooltip}>
             {iconElement}
-        </OverlayTrigger>
+        </Tooltip>
     ) :
         iconElement;
 };

--- a/client/components/UI/IconMix.tsx
+++ b/client/components/UI/IconMix.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {values} from 'lodash';
-import {OverlayTrigger, Tooltip} from 'react-bootstrap';
+import {Tooltip} from 'superdesk-ui-framework/react';
 import classNames from 'classnames';
 
 import {ICON_COLORS} from './constants';
@@ -58,13 +58,9 @@ const IconMix = ({icon, subIcon, big, doubleSize, className, tooltip, color}) =>
     }
 
     return tooltip ? (
-        <OverlayTrigger
-            overlay={
-                <Tooltip id="icon_list_item">{tooltip}</Tooltip>
-            }
-        >
+        <Tooltip content={tooltip}>
             {iconElement}
-        </OverlayTrigger>
+        </Tooltip>
     ) :
         iconElement;
 };

--- a/client/components/UI/List/PubStatus.tsx
+++ b/client/components/UI/List/PubStatus.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import {OverlayTrigger, Tooltip} from 'react-bootstrap';
 import PropTypes from 'prop-types';
+import {Tooltip} from 'superdesk-ui-framework/react';
 
 import {TOOLTIPS} from '../../../constants';
 
@@ -43,12 +43,9 @@ export const PubStatus = ({item, isPublic}) => {
     return (
         <Column>
             {title && (
-                <OverlayTrigger
-                    placement="right"
-                    overlay={<Tooltip id="badge_pub_status">{title}</Tooltip>}
-                >
+                <Tooltip content={title} placement="right">
                     {badge}
-                </OverlayTrigger>
+                </Tooltip>
             )}
             {!title && (badge)}
         </Column>

--- a/client/components/UI/SubNav/Dropdown.tsx
+++ b/client/components/UI/SubNav/Dropdown.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import {OverlayTrigger, Tooltip} from 'react-bootstrap';
 import classNames from 'classnames';
 import {defer, get, groupBy} from 'lodash';
+import {Tooltip} from 'superdesk-ui-framework/react';
 
 import {Menu, Label, Divider, Dropdown as DropMenu} from '../Dropdown';
 import {gettext} from '../utils';
@@ -197,16 +197,9 @@ export class Dropdown extends React.Component<IProps, IState> {
                 className={this.props.className}
             >
                 {this.props.tooltip ? (
-                    <OverlayTrigger
-                        placement="left"
-                        overlay={(
-                            <Tooltip id="create_new_btn">
-                                {this.props.tooltip}
-                            </Tooltip>
-                        )}
-                    >
-                        <span>{this.renderButtonDropMenu()}</span>
-                    </OverlayTrigger>
+                    <Tooltip content={this.props.tooltip} placement="left">
+                        {this.renderButtonDropMenu()}
+                    </Tooltip>
                 ) :
                     this.renderButtonDropMenu()
                 }

--- a/client/components/fields/calendars.tsx
+++ b/client/components/fields/calendars.tsx
@@ -3,8 +3,7 @@
 import React from 'react';
 import {connect} from 'react-redux';
 import {get} from 'lodash';
-import {Spacer} from 'superdesk-ui-framework/react';
-import {OverlayTrigger, Tooltip} from 'react-bootstrap';
+import {Spacer, Tooltip} from 'superdesk-ui-framework/react';
 import {ICalendar, IFieldsProps, IPlanningAppState} from '../../interfaces';
 import {superdeskApi} from '../../superdeskApi';
 import {getVocabularyItemFieldTranslated} from '../../utils/vocabularies';
@@ -53,20 +52,17 @@ class CalendarsComponent extends React.PureComponent<IProps> {
                 <span className="sd-list-item__text-label">{gettext('Calendar:')}</span>
                 {<span className="sd-list-item__text-strong sd-list-item--element-rm-10">
                     {calendars.length > 0 ? (
-                        <OverlayTrigger
-                            placement="left"
-                            overlay={(
-                                <Tooltip
-                                    id="location_tooltip"
-                                    className="tooltip--text-left"
-                                >
+                        <Tooltip
+                            content={
+                                <>
                                     {calendars.map((calendar) => (
                                         <div key={calendar.qcode}>
                                             {calendar.tooltip}
                                         </div>
                                     ))}
-                                </Tooltip>
-                            )}
+                                </>
+                            }
+                            placement="left"
                         >
                             <span>
                                 {calendars.map((calendar, index, array) => (
@@ -78,7 +74,7 @@ class CalendarsComponent extends React.PureComponent<IProps> {
                                     </span>
                                 ))}
                             </span>
-                        </OverlayTrigger>
+                        </Tooltip>
                     ) : (
                         <span>
                             {gettext('No calendars assigned')}

--- a/client/components/fields/calendars.tsx
+++ b/client/components/fields/calendars.tsx
@@ -53,7 +53,7 @@ class CalendarsComponent extends React.PureComponent<IProps> {
                 {<span className="sd-list-item__text-strong sd-list-item--element-rm-10">
                     {calendars.length > 0 ? (
                         <Tooltip
-                            content={
+                            content={() => (
                                 <>
                                     {calendars.map((calendar) => (
                                         <div key={calendar.qcode}>
@@ -61,7 +61,7 @@ class CalendarsComponent extends React.PureComponent<IProps> {
                                         </div>
                                     ))}
                                 </>
-                            }
+                            )}
                             placement="left"
                         >
                             <span>

--- a/package-lock.json
+++ b/package-lock.json
@@ -11183,9 +11183,9 @@
           }
         },
         "superdesk-ui-framework": {
-          "version": "4.0.94",
-          "resolved": "https://registry.npmjs.org/superdesk-ui-framework/-/superdesk-ui-framework-4.0.94.tgz",
-          "integrity": "sha512-yApsiE9mVHpE6ZlPjLlNGtUz2PDVxRbHccmGxcAf0mzhiYpl6tbIiBlr1IVPUOJBSmrDTRT69kLkxdI1jPyYPQ==",
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/superdesk-ui-framework/-/superdesk-ui-framework-5.0.3.tgz",
+          "integrity": "sha512-5W+p85b0XrbRYhLZWE7vp+F7/aNCBfjqGCCRY+M8VhbsF8ODuO5WOIj9En664APBhCE30C8AtRAsK3tbHx547A==",
           "dev": true,
           "requires": {
             "@popperjs/core": "^2.4.0",
@@ -11223,9 +11223,9 @@
       }
     },
     "superdesk-ui-framework": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/superdesk-ui-framework/-/superdesk-ui-framework-5.1.0.tgz",
-      "integrity": "sha512-CPAfSfj14oS5jW+bUohQMBCjxkGoaTH/GfLyohLJ2jBKtprVImh6Z9Rnqod8HAHNm1JCE2Y0czkIjnXtybixMQ==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/superdesk-ui-framework/-/superdesk-ui-framework-5.1.2.tgz",
+      "integrity": "sha512-H9OgvZ0z8ujAUPWwtrpDRNseQdI9aglQGoXZI7NOjSlanO2S1glvD9sklHHG9Xs6JooXXjdMiWB//iW7dA/11Q==",
       "dev": true,
       "requires": {
         "@popperjs/core": "^2.4.0",
@@ -11268,9 +11268,9 @@
           }
         },
         "csstype": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-          "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.0.tgz",
+          "integrity": "sha512-si++xzRAY9iPp60roQiFta7OFbhrgvcthrhlNAGeQptSY25uJjkfUV8OArC3KLocB8JT8ohz+qgxWCmz8RhjIg==",
           "dev": true
         },
         "dom-helpers": {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "style-loader": "^2.0.0",
     "superdesk-code-style": "1.5.0",
     "superdesk-core": "github:superdesk/superdesk-client-core#release/3.1",
-    "superdesk-ui-framework": "5.1.0",
+    "superdesk-ui-framework": "5.1.2",
     "ts-loader": "^8.4.0",
     "ts-node": "~7.0.1",
     "tslint": "5.11.0",


### PR DESCRIPTION
### Purpose
- Migrates all tooltip usage from react-bootstrap's OverlayTrigger and Tooltip components to component from superdesk-ui-framework/react.
- Update superdesk-ui-framework dependency to version 5.1.2

[STT-1462]


[STT-1462]: https://sofab.atlassian.net/browse/STT-1462?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ