### PR TITLE
[STT-1491] - Fix pagination infinite loop

### DIFF
--- a/client/components/Main/ListPanel.tsx
+++ b/client/components/Main/ListPanel.tsx
@@ -272,19 +272,19 @@ export class ListPanel extends React.Component<IProps, IState> {
     }
 
     handleScroll(event) {
-        if (this.state.isNextPageLoading) {
+        if (this.state.isNextPageLoading || this.props.isAllListItemsLoaded) {
             return;
         }
 
         const node = event.target;
 
-
         // Load more items if there's any if scroll position is 100px before end of the scrollable list
         if (node.scrollHeight - node.scrollTop - node.clientHeight <= END_OF_LIST_OFFSET) {
-            this.setState({isNextPageLoading: true, scrollTop: node.scrollTop});
-
-            this.props.loadMore(this.props.activeFilter)
-                .then(this.unsetNextPageLoading, this.unsetNextPageLoading);
+            this.setState({isNextPageLoading: true, scrollTop: node.scrollTop}, () => {
+                this.props
+                    .loadMore(this.props.activeFilter)
+                    .then(this.unsetNextPageLoading, this.unsetNextPageLoading);
+            });
         }
     }
 

--- a/client/reducers/eventsplanning.ts
+++ b/client/reducers/eventsplanning.ts
@@ -85,10 +85,12 @@ const eventsPlanningReducer = createReducer<IEventsPlanningState>(initialState, 
             draft.currentFilter = payload === EVENTS_PLANNING.FILTER.ALL_EVENTS_PLANNING ? null : payload;
         }),
 
-    [MAIN.ACTIONS.CLEAR_SEARCH]: (state, payload: keyof IMainState['search']) =>
-        payload !== 'COMBINED' ? state : produce(state, (draft) => {
-            draft.currentFilter = null;
-        }),
+    [MAIN.ACTIONS.CLEAR_SEARCH]: (state, payload: keyof IMainState['search']) => (
+        payload !== 'COMBINED' ? state : {
+            ...state,
+            currentFilter: null,
+        }
+    ),
 });
 
 export default eventsPlanningReducer;

--- a/client/reducers/eventsplanning.ts
+++ b/client/reducers/eventsplanning.ts
@@ -1,4 +1,5 @@
-import {cloneDeep, get, uniq, sortBy} from 'lodash';
+import {get, sortBy} from 'lodash';
+import {produce} from 'immer';
 
 import {IEventsPlanningState, IMainState, ISearchFilter} from '../interfaces';
 import {EVENTS_PLANNING, INIT_STORE, RESET_STORE, MAIN} from '../constants';
@@ -35,27 +36,28 @@ const eventsPlanningReducer = createReducer<IEventsPlanningState>(initialState, 
 
     [INIT_STORE]: () => (initialState),
 
-    [EVENTS_PLANNING.ACTIONS.SET_EVENTS_PLANNING_LIST]: (state, payload) => (
-        {
-            ...state,
-            eventsAndPlanningInList: (payload || []).map((e) => e._id),
-        }
-    ),
-    [EVENTS_PLANNING.ACTIONS.ADD_EVENTS_PLANNING_LIST]: (state, payload) => (
-        {
-            ...state,
-            eventsAndPlanningInList: uniq([
-                ...cloneDeep(state.eventsAndPlanningInList || []),
-                ...(payload || []).map((e) => e._id),
-            ]),
-        }
-    ),
-    [EVENTS_PLANNING.ACTIONS.CLEAR_EVENTS_PLANNING_LIST]: (state, payload) => (
-        {
-            ...state,
-            eventsAndPlanningInList: [],
-        }
-    ),
+    [EVENTS_PLANNING.ACTIONS.SET_EVENTS_PLANNING_LIST]: (state, payload) =>
+        produce(state, (draft) => {
+            draft.eventsAndPlanningInList = (payload || []).map((e) => e._id);
+        }),
+
+    [EVENTS_PLANNING.ACTIONS.ADD_EVENTS_PLANNING_LIST]: (state, payload) =>
+        produce(state, (draft) => {
+            const newIds = (payload || []).map((e) => e._id);
+            const existingIds = new Set(draft.eventsAndPlanningInList || []);
+
+            newIds.forEach((id) => {
+                if (!existingIds.has(id)) {
+                    draft.eventsAndPlanningInList.push(id);
+                }
+            });
+        }),
+
+    [EVENTS_PLANNING.ACTIONS.CLEAR_EVENTS_PLANNING_LIST]: (state, payload) =>
+        produce(state, (draft) => {
+            draft.eventsAndPlanningInList = [];
+        }),
+
     [EVENTS_PLANNING.ACTIONS.SHOW_RELATED_PLANNINGS]: (state, payload) => {
         const eventId = getItemId(payload);
 
@@ -63,38 +65,30 @@ const eventsPlanningReducer = createReducer<IEventsPlanningState>(initialState, 
             return state;
         }
 
-        return {
-            ...state,
-            relatedPlannings: {
-                ...state.relatedPlannings,
-                [eventId]: get(payload, 'planning_ids', []),
-            },
-        };
+        return produce(state, (draft) => {
+            draft.relatedPlannings[eventId] = get(payload, 'planning_ids', []);
+        });
     },
-    [EVENTS_PLANNING.ACTIONS.ADD_OR_REPLACE_EVENTS_PLANNING_FILTER]: (state, payload) => (
-        {
-            ...state,
-            filters: addOrReplaceFilters([...state.filters], payload),
-        }
-    ),
-    [EVENTS_PLANNING.ACTIONS.RECEIVE_EVENTS_PLANNING_FILTERS]: (state, payload) => (
-        {
-            ...state,
-            filters: sortBy([...payload], [(f) => f.name.toLowerCase()]),
-        }
-    ),
-    [EVENTS_PLANNING.ACTIONS.SELECT_EVENTS_PLANNING_FILTER]: (state, payload: ISearchFilter['_id']) => (
-        {
-            ...state,
-            currentFilter: payload === EVENTS_PLANNING.FILTER.ALL_EVENTS_PLANNING ? null : payload,
-        }
-    ),
-    [MAIN.ACTIONS.CLEAR_SEARCH]: (state, payload: keyof IMainState['search']) => (
-        payload !== 'COMBINED' ? state : {
-            ...state,
-            currentFilter: null,
-        }
-    ),
+
+    [EVENTS_PLANNING.ACTIONS.ADD_OR_REPLACE_EVENTS_PLANNING_FILTER]: (state, payload) =>
+        produce(state, (draft) => {
+            draft.filters = addOrReplaceFilters([...draft.filters], payload);
+        }),
+
+    [EVENTS_PLANNING.ACTIONS.RECEIVE_EVENTS_PLANNING_FILTERS]: (state, payload) =>
+        produce(state, (draft) => {
+            draft.filters = sortBy([...payload], [(f) => f.name.toLowerCase()]);
+        }),
+
+    [EVENTS_PLANNING.ACTIONS.SELECT_EVENTS_PLANNING_FILTER]: (state, payload: ISearchFilter['_id']) =>
+        produce(state, (draft) => {
+            draft.currentFilter = payload === EVENTS_PLANNING.FILTER.ALL_EVENTS_PLANNING ? null : payload;
+        }),
+
+    [MAIN.ACTIONS.CLEAR_SEARCH]: (state, payload: keyof IMainState['search']) =>
+        payload !== 'COMBINED' ? state : produce(state, (draft) => {
+            draft.currentFilter = null;
+        }),
 });
 
 export default eventsPlanningReducer;


### PR DESCRIPTION
### What has changed
- Prevent loading more items once all list items are fetched by also checking isAllListItemsLoaded in the scroll handler.
- Ensure isNextPageLoading is only reset after loadMore completes by moving the call into a setState callback.
- Refactor eventsplanning reducer cases to use immer’s produce instead of object spreads, cloneDeep, and uniq.
- Keep eventsAndPlanningInList deduplicated by manually checking for existing IDs before pushing new ones.

Resolves: [STT-1491]



[STT-1491]: https://sofab.atlassian.net/browse/STT-1491?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ