### PR TITLE
avoid cloneDeep in reducers

### DIFF
--- a/client/reducers/assignment.ts
+++ b/client/reducers/assignment.ts
@@ -1,8 +1,9 @@
-import {uniq, keyBy, get, cloneDeep, filter, initial} from 'lodash';
+import {uniq, keyBy, get, filter} from 'lodash';
 import {ASSIGNMENTS, RESET_STORE, INIT_STORE, SORT_DIRECTION} from '../constants';
 import moment from 'moment';
 import {createReducer} from './createReducer';
 import {getItemId} from '../utils';
+import {produce} from 'immer';
 
 const initialState = {
     archive: {},
@@ -150,7 +151,9 @@ const assignmentReducer = createReducer(initialState, {
     },
 
     [ASSIGNMENTS.ACTIONS.SET_LIST_ITEMS]: (state, payload) => (
-        setList(cloneDeep(state), payload)
+        produce(state, (draft) => {
+            setList(draft, payload);
+        })
     ),
 
     [ASSIGNMENTS.ACTIONS.MY_ASSIGNMENTS_TOTAL]: (state, payload) => (
@@ -161,7 +164,9 @@ const assignmentReducer = createReducer(initialState, {
     ),
 
     [ASSIGNMENTS.ACTIONS.ADD_LIST_ITEMS]: (state, payload) => (
-        addToList(cloneDeep(state), payload)
+        produce(state, (draft) => {
+            addToList(draft, payload);
+        })
     ),
 
     [ASSIGNMENTS.ACTIONS.CHANGE_LIST_VIEW_MODE]: (state, payload) => (
@@ -172,11 +177,15 @@ const assignmentReducer = createReducer(initialState, {
     ),
 
     [ASSIGNMENTS.ACTIONS.SET_LIST_PAGE]: (state, payload) => (
-        setLastPage(cloneDeep(state), payload)
+        produce(state, (draft) => {
+            setLastPage(draft, payload);
+        })
     ),
 
     [ASSIGNMENTS.ACTIONS.SET_GROUP_SORT_ORDER]: (state, payload) => (
-        setListSortOrder(cloneDeep(state), payload)
+        produce(state, (draft) => {
+            setListSortOrder(draft, payload);
+        })
     ),
 
     [ASSIGNMENTS.ACTIONS.SET_LOADING]: (state, payload) => (
@@ -220,37 +229,29 @@ const assignmentReducer = createReducer(initialState, {
     [ASSIGNMENTS.ACTIONS.LOCK_ASSIGNMENT]: (state, payload) => {
         if (!(payload.assignment._id in state.assignments)) return state;
 
-        let assignments = cloneDeep(state.assignments);
-        let assignment = assignments[payload.assignment._id];
+        return produce(state, (draft) => {
+            let assignment = draft.assignments[payload.assignment._id];
 
-        assignment.lock_action = payload.assignment.lock_action;
-        assignment.lock_user = payload.assignment.lock_user;
-        assignment.lock_time = payload.assignment.lock_time;
-        assignment.lock_session = payload.assignment.lock_session;
-        assignment._etag = payload.assignment._etag;
-
-        return {
-            ...state,
-            assignments,
-        };
+            assignment.lock_action = payload.assignment.lock_action;
+            assignment.lock_user = payload.assignment.lock_user;
+            assignment.lock_time = payload.assignment.lock_time;
+            assignment.lock_session = payload.assignment.lock_session;
+            assignment._etag = payload.assignment._etag;
+        });
     },
 
     [ASSIGNMENTS.ACTIONS.UNLOCK_ASSIGNMENT]: (state, payload) => {
         if (!(payload.assignment._id in state.assignments)) return state;
 
-        let assignments = cloneDeep(state.assignments);
-        let assignment = assignments[payload.assignment._id];
+        return produce(state, (draft) => {
+            let assignment = draft.assignments[payload.assignment._id];
 
-        delete assignment.lock_action;
-        delete assignment.lock_user;
-        delete assignment.lock_time;
-        delete assignment.lock_session;
-        assignment._etag = payload.assignment._etag;
-
-        return {
-            ...state,
-            assignments,
-        };
+            delete assignment.lock_action;
+            delete assignment.lock_user;
+            delete assignment.lock_time;
+            delete assignment.lock_session;
+            assignment._etag = payload.assignment._etag;
+        });
     },
 
     [ASSIGNMENTS.ACTIONS.RECEIVED_ARCHIVE]: (state, payload) => {
@@ -275,32 +276,30 @@ const assignmentReducer = createReducer(initialState, {
         };
     },
 
-    [ASSIGNMENTS.ACTIONS.REMOVE_ASSIGNMENT]: (oldState, payload) => {
-        const state = cloneDeep(oldState);
+    [ASSIGNMENTS.ACTIONS.REMOVE_ASSIGNMENT]: (oldState, payload) => (
+        produce(oldState, (draft) => {
+            // Remove the assignment from the stored list of assignments
+            (get(payload, 'assignments') || []).forEach((a) => {
+                if (a in draft.assignments) {
+                    delete draft.assignments[a];
+                    // If this assignment is being viewed,
+                    // then close the preview and de-select the assignment
+                    if (draft.currentAssignmentId === a) {
+                        draft.previewOpened = false;
+                        draft.currentAssignmentId = null;
+                    }
 
-        // Remove the assignment from the stored list of assignments
-        (get(payload, 'assignments') || []).forEach((a) => {
-            if (a in state.assignments) {
-                delete state.assignments[a];
-                // If this assignment is being viewed,
-                // then close the preview and de-select the assignment
-                if (state.currentAssignmentId === a) {
-                    state.previewOpened = false;
-                    state.currentAssignmentId = null;
+                    // Remove this assignment from any list groups
+                    filterList(draft, ASSIGNMENTS.LIST_GROUPS.IN_PROGRESS.id, a);
+                    filterList(draft, ASSIGNMENTS.LIST_GROUPS.TODO.id, a);
+                    filterList(draft, ASSIGNMENTS.LIST_GROUPS.COMPLETED.id, a);
+                    filterList(draft, ASSIGNMENTS.LIST_GROUPS.CURRENT.id, a);
+                    filterList(draft, ASSIGNMENTS.LIST_GROUPS.TODAY.id, a);
+                    filterList(draft, ASSIGNMENTS.LIST_GROUPS.FUTURE.id, a);
                 }
-
-                // Remove this assignment from any list groups
-                filterList(state, ASSIGNMENTS.LIST_GROUPS.IN_PROGRESS.id, a);
-                filterList(state, ASSIGNMENTS.LIST_GROUPS.TODO.id, a);
-                filterList(state, ASSIGNMENTS.LIST_GROUPS.COMPLETED.id, a);
-                filterList(state, ASSIGNMENTS.LIST_GROUPS.CURRENT.id, a);
-                filterList(state, ASSIGNMENTS.LIST_GROUPS.TODAY.id, a);
-                filterList(state, ASSIGNMENTS.LIST_GROUPS.FUTURE.id, a);
-            }
-        });
-
-        return state;
-    },
+            });
+        })
+    ),
 
     [ASSIGNMENTS.ACTIONS.RECEIVE_ASSIGNMENT_HISTORY]: (state, payload) => ({
         ...state,

--- a/client/reducers/events.ts
+++ b/client/reducers/events.ts
@@ -1,5 +1,6 @@
-import {orderBy, cloneDeep, uniq, get} from 'lodash';
+import {orderBy, uniq, get} from 'lodash';
 import moment from 'moment';
+import {produce} from 'immer';
 
 import {IEventState, IMainState, LIST_VIEW_TYPE} from '../interfaces';
 
@@ -17,30 +18,30 @@ const initialState: IEventState = {
     eventTemplates: [],
 };
 
-const modifyEventsBeingAdded = (state, payload) => {
-    let _events = cloneDeep(state.events);
+const modifyEventsBeingAdded = (state, payload) => (
+    produce(state, (draft) => {
+        let _events = draft.events;
 
-    payload.forEach((e) => {
-        _events[e._id] = e;
+        payload.forEach((e) => {
+            _events[e._id] = e;
 
-        // Change dates to moment objects
-        if (e.dates) {
-            e.dates.start = moment(e.dates.start);
-            e.dates.end = moment(e.dates.end);
-            if (get(e, 'dates.recurring_rule.until')) {
-                e.dates.recurring_rule.until = moment(e.dates.recurring_rule.until);
+            // Change dates to moment objects
+            if (e.dates) {
+                e.dates.start = moment(e.dates.start);
+                e.dates.end = moment(e.dates.end);
+                if (get(e, 'dates.recurring_rule.until')) {
+                    e.dates.recurring_rule.until = moment(e.dates.recurring_rule.until);
+                }
+                e._startTime = moment(e.dates.start);
+                e._endTime = moment(e.dates.end);
             }
-            e._startTime = moment(e.dates.start);
-            e._endTime = moment(e.dates.end);
-        }
 
-        if (e.location && Array.isArray(e.location)) {
-            e.location = e.location[0];
-        }
-    });
-
-    return _events;
-};
+            if (e.location && Array.isArray(e.location)) {
+                e.location = e.location[0];
+            }
+        });
+    })
+);
 
 const removeLock = (event, etag = null) => {
     delete event.lock_action;
@@ -78,14 +79,9 @@ const eventsReducer = createReducer<IEventState>(initialState, {
 
     [INIT_STORE]: () => ({...initialState}),
 
-    [EVENTS.ACTIONS.ADD_EVENTS]: (state, payload) => {
-        const _events = modifyEventsBeingAdded(state, payload);
-
-        return {
-            ...state,
-            events: _events,
-        };
-    },
+    [EVENTS.ACTIONS.ADD_EVENTS]: (state, payload) => (
+        modifyEventsBeingAdded(state, payload)
+    ),
 
     [EVENTS.ACTIONS.SET_EVENTS_LIST]: (state, payload) => (
         {
@@ -127,108 +123,92 @@ const eventsReducer = createReducer<IEventState>(initialState, {
         if (!(payload.event_id in state.events) && get(payload, 'cancelled_items.length', 0) < 1)
             return state;
 
-        let events = cloneDeep(state.events);
+        return produce(state, (draft) => {
+            let events = draft.events;
 
-        // First mark the original Event as cancelled
-        markEventCancelled(
-            events,
-            payload.event_id,
-            payload.etag,
-            payload.reason,
-            payload.occur_status,
-            payload.actionedDate
-        );
-
-        // Now mark all associated Events that are also cancelled
-        (get(payload, 'cancelled_items') || []).forEach(
-            (event) => markEventCancelled(
+            // First mark the original Event as cancelled
+            markEventCancelled(
                 events,
-                event._id,
-                event._etag,
+                payload.event_id,
+                payload.etag,
                 payload.reason,
                 payload.occur_status,
                 payload.actionedDate
-            )
-        );
+            );
 
-        return {
-            ...state,
-            events,
-        };
+            // Now mark all associated Events that are also cancelled
+            (get(payload, 'cancelled_items') || []).forEach(
+                (event) => markEventCancelled(
+                    events,
+                    event._id,
+                    event._etag,
+                    payload.reason,
+                    payload.occur_status,
+                    payload.actionedDate
+                )
+            );
+        });
     },
 
     [EVENTS.ACTIONS.MARK_EVENT_HAS_PLANNINGS]: (state, payload) => {
         // If the event is not loaded, disregard this action
         if (!(payload.event_item in state.events)) return state;
 
-        let events = cloneDeep(state.events);
-        let event = events[payload.event_item];
+        return produce(state, (draft) => {
+            let events = draft.events;
+            let event = events[payload.event_item];
+            const planningIds = get(event, 'planning_ids', []);
 
-        const planningIds = get(event, 'planning_ids', []);
-
-        planningIds.push(payload.planning_item);
-        event.planning_ids = planningIds;
-
-        return {
-            ...state,
-            events,
-        };
+            planningIds.push(payload.planning_item);
+            event.planning_ids = planningIds;
+        });
     },
 
-    [EVENTS.ACTIONS.LOCK_EVENT]: (state, payload) => {
-        let events = cloneDeep(state.events);
-        const newEvent = payload.event;
-        let event = get(events, newEvent._id, payload.event);
+    [EVENTS.ACTIONS.LOCK_EVENT]: (state, payload) => (
+        produce(state, (draft) => {
+            let events = draft.events;
+            const newEvent = payload.event;
+            let event = get(events, newEvent._id, payload.event);
 
-        event.lock_action = newEvent.lock_action;
-        event.lock_user = newEvent.lock_user;
-        event.lock_time = newEvent.lock_time;
-        event.lock_session = newEvent.lock_session;
-        event._etag = newEvent._etag;
-
-        return {
-            ...state,
-            events,
-        };
-    },
+            event.lock_action = newEvent.lock_action;
+            event.lock_user = newEvent.lock_user;
+            event.lock_time = newEvent.lock_time;
+            event.lock_session = newEvent.lock_session;
+            event._etag = newEvent._etag;
+        })
+    ),
 
     [EVENTS.ACTIONS.UNLOCK_EVENT]: (state, payload) => {
         // If the event is not loaded, disregard this action
         if (!(payload.event._id in state.events)) return state;
 
-        let events = cloneDeep(state.events);
-        const newEvent = payload.event;
-        let event = events[newEvent._id];
+        return produce(state, (draft) => {
+            let events = draft.events;
+            const newEvent = payload.event;
+            let event = events[newEvent._id];
 
-        removeLock(event, newEvent._etag);
-
-        return {
-            ...state,
-            events,
-        };
+            removeLock(event, newEvent._etag);
+        });
     },
 
     [EVENTS.ACTIONS.MARK_EVENT_POSTPONED]: (state, payload) => {
         // If the event is not loaded, disregard this action
         if (!(payload.event._id in state.events)) return state;
 
-        let events = cloneDeep(state.events);
-        let event = events[payload.event._id];
+        return produce(state, (draft) => {
+            let events = draft.events;
+            let event = events[payload.event._id];
 
-        if (get(payload, 'reason.length', 0) > 0) {
-            event.state_reason = payload.reason;
-        }
+            if (get(payload, 'reason.length', 0) > 0) {
+                event.state_reason = payload.reason;
+            }
 
-        if (get(payload, 'actionedDate')) {
-            event.actioned_date = payload.actionedDate;
-        }
+            if (get(payload, 'actionedDate')) {
+                event.actioned_date = payload.actionedDate;
+            }
 
-        event.state = WORKFLOW_STATE.POSTPONED;
-
-        return {
-            ...state,
-            events,
-        };
+            event.state = WORKFLOW_STATE.POSTPONED;
+        });
     },
 
     [EVENTS.ACTIONS.SPIKE_EVENT]: (state, payload) => {
@@ -239,14 +219,11 @@ const eventsReducer = createReducer<IEventState>(initialState, {
 
         // Otherwise iterate over the items and mark them
         // with their new etag and spike state
-        let events = cloneDeep(state.events);
+        return produce(state, (draft) => {
+            let events = draft.events;
 
-        payload.items.forEach((event) => spikeEvent(events, event));
-
-        return {
-            ...state,
-            events,
-        };
+            payload.items.forEach((event) => spikeEvent(events, event));
+        });
     },
 
     [EVENTS.ACTIONS.UNSPIKE_EVENT]: (state, payload) => {
@@ -257,14 +234,11 @@ const eventsReducer = createReducer<IEventState>(initialState, {
 
         // Otherwise iterate over the items and mark them
         // with their new etag and spike state
-        let events = cloneDeep(state.events);
+        return produce(state, (draft) => {
+            let events = draft.events;
 
-        payload.items.forEach((event) => unspikeEvent(events, event));
-
-        return {
-            ...state,
-            events,
-        };
+            payload.items.forEach((event) => unspikeEvent(events, event));
+        });
     },
 
     [EVENTS.ACTIONS.MARK_EVENT_POSTED]: (state, payload) => (
@@ -298,19 +272,16 @@ const eventsReducer = createReducer<IEventState>(initialState, {
         }
     ),
 
-    [EVENTS.ACTIONS.EXPIRE_EVENTS]: (state, payload) => {
-        let events = cloneDeep(state.events);
+    [EVENTS.ACTIONS.EXPIRE_EVENTS]: (state, payload) => (
+        produce(state, (draft) => {
+            let events = draft.events;
 
-        payload.forEach((eventId) => {
-            if (events[eventId])
-                events[eventId].expired = true;
-        });
-
-        return {
-            ...state,
-            events,
-        };
-    },
+            payload.forEach((eventId) => {
+                if (events[eventId])
+                    events[eventId].expired = true;
+            });
+        })
+    ),
 
     [EVENTS.ACTIONS.RECEIVE_EVENT_TEMPLATES]: (state, payload) => ({
         ...state,
@@ -330,22 +301,20 @@ const onEventPostChanged = (state, payload) => {
 
     // Otherwise iterate over the items and mark them
     // with their new etag, state and pubstatus values
-    let events = cloneDeep(state.events);
 
-    payload.items.forEach((event) =>
-        updateEventPubstatus(
-            events,
-            event.id,
-            event.etag,
-            payload.state,
-            payload.pubstatus
-        )
-    );
+    return produce(state, (draft) => {
+        let events = draft.events;
 
-    return {
-        ...state,
-        events,
-    };
+        payload.items.forEach((event) =>
+            updateEventPubstatus(
+                events,
+                event.id,
+                event.etag,
+                payload.state,
+                payload.pubstatus
+            )
+        );
+    });
 };
 
 const updateEventPubstatus = (events, eventId, etag, state, pubstatus) => {

--- a/client/reducers/eventsplanning.ts
+++ b/client/reducers/eventsplanning.ts
@@ -1,10 +1,11 @@
-import {cloneDeep, get, uniq, sortBy} from 'lodash';
+import {get, uniq, sortBy} from 'lodash';
 
 import {IEventsPlanningState, IMainState, ISearchFilter} from '../interfaces';
 import {EVENTS_PLANNING, INIT_STORE, RESET_STORE, MAIN} from '../constants';
 
 import {createReducer} from './createReducer';
 import {getItemId} from '../utils';
+import {produce} from 'immer';
 
 const initialState: IEventsPlanningState = {
     eventsAndPlanningInList: [],
@@ -42,13 +43,12 @@ const eventsPlanningReducer = createReducer<IEventsPlanningState>(initialState, 
         }
     ),
     [EVENTS_PLANNING.ACTIONS.ADD_EVENTS_PLANNING_LIST]: (state, payload) => (
-        {
-            ...state,
-            eventsAndPlanningInList: uniq([
-                ...cloneDeep(state.eventsAndPlanningInList || []),
+        produce(state, (draft) => {
+            draft.eventsAndPlanningInList = uniq([
+                ...draft.eventsAndPlanningInList || [],
                 ...(payload || []).map((e) => e._id),
-            ]),
-        }
+            ]);
+        })
     ),
     [EVENTS_PLANNING.ACTIONS.CLEAR_EVENTS_PLANNING_LIST]: (state, payload) => (
         {

--- a/client/reducers/locks.ts
+++ b/client/reducers/locks.ts
@@ -1,7 +1,7 @@
 import {ILockedItems, ILock, IWebsocketMessageData} from '../interfaces';
 import {createReducer} from './createReducer';
 import {RESET_STORE, INIT_STORE, LOCKS} from '../constants';
-import {cloneDeep, get} from 'lodash';
+import {produce} from 'immer';
 
 const initialLockState: ILockedItems = {
     event: {},
@@ -62,10 +62,14 @@ export default createReducer(initialLockState, {
     ),
 
     [LOCKS.ACTIONS.SET_ITEM_AS_LOCKED]: (state: ILockedItems, payload: IWebsocketMessageData['ITEM_LOCKED']) => (
-        addLock(cloneDeep(state), payload)
+        produce(state, (draft) => {
+            addLock(draft, payload);
+        })
     ),
 
     [LOCKS.ACTIONS.SET_ITEM_AS_UNLOCKED]: (state: ILockedItems, payload: IWebsocketMessageData['ITEM_UNLOCKED']) => (
-        removeLock(cloneDeep(state), payload)
+        produce(state, (draft) => {
+            removeLock(draft, payload);
+        })
     ),
 });

--- a/client/reducers/planning.ts
+++ b/client/reducers/planning.ts
@@ -1,4 +1,4 @@
-import {cloneDeep, get, uniq, find} from 'lodash';
+import {get, uniq, find} from 'lodash';
 import {createReducer} from './createReducer';
 import {getItemType, planningUtils} from '../utils';
 import {
@@ -11,6 +11,7 @@ import {
     MAIN,
     ITEM_TYPE,
 } from '../constants';
+import {produce} from 'immer';
 
 const initialState = {
     plannings: {},
@@ -20,9 +21,6 @@ const initialState = {
     readOnly: true,
     planningHistoryItems: [],
 };
-
-let plannings;
-let plan;
 
 const planningReducer = createReducer(initialState, {
     [RESET_STORE]: () => ({...initialState}),
@@ -63,141 +61,120 @@ const planningReducer = createReducer(initialState, {
         planningHistoryItems: payload,
     }),
 
-    [PLANNING.ACTIONS.MARK_PLANNING_CANCELLED]: (state, payload) => {
-        plannings = cloneDeep(state.plannings);
-        plan = get(plannings, payload.planning_item, null);
+    [PLANNING.ACTIONS.MARK_PLANNING_CANCELLED]: (state, payload) => (
+        produce(state, (draft) => {
+            const plannings = draft.plannings;
+            const plan = get(plannings, payload.planning_item, null);
 
-        // If the planning item is not loaded, disregard this action
-        if (plan === null) return state;
+            // If the planning item is not loaded, disregard this action
+            if (plan === null) return;
 
-        markPlaning(plan, payload, 'cancelled');
-        plan.state = WORKFLOW_STATE.CANCELLED;
-        plan.coverages.forEach((coverage) => {
-            markCoverage(coverage, payload, 'cancelled');
-            get(coverage, 'scheduled_updates', []).forEach(
-                (s) => markCoverage(s, payload, 'cancelled')
-            );
-        });
-
-        return {
-            ...state,
-            plannings,
-        };
-    },
-
-    [PLANNING.ACTIONS.MARK_COVERAGE_CANCELLED]: (state, payload) => {
-        plannings = cloneDeep(state.plannings);
-        plan = get(plannings, payload.planning_item, null);
-
-        // If the planning item is not loaded, disregard this action
-        if (plan === null) return state;
-
-        if ('etag' in payload) {
-            plan._etag = payload.etag;
-        }
-
-        plan.coverages.forEach((coverage) => {
-            if (payload.ids.indexOf(coverage.coverage_id) !== -1) {
+            markPlaning(plan, payload, 'cancelled');
+            plan.state = WORKFLOW_STATE.CANCELLED;
+            plan.coverages.forEach((coverage) => {
                 markCoverage(coverage, payload, 'cancelled');
+                get(coverage, 'scheduled_updates', []).forEach(
+                    (s) => markCoverage(s, payload, 'cancelled')
+                );
+            });
+        })
+    ),
+
+    [PLANNING.ACTIONS.MARK_COVERAGE_CANCELLED]: (state, payload) => (
+        produce(state, (draft) => {
+            const plannings = draft.plannings;
+            const plan = get(plannings, payload.planning_item, null);
+
+            // If the planning item is not loaded, disregard this action
+            if (plan === null) return;
+
+            if ('etag' in payload) {
+                plan._etag = payload.etag;
             }
-        });
 
-        return {
-            ...state,
-            plannings,
-        };
-    },
+            plan.coverages.forEach((coverage) => {
+                if (payload.ids.indexOf(coverage.coverage_id) !== -1) {
+                    markCoverage(coverage, payload, 'cancelled');
+                }
+            });
+        })
+    ),
 
-    [PLANNING.ACTIONS.MARK_PLANNING_POSTPONED]: (state, payload) => {
-        plannings = cloneDeep(state.plannings);
-        plan = get(plannings, payload.planning_item, null);
+    [PLANNING.ACTIONS.MARK_PLANNING_POSTPONED]: (state, payload) => (
+        produce(state, (draft) => {
+            const plannings = draft.plannings;
+            const plan = get(plannings, payload.planning_item, null);
 
-        // If the planning item is not loaded, disregard this action
-        if (plan === null) return state;
+            // If the planning item is not loaded, disregard this action
+            if (plan === null) return;
 
-        markPlaning(plan, payload, 'postponed');
-        plan.state = WORKFLOW_STATE.POSTPONED;
-        plan.coverages.forEach((coverage) => markCoverage(coverage, payload, 'postponed'));
-
-        return {
-            ...state,
-            plannings,
-        };
-    },
+            markPlaning(plan, payload, 'postponed');
+            plan.state = WORKFLOW_STATE.POSTPONED;
+            plan.coverages.forEach((coverage) => markCoverage(coverage, payload, 'postponed'));
+        })
+    ),
 
     [PLANNING.ACTIONS.LOCK_PLANNING]: (state, payload) => {
         if (!(payload.plan._id in state.plannings)) return state;
 
-        plannings = cloneDeep(state.plannings);
-        const newPlan = payload.plan;
+        return produce(state, (draft) => {
+            const plannings = draft.plannings;
+            const newPlan = payload.plan;
 
-        plan = plannings[newPlan._id];
+            const plan = plannings[newPlan._id];
 
-        plan.lock_action = newPlan.lock_action;
-        plan.lock_user = newPlan.lock_user;
-        plan.lock_time = newPlan.lock_time;
-        plan.lock_session = newPlan.lock_session;
-        plan._etag = newPlan._etag;
-
-        return {
-            ...state,
-            plannings,
-        };
+            plan.lock_action = newPlan.lock_action;
+            plan.lock_user = newPlan.lock_user;
+            plan.lock_time = newPlan.lock_time;
+            plan.lock_session = newPlan.lock_session;
+            plan._etag = newPlan._etag;
+        });
     },
 
     [PLANNING.ACTIONS.UNLOCK_PLANNING]: (state, payload) => {
         // If the planning is not loaded, disregard this action
         if (!(payload.plan._id in state.plannings)) return state;
 
-        plannings = cloneDeep(state.plannings);
-        const newPlan = payload.plan;
+        return produce(state, (draft) => {
+            const plannings = draft.plannings;
+            const newPlan = payload.plan;
 
-        plan = plannings[newPlan._id];
+            const plan = plannings[newPlan._id];
 
-        delete plan.lock_action;
-        delete plan.lock_user;
-        delete plan.lock_time;
-        delete plan.lock_session;
-        plan._etag = newPlan._etag;
-
-        return {
-            ...state,
-            plannings,
-        };
+            delete plan.lock_action;
+            delete plan.lock_user;
+            delete plan.lock_time;
+            delete plan.lock_session;
+            plan._etag = newPlan._etag;
+        });
     },
 
     [PLANNING.ACTIONS.SPIKE_PLANNING]: (state, payload) => {
         // If the planning is not loaded, disregard this action
         if (!(payload.id in state.plannings)) return state;
 
-        const plannings = cloneDeep(state.plannings);
-        const plan = plannings[payload.id];
+        return produce(state, (draft) => {
+            const plannings = draft.plannings;
+            const plan = plannings[payload.id];
 
-        plan._etag = payload.etag;
-        plan.state = payload.state;
-        plan.revert_state = payload.revert_state;
-
-        return {
-            ...state,
-            plannings,
-        };
+            plan._etag = payload.etag;
+            plan.state = payload.state;
+            plan.revert_state = payload.revert_state;
+        });
     },
 
     [PLANNING.ACTIONS.UNSPIKE_PLANNING]: (state, payload) => {
         // If the planning is not loaded, disregard this action
         if (!(payload.id in state.plannings)) return state;
 
-        const plannings = cloneDeep(state.plannings);
-        const plan = plannings[payload.id];
+        return produce(state, (draft) => {
+            const plannings = draft.plannings;
+            const plan = plannings[payload.id];
 
-        plan._etag = payload.etag;
-        plan.state = payload.state;
-        delete plan.revert_state;
-
-        return {
-            ...state,
-            plannings,
-        };
+            plan._etag = payload.etag;
+            plan.state = payload.state;
+            delete plan.revert_state;
+        });
     },
 
     [ASSIGNMENTS.ACTIONS.REMOVE_ASSIGNMENT]: (state, payload) => {
@@ -207,23 +184,21 @@ const planningReducer = createReducer(initialState, {
             return state;
         }
 
-        let plannings = cloneDeep(state.plannings);
-        let plan = plannings[payload.planning];
+        return produce(state, (draft) => {
+            const plannings = draft.plannings;
+            const plan = plannings[payload.planning];
 
-        plan._etag = payload.planning_etag;
+            plan._etag = payload.planning_etag;
 
-        const coverage = find(get(plan, 'coverages', []), (c) => c.coverage_id === payload.coverage);
+            const coverage = find(get(plan, 'coverages', []), (c) => c.coverage_id === payload.coverage);
 
-        if (coverage) {
-            delete coverage.assigned_to;
-            coverage.workflow_status = WORKFLOW_STATE.DRAFT;
-        }
-
-        return {
-            ...state,
-            plannings,
-        };
+            if (coverage) {
+                delete coverage.assigned_to;
+                coverage.workflow_status = WORKFLOW_STATE.DRAFT;
+            }
+        });
     },
+
     [MAIN.ACTIONS.PREVIEW]: (state, payload) => {
         if (getItemType(payload) === ITEM_TYPE.PLANNING) {
             return {
@@ -235,19 +210,16 @@ const planningReducer = createReducer(initialState, {
         }
     },
 
-    [PLANNING.ACTIONS.EXPIRE_PLANNING]: (state, payload) => {
-        let plannings = cloneDeep(state.plannings);
+    [PLANNING.ACTIONS.EXPIRE_PLANNING]: (state, payload) => (
+        produce(state, (draft) => {
+            const plannings = draft.plannings;
 
-        payload.forEach((planId) => {
-            if (plannings[planId])
-                plannings[planId].expired = true;
-        });
-
-        return {
-            ...state,
-            plannings,
-        };
-    },
+            payload.forEach((planId) => {
+                if (plannings[planId])
+                    plannings[planId].expired = true;
+            });
+        })
+    ),
 });
 
 const markPlaning = (plan, payload, action) => {


### PR DESCRIPTION
SDCP-1037

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

### Front-end checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)

Resolves: #[issue-number]

