### PR TITLE
[STT-1463] Config to exclude Asignee fields in JSON Planning formatter

### DIFF
--- a/server/planning/output_formatters/json_planning.py
+++ b/server/planning/output_formatters/json_planning.py
@@ -196,9 +196,10 @@ class JsonPlanningFormatter(BaseJsonFormatter):
         return deliveries, assignment.get("assigned_to").get("state")
 
     async def _expand_coverage_contacts(self, coverage):
+        ASIGNEE_FIELDS = get_config(list[str], "PLANNING_JSON_EXCLUDE_ASSIGNEE_FIELDS", [])
         EXTENDED_INFO = get_config(bool, "PLANNING_JSON_ASSIGNED_INFO_EXTENDED", False)
 
-        if (coverage.get("assigned_to") or {}).get("contact"):
+        if "contact" not in ASIGNEE_FIELDS and (coverage.get("assigned_to") or {}).get("contact"):
             expanded_contacts = await expand_contact_info([coverage["assigned_to"]["contact"]])
             if expanded_contacts:
                 coverage["coverage_provider_contact_info"] = {
@@ -206,7 +207,7 @@ class JsonPlanningFormatter(BaseJsonFormatter):
                     "last_name": expanded_contacts[0]["last_name"],
                 }
 
-        if (coverage.get("assigned_to") or {}).get("user"):
+        if "user" not in ASIGNEE_FIELDS and (coverage.get("assigned_to") or {}).get("user"):
             user = get_resource_service("users").find_one(req=None, _id=coverage["assigned_to"]["user"])
             if user and not user.get("private"):
                 coverage["assigned_user"] = {
@@ -220,7 +221,7 @@ class JsonPlanningFormatter(BaseJsonFormatter):
                         email=user.get("email"),
                     )
 
-        if (coverage.get("assigned_to") or {}).get("desk"):
+        if "desk" not in ASIGNEE_FIELDS and (coverage.get("assigned_to") or {}).get("desk"):
             desk = get_resource_service("desks").find_one(req=None, _id=coverage["assigned_to"]["desk"])
             if desk:
                 coverage["assigned_desk"] = {

--- a/server/planning/tests/output_formatters/json_planning_test.py
+++ b/server/planning/tests/output_formatters/json_planning_test.py
@@ -452,3 +452,32 @@ class JsonPlanningTestCase(TestCase):
         self.assertIsNone((await self.format(item)).get("event_item"))
         item.pop("related_events")
         self.assertIsNone((await self.format(item)).get("event_item"))
+
+    async def test_exclude_asignee_fields(self):
+        item = deepcopy(self.item)
+        desk_id = ObjectId()
+        user_id = ObjectId()
+
+        item["coverages"][0]["assigned_to"].update(
+            desk=desk_id,
+            user=user_id,
+        )
+
+        async with self.app.app_context():
+            self.app.data.insert(
+                "desks",
+                [{"_id": desk_id, "name": "sports", "email": "sports@example.com"}],
+            )
+            self.app.data.insert("users", [{"_id": user_id, "display_name": "John Doe", "email": "john@example.com"}])
+
+        output_item = await self.format(item)
+        coverage = output_item["coverages"][0]
+        assert "assigned_user" in coverage
+        assert "assigned_desk" in coverage
+
+        with mock.patch.dict(self.app.config, {"PLANNING_JSON_EXCLUDE_ASSIGNEE_FIELDS": ["desk"]}):
+            output_item = await self.format(item)
+
+        coverage = output_item["coverages"][0]
+        assert "assigned_user" in coverage
+        assert "assigned_desk" not in coverage


### PR DESCRIPTION
### Purpose
At the moment there is no way to exclude Desk, User or Contacts from Coverages in the JSON Planning formatter.

### What has changed
Add new config `PLANNING_JSON_EXCLUDE_ASSIGNEE_FIELDS` to define fields to exclude. Supports one of:
* desk
* user
* contact

Resolves: [STT-1463](https://sofab.atlassian.net/browse/STT-1463)



[STT-1463]: https://sofab.atlassian.net/browse/STT-1463?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ