### PR TITLE
Fix assignment count display in group list

### DIFF
--- a/client/components/Assignments/AssignmentGroupList.tsx
+++ b/client/components/Assignments/AssignmentGroupList.tsx
@@ -305,9 +305,9 @@ class AssignmentGroupListComponent extends React.Component<IProps, IState> {
                             <div className="sd-list-header__number sd-flex-grow">
                                 <span className="a11y-only">{gettext(
                                     'Number of Assignments: ',
-                                    {count: (assignmentsCount)}
+                                    {count: (totalCount)}
                                 )}</span>
-                                <span className="badge">{(assignmentsCount)}</span>
+                                <span className="badge">{(totalCount)}</span>
                             </div>
                         )}
 


### PR DESCRIPTION
### Purpose
To fix a regression introduced in https://github.com/superdesk/superdesk-planning/pull/2606 which showed the count of the assignments only in the frontend side and also considering the filtered by day. 

### What has changed
Replaces usage of `assignmentsCount` with `totalCount` for displaying the number of assignments in AssignmentGroupListComponent. Ensures the correct count is shown in the UI.

Resolves: [STT-1487]


[STT-1487]: https://sofab.atlassian.net/browse/STT-1487?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ