### PR TITLE
test e2e on 3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-.
 # Superdesk Planning
 [![Build Status](https://travis-ci.org/superdesk/superdesk-planning.svg?branch=master)](https://travis-ci.org/superdesk/superdesk-planning)
 [![Coverage Status](https://coveralls.io/repos/github/superdesk/superdesk-planning/badge.svg?branch=master)](https://coveralls.io/github/superdesk/superdesk-planning?branch=master)

--- a/client/actions/events/api.ts
+++ b/client/actions/events/api.ts
@@ -452,6 +452,7 @@ const updateEventTime = (original, updates) => (
                 dates: {
                     ...updates.dates,
                     no_end_time: false,
+                    all_day: false,
                 },
                 [TO_BE_CONFIRMED_FIELD]: false,
             }

--- a/client/actions/events/api.ts
+++ b/client/actions/events/api.ts
@@ -449,7 +449,10 @@ const updateEventTime = (original, updates) => (
             original,
             {
                 update_method: get(updates, 'update_method.value', EVENTS.UPDATE_METHODS[0].value),
-                dates: updates.dates,
+                dates: {
+                    ...updates.dates,
+                    no_end_time: false,
+                },
                 [TO_BE_CONFIRMED_FIELD]: false,
             }
         );

--- a/client/components/Agendas/AgendaNameList.tsx
+++ b/client/components/Agendas/AgendaNameList.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {get, sortBy} from 'lodash';
 import {gettext} from '../../utils';
-import {OverlayTrigger, Tooltip} from 'react-bootstrap';
+import {Tooltip} from 'superdesk-ui-framework/react';
 
 export const AgendaNameList = ({agendas}) => {
     let tooltipElem = (agendas || []).map((a) =>
@@ -13,14 +13,7 @@ export const AgendaNameList = ({agendas}) => {
         <span>
             {get(agendas, 'length', 0) === 0 ? gettext('No Agenda Assigned.') :
                 (
-                    <OverlayTrigger
-                        placement="left"
-                        overlay={(
-                            <Tooltip id="agenda_tooltip" className="tooltip--text-left">
-                                {tooltipElem}
-                            </Tooltip>
-                        )}
-                    >
+                    <Tooltip content={tooltipElem} placement="left">
                         <span>
                             {sortBy(agendas.filter((a) => a), [(a) => get(a, 'name', '').toLowerCase()])
                                 .map((a, index, arr) => (
@@ -30,8 +23,9 @@ export const AgendaNameList = ({agendas}) => {
                                     >
                                         {a.name}{index === arr.length - 1 ? '' : ', '}
                                     </span>
-                                ))}</span>
-                    </OverlayTrigger>
+                                ))}
+                        </span>
+                    </Tooltip>
                 )
             }
         </span>

--- a/client/components/Assignments/AssignmentEditor.tsx
+++ b/client/components/Assignments/AssignmentEditor.tsx
@@ -220,6 +220,7 @@ export class AssignmentEditorComponent extends React.PureComponent<IProps> {
                     <Row style={{padding: '2rem 0', margin: '0 0 1.8em 0'}}>
                         <div data-test-id={this.FIELDS.USER}>
                             <SelectUser
+                                key={this.props.value.assigned_to?.desk ?? null}
                                 disabled={disableUserSelection}
                                 deskId={deskId}
                                 selectedUserId={userId}

--- a/client/components/Assignments/AssignmentGroupList.tsx
+++ b/client/components/Assignments/AssignmentGroupList.tsx
@@ -14,7 +14,6 @@ import {AssignmentMultiTextItem} from './AssignmentItem/AssignmentMultiTextItem'
 import {Header, Group} from '../UI/List';
 import {OrderDirectionIcon} from '../OrderBar';
 import {ListItemLoader, LoadMoreIndicator} from 'superdesk-ui-framework/react';
-import moment from 'moment';
 
 const focusElement = throttle((element: HTMLElement) => {
     element.focus();
@@ -283,11 +282,7 @@ class AssignmentGroupListComponent extends React.Component<IProps, IState> {
         } = this.props;
         const listStyle = setMaxHeight ? {maxHeight: this.getListMaxHeight() + 'px'} : {};
         const headingId = `heading--${this.props.groupKey}`;
-        const filteredAssignments = this.props.dayField == null
-            ? assignments
-            : assignments.filter((assignment) =>
-                moment(assignment.planning.scheduled).isSameOrAfter(moment(this.props.dayField)),
-            );
+        const assignmentsCount = assignments?.length ?? 0;
 
         return (
             <div data-test-id="assignment-group__list">
@@ -310,9 +305,9 @@ class AssignmentGroupListComponent extends React.Component<IProps, IState> {
                             <div className="sd-list-header__number sd-flex-grow">
                                 <span className="a11y-only">{gettext(
                                     'Number of Assignments: ',
-                                    {count: (totalCount ?? 0)}
+                                    {count: (assignmentsCount)}
                                 )}</span>
-                                <span className="badge">{(totalCount ?? 0)}</span>
+                                <span className="badge">{(assignmentsCount)}</span>
                             </div>
                         )}
 
@@ -342,15 +337,15 @@ class AssignmentGroupListComponent extends React.Component<IProps, IState> {
                     tabIndex={-1}
                 >
                     {/* only show this loader when no items exist yet */}
-                    {isLoading === true && (filteredAssignments?.length ?? 0) === 0 && <ListItemLoader />}
+                    {isLoading === true && (assignmentsCount) === 0 && <ListItemLoader />}
 
-                    {filteredAssignments?.length > 0 && (
+                    {assignmentsCount > 0 && (
                         <>
-                            {filteredAssignments.map((assignment) => this.rowRenderer(assignment))}
+                            {assignments.map((assignment) => this.rowRenderer(assignment))}
 
                             <LoadMoreIndicator
                                 loading={this.state.isNextPageLoading}
-                                currentCount={filteredAssignments.length}
+                                currentCount={assignmentsCount}
                                 totalCount={totalCount}
                                 loadingText={gettext('Loading more...')}
                             />
@@ -358,7 +353,7 @@ class AssignmentGroupListComponent extends React.Component<IProps, IState> {
                     )}
 
                     {/* only when not loading and no items */}
-                    {!isLoading && (filteredAssignments?.length ?? 0) === 0 && (
+                    {!isLoading && (assignmentsCount) === 0 && (
                         <li className="sd-list-item-group__empty-msg">{groupEmptyMessage}</li>
                     )}
                 </Group>

--- a/client/components/Assignments/AssignmentGroupList.tsx
+++ b/client/components/Assignments/AssignmentGroupList.tsx
@@ -90,20 +90,20 @@ class AssignmentGroupListComponent extends React.Component<IProps, IState> {
         }
     }
 
-    handleScroll(event: React.UIEvent) {
-        if (this.state.isNextPageLoading) {
+    handleScroll(event: React.UIEvent<HTMLUListElement>) {
+        if (this.state.isNextPageLoading || this.props.isLoading) {
             return;
         }
 
-        const node = event.target;
+        const node = event.target as HTMLUListElement;
         const {totalCount, assignments, loadMoreAssignments, groupKey} = this.props;
 
         if (node && totalCount > get(assignments, 'length', 0)) {
             if (node.scrollTop + node.offsetHeight + 200 >= node.scrollHeight) {
-                this.setState({isNextPageLoading: true});
-
-                loadMoreAssignments(groupKey)
-                    .finally(() => this.setState({isNextPageLoading: false}));
+                this.setState({isNextPageLoading: true}, () => {
+                    loadMoreAssignments(groupKey)
+                        .finally(() => this.setState({isNextPageLoading: false}));
+                });
             }
         }
     }

--- a/client/components/Assignments/AssignmentGroupList.tsx
+++ b/client/components/Assignments/AssignmentGroupList.tsx
@@ -37,7 +37,6 @@ interface IProps {
     hideItemActions?: boolean;
     privileges?: any;
     startWorking?: () => any;
-    totalCount?: number;
     changeAssignmentListSingleGroupView?: (groupKey: string) => any;
     assignmentListSingleGroupView?: string;
     preview?: () => any;
@@ -58,6 +57,16 @@ interface IProps {
     isLoading?: boolean;
     dayField?: string;
     archiveItems: {[itemId: string]: IArticle};
+
+    /**
+     * Total number of assignments in the current group as reported by the server
+     */
+    totalCount?: number;
+
+    /**
+     * The actual count of assignments that have been fetched from the server for the current group
+     */
+    groupAssignmentsFetchedCount: number;
 }
 
 interface IState {
@@ -96,9 +105,9 @@ class AssignmentGroupListComponent extends React.Component<IProps, IState> {
         }
 
         const node = event.target as HTMLUListElement;
-        const {totalCount, assignments, loadMoreAssignments, groupKey} = this.props;
+        const {totalCount, groupAssignmentsFetchedCount, loadMoreAssignments, groupKey} = this.props;
 
-        if (node && totalCount > get(assignments, 'length', 0)) {
+        if (node && totalCount > groupAssignmentsFetchedCount) {
             if (node.scrollTop + node.offsetHeight + 200 >= node.scrollHeight) {
                 this.setState({isNextPageLoading: true}, () => {
                     loadMoreAssignments(groupKey)
@@ -380,6 +389,7 @@ const mapStateToProps = (state, ownProps) => {
         isLoading: assignmentDataSelector.isLoading(state),
         archiveItems: selectors.getStoredArchiveItems(state),
         totalCount: assignmentDataSelector.countSelector(state),
+        groupAssignmentsFetchedCount: assignmentDataSelector.assignmentIds(state).length,
     };
 };
 

--- a/client/components/Assignments/AssignmentGroupList.tsx
+++ b/client/components/Assignments/AssignmentGroupList.tsx
@@ -13,7 +13,7 @@ import {assignmentUtils} from '../../utils';
 import {AssignmentMultiTextItem} from './AssignmentItem/AssignmentMultiTextItem';
 import {Header, Group} from '../UI/List';
 import {OrderDirectionIcon} from '../OrderBar';
-import {ListItemLoader} from 'superdesk-ui-framework/react/components/ListItemLoader';
+import {ListItemLoader, LoadMoreIndicator} from 'superdesk-ui-framework/react';
 import moment from 'moment';
 
 const focusElement = throttle((element: HTMLElement) => {
@@ -207,7 +207,7 @@ class AssignmentGroupListComponent extends React.Component<IProps, IState> {
         }
     }
 
-    rowRenderer(index) {
+    rowRenderer(assignment) {
         const {
             users,
             session,
@@ -219,7 +219,6 @@ class AssignmentGroupListComponent extends React.Component<IProps, IState> {
             archiveItems,
         } = this.props;
 
-        const assignment = this.props.assignments[index];
         const assignedUser = users.find((user) => get(assignment, 'assigned_to.user') === user._id);
         const isCurrentUser = assignedUser && assignedUser._id === session.identity._id;
         const onDoubleClick = assignmentUtils.assignmentHasContent(assignment) ?
@@ -333,15 +332,25 @@ class AssignmentGroupListComponent extends React.Component<IProps, IState> {
                     refNode={(assignmentsList) => this.dom.list = assignmentsList}
                     tabIndex={-1}
                 >
-                    {isLoading === true && (
-                        <ListItemLoader />
+                    {/* only show this loader when no items exist yet */}
+                    {isLoading === true && (filteredAssignments?.length ?? 0) === 0 && <ListItemLoader />}
+
+                    {filteredAssignments?.length > 0 && (
+                        <>
+                            {filteredAssignments.map((assignment) => this.rowRenderer(assignment))}
+
+                            <LoadMoreIndicator
+                                loading={this.state.isNextPageLoading}
+                                currentCount={filteredAssignments.length}
+                                totalCount={totalCount}
+                                loadingText={gettext('Loading more...')}
+                            />
+                        </>
                     )}
-                    {isLoading !== true && (
-                        (filteredAssignments?.length ?? 0) > 0 ? (
-                            filteredAssignments.map((_assignment, index) => this.rowRenderer(index))
-                        ) : (
-                            <li className="sd-list-item-group__empty-msg">{groupEmptyMessage}</li>
-                        )
+
+                    {/* only when not loading and no items */}
+                    {!isLoading && (filteredAssignments?.length ?? 0) === 0 && (
+                        <li className="sd-list-item-group__empty-msg">{groupEmptyMessage}</li>
                     )}
                 </Group>
             </div>

--- a/client/components/Assignments/AssignmentItem/index.tsx
+++ b/client/components/Assignments/AssignmentItem/index.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import moment from 'moment';
 import {get, debounce, Cancelable} from 'lodash';
-import {OverlayTrigger, Tooltip} from 'react-bootstrap';
 
 import {superdeskApi} from '../../../superdeskApi';
 import {IUser, IDesk, IArticle} from 'superdesk-api';
@@ -19,7 +18,7 @@ import {assignmentUtils, planningUtils} from '../../../utils';
 import {ASSIGNMENTS, CLICK_DELAY} from '../../../constants';
 import {editPlanningInNewTab, getAssignmentTypeInfo} from '../../../utils/assignments';
 
-import {Menu} from 'superdesk-ui-framework/react';
+import {Menu, Tooltip} from 'superdesk-ui-framework/react';
 import {UserAvatar} from '../../../components/UserAvatar';
 import {Item, Border, Column} from '../../UI/List';
 
@@ -143,12 +142,12 @@ export class AssignmentItem extends React.Component<IAssignmentItemProps, IState
         return (
             <Column>
                 <span className="a11y-only">{tooltip}</span>
-                <OverlayTrigger
+                <Tooltip
+                    content={tooltip}
                     placement="right"
-                    overlay={<Tooltip id="content_type">{tooltip}</Tooltip>}
                 >
                     <i className={className} />
-                </OverlayTrigger>
+                </Tooltip>
             </Column>
         );
     }

--- a/client/components/Coverages/CoverageAddAdvancedModal.tsx
+++ b/client/components/Coverages/CoverageAddAdvancedModal.tsx
@@ -333,6 +333,7 @@ class CoverageAddAdvancedModalComponent extends React.Component<IProps, IState> 
                                             </Select>
                                             <div style={{width: '100%'}}>
                                                 <SelectUser
+                                                    key={`${coverage.desk?._id}-${index}`}
                                                     deskId={coverage.desk?._id ?? undefined}
                                                     selectedUserId = {coverage.user?._id}
                                                     onSelect={(user) => {

--- a/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx
+++ b/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx
@@ -70,6 +70,7 @@ class CoverageFormHeaderComponent extends React.PureComponent<IProps> {
             disableDeskSelection: this.props.addNewsItemToPlanning != null || (
                 this.props.value.assigned_to?.state != null
                 && ![
+                    ASSIGNMENTS.WORKFLOW_STATE.DRAFT,
                     ASSIGNMENTS.WORKFLOW_STATE.ASSIGNED,
                     ASSIGNMENTS.WORKFLOW_STATE.SUBMITTED,
                 ].includes(this.props.value.assigned_to.state)

--- a/client/components/Editor/bookmarks/AddCoverageBookmark.tsx
+++ b/client/components/Editor/bookmarks/AddCoverageBookmark.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {OverlayTrigger, Tooltip} from 'react-bootstrap';
+import {Tooltip} from 'superdesk-ui-framework/react';
 import classNames from 'classnames';
 
 import {EDITOR_TYPE, IBookmarkProps, IG2ContentType, IPlanningCoverageItem, IPlanningItem} from '../../../interfaces';
@@ -52,13 +52,9 @@ export class AddCoverageBookmark extends React.PureComponent<IProps> {
                 target="icon-plus-sign"
                 language={this.props.item.language}
                 button={({toggleMenu}) => (
-                    <OverlayTrigger
+                    <Tooltip
+                        content={gettext('Add Coverage')}
                         placement="right"
-                        overlay={(
-                            <Tooltip id="coverage_links">
-                                {gettext('Add Coverage')}
-                            </Tooltip>
-                        )}
                     >
                         <button
                             data-test-id={`editor--bookmarks__${this.props.bookmark.id}`}
@@ -74,7 +70,7 @@ export class AddCoverageBookmark extends React.PureComponent<IProps> {
                         >
                             <Icon name="plus-sign" />
                         </button>
-                    </OverlayTrigger>
+                    </Tooltip>
                 )}
             />
         );

--- a/client/components/Editor/bookmarks/AddPlanningBookmark.tsx
+++ b/client/components/Editor/bookmarks/AddPlanningBookmark.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {OverlayTrigger, Tooltip} from 'react-bootstrap';
+import {Tooltip} from 'superdesk-ui-framework/react';
 import classNames from 'classnames';
 
 import {EDITOR_TYPE, IBookmarkProps} from '../../../interfaces';
@@ -26,13 +26,9 @@ export class AddPlanningBookmark extends React.PureComponent<IBookmarkProps> {
         const {gettext} = superdeskApi.localization;
 
         return (
-            <OverlayTrigger
+            <Tooltip
+                content={gettext('Add Planning Item')}
                 placement="right"
-                overlay={(
-                    <Tooltip id="add_planning_item">
-                        {gettext('Add Planning Item')}
-                    </Tooltip>
-                )}
             >
                 <button
                     data-test-id={`editor--bookmarks__${this.props.bookmark.id}`}
@@ -48,7 +44,7 @@ export class AddPlanningBookmark extends React.PureComponent<IBookmarkProps> {
                 >
                     <Icon name="plus-large" />
                 </button>
-            </OverlayTrigger>
+            </Tooltip>
         );
     }
 }

--- a/client/components/Editor/bookmarks/AssociatedPlanningsBookmark.tsx
+++ b/client/components/Editor/bookmarks/AssociatedPlanningsBookmark.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {OverlayTrigger, Tooltip} from 'react-bootstrap';
+import {Tooltip} from 'superdesk-ui-framework/react';
 import classNames from 'classnames';
 
 import {EDITOR_TYPE, IBookmarkProps, IEventItem, IPlanningItem} from '../../../interfaces';
@@ -50,16 +50,12 @@ export class AssociatedPlanningsBookmark extends React.Component<IProps, IState>
         const {gettext} = superdeskApi.localization;
 
         return this.props.item.associated_plannings.map((plan, index) => (
-            <OverlayTrigger
+            <Tooltip
                 key={plan._id}
+                content={gettext('Planning: {{ name }}', {
+                    name: plan.slugline || plan.headline || plan.name,
+                })}
                 placement="right"
-                overlay={(
-                    <Tooltip id="associated_plannings">
-                        {gettext('Planning: {{ name }}', {
-                            name: plan.slugline || plan.headline || plan.name,
-                        })}
-                    </Tooltip>
-                )}
             >
                 <button
                     data-test-id={`editor--bookmarks__planning-${index}`}
@@ -77,7 +73,7 @@ export class AssociatedPlanningsBookmark extends React.Component<IProps, IState>
                 >
                     <Icon name="calendar" />
                 </button>
-            </OverlayTrigger>
+            </Tooltip>
         ));
     }
 

--- a/client/components/Editor/bookmarks/FormGroupBookmark.tsx
+++ b/client/components/Editor/bookmarks/FormGroupBookmark.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {OverlayTrigger, Tooltip} from 'react-bootstrap';
+import {Tooltip} from 'superdesk-ui-framework/react';
 import classNames from 'classnames';
 
 import {EDITOR_TYPE, IBookmarkProps, IEditorBookmarkGroup} from '../../../interfaces';
@@ -29,13 +29,9 @@ export class FormGroupBookmark extends React.PureComponent<IProps> {
 
     renderForPanel() {
         return (
-            <OverlayTrigger
+            <Tooltip
+                content={this.props.bookmark.tooltip}
                 placement="right"
-                overlay={(
-                    <Tooltip id={this.props.bookmark.id}>
-                        {this.props.bookmark.tooltip}
-                    </Tooltip>
-                )}
             >
                 <button
                     data-test-id={`editor--bookmarks__${this.props.bookmark.id}`}
@@ -51,7 +47,7 @@ export class FormGroupBookmark extends React.PureComponent<IProps> {
                 >
                     <Icon name={this.props.bookmark.icon} />
                 </button>
-            </OverlayTrigger>
+            </Tooltip>
         );
     }
 

--- a/client/components/Events/tests/EventPreviewContent_test.tsx
+++ b/client/components/Events/tests/EventPreviewContent_test.tsx
@@ -100,7 +100,7 @@ describe('<EventPreviewContent />', () => {
         restoreSinonStub(timeUtils.localTimeZone);
     });
 
-    it('renders an event with all its details', () => {
+    fit('renders an event with all its details', () => {
         const wrapper = getWrapper();
 
         const dateString = eventUtils.getDateStringForEvent(
@@ -165,7 +165,7 @@ describe('<EventPreviewContent />', () => {
 
         let relatedPlannings = wrapper.find('.related-plannings');
 
-        const relPlan = relatedPlannings.find('span').first();
+        const relPlan = relatedPlannings.find('span.sd-list-item__slugline').first();
 
         expect(relPlan.text()).toBe('Planning2'); // expect to display slugline (i.e. Planning2)
     });

--- a/client/components/Events/tests/EventPreviewContent_test.tsx
+++ b/client/components/Events/tests/EventPreviewContent_test.tsx
@@ -100,7 +100,7 @@ describe('<EventPreviewContent />', () => {
         restoreSinonStub(timeUtils.localTimeZone);
     });
 
-    fit('renders an event with all its details', () => {
+    it('renders an event with all its details', () => {
         const wrapper = getWrapper();
 
         const dateString = eventUtils.getDateStringForEvent(

--- a/client/components/Location/Location_test.tsx
+++ b/client/components/Location/Location_test.tsx
@@ -28,7 +28,9 @@ describe('<Location />', () => {
         );
 
         expect(wrapper.text()).toBe(name);
-        expect(wrapper.html()).toBe('<span class="sd-list-item__location">location_name</span>');
+        expect(wrapper.html()).toBe(
+            '<span style="display: contents;"><span class="sd-list-item__location">location_name</span></span>',
+        );
         wrapper = mount(
             <Provider store={store}>
                 <Location address={address} />
@@ -36,7 +38,9 @@ describe('<Location />', () => {
         );
 
         expect(wrapper.text()).toBe(address);
-        expect(wrapper.html()).toBe('<span class="sd-list-item__location">location_address</span>');
+        expect(wrapper.html()).toBe(
+            '<span style="display: contents;"><span class="sd-list-item__location">location_address</span></span>',
+        );
     });
 
     it('render single line with map', () => {

--- a/client/components/Location/index.tsx
+++ b/client/components/Location/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {OverlayTrigger, Tooltip} from 'react-bootstrap';
+import {Tooltip} from 'superdesk-ui-framework/react';
 
 import {appConfig} from 'appConfig';
 
@@ -13,22 +13,22 @@ export const Location = ({name, address, multiLine, details}) => {
 
     // eslint-disable-next-line react/no-multi-comp
     const renderSingleline = () => (
-        <OverlayTrigger
-            overlay={(
-                <Tooltip id="location_tooltip" className="tooltip--text-left">
+        <Tooltip
+            content={() => (
+                <>
                     {name && <div className="sd-line-input__label">{name}</div>}
                     {address && (
                         <div className="sd-line-input__input--address">
                             {address}
                         </div>
                     )}
-                </Tooltip>
+                </>
             )}
         >
             <span className="sd-list-item__location">
                 {name || address}
             </span>
-        </OverlayTrigger>
+        </Tooltip>
     );
 
     // eslint-disable-next-line react/no-multi-comp

--- a/client/components/Planning/PlanningItem.tsx
+++ b/client/components/Planning/PlanningItem.tsx
@@ -2,8 +2,7 @@ import React from 'react';
 import {connect} from 'react-redux';
 import {get, isEqual} from 'lodash';
 import moment from 'moment';
-import {OverlayTrigger, Tooltip} from 'react-bootstrap';
-import {Menu} from 'superdesk-ui-framework/react';
+import {Menu, Tooltip} from 'superdesk-ui-framework/react';
 
 import {superdeskApi} from '../../superdeskApi';
 import {
@@ -314,13 +313,9 @@ class PlanningItemComponent extends React.Component<IProps, IState> {
                 )}
                 {showAddCoverage && !isItemLocked && (
                     <Column border={false}>
-                        <OverlayTrigger
+                        <Tooltip
+                            content={gettext('Add as coverage')}
                             placement="left"
-                            overlay={(
-                                <Tooltip id={getItemId(item)}>
-                                    {gettext('Add as coverage')}
-                                </Tooltip>
-                            )}
                         >
                             <NavButton
                                 className="dropdown sd-create-btn"
@@ -330,7 +325,7 @@ class PlanningItemComponent extends React.Component<IProps, IState> {
                             >
                                 <span className="circle" />
                             </NavButton>
-                        </OverlayTrigger>
+                        </Tooltip>
                     </Column>
                 )}
                 {this.renderItemActions()}

--- a/client/components/UI/Icon.tsx
+++ b/client/components/UI/Icon.tsx
@@ -2,8 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import {values} from 'lodash';
-
-import {OverlayTrigger, Tooltip} from 'react-bootstrap';
+import {Tooltip} from 'superdesk-ui-framework/react';
 
 import {ICON_COLORS} from './constants';
 
@@ -28,13 +27,9 @@ const Icon = ({icon, doubleSize, big, className, tooltip, color}) => {
     );
 
     return tooltip ? (
-        <OverlayTrigger
-            overlay={
-                <Tooltip id="icon_list_item">{tooltip}</Tooltip>
-            }
-        >
+        <Tooltip content={tooltip}>
             {iconElement}
-        </OverlayTrigger>
+        </Tooltip>
     ) :
         iconElement;
 };

--- a/client/components/UI/IconMix.tsx
+++ b/client/components/UI/IconMix.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {values} from 'lodash';
-import {OverlayTrigger, Tooltip} from 'react-bootstrap';
+import {Tooltip} from 'superdesk-ui-framework/react';
 import classNames from 'classnames';
 
 import {ICON_COLORS} from './constants';
@@ -58,13 +58,9 @@ const IconMix = ({icon, subIcon, big, doubleSize, className, tooltip, color}) =>
     }
 
     return tooltip ? (
-        <OverlayTrigger
-            overlay={
-                <Tooltip id="icon_list_item">{tooltip}</Tooltip>
-            }
-        >
+        <Tooltip content={tooltip}>
             {iconElement}
-        </OverlayTrigger>
+        </Tooltip>
     ) :
         iconElement;
 };

--- a/client/components/UI/List/PubStatus.tsx
+++ b/client/components/UI/List/PubStatus.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import {OverlayTrigger, Tooltip} from 'react-bootstrap';
 import PropTypes from 'prop-types';
+import {Tooltip} from 'superdesk-ui-framework/react';
 
 import {TOOLTIPS} from '../../../constants';
 
@@ -43,12 +43,9 @@ export const PubStatus = ({item, isPublic}) => {
     return (
         <Column>
             {title && (
-                <OverlayTrigger
-                    placement="right"
-                    overlay={<Tooltip id="badge_pub_status">{title}</Tooltip>}
-                >
+                <Tooltip content={title} placement="right">
                     {badge}
-                </OverlayTrigger>
+                </Tooltip>
             )}
             {!title && (badge)}
         </Column>

--- a/client/components/UI/SubNav/Dropdown.tsx
+++ b/client/components/UI/SubNav/Dropdown.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import {OverlayTrigger, Tooltip} from 'react-bootstrap';
 import classNames from 'classnames';
 import {defer, get, groupBy} from 'lodash';
+import {Tooltip} from 'superdesk-ui-framework/react';
 
 import {Menu, Label, Divider, Dropdown as DropMenu} from '../Dropdown';
 import {gettext} from '../utils';
@@ -197,16 +197,9 @@ export class Dropdown extends React.Component<IProps, IState> {
                 className={this.props.className}
             >
                 {this.props.tooltip ? (
-                    <OverlayTrigger
-                        placement="left"
-                        overlay={(
-                            <Tooltip id="create_new_btn">
-                                {this.props.tooltip}
-                            </Tooltip>
-                        )}
-                    >
-                        <span>{this.renderButtonDropMenu()}</span>
-                    </OverlayTrigger>
+                    <Tooltip content={this.props.tooltip} placement="left">
+                        {this.renderButtonDropMenu()}
+                    </Tooltip>
                 ) :
                     this.renderButtonDropMenu()
                 }

--- a/client/components/fields/calendars.tsx
+++ b/client/components/fields/calendars.tsx
@@ -3,8 +3,7 @@
 import React from 'react';
 import {connect} from 'react-redux';
 import {get} from 'lodash';
-import {Spacer} from 'superdesk-ui-framework/react';
-import {OverlayTrigger, Tooltip} from 'react-bootstrap';
+import {Spacer, Tooltip} from 'superdesk-ui-framework/react';
 import {ICalendar, IFieldsProps, IPlanningAppState} from '../../interfaces';
 import {superdeskApi} from '../../superdeskApi';
 import {getVocabularyItemFieldTranslated} from '../../utils/vocabularies';
@@ -53,20 +52,17 @@ class CalendarsComponent extends React.PureComponent<IProps> {
                 <span className="sd-list-item__text-label">{gettext('Calendar:')}</span>
                 {<span className="sd-list-item__text-strong sd-list-item--element-rm-10">
                     {calendars.length > 0 ? (
-                        <OverlayTrigger
-                            placement="left"
-                            overlay={(
-                                <Tooltip
-                                    id="location_tooltip"
-                                    className="tooltip--text-left"
-                                >
+                        <Tooltip
+                            content={() => (
+                                <>
                                     {calendars.map((calendar) => (
                                         <div key={calendar.qcode}>
                                             {calendar.tooltip}
                                         </div>
                                     ))}
-                                </Tooltip>
+                                </>
                             )}
+                            placement="left"
                         >
                             <span>
                                 {calendars.map((calendar, index, array) => (
@@ -78,7 +74,7 @@ class CalendarsComponent extends React.PureComponent<IProps> {
                                     </span>
                                 ))}
                             </span>
-                        </OverlayTrigger>
+                        </Tooltip>
                     ) : (
                         <span>
                             {gettext('No calendars assigned')}

--- a/client/components/fields/editor/EventRelatedPlannings/EmbeddedCoverageForm.tsx
+++ b/client/components/fields/editor/EventRelatedPlannings/EmbeddedCoverageForm.tsx
@@ -182,6 +182,7 @@ export class EmbeddedCoverageFormComponent extends React.PureComponent<IProps, I
                             style={{padding: '2rem 0'}}
                         >
                             <SelectUser
+                                key={coverage.desk?._id}
                                 deskId={coverage.desk?._id}
                                 onSelect={(user) => {
                                     this.onUserChange(null, user);

--- a/client/components/fields/editor/EventSchedule.tsx
+++ b/client/components/fields/editor/EventSchedule.tsx
@@ -170,10 +170,15 @@ export class EditorFieldEventSchedule extends React.PureComponent<IEventSchedule
                 moment(fieldValue);
         };
 
-        addChange('dates.start', dates.start);
-        addChange('_startTime', _startTime);
-        addChange('dates.end', dates.end);
-        addChange('_endTime', _endTime);
+        if (dates.start != null && dates.all_day !== true) {
+            addChange('dates.start', dates.start);
+            addChange('_startTime', _startTime);
+        }
+
+        if (dates.end != null && dates.no_end_time !== true && dates.all_day !== true) {
+            addChange('dates.end', dates.end);
+            addChange('_endTime', _endTime);
+        }
 
         this.props.onChange(changes);
     }

--- a/client/constants/assignments.ts
+++ b/client/constants/assignments.ts
@@ -55,6 +55,7 @@ export const ASSIGNMENTS = {
         SET_LOADING: 'SET_LOADING',
     },
     WORKFLOW_STATE: {
+        DRAFT: 'draft',
         ASSIGNED: 'assigned',
         IN_PROGRESS: 'in_progress',
         COMPLETED: 'completed',

--- a/client/selectors/assignments.ts
+++ b/client/selectors/assignments.ts
@@ -17,6 +17,7 @@ import {currentUserId} from './general';
 import {coverageProfiles} from './coverageProfiles';
 import {getItemsById} from '../utils';
 import {ASSIGNMENTS, SORT_DIRECTION, ALL_DESKS} from '../constants';
+import moment from 'moment';
 
 export const getStoredAssignments = (state) => get(state, 'assignment.assignments', {});
 export const getStoredArchiveItems = (state) => get(state, 'assignment.archive', {});
@@ -45,12 +46,10 @@ const filterBySelectedDay = (
 ) => {
     if (selectedDate == null) return assignments;
 
-    const targetDay = new Date(selectedDate).toDateString();
-
     return assignments.filter((assignment) => {
         const scheduled = assignment?.planning?.scheduled;
 
-        return scheduled != null && new Date(scheduled).toDateString() === targetDay;
+        return scheduled != null && moment(scheduled).isSame(selectedDate, 'day');
     });
 };
 

--- a/client/styles/index.scss
+++ b/client/styles/index.scss
@@ -122,3 +122,7 @@
         word-break: break-word;
     }
 }
+
+[class="icon-dots-vertical"], [class="icon-pencil"] {
+    pointer-events: unset !important;
+}

--- a/client/utils/events.tsx
+++ b/client/utils/events.tsx
@@ -973,7 +973,8 @@ function getEventActions(
 
     let actions = [];
     const isExpired = isItemExpired(item);
-    let alllowedCallBacks = [
+
+    let allowedCallBacks = [
         EVENTS.ITEM_ACTIONS.PREVIEW.actionName,
         EVENTS.ITEM_ACTIONS.EDIT_EVENT.actionName,
         EVENTS.ITEM_ACTIONS.EDIT_EVENT_MODAL.actionName,
@@ -982,7 +983,6 @@ function getEventActions(
         EVENTS.ITEM_ACTIONS.CANCEL_EVENT.actionName,
         EVENTS.ITEM_ACTIONS.SPIKE.actionName,
         EVENTS.ITEM_ACTIONS.UNSPIKE.actionName,
-        EVENTS.ITEM_ACTIONS.UPDATE_TIME.actionName,
         EVENTS.ITEM_ACTIONS.POSTPONE_EVENT.actionName,
         EVENTS.ITEM_ACTIONS.RESCHEDULE_EVENT.actionName,
         EVENTS.ITEM_ACTIONS.UPDATE_REPETITIONS.actionName,
@@ -990,19 +990,23 @@ function getEventActions(
         EVENTS.ITEM_ACTIONS.MARK_AS_COMPLETED.actionName,
     ];
 
+    if (appConfig.planning_event_link_method !== 'many_secondary') {
+        allowedCallBacks.push(EVENTS.ITEM_ACTIONS.UPDATE_TIME.actionName);
+    }
+
     if (appConfig.event_templates_enabled === true) {
-        alllowedCallBacks.push(EVENTS.ITEM_ACTIONS.SAVE_AS_TEMPLATE.actionName);
+        allowedCallBacks.push(EVENTS.ITEM_ACTIONS.SAVE_AS_TEMPLATE.actionName);
     }
 
     if (isExpired && !privileges[PRIVILEGES.EDIT_EXPIRED]) {
-        alllowedCallBacks = [EVENTS.ITEM_ACTIONS.DUPLICATE.actionName];
+        allowedCallBacks = [EVENTS.ITEM_ACTIONS.DUPLICATE.actionName];
     }
 
     if (isItemSpiked(item)) {
-        alllowedCallBacks = [EVENTS.ITEM_ACTIONS.UNSPIKE.actionName];
+        allowedCallBacks = [EVENTS.ITEM_ACTIONS.UNSPIKE.actionName];
     }
 
-    alllowedCallBacks.forEach((callbackName) => {
+    allowedCallBacks.forEach((callbackName) => {
         const action = find(EVENTS.ITEM_ACTIONS, (action) => action.actionName === callbackName);
 
         if (callBacks[action.actionName]) {

--- a/e2e/cypress/support/common/inputs/coverageUserSelectInput.ts
+++ b/e2e/cypress/support/common/inputs/coverageUserSelectInput.ts
@@ -15,7 +15,7 @@ export class CoverageUserSelectInput extends Input {
 
         popup.element.find('[data-test-id="filter-input"]', {timeout: 2000})
             .should('be.enabled')
-            .type(value);
+            .type(value, {force: true});
 
         popup.element.find('li')
             .first()

--- a/package-lock.json
+++ b/package-lock.json
@@ -11077,7 +11077,7 @@
         "sass-loader": "^10.5.2",
         "shallow-equal": "^3.1.0",
         "shortid": "2.2.8",
-        "superdesk-ui-framework": "4.0.94",
+        "superdesk-ui-framework": "5.0.3",
         "ts-loader": "^8.4.0",
         "typescript": "~4.9.5",
         "uuid": "8.3.1",
@@ -11223,9 +11223,9 @@
       }
     },
     "superdesk-ui-framework": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/superdesk-ui-framework/-/superdesk-ui-framework-4.1.2.tgz",
-      "integrity": "sha512-9z1v1A2CRsf9Hde6MqxzD0/EP2PY+ZmQnXnQJDiX1KCHwQE7FeUSRubaCm6Vd3jrTe1BLqiT/ElkMdwo6VCPyg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/superdesk-ui-framework/-/superdesk-ui-framework-5.1.0.tgz",
+      "integrity": "sha512-CPAfSfj14oS5jW+bUohQMBCjxkGoaTH/GfLyohLJ2jBKtprVImh6Z9Rnqod8HAHNm1JCE2Y0czkIjnXtybixMQ==",
       "dev": true,
       "requires": {
         "@popperjs/core": "^2.4.0",
@@ -11240,7 +11240,6 @@
         "react-beautiful-dnd": "^13.0.0",
         "react-id-generator": "^3.0.0",
         "react-scrollspy": "^3.4.3",
-        "tippy.js": "^6.3.7",
         "weekstart": "^2.0.0"
       },
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11183,9 +11183,9 @@
           }
         },
         "superdesk-ui-framework": {
-          "version": "4.0.94",
-          "resolved": "https://registry.npmjs.org/superdesk-ui-framework/-/superdesk-ui-framework-4.0.94.tgz",
-          "integrity": "sha512-yApsiE9mVHpE6ZlPjLlNGtUz2PDVxRbHccmGxcAf0mzhiYpl6tbIiBlr1IVPUOJBSmrDTRT69kLkxdI1jPyYPQ==",
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/superdesk-ui-framework/-/superdesk-ui-framework-5.0.3.tgz",
+          "integrity": "sha512-5W+p85b0XrbRYhLZWE7vp+F7/aNCBfjqGCCRY+M8VhbsF8ODuO5WOIj9En664APBhCE30C8AtRAsK3tbHx547A==",
           "dev": true,
           "requires": {
             "@popperjs/core": "^2.4.0",
@@ -11223,9 +11223,9 @@
       }
     },
     "superdesk-ui-framework": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/superdesk-ui-framework/-/superdesk-ui-framework-5.1.0.tgz",
-      "integrity": "sha512-CPAfSfj14oS5jW+bUohQMBCjxkGoaTH/GfLyohLJ2jBKtprVImh6Z9Rnqod8HAHNm1JCE2Y0czkIjnXtybixMQ==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/superdesk-ui-framework/-/superdesk-ui-framework-5.1.2.tgz",
+      "integrity": "sha512-H9OgvZ0z8ujAUPWwtrpDRNseQdI9aglQGoXZI7NOjSlanO2S1glvD9sklHHG9Xs6JooXXjdMiWB//iW7dA/11Q==",
       "dev": true,
       "requires": {
         "@popperjs/core": "^2.4.0",
@@ -11268,9 +11268,9 @@
           }
         },
         "csstype": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-          "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.0.tgz",
+          "integrity": "sha512-si++xzRAY9iPp60roQiFta7OFbhrgvcthrhlNAGeQptSY25uJjkfUV8OArC3KLocB8JT8ohz+qgxWCmz8RhjIg==",
           "dev": true
         },
         "dom-helpers": {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "style-loader": "^2.0.0",
     "superdesk-code-style": "1.5.0",
     "superdesk-core": "github:superdesk/superdesk-client-core#release/3.1",
-    "superdesk-ui-framework": "^4.0.91",
+    "superdesk-ui-framework": "5.1.0",
     "ts-loader": "^8.4.0",
     "ts-node": "~7.0.1",
     "tslint": "5.11.0",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "style-loader": "^2.0.0",
     "superdesk-code-style": "1.5.0",
     "superdesk-core": "github:superdesk/superdesk-client-core#release/3.1",
-    "superdesk-ui-framework": "5.1.0",
+    "superdesk-ui-framework": "5.1.2",
     "ts-loader": "^8.4.0",
     "ts-node": "~7.0.1",
     "tslint": "5.11.0",

--- a/server/features/search.feature
+++ b/server/features/search.feature
@@ -193,11 +193,11 @@ Feature: Search Feature
     Scenario: Search events and planning using calendars and agenda
         Given "agenda"
         """
-            [
-                {"name": "sports", "_id": "sports", "is_enabled": true},
-                {"name": "finance", "_id": "finance", "is_enabled": true},
-                {"name": "entertainment", "_id": "entertainment", "is_enabled": true}
-            ]
+        [
+            {"name": "sports", "_id": "68e5df45ac0f6c8b678c17b1", "is_enabled": true},
+            {"name": "finance", "_id": "68e5df45ac0f6c8b678c17b2", "is_enabled": true},
+            {"name": "entertainment", "_id": "68e5df45ac0f6c8b678c17b3", "is_enabled": true}
+        ]
         """
         And "events"
             """
@@ -268,7 +268,7 @@ Feature: Search Feature
                 "headline": "test headline",
                 "slugline": "slug123",
                 "planning_date": "2016-01-02T12:00:00+0000",
-                "agendas": ["sports"]
+                "agendas": ["68e5df45ac0f6c8b678c17b1"]
             },
             {
                 "guid": "planning_2",
@@ -277,7 +277,7 @@ Feature: Search Feature
                 "slugline": "slug123",
                 "related_events": [{"_id": "event_123", "link_type": "primary"}],
                 "planning_date": "2016-01-02T13:00:00+0000",
-                "agendas": ["sports"]
+                "agendas": ["68e5df45ac0f6c8b678c17b1"]
             },
             {
                 "guid": "planning_3",
@@ -286,7 +286,7 @@ Feature: Search Feature
                 "slugline": "slug456",
                 "related_events": [{"_id": "event_456", "link_type": "primary"}],
                 "planning_date": "2016-01-02T14:00:00+0000",
-                "agendas": ["finance"]
+                "agendas": ["68e5df45ac0f6c8b678c17b2"]
             },
             {
                 "guid": "planning_4",
@@ -295,7 +295,7 @@ Feature: Search Feature
                 "slugline": "slug456",
                 "related_events": [{"_id": "event_456", "link_type": "primary"}],
                 "planning_date": "2016-01-02T14:00:00+0000",
-                "agendas": ["entertainment"]
+                "agendas": ["68e5df45ac0f6c8b678c17b3"]
             },
             {
                 "guid": "planning_5",
@@ -304,7 +304,7 @@ Feature: Search Feature
                 "slugline": "slug456",
                 "related_events": [{"_id": "event_786", "link_type": "primary"}],
                 "planning_date": "2016-01-02T14:00:00+0000",
-                "agendas": ["sports", "finance"]
+                "agendas": ["68e5df45ac0f6c8b678c17b1", "68e5df45ac0f6c8b678c17b2"]
             },
             {
                 "guid": "planning_6",
@@ -312,7 +312,7 @@ Feature: Search Feature
                 "headline": "test headline",
                 "slugline": "slug456",
                 "planning_date": "2016-01-02T14:00:00+0000",
-                "agendas": ["entertainment"]
+                "agendas": ["68e5df45ac0f6c8b678c17b3"]
             }
         ]
         """
@@ -343,7 +343,7 @@ Feature: Search Feature
             ]
         }
         """
-        When we get "/events_planning_search?agendas=sports&calendars=sports&start_date=2016-01-02T00:00:00%2B0000"
+        When we get "/events_planning_search?agendas=68e5df45ac0f6c8b678c17b1&calendars=sports&start_date=2016-01-02T00:00:00%2B0000"
         Then we get list with 5 items
         """
         {
@@ -356,7 +356,7 @@ Feature: Search Feature
             ]
         }
         """
-        When we get "/events_planning_search?agendas=sports&calendars=sports,finance&start_date=2016-01-02T00:00:00%2B0000"
+        When we get "/events_planning_search?agendas=68e5df45ac0f6c8b678c17b1&calendars=sports,finance&start_date=2016-01-02T00:00:00%2B0000"
         Then we get list with 5 items
         """
         {
@@ -369,7 +369,7 @@ Feature: Search Feature
             ]
         }
         """
-        When we get "/events_planning_search?agendas=sports,finance&calendars=sports,finance&start_date=2016-01-02T00:00:00%2B0000"
+        When we get "/events_planning_search?agendas=68e5df45ac0f6c8b678c17b1,68e5df45ac0f6c8b678c17b2&calendars=sports,finance&start_date=2016-01-02T00:00:00%2B0000"
         Then we get list with 6 items
         """
         {
@@ -383,7 +383,7 @@ Feature: Search Feature
             ]
         }
         """
-        When we get "/events_planning_search?agendas=entertainment&start_date=2016-01-02T00:00:00%2B0000"
+        When we get "/events_planning_search?agendas=68e5df45ac0f6c8b678c17b3&start_date=2016-01-02T00:00:00%2B0000"
         Then we get list with 2 items
         """
         {
@@ -393,7 +393,7 @@ Feature: Search Feature
             ]
         }
         """
-        When we get "/events_planning_search?agendas=sports&start_date=2016-01-02T00:00:00%2B0000"
+        When we get "/events_planning_search?agendas=68e5df45ac0f6c8b678c17b1&start_date=2016-01-02T00:00:00%2B0000"
         Then we get list with 3 items
         """
         {

--- a/server/features/search_combined.feature
+++ b/server/features/search_combined.feature
@@ -2,11 +2,11 @@ Feature: Search Events and Planning
     Background: Initial setup
         Given "agenda"
         """
-            [
-                {"name": "sports", "_id": "sports", "is_enabled": true},
-                {"name": "finance", "_id": "finance", "is_enabled": true},
-                {"name": "entertainment", "_id": "entertainment", "is_enabled": true}
-            ]
+        [
+            {"name": "sports", "_id": "68e5df45ac0f6c8b678c17b1", "is_enabled": true},
+            {"name": "finance", "_id": "68e5df45ac0f6c8b678c17b2", "is_enabled": true},
+            {"name": "entertainment", "_id": "68e5df45ac0f6c8b678c17b3", "is_enabled": true}
+        ]
         """
         And "events"
             """

--- a/server/features/search_events.feature
+++ b/server/features/search_events.feature
@@ -2,11 +2,11 @@ Feature: Event Search
     Background: Initial setup
         Given "agenda"
         """
-            [
-                {"name": "sports", "_id": "sports", "is_enabled": true},
-                {"name": "finance", "_id": "finance", "is_enabled": true},
-                {"name": "entertainment", "_id": "entertainment", "is_enabled": true}
-            ]
+        [
+            {"name": "sports", "_id": "68e5df45ac0f6c8b678c17b1", "is_enabled": true},
+            {"name": "finance", "_id": "68e5df45ac0f6c8b678c17b2", "is_enabled": true},
+            {"name": "entertainment", "_id": "68e5df45ac0f6c8b678c17b3", "is_enabled": true}
+        ]
         """
         And "events"
             """
@@ -102,7 +102,7 @@ Feature: Event Search
                 "headline": "test headline",
                 "slugline": "slug123",
                 "planning_date": "2016-01-02T12:00:00+0000",
-                "agendas": ["sports"]
+                "agendas": ["68e5df45ac0f6c8b678c17b1"]
             }
         ]
         """

--- a/server/features/search_planning.feature
+++ b/server/features/search_planning.feature
@@ -2,11 +2,11 @@ Feature: Planning Search
     Background: Initial setup
         Given "agenda"
         """
-            [
-                {"name": "sports", "_id": "sports", "is_enabled": true},
-                {"name": "finance", "_id": "finance", "is_enabled": true},
-                {"name": "entertainment", "_id": "entertainment", "is_enabled": true}
-            ]
+        [
+            {"name": "sports", "_id": "68e5df45ac0f6c8b678c17b1", "is_enabled": true},
+            {"name": "finance", "_id": "68e5df45ac0f6c8b678c17b2", "is_enabled": true},
+            {"name": "entertainment", "_id": "68e5df45ac0f6c8b678c17b3", "is_enabled": true}
+        ]
         """
         And "events"
             """
@@ -316,7 +316,7 @@ Feature: Planning Search
 
     @auth
     Scenario: Search by planning specific parameters
-        When we get "/events_planning_search?repo=planning&only_future=false&agendas=sports,finance"
+        When we get "/events_planning_search?repo=planning&only_future=false&agendas=68e5df45ac0f6c8b678c17b1,68e5df45ac0f6c8b678c17b2"
         Then we get list with 3 items
         """
         {"_items": [

--- a/server/planning/types/agendas.py
+++ b/server/planning/types/agendas.py
@@ -1,11 +1,11 @@
 from typing import Annotated
 
-from .base import BasePlanningModel
+from .base import BasePlanningModelWithObjectId
 from superdesk.core.resources import fields, Dataclass
 from superdesk.core.resources.validators import validate_iunique_value_async
 
 
-class AgendasResourceModel(BasePlanningModel):
+class AgendasResourceModel(BasePlanningModelWithObjectId):
     name: Annotated[fields.Keyword, validate_iunique_value_async("agenda", "name")]
     is_enabled: bool = True
 

--- a/server/planning/types/assignment.py
+++ b/server/planning/types/assignment.py
@@ -6,7 +6,7 @@ from superdesk.utc import utcnow
 from superdesk.core.resources import fields, dataclass
 from superdesk.core.resources.validators import validate_data_relation_async
 
-from .base import BasePlanningModel
+from .base import BasePlanningModelWithObjectId
 from .common import LockFieldsMixin, AssignmentCoverage
 from .enums import AssignmentPublishedState, AssignmentWorkflowState
 
@@ -32,9 +32,7 @@ class AssignedTo:
     coverage_provider: CoverageProvider | None = None
 
 
-class AssignmentResourceModel(BasePlanningModel, LockFieldsMixin):
-    id: Annotated[fields.ObjectId, Field(alias="_id", default_factory=fields.ObjectId)]
-
+class AssignmentResourceModel(BasePlanningModelWithObjectId, LockFieldsMixin):
     firstcreated: datetime = Field(default_factory=utcnow)
     versioncreated: datetime = Field(default_factory=utcnow)
 

--- a/server/planning/types/base.py
+++ b/server/planning/types/base.py
@@ -1,9 +1,18 @@
 from typing import Annotated
-from superdesk.core.resources import ResourceModel
+
+from superdesk.core.resources import ResourceModel, ResourceModelWithObjectId
 from superdesk.core.resources.fields import ObjectId
 from superdesk.core.resources.validators import validate_data_relation_async
 
 
-class BasePlanningModel(ResourceModel):
+class VersionCreatorMixin:
     original_creator: Annotated[ObjectId | None, validate_data_relation_async("users")] = None
     version_creator: Annotated[ObjectId | None, validate_data_relation_async("users")] = None
+
+
+class BasePlanningModel(ResourceModel, VersionCreatorMixin):
+    pass
+
+
+class BasePlanningModelWithObjectId(ResourceModelWithObjectId, VersionCreatorMixin):
+    pass

--- a/server/planning/types/filters.py
+++ b/server/planning/types/filters.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from superdesk.core.resources import fields, Dataclass
 from superdesk.core.resources.validators import validate_data_relation_async, validate_iunique_value_async
 
-from .base import BasePlanningModel
+from .base import BasePlanningModelWithObjectId
 from .enums import LockState, SpikedState, SearchItemType, SearchScheduleFrequency, SearchWeekDay, SearchDateRange
 
 
@@ -86,7 +86,7 @@ class FilterParams(Dataclass):
     coverage_assignment_status: str | None = None
 
 
-class EventPlanningFilter(BasePlanningModel):
+class EventPlanningFilter(BasePlanningModelWithObjectId):
     name: Annotated[str, validate_iunique_value_async("events_planning_filters", "name")]
     item_type: SearchItemType = Field(default=SearchItemType.COMBINED)
     params: FilterParams = Field(default_factory=FilterParams)

--- a/server/planning/types/locations.py
+++ b/server/planning/types/locations.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import Any, Annotated
 from pydantic import Field
 
-from planning.types.base import BasePlanningModel
+from planning.types.base import BasePlanningModelWithObjectId
 
 from superdesk.utc import utcnow
 from superdesk.core.resources import fields, dataclass
@@ -34,7 +34,7 @@ class Address:
     address_type: str | None = Field(alias="type", default=None)
 
 
-class LocationResourceModel(BasePlanningModel):
+class LocationResourceModel(BasePlanningModelWithObjectId):
     guid: Annotated[
         fields.Keyword,
         validate_iunique_value_async("locations", "guid"),


### PR DESCRIPTION
### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

### Front-end checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)

Resolves: #[issue-number]

