### PR TITLE
[STT-1489] - Use and track disabled prop for coverage editor fileds and add button

### DIFF
--- a/client/components/Coverages/CoverageAddButton/index.tsx
+++ b/client/components/Coverages/CoverageAddButton/index.tsx
@@ -10,6 +10,7 @@ interface IProps {
     className?: string;
     buttonClass?: string;
     language?: string;
+    disabled?: boolean;
 
     onChange(field: string, value: Array<DeepPartial<IPlanningCoverageItem>>): void;
     createCoverage(qcode: IG2ContentType['qcode']): DeepPartial<IPlanningCoverageItem>;
@@ -45,6 +46,7 @@ export class CoverageAddButton extends React.Component<IProps> {
                 target="icon-plus-large"
                 button={({toggleMenu}) => (
                     <Button
+                        disabled={this.props.disabled}
                         data-test-id="create-button"
                         type="primary"
                         icon="plus-large"

--- a/client/components/Coverages/CoverageArrayInput.tsx
+++ b/client/components/Coverages/CoverageArrayInput.tsx
@@ -33,7 +33,7 @@ interface IOwnProps {
     addButtonText?: string; // defaults to 'Add a coverage'
     item: IPlanningItem;
     value: Array<IPlanningCoverageItem>;
-    readOnly: boolean;
+    disabled: boolean;
     addNewsItemToPlanning?: IArticle;
     useLocalNavigation?: boolean;
     navigation?: any;
@@ -116,7 +116,7 @@ class CoverageArrayInputComponent extends React.Component<IProps, IState> {
         const prevCount = prevProps.value?.length ?? 0;
 
         if (currentCount > prevCount &&
-            (!this.props.readOnly || this.props.addNewsItemToPlanning != null) &&
+            (!this.props.disabled || this.props.addNewsItemToPlanning != null) &&
             currentCount - prevCount === 1
         ) {
             const coverageId = this.props.value[this.props.value.length - 1].coverage_id;
@@ -164,7 +164,7 @@ class CoverageArrayInputComponent extends React.Component<IProps, IState> {
             maxCoverageCount = 0,
             addOnly,
             originalCount,
-            readOnly,
+            disabled,
             message,
             popupContainer,
             onPopupOpen,
@@ -223,10 +223,11 @@ class CoverageArrayInputComponent extends React.Component<IProps, IState> {
                     coverageAddAdvancedMode,
                     language,
                     editorType,
+                    disabled,
                 }}
                 element={CoverageEditor}
                 createCoverage={createCoverage}
-                readOnly={readOnly}
+                disabled={disabled}
                 maxCount={maxCoverageCount}
                 addOnly={addOnly}
                 originalCount={originalCount}

--- a/client/components/Coverages/CoverageEditor/CoverageForm.tsx
+++ b/client/components/Coverages/CoverageEditor/CoverageForm.tsx
@@ -35,7 +35,7 @@ import {isCoverageAssigned, isCoverageDraft} from '../../../utils/planning';
 interface IOwnProps {
     field: string;
     value: IPlanningCoverageItem;
-    readOnly: boolean;
+    disabled: boolean;
     message: string | {[key: string]: any};
     item: IPlanningItem;
     diff: Partial<IPlanningItem>;
@@ -375,7 +375,7 @@ export class CoverageFormComponent extends React.Component<IProps, IState> {
         const hideXmpFileInput = this.props.value.planning?.xmp_file != null;
         const readOnlyFields = planningUtils.getCoverageReadOnlyFields(
             this.props.value,
-            this.props.readOnly,
+            this.props.disabled,
             this.props.newsCoverageStatus,
             this.props.addNewsItemToPlanning
         );
@@ -384,8 +384,8 @@ export class CoverageFormComponent extends React.Component<IProps, IState> {
             language: this.props.value.planning?.language ?? this.props.language,
             onChange: this.onChange,
             errors: this.props.errors,
-            readOnly: this.props.readOnly,
-            disabled: this.props.readOnly,
+            readOnly: this.props.disabled,
+            disabled: this.props.disabled,
             profile: profile,
             editorType: this.props.editorType,
         };
@@ -436,7 +436,7 @@ export class CoverageFormComponent extends React.Component<IProps, IState> {
                 onChange: this.onAnpaCategoryChange,
             },
             g2_content_type: {
-                readOnly: this.props.readOnly || readOnlyFields.g2_content_type,
+                readOnly: this.props.disabled || readOnlyFields.g2_content_type,
                 field: 'planning.g2_content_type',
                 onChange: this.onContentTypeChange,
                 clearable: false,
@@ -448,7 +448,7 @@ export class CoverageFormComponent extends React.Component<IProps, IState> {
                 clearable: false,
             },
             xmp_file: {
-                readOnly: this.props.readOnly || readOnlyFields.xmp_file,
+                readOnly: this.props.disabled || readOnlyFields.xmp_file,
                 field: 'planning.xmp_file',
                 enabled: showXmpFileInput,
                 hideInput: hideXmpFileInput,
@@ -458,57 +458,57 @@ export class CoverageFormComponent extends React.Component<IProps, IState> {
                 onRemoveFile: this.onRemoveXmpFile,
             },
             genre: {
-                readOnly: this.props.readOnly || readOnlyFields.genre,
+                readOnly: this.props.disabled || readOnlyFields.genre,
                 field: 'planning.genre',
                 defaultValue: contentTypeQcode === 'text' ? defaultGenre : null,
                 clearable: true,
             },
             slugline: {
-                readOnly: this.props.readOnly || readOnlyFields.slugline,
+                readOnly: this.props.disabled || readOnlyFields.slugline,
                 field: 'planning.slugline',
             },
             headline: {
-                readOnly: this.props.readOnly || readOnlyFields.headline,
+                readOnly: this.props.disabled || readOnlyFields.headline,
                 field: 'planning.headline',
             },
             ednote: {
-                readOnly: this.props.readOnly || readOnlyFields.ednote,
+                readOnly: this.props.disabled || readOnlyFields.ednote,
                 field: 'planning.ednote',
             },
             location: {
-                readOnly: this.props.readOnly || readOnlyFields.location,
-                enableExternalSearch: !(this.props.readOnly || readOnlyFields.location),
+                readOnly: this.props.disabled || readOnlyFields.location,
+                enableExternalSearch: !(this.props.disabled || readOnlyFields.location),
                 field: 'planning.location',
                 storeAsArray: true,
             },
             keyword: {
-                readOnly: this.props.readOnly || readOnlyFields.keyword,
+                readOnly: this.props.disabled || readOnlyFields.keyword,
                 field: 'planning.keyword',
             },
             internal_note: {
-                readOnly: this.props.readOnly || readOnlyFields.internal_note,
+                readOnly: this.props.disabled || readOnlyFields.internal_note,
                 field: 'planning.internal_note',
             },
             files: {
-                readOnly: this.props.readOnly || readOnlyFields.files,
+                readOnly: this.props.disabled || readOnlyFields.files,
                 field: 'planning.files',
                 uploadFiles: this.props.uploadFiles,
                 removeFile: this.props.removeFile,
                 files: this.props.files,
             },
             multiple_content: {
-                disabled: this.props.readOnly
+                disabled: this.props.disabled
                     ?? (coverageProfile?.schema?.['multiple_content'] as IProfileSchemaTypeList)?.read_only
                     ?? false,
                 field: 'planning.multiple_content',
                 defaultValue: (coverageProfile?.schema?.['multiple_content'] as IProfileSchemaTypeList)?.default_value,
             },
             news_coverage_status: {
-                readOnly: this.props.readOnly || readOnlyFields.newsCoverageStatus,
+                readOnly: this.props.disabled || readOnlyFields.newsCoverageStatus,
                 field: 'news_coverage_status',
             },
             scheduled: {
-                readOnly: this.props.readOnly || readOnlyFields.scheduled,
+                readOnly: this.props.disabled || readOnlyFields.scheduled,
                 field: 'planning.scheduled',
                 timeField: 'planning.scheduled',
                 toBeConfirmed: this.props.value?._time_to_be_confirmed,
@@ -517,7 +517,7 @@ export class CoverageFormComponent extends React.Component<IProps, IState> {
                 canClearTime: false,
             },
             no_content_linking: {
-                readOnly: this.props.readOnly || readOnlyFields.flags,
+                readOnly: this.props.disabled || readOnlyFields.flags,
                 field: 'flags.no_content_linking',
             },
             scheduled_updates: {
@@ -547,7 +547,8 @@ export class CoverageFormComponent extends React.Component<IProps, IState> {
         const shouldDisableToggle = () => {
             const {value, diff} = this.props;
 
-            return !(isCoverageDraft(value) && isCoverageAssigned(value) && !isItemExpired(diff));
+            return this.props.disabled
+                || !(isCoverageDraft(value) && isCoverageAssigned(value) && !isItemExpired(diff));
         };
 
         fieldProps.add_coverage_to_workflow = {

--- a/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx
+++ b/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx
@@ -18,7 +18,7 @@ interface IOwnProps {
     value: IPlanningCoverageItem | ICoverageScheduledUpdate;
     users: Array<IUser>;
     desks: Array<IDesk>;
-    readOnly?: boolean;
+    disabled?: boolean;
     addNewsItemToPlanning?: IArticle;
     onChange(field: string, value: any): void;
     onFocus?(): void;
@@ -122,13 +122,13 @@ class CoverageFormHeaderComponent extends React.PureComponent<IProps> {
         const {
             value,
             addNewsItemToPlanning,
-            readOnly,
+            disabled,
             lockedItems,
         } = this.props;
 
         if (addNewsItemToPlanning != null
             || (value as ICoverageScheduledUpdate).scheduled_update_id != null
-            || readOnly === true
+            || disabled === true
         ) {
             return null;
         }
@@ -189,7 +189,7 @@ class CoverageFormHeaderComponent extends React.PureComponent<IProps> {
             value,
             users,
             desks,
-            readOnly,
+            disabled,
         } = this.props;
 
         const userAssigned = getCreator(value, 'assigned_to.user', users);
@@ -216,7 +216,7 @@ class CoverageFormHeaderComponent extends React.PureComponent<IProps> {
                                 </span>
                             </span>
                         </ListRow>
-                        {!cancelled && !readOnly && (
+                        {!cancelled && !disabled && (
                             <ListRow>
                                 <Button
                                     id="editAssignment"

--- a/client/components/Coverages/CoverageEditor/index.tsx
+++ b/client/components/Coverages/CoverageEditor/index.tsx
@@ -49,7 +49,7 @@ interface IOwnProps {
     contentTypes: Array<IG2ContentType>;
     coverageProviders: Array<ICoverageProvider>;
     priorities: Array<IAssignmentPriority>;
-    readOnly: boolean;
+    disabled: boolean;
     message: any;
     diff: any; // planning item
     formProfile: any;
@@ -186,7 +186,7 @@ export class CoverageEditorComponent extends React.PureComponent<IProps> {
             contentTypes,
             newsCoverageStatus,
             coverageProviders,
-            readOnly,
+            disabled,
             message,
             invalid,
             addNewsItemToPlanning,
@@ -209,7 +209,7 @@ export class CoverageEditorComponent extends React.PureComponent<IProps> {
         // `this.props.field` can be 'coverages[0]'
         const fieldOfArray = 'coverages';
 
-        if (!readOnly && !addNewsItemToPlanning) {
+        if (!disabled && !addNewsItemToPlanning) {
             const language = value.planning?.language ?? getUserInterfaceLanguageFromCV();
 
             itemActions = [
@@ -320,7 +320,7 @@ export class CoverageEditorComponent extends React.PureComponent<IProps> {
                 onChange={onChange}
                 users={users}
                 desks={desks}
-                readOnly={readOnly}
+                disabled={disabled}
                 addNewsItemToPlanning={addNewsItemToPlanning}
                 {...props}
             />
@@ -333,7 +333,7 @@ export class CoverageEditorComponent extends React.PureComponent<IProps> {
                 diff={diff}
                 index={index}
                 onChange={onChange}
-                readOnly={readOnly}
+                disabled={disabled}
                 message={message}
                 item={diff}
                 hasAssignment={planningUtils.isCoverageAssigned(value)}

--- a/client/components/Coverages/CoveragePreview/index.tsx
+++ b/client/components/Coverages/CoveragePreview/index.tsx
@@ -186,7 +186,7 @@ export class CoveragePreview extends React.PureComponent<IProps> {
                                 desks={desks}
                                 newsCoverageStatus={newsCoverageStatus}
                                 forPreview
-                                readOnly
+                                disabled
                             />
                         ))}
                     </PreviewRow>

--- a/client/components/Coverages/ScheduledUpdate/ScheduledUpdateForm.tsx
+++ b/client/components/Coverages/ScheduledUpdate/ScheduledUpdateForm.tsx
@@ -18,7 +18,7 @@ interface IProps {
     value: any;
     onChange: (field: string, value: any) => void;
     newsCoverageStatus: Array<any>;
-    readOnly: boolean;
+    disabled: boolean;
     item?: any;
     diff: any;
     formProfile?: any;
@@ -66,7 +66,7 @@ export class ScheduledUpdateForm extends React.Component<IProps> {
             index,
             onChange,
             newsCoverageStatus,
-            readOnly,
+            disabled,
             item,
             diff,
             formProfile,
@@ -93,7 +93,7 @@ export class ScheduledUpdateForm extends React.Component<IProps> {
 
         const roFields = planningUtils.getCoverageReadOnlyFields(
             value,
-            readOnly,
+            disabled,
             newsCoverageStatus,
             addNewsItemToPlanning
         );
@@ -121,7 +121,7 @@ export class ScheduledUpdateForm extends React.Component<IProps> {
                     onPopupOpen={onPopupOpen}
                     onPopupClose={onPopupClose}
                     singleValue={true}
-                    readOnly={readOnly}
+                    readOnly={disabled}
                 />
 
                 <Field

--- a/client/components/Coverages/ScheduledUpdate/index.tsx
+++ b/client/components/Coverages/ScheduledUpdate/index.tsx
@@ -40,7 +40,7 @@ interface IProps {
     newsCoverageStatus: Array<IPlanningNewsCoverageStatus>;
     coverageProviders: Array<ICoverageProvider>;
     priorities: Array<IAssignmentPriority>;
-    readOnly: boolean;
+    disabled: boolean;
     addNewsItemToPlanning?: IArticle;
     openCoverageIds: Array<IPlanningCoverageItem['coverage_id']>;
     autoAssignToWorkflow: boolean;
@@ -98,7 +98,7 @@ export class ScheduledUpdate extends React.PureComponent<IProps> {
             onChange,
             coverageProviders,
             priorities,
-            readOnly,
+            disabled,
             addNewsItemToPlanning,
             popupContainer,
             onPopupOpen,
@@ -120,7 +120,7 @@ export class ScheduledUpdate extends React.PureComponent<IProps> {
         // Coverage item actions
         let itemActions = [];
 
-        if (!readOnly && !addNewsItemToPlanning) {
+        if (!disabled && !addNewsItemToPlanning) {
             // To be done in the next iteration
             if (planningUtils.canCancelCoverage(value, planning, 'scheduled_update_id')) {
                 itemActions.push({
@@ -178,7 +178,7 @@ export class ScheduledUpdate extends React.PureComponent<IProps> {
                 index={index}
                 coverage={value}
                 itemActionComponent={itemActionComponent}
-                readOnly={readOnly}
+                readOnly={disabled}
                 isPreview={forPreview}
                 workflowStateReasonPrefix={`coverages[${coverageIndex}].scheduled_updates[${index}]`}
             />
@@ -199,7 +199,7 @@ export class ScheduledUpdate extends React.PureComponent<IProps> {
                 onChange={onChange}
                 users={users}
                 desks={desks}
-                readOnly={readOnly}
+                disabled={disabled}
                 addNewsItemToPlanning={addNewsItemToPlanning}
             />
         );
@@ -244,7 +244,7 @@ export class ScheduledUpdate extends React.PureComponent<IProps> {
                 coverageIndex={coverageIndex}
                 newsCoverageStatus={newsCoverageStatus}
                 genres={genres}
-                readOnly={readOnly}
+                readOnly={disabled}
                 hasAssignment={planningUtils.isCoverageAssigned(value)}
                 addNewsItemToPlanning={addNewsItemToPlanning}
                 onFieldFocus={onFocus}

--- a/client/components/Coverages/ScheduledUpdate/index.tsx
+++ b/client/components/Coverages/ScheduledUpdate/index.tsx
@@ -194,6 +194,7 @@ export class ScheduledUpdate extends React.PureComponent<IProps> {
             />
         ) : (
             <CoverageFormHeader
+                coverages={[]}
                 field={fieldName}
                 value={value}
                 onChange={onChange}
@@ -244,7 +245,7 @@ export class ScheduledUpdate extends React.PureComponent<IProps> {
                 coverageIndex={coverageIndex}
                 newsCoverageStatus={newsCoverageStatus}
                 genres={genres}
-                readOnly={disabled}
+                disabled={disabled}
                 hasAssignment={planningUtils.isCoverageAssigned(value)}
                 addNewsItemToPlanning={addNewsItemToPlanning}
                 onFieldFocus={onFocus}

--- a/client/components/Editor/EditorBookmarksBar.tsx
+++ b/client/components/Editor/EditorBookmarksBar.tsx
@@ -103,7 +103,7 @@ class EditorBookmarksBarComponent extends React.PureComponent<IProps> {
                                         editorType={this.props.editorType}
                                         index={index}
                                         item={this.props.item}
-                                        readOnly={readOnly}
+                                        disabled={readOnly}
                                     />
                                 );
                             } else if (bookmark.type === BOOKMARK_TYPE.formGroup) {
@@ -115,7 +115,7 @@ class EditorBookmarksBarComponent extends React.PureComponent<IProps> {
                                         editorType={this.props.editorType}
                                         index={index}
                                         item={this.props.item}
-                                        readOnly={readOnly}
+                                        disabled={readOnly}
                                     />
                                 );
                             } else if (bookmark.type === BOOKMARK_TYPE.custom && !bookmark.disabled) {
@@ -129,7 +129,7 @@ class EditorBookmarksBarComponent extends React.PureComponent<IProps> {
                                         editorType={this.props.editorType}
                                         index={index}
                                         item={this.props.item}
-                                        readOnly={readOnly}
+                                        disabled={readOnly}
                                     />
                                 );
                             }

--- a/client/components/Editor/bookmarks/AddCoverageBookmark.tsx
+++ b/client/components/Editor/bookmarks/AddCoverageBookmark.tsx
@@ -104,7 +104,7 @@ export class AddCoverageBookmark extends React.PureComponent<IProps> {
     }
 
     render() {
-        if (this.props.readOnly) {
+        if (this.props.disabled) {
             return null;
         }
 

--- a/client/components/Editor/bookmarks/AddPlanningBookmark.tsx
+++ b/client/components/Editor/bookmarks/AddPlanningBookmark.tsx
@@ -19,7 +19,7 @@ export class AddPlanningBookmark extends React.PureComponent<IBookmarkProps> {
     }
 
     render() {
-        if (this.props.readOnly || this.props.editorType === EDITOR_TYPE.POPUP) {
+        if (this.props.disabled || this.props.editorType === EDITOR_TYPE.POPUP) {
             return null;
         }
 

--- a/client/components/Editor/bookmarks/CoveragesBookmark.tsx
+++ b/client/components/Editor/bookmarks/CoveragesBookmark.tsx
@@ -22,7 +22,7 @@ import {Row} from '../../UI/Form';
 import * as List from '../../UI/List';
 import {CoverageItem} from '../../Coverages';
 import {getAvatarForCoverage, isAvatarPlaceholder} from '../../Coverages/CoverageIcons';
-
+import {CoverageEditorComponent} from 'components/Coverages/CoverageEditor';
 
 interface IProps extends IBookmarkProps {
     users: Array<IUser>;
@@ -55,7 +55,7 @@ class CoveragesBookmarkComponent extends React.Component<IProps, IState> {
         this.toggleCoverages = this.toggleCoverages.bind(this);
     }
 
-    getCoverageEditorInstance(coverageId: IPlanningCoverageItem['coverage_id']): CoverageEditor | undefined {
+    getCoverageEditorInstance(coverageId: IPlanningCoverageItem['coverage_id']): CoverageEditorComponent | undefined {
         return this.editorApi.dom.fields[`coverage_${coverageId}`]?.current;
     }
 

--- a/client/components/Editor/bookmarks/CoveragesBookmark.tsx
+++ b/client/components/Editor/bookmarks/CoveragesBookmark.tsx
@@ -20,7 +20,7 @@ import * as selectors from '../../../selectors';
 import {Avatar, AvatarPlaceholder, Icon} from 'superdesk-ui-framework/react';
 import {Row} from '../../UI/Form';
 import * as List from '../../UI/List';
-import {CoverageEditor, CoverageItem} from '../../Coverages';
+import {CoverageItem} from '../../Coverages';
 import {getAvatarForCoverage, isAvatarPlaceholder} from '../../Coverages/CoverageIcons';
 
 

--- a/client/components/Planning/PlanningEditor/index.tsx
+++ b/client/components/Planning/PlanningEditor/index.tsx
@@ -378,6 +378,7 @@ class PlanningEditorComponent extends React.Component<IProps, IState> {
                         useLocalNavigation: !this.props.inModalView,
                         navigation: this.props.navigation,
                         maxCoverageCount: maxCoverageCount,
+                        disabled: this.props.readOnly,
                         addOnly: this.props.addNewsItemToPlanning != null,
                         originalCount: this.props.item?.coverages?.length ?? 0,
                         message: this.props.message,

--- a/client/components/UI/Form/InputArray/index.tsx
+++ b/client/components/UI/Form/InputArray/index.tsx
@@ -29,7 +29,7 @@ interface IProps {
     originalCount: number;
     element: React.ComponentClass<any>;
     createCoverage: (coverageType: ICoverageType) => DeepPartial<IPlanningCoverageItem>;
-    readOnly: boolean;
+    disabled: boolean;
     message: any;
     invalid: boolean;
     buttonWithLabel: boolean;
@@ -129,7 +129,7 @@ export class InputArray extends React.PureComponent<IProps> {
             addOnly,
             originalCount,
             element,
-            readOnly,
+            disabled,
             message,
             invalid,
             buttonWithLabel,
@@ -140,8 +140,8 @@ export class InputArray extends React.PureComponent<IProps> {
         } = this.props;
 
         const Component = element;
-        const showAddButton = (maxCount ? value.length < maxCount : true) && !readOnly;
-        const isIndexReadOnly = (index) => (addOnly && index === originalCount) ? false : readOnly;
+        const showAddButton = (maxCount ? value.length < maxCount : true) && !disabled;
+        const isIndexReadOnly = (index) => (addOnly && index === originalCount) ? false : disabled;
         const addButton = this.renderButton();
 
         const hasLabel = (label ?? '').length > 0;
@@ -165,7 +165,7 @@ export class InputArray extends React.PureComponent<IProps> {
                 onChange={onChange}
                 value={val}
                 remove={() => this.remove(index)}
-                readOnly={isIndexReadOnly(index)}
+                disabled={isIndexReadOnly(index)}
                 message={get(message, `[${index}]`)}
                 invalid={!!get(message, `[${index}]`)}
             />

--- a/client/components/fields/editor/Coverages.tsx
+++ b/client/components/fields/editor/Coverages.tsx
@@ -19,7 +19,7 @@ export class EditorFieldCoverages extends React.PureComponent<IPropsEditorFieldC
                 testId="field-coverages"
                 field={this.props.field ?? 'coverages'}
                 value={value}
-                readOnly={this.props.readOnly}
+                disabled={this.props.disabled}
                 addButtonText={this.props.addButtonText ?? gettext('Add a coverage')}
                 createUploadLink={getFileDownloadURL}
             />

--- a/client/components/fields/editor/ScheduledUpdates.tsx
+++ b/client/components/fields/editor/ScheduledUpdates.tsx
@@ -24,7 +24,6 @@ import {planningApis} from '../../../api';
 
 interface IProps extends IEditorFieldProps {
     index: number;
-    readOnly?: boolean;
     newsCoverageStatus: Array<IPlanningNewsCoverageStatus>;
     contentTypes: Array<IG2ContentType>;
     genres: Array<IGenre>;
@@ -76,7 +75,7 @@ class EditorFieldScheduledUpdatesComponent extends React.PureComponent<IProps> {
                         coverageIndex={this.props.index}
                         index={index}
                         newsCoverageStatus={this.props.newsCoverageStatus}
-                        readOnly={this.props.readOnly}
+                        disabled={this.props.disabled}
                         contentTypes={this.props.contentTypes}
                         onRemove={this.props.onRemoveScheduledUpdate.bind(null, index)}
                         onScheduleChanged={this.props.onScheduleChanged}
@@ -94,6 +93,7 @@ class EditorFieldScheduledUpdatesComponent extends React.PureComponent<IProps> {
                 ))}
                 {!this.props.canCreateScheduledUpdate ? null : (
                     <Button
+                        disabled={this.props.disabled}
                         type="primary"
                         text={gettext('Schedule an update')}
                         onClick={this.props.onAddScheduledUpdate}

--- a/client/components/fields/editor/coverages.interface.ts
+++ b/client/components/fields/editor/coverages.interface.ts
@@ -22,7 +22,7 @@ export interface IPropsEditorFieldCoverages extends IEditorFieldProps {
     originalCount?: number;
     message: string | {[key: string]: any};
     event?: IEventItem;
-    readOnly: boolean;
+    disabled: boolean;
 
     // HOC mode - optional; added to support "add button" as mini toolbar in authoring-react
     children?: (options: IInputArrayHocModeOptions) => React.ReactNode;

--- a/client/interfaces.ts
+++ b/client/interfaces.ts
@@ -2173,7 +2173,7 @@ export interface IBookmarkProps {
     editorType: EDITOR_TYPE;
     index: number;
     item?: DeepPartial<IEventOrPlanningItem>;
-    readOnly: boolean;
+    disabled: boolean;
 }
 
 export interface IEditorBookmarkCustom extends IEditorBookmarkBase {

--- a/client/planning-extension/src/authoring-react-fields/coverages/editor.tsx
+++ b/client/planning-extension/src/authoring-react-fields/coverages/editor.tsx
@@ -34,7 +34,7 @@ export class Editor extends React.PureComponent<IProps> {
             >
                 {(changedValue, onChange) => (
                     <EditorFieldCoverages
-                        readOnly={false}
+                        disabled={this.props.readOnly}
                         field="coverages"
                         item={{
                             ...this.props.item,


### PR DESCRIPTION
### Purpose
Keep track of item state in coverages - locked or in edit mode.

### What has changed
Rename readOnly prop to `disabled` so it's consistent with other usages, also pass it along the components and fields so they make use of it.

Resolves: #[STT-1489]



[STT-1489]: https://sofab.atlassian.net/browse/STT-1489?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ