### PR TITLE
implement debounce in text fields (#2419)

### DIFF
--- a/client/components/UI/Form/ExpandableTextArea.tsx
+++ b/client/components/UI/Form/ExpandableTextArea.tsx
@@ -219,5 +219,5 @@ ExpandableTextArea.defaultProps = {
     nativeOnChange: false,
     readOnly: false,
     initialFocus: false,
-    autoHeightTimeout: 50,
+    autoHeightTimeout: 100,
 };

--- a/client/components/UI/Form/TextArea.tsx
+++ b/client/components/UI/Form/TextArea.tsx
@@ -138,7 +138,7 @@ TextArea.propTypes = {
 TextArea.defaultProps = {
     readOnly: false,
     autoHeight: true,
-    autoHeightTimeout: 50,
+    autoHeightTimeout: 200,
     nativeOnChange: false,
     paddingRight60: false,
     multiLine: true,

--- a/client/components/fields/editor/base/dynamicTextTypeField.tsx
+++ b/client/components/fields/editor/base/dynamicTextTypeField.tsx
@@ -6,6 +6,7 @@ import {EditorFieldText} from './text';
 import {EditorFieldTextArea} from './textArea';
 import {EditorFieldExpandableTextArea} from './expandableTextArea';
 import {EditorFieldTextEditor3} from './textEditor3';
+import {CHANGE_DELAY} from '../../../../constants';
 
 export function getTextFieldComponent(schema?: IProfileSchemaTypeString) {
     switch (schema?.field_type) {
@@ -32,6 +33,8 @@ export class EditorFieldDynamicTextType extends React.PureComponent<IProps> {
     render() {
         const Component = getTextFieldComponent(this.props.schema);
         const {refNode, ...props} = this.props;
+
+        props.debounce = CHANGE_DELAY;
 
         // TODO: Support min/max length, required etc from props.schema
 

--- a/client/components/fields/editor/base/expandableTextArea.tsx
+++ b/client/components/fields/editor/base/expandableTextArea.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {get} from 'lodash';
+import {debounce, get} from 'lodash';
 
 import {IEditorFieldProps, IProfileSchemaTypeString} from '../../../../interfaces';
 
@@ -12,13 +12,26 @@ interface IProps extends IEditorFieldProps {
     noPadding?: boolean;
 }
 
-export class EditorFieldExpandableTextArea extends React.PureComponent<IProps> {
+interface IState {
+    value: string;
+}
+
+export class EditorFieldExpandableTextArea extends React.PureComponent<IProps, IState> {
     node: React.RefObject<HTMLDivElement>;
 
     constructor(props) {
         super(props);
 
         this.node = React.createRef();
+
+        this.state = {value: get(props.item, props.field, props.defaultValue || '')};
+
+        this.onChange = this.onChange.bind(this);
+        this.propsOnChange = debounce(
+            this.propsOnChange.bind(this),
+            props.debounce ?? 0,
+            {maxWait: 1000},
+        );
     }
 
     focus() {
@@ -27,9 +40,19 @@ export class EditorFieldExpandableTextArea extends React.PureComponent<IProps> {
         }
     }
 
+    onChange(field: string, value: string) {
+        this.setState({value}, () => {
+            this.propsOnChange(this.state.value);
+        });
+    }
+
+    propsOnChange(value: string) {
+        this.props.onChange(this.props.field, value);
+    }
+
     render() {
         const field = this.props.field;
-        const value = get(this.props.item, field, this.props.defaultValue);
+        const value = this.state.value;
         const error = get(this.props.errors ?? {}, field);
 
         return (
@@ -46,6 +69,7 @@ export class EditorFieldExpandableTextArea extends React.PureComponent<IProps> {
                     maxLength={this.props.maxLength ?? this.props.schema?.maxlength}
                     invalid={this.props.invalid ?? (error != null && this.props.showErrors)}
                     noMargin={true}
+                    onChange={this.onChange}
                 />
             </Row>
         );

--- a/client/components/fields/editor/base/text.interface.ts
+++ b/client/components/fields/editor/base/text.interface.ts
@@ -8,4 +8,5 @@ export interface IEditorFieldTextProps extends IEditorFieldProps {
     schema?: IProfileSchemaTypeString;
     noPadding: boolean;
     language?: string;
+    debounce?: number;
 }

--- a/client/components/fields/editor/base/text.tsx
+++ b/client/components/fields/editor/base/text.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {get, uniqueId} from 'lodash';
+import {debounce, get, uniqueId} from 'lodash';
 import {IRestApiResponse} from 'superdesk-api';
 import {appConfig} from 'appConfig';
 
@@ -11,6 +11,7 @@ import {Row} from '../../../UI/Form';
 
 interface IState {
     key: string;
+    value: string;
     suggestions: string[];
 }
 
@@ -21,19 +22,19 @@ export class EditorFieldText extends React.Component<IEditorFieldTextProps, ISta
         super(props);
 
         this.onChange = this.onChange.bind(this);
+        this.propsOnChange = debounce(
+            this.propsOnChange.bind(this),
+            props.debounce ?? 0,
+            {maxWait: 1000},
+        );
         this.searchSuggestions = this.searchSuggestions.bind(this);
         this.node = React.createRef();
 
         this.state = {
             key: uniqueId(),
             suggestions: [],
+            value: get(props.item, props.field, props.defaultValue || ''),
         };
-    }
-
-    componentDidUpdate(prevProps: Readonly<IEditorFieldTextProps>, prevState: Readonly<IState>, snapshot?: any) {
-        if (get(prevProps.item, prevProps.field) !== get(this.props.item, this.props.field)) {
-            this.onPropValueChanged();
-        }
     }
 
     componentDidMount(): void {
@@ -46,22 +47,14 @@ export class EditorFieldText extends React.Component<IEditorFieldTextProps, ISta
         }
     }
 
-    onPropValueChanged() {
-        // If the value on the provided item has changed
-        // Check this new value against the value in the `input` element directly
-        // If these two differ, then force a re-mount/render of the `input` element
-        // Using the React `key` attribute
-
-        const node = this.getInputElement();
-        const propValue = get(this.props.item, this.props.field);
-
-        if (node != null && node.value !== propValue) {
-            this.setState({key: uniqueId()});
-        }
+    onChange(value: string) {
+        this.setState({value}, () => {
+            this.propsOnChange(this.state.value);
+        });
     }
 
-    onChange(newValue) {
-        this.props.onChange(this.props.field, newValue);
+    propsOnChange(value: string) {
+        this.props.onChange(this.props.field, value);
     }
 
     getInputElement(): HTMLInputElement | undefined {
@@ -89,8 +82,6 @@ export class EditorFieldText extends React.Component<IEditorFieldTextProps, ISta
     }
 
     searchSuggestions(searchString: string, callback: (result: Array<any>) => void) {
-        const currentValue = this.props.item[this.props.field];
-
         callback(this.state.suggestions.filter(
             (name) => name.toLowerCase().includes(searchString.toLowerCase()),
         ));
@@ -101,7 +92,7 @@ export class EditorFieldText extends React.Component<IEditorFieldTextProps, ISta
 
     render() {
         const field = this.props.field;
-        const value = get(this.props.item, field, this.props.defaultValue);
+        const value = this.state.value;
         const error = get(this.props.errors ?? {}, field);
 
         return (

--- a/client/components/fields/editor/base/textArea.interface.ts
+++ b/client/components/fields/editor/base/textArea.interface.ts
@@ -8,4 +8,5 @@ export interface IEditorFieldTextAreaProps extends IEditorFieldProps {
     rows?: number;
     labelIcon?: string;
     noPadding?: boolean;
+    debounce?: number;
 }

--- a/client/components/fields/editor/base/textArea.tsx
+++ b/client/components/fields/editor/base/textArea.tsx
@@ -1,16 +1,29 @@
 import * as React from 'react';
-import {get} from 'lodash';
+import {debounce, get} from 'lodash';
 
 import {IEditorFieldTextAreaProps} from './textArea.interface';
 import {Row, TextAreaInput} from '../../../UI/Form';
 
-export class EditorFieldTextArea extends React.PureComponent<IEditorFieldTextAreaProps> {
+interface IState {
+    value: string;
+}
+
+export class EditorFieldTextArea extends React.PureComponent<IEditorFieldTextAreaProps, IState> {
     node: React.RefObject<HTMLDivElement>;
 
     constructor(props: IEditorFieldTextAreaProps) {
         super(props);
 
         this.node = React.createRef();
+
+        this.state = {value: get(props.item, props.field, props.defaultValue || '')};
+
+        this.onChange = this.onChange.bind(this);
+        this.propsOnChange = debounce(
+            this.propsOnChange.bind(this),
+            props.debounce ?? 0,
+            {maxWait: 1000},
+        );
     }
 
     focus() {
@@ -19,9 +32,19 @@ export class EditorFieldTextArea extends React.PureComponent<IEditorFieldTextAre
         }
     }
 
+    onChange(field: string, value: string) {
+        this.setState({value}, () => {
+            this.propsOnChange(this.state.value);
+        });
+    }
+
+    propsOnChange(value: string) {
+        this.props.onChange(this.props.field, value);
+    }
+
     render() {
         const field = this.props.field;
-        const value = get(this.props.item, field, this.props.defaultValue);
+        const value = this.state.value;
         const error = get(this.props.errors ?? {}, field);
 
         return (
@@ -38,6 +61,7 @@ export class EditorFieldTextArea extends React.PureComponent<IEditorFieldTextAre
                     maxLength={this.props.maxLength ?? this.props.schema?.maxlength}
                     invalid={this.props.invalid ?? (error != null && this.props.showErrors)}
                     noMargin={true}
+                    onChange={this.onChange}
                 />
             </Row>
         );

--- a/client/constants/index.ts
+++ b/client/constants/index.ts
@@ -95,6 +95,9 @@ export const TEMP_ID_PREFIX = 'tempId-';
 // The delay in ms for use with single and double click detection
 export const CLICK_DELAY = 250;
 
+// The delay in ms for use with input changes
+export const CHANGE_DELAY = 500;
+
 export const USER_ACTIONS = {
     RECEIVE_USER_PREFERENCES: 'RECEIVE_USER_PREFERENCES',
 };

--- a/client/interfaces.ts
+++ b/client/interfaces.ts
@@ -1714,6 +1714,7 @@ export interface IEditorFieldProps<T = any> {
     editorType?: EDITOR_TYPE;
 
     profile?: IPlanningContentProfile;
+    debounce?: number;
 
     // overloads don't work in interfaces
     // onChange(values: {[key: string]: any}): void;

--- a/client/reducers/forms.ts
+++ b/client/reducers/forms.ts
@@ -5,8 +5,11 @@ import {IPlanningContentProfile} from '../interfaces';
 import {AUTOSAVE, ITEM_TYPE, MAIN, FORMS} from '../constants';
 import {createReducer} from './createReducer';
 import {eventUtils, getItemId, getItemType, planningUtils} from '../utils';
-import {cloneDeep, get, set} from 'lodash';
+import {get, set} from 'lodash';
 import {EDITOR_TYPE, IEditorFormState, IFormState} from '../interfaces';
+import {produce, setAutoFreeze} from 'immer';
+
+setAutoFreeze(false);
 
 const initialState: IFormState = {
     profiles: {},
@@ -47,75 +50,71 @@ function updateEditor(
     modal: boolean,
     updates: DeepPartial<IFormState>['editors']['panel']
 ): IFormState {
-    const newState = cloneDeep(state);
-
-    if (modal) {
-        newState.editors[EDITOR_TYPE.POPUP] = {
-            ...newState.editors[EDITOR_TYPE.POPUP],
-            ...updates,
-        };
-    } else {
-        newState.editors[EDITOR_TYPE.INLINE] = {
-            ...newState.editors[EDITOR_TYPE.INLINE],
-            ...updates,
-        };
-    }
+    const newState = produce(state, (draft) => {
+        if (modal) {
+            Object.assign(draft.editors[EDITOR_TYPE.POPUP], updates);
+        } else {
+            Object.assign(draft.editors[EDITOR_TYPE.INLINE], updates);
+        }
+    });
 
     return newState;
 }
 
 function updateFormGroups(action: string, state: IFormState, payload: any): IFormState {
-    const newState = cloneDeep(state);
-    const editor: IEditorFormState = newState.editors[payload.editor];
+    const newState = produce(state, (draft) => {
+        const editor: IEditorFormState = draft.editors[payload.editor];
 
-    switch (action) {
-    case MAIN.ACTIONS.FORMS_GROUP_SET:
-        editor.groups = payload.groups;
-        break;
-    case MAIN.ACTIONS.FORMS_GROUP_CLEAR:
-        editor.groups = {};
-        break;
-    case MAIN.ACTIONS.FORMS_GROUP_DELETE:
-        delete editor.groups[payload.groupId];
-        break;
-    case MAIN.ACTIONS.FORMS_GROUP_UPDATE:
-        editor.groups[payload.group.id] = {
-            ...editor.groups[payload.group.id],
-            ...payload.updates,
-        };
-        break;
-    }
+        switch (action) {
+        case MAIN.ACTIONS.FORMS_GROUP_SET:
+            editor.groups = payload.groups;
+            break;
+        case MAIN.ACTIONS.FORMS_GROUP_CLEAR:
+            editor.groups = {};
+            break;
+        case MAIN.ACTIONS.FORMS_GROUP_DELETE:
+            delete editor.groups[payload.groupId];
+            break;
+        case MAIN.ACTIONS.FORMS_GROUP_UPDATE:
+            editor.groups[payload.group.id] = {
+                ...editor.groups[payload.group.id],
+                ...payload.updates,
+            };
+            break;
+        }
+    });
 
     return newState;
 }
 
 function updateFormBookmarks(action: string, state: IFormState, payload: any): IFormState {
-    const newState = cloneDeep(state);
-    const editor: IEditorFormState = newState.editors[payload.editor];
+    const newState = produce(state, (draft) => {
+        const editor: IEditorFormState = draft.editors[payload.editor];
 
-    switch (action) {
-    case MAIN.ACTIONS.FORMS_BOOKMARKS_SET:
-        editor.bookmarks = payload.bookmarks;
-        break;
-    case MAIN.ACTIONS.FORMS_BOOKMARKS_CLEAR:
-        editor.bookmarks = {};
-        editor.activeBookmarkId = null;
-        break;
-    case MAIN.ACTIONS.FORMS_BOOKMARKS_DELETE:
-        delete editor.bookmarks[payload.bookmarkId];
-
-        if (payload.bookmarkId === editor.activeBookmarkId) {
+        switch (action) {
+        case MAIN.ACTIONS.FORMS_BOOKMARKS_SET:
+            editor.bookmarks = payload.bookmarks;
+            break;
+        case MAIN.ACTIONS.FORMS_BOOKMARKS_CLEAR:
+            editor.bookmarks = {};
             editor.activeBookmarkId = null;
-        }
+            break;
+        case MAIN.ACTIONS.FORMS_BOOKMARKS_DELETE:
+            delete editor.bookmarks[payload.bookmarkId];
 
-        break;
-    case MAIN.ACTIONS.FORMS_BOOKMARKS_UPDATE:
-        editor.bookmarks[payload.bookmark.id] = {
-            ...editor.bookmarks[payload.bookmark.id],
-            ...payload.updates,
-        };
-        break;
-    }
+            if (payload.bookmarkId === editor.activeBookmarkId) {
+                editor.activeBookmarkId = null;
+            }
+
+            break;
+        case MAIN.ACTIONS.FORMS_BOOKMARKS_UPDATE:
+            editor.bookmarks[payload.bookmark.id] = {
+                ...editor.bookmarks[payload.bookmark.id],
+                ...payload.updates,
+            };
+            break;
+        }
+    });
 
     return newState;
 }
@@ -125,11 +124,12 @@ function setPopupForm(state: IFormState, payload: {
     component: React.ComponentClass,
     props: any,
 }): IFormState {
-    const newState = cloneDeep(state);
-    const editor: IEditorFormState = newState.editors[payload.editor];
+    const newState = produce(state, (draft) => {
+        const editor: IEditorFormState = draft.editors[payload.editor];
 
-    editor.popupFormComponent = payload.component;
-    editor.popupFormProps = payload.props;
+        editor.popupFormComponent = payload.component;
+        editor.popupFormProps = payload.props;
+    });
 
     return newState;
 }
@@ -167,16 +167,17 @@ const formsReducer = createReducer(initialState, {
     ),
 
     [AUTOSAVE.ACTIONS.RECEIVE]: (state, payload) => {
-        const newState = cloneDeep(state);
-        const itemId = getItemId(payload);
-        const itemType = getItemType(payload);
-        const itemPath = `autosaves.${itemType}["${itemId}"]`;
+        const newState = produce(state, (draft) => {
+            const itemId = getItemId(payload);
+            const itemType = getItemType(payload);
+            const itemPath = `autosaves.${itemType}["${itemId}"]`;
 
-        if (itemType === ITEM_TYPE.EVENT) {
-            set(newState, itemPath, eventUtils.modifyForClient(payload, true));
-        } else if (itemType === ITEM_TYPE.PLANNING) {
-            set(newState, itemPath, planningUtils.modifyForClient(payload));
-        }
+            if (itemType === ITEM_TYPE.EVENT) {
+                set(draft, itemPath, eventUtils.modifyForClient(payload, true));
+            } else if (itemType === ITEM_TYPE.PLANNING) {
+                set(draft, itemPath, planningUtils.modifyForClient(payload));
+            }
+        });
 
         return newState;
     },
@@ -189,31 +190,33 @@ const formsReducer = createReducer(initialState, {
             return state;
         }
 
-        const newState = cloneDeep(state);
-        const autosaves = get(newState, `autosaves.${itemType}`);
+        const newState = produce(state, (draft) => {
+            const autosaves = get(draft, `autosaves.${itemType}`);
 
-        if (autosaves[itemId]) {
-            delete autosaves[itemId];
-        }
+            if (autosaves[itemId]) {
+                delete autosaves[itemId];
+            }
+        });
 
         return newState;
     },
 
     [AUTOSAVE.ACTIONS.RECEIVE_ALL]: (state, payload) => {
-        const newState = cloneDeep(state);
-        const items = {};
+        const newState = produce(state, (draft) => {
+            const items = {};
 
-        if (payload.itemType === ITEM_TYPE.EVENT) {
-            payload.autosaves.forEach((item) => {
-                items[getItemId(item)] = eventUtils.modifyForClient(item, true);
-            });
-        } else if (payload.itemType === ITEM_TYPE.PLANNING) {
-            payload.autosaves.forEach((item) => {
-                items[getItemId(item)] = planningUtils.modifyForClient(item);
-            });
-        }
+            if (payload.itemType === ITEM_TYPE.EVENT) {
+                payload.autosaves.forEach((item) => {
+                    items[getItemId(item)] = eventUtils.modifyForClient(item, true);
+                });
+            } else if (payload.itemType === ITEM_TYPE.PLANNING) {
+                payload.autosaves.forEach((item) => {
+                    items[getItemId(item)] = planningUtils.modifyForClient(item);
+                });
+            }
 
-        set(newState, `autosaves.${payload.itemType}`, items);
+            set(draft, `autosaves.${payload.itemType}`, items);
+        });
 
         return newState;
     },
@@ -243,9 +246,9 @@ const formsReducer = createReducer(initialState, {
     [MAIN.ACTIONS.FORMS_BOOKMARKS_CLEAR]: updateFormBookmarks.bind(null, MAIN.ACTIONS.FORMS_BOOKMARKS_CLEAR),
 
     [MAIN.ACTIONS.FORMS_BOOKMARKS_SET_ACTIVE_ID]: (state, payload) => {
-        const newState = cloneDeep(state);
-
-        newState.editors[payload.editor].activeBookmarkId = payload.bookmarkId;
+        const newState = produce(state, (draft) => {
+            draft.editors[payload.editor].activeBookmarkId = payload.bookmarkId;
+        });
 
         return newState;
     },

--- a/e2e/cypress/support/common/inputs/input.ts
+++ b/e2e/cypress/support/common/inputs/input.ts
@@ -37,10 +37,10 @@ export class Input {
      * @param {string} value - The value to type into the input field
      */
     type(value) {
+        this.clear();
         cy.log('Common.Input.type');
-        this.element
-            .clear()
-            .type(value);
+        this.element.type(value);
+        cy.wait(250); // Wait for any potential debounce
     }
 
     /**
@@ -56,6 +56,7 @@ export class Input {
     clear() {
         cy.log('Common.Input.clear');
         this.element.clear();
+        cy.wait(250); // Wait for any potential debounce
     }
 
     expectError(message) {

--- a/e2e/cypress/support/planning/advancedSearch.ts
+++ b/e2e/cypress/support/planning/advancedSearch.ts
@@ -254,6 +254,7 @@ export class AdvancedSearch {
                     throw new Error(`Field "${name}" not registered with e2e search helper`);
                 } else if (value?.length || isBoolean(value)) {
                     field.type(value);
+                    cy.wait(100); // Wait for any potential debounce
                 } else {
                     field.clear();
                 }


### PR DESCRIPTION
* implement debounce in text fields

handle field value via local state and debounce redux state updates.

SDCP-954

* handle feedback

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

### Front-end checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)

Resolves: #[issue-number]

