### PR TITLE
fix error when handling unprocessed files in output

### DIFF
--- a/server/planning/output_formatters/file_providers.py
+++ b/server/planning/output_formatters/file_providers.py
@@ -31,6 +31,7 @@ def get_event_planning_files_for_transmission(
             resource="events_files" if item["type"] == "event" else "planning_files",
         )
         for file in item.get("files") or []
+        if isinstance(file, dict)
     }
 
 

--- a/server/planning/tests/output_formatters/file_providers_test.py
+++ b/server/planning/tests/output_formatters/file_providers_test.py
@@ -112,6 +112,10 @@ class FileProvidersTestCase(TestCase):
     def test_ignores_ftp_transmitter(self):
         self.assertDictEqual(get_event_planning_files_for_transmission(FTPPublishService.NAME, self.event_item), {})
 
+    def test_handle_unprocessed_files(self):
+        planning_item = {"type": "planning", "files": ["fileid"]}
+        self.assertEqual({}, get_event_planning_files_for_transmission(HTTPPushService.NAME, planning_item))
+
     @mock.patch(
         "superdesk.publish.transmitters.http_push.get_current_app", return_value=MockApp(TestEventMedia(b"bin"))
     )


### PR DESCRIPTION
not sure how it gets set, probably via some json formatter override.

```
TypeError
string indices must be integers
```

STT-1498

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

### Front-end checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)

Resolves: #[issue-number]

