### PR TITLE
cherry pick reducer changes from 2.10

### DIFF
--- a/client/constants/index.ts
+++ b/client/constants/index.ts
@@ -69,6 +69,7 @@ export const SPIKED_STATE = {
 
 export const RESET_STORE = 'RESET_STORE';
 export const INIT_STORE = 'INIT_STORE';
+export const INITIAL_STATE = '_INITIAL_STATE';
 export const FORM_NAMES = {
     PlanningForm: 'planning',
     EventForm: 'event',

--- a/client/reducers/agenda.ts
+++ b/client/reducers/agenda.ts
@@ -34,9 +34,9 @@ const initialState: IAgendaState = {
 const agendaReducer = (state = initialState, action) => {
     switch (action.type) {
     case RESET_STORE:
-        return initialState;
+        return {...initialState};
     case INIT_STORE:
-        return initialState;
+        return {...initialState};
     case AGENDA.ACTIONS.REQUEST_AGENDAS:
         return {
             ...state,

--- a/client/reducers/assignment.ts
+++ b/client/reducers/assignment.ts
@@ -128,9 +128,9 @@ const filterList = (state, listId, assignmentId) => {
 };
 
 const assignmentReducer = createReducer(initialState, {
-    [RESET_STORE]: () => (null),
+    [RESET_STORE]: () => ({...initialState}),
 
-    [INIT_STORE]: () => (initialState),
+    [INIT_STORE]: () => ({...initialState}),
 
     [ASSIGNMENTS.ACTIONS.RECEIVED_ASSIGNMENTS]: produce((draftState, actionPayload) => {
         const receivedAssignments = modifyAssignmentBeingAdded(actionPayload);

--- a/client/reducers/contacts.ts
+++ b/client/reducers/contacts.ts
@@ -8,6 +8,7 @@ const contacts = (state = initialState, action) => {
     switch (action.type) {
     case 'RECEIVE_CONTACTS':
         newState = {
+            ...state,
             contacts: uniqBy([...action.payload.contacts, ...state.contacts], '_id'),
             loading: false,
         };
@@ -20,7 +21,7 @@ const contacts = (state = initialState, action) => {
         return newState;
 
     case 'ADD_CONTACT':
-        return {contacts: uniqBy([action.payload, ...state.contacts], '_id')};
+        return {...state, contacts: uniqBy([action.payload, ...state.contacts], '_id')};
 
     case 'LOADING_CONTACTS':
         return {

--- a/client/reducers/createReducer.ts
+++ b/client/reducers/createReducer.ts
@@ -1,14 +1,17 @@
+import {INITIAL_STATE} from '../constants';
+
 export function createReducer<T = any>(initialState: T, reducerMap: {[key: string]: (state: T, payload: any) => T}) {
     return (state = initialState, action) => {
         const reducer = reducerMap[action.type];
 
         if (reducer) {
             return reducer(state, action.payload);
+        } else if (action.type === INITIAL_STATE) {
+            // workaround to handle createStore with only subset of initial state
+            return {...initialState, ...state};
         } else {
-            return {
-                ...initialState,
-                ...state,
-            };
+            // no reducer matched, return current state
+            return state;
         }
     };
 }

--- a/client/reducers/events.ts
+++ b/client/reducers/events.ts
@@ -1,5 +1,6 @@
-import {orderBy, cloneDeep, uniq, get} from 'lodash';
+import {orderBy, uniq, get} from 'lodash';
 import moment from 'moment';
+import {produce} from 'immer';
 
 import {IEventState, IMainState, GROUP_LIST_BY} from '../interfaces';
 
@@ -17,26 +18,26 @@ const initialState: IEventState = {
     eventTemplates: [],
 };
 
-const modifyEventsBeingAdded = (state, payload) => {
-    let _events = cloneDeep(state.events);
+const modifyEventsBeingAdded = (state, payload) => (
+    produce(state, (draft) => {
+        let _events = draft.events;
 
-    payload.forEach((e) => {
-        _events[e._id] = e;
+        payload.forEach((e) => {
+            _events[e._id] = e;
 
-        // Change dates to moment objects
-        if (e.dates) {
-            e.dates.start = moment(e.dates.start);
-            e.dates.end = moment(e.dates.end);
-            if (get(e, 'dates.recurring_rule.until')) {
-                e.dates.recurring_rule.until = moment(e.dates.recurring_rule.until);
+            // Change dates to moment objects
+            if (e.dates) {
+                e.dates.start = moment(e.dates.start);
+                e.dates.end = moment(e.dates.end);
+                if (get(e, 'dates.recurring_rule.until')) {
+                    e.dates.recurring_rule.until = moment(e.dates.recurring_rule.until);
+                }
+                e._startTime = moment(e.dates.start);
+                e._endTime = moment(e.dates.end);
             }
-            e._startTime = moment(e.dates.start);
-            e._endTime = moment(e.dates.end);
-        }
-    });
-
-    return _events;
-};
+        });
+    })
+);
 
 const removeLock = (event, etag = null) => {
     delete event.lock_action;
@@ -74,14 +75,9 @@ const eventsReducer = createReducer<IEventState>(initialState, {
 
     [INIT_STORE]: () => ({...initialState}),
 
-    [EVENTS.ACTIONS.ADD_EVENTS]: (state, payload) => {
-        const _events = modifyEventsBeingAdded(state, payload);
-
-        return {
-            ...state,
-            events: _events,
-        };
-    },
+    [EVENTS.ACTIONS.ADD_EVENTS]: (state, payload) => (
+        modifyEventsBeingAdded(state, payload)
+    ),
 
     [EVENTS.ACTIONS.SET_EVENTS_LIST]: (state, payload) => (
         {
@@ -123,105 +119,90 @@ const eventsReducer = createReducer<IEventState>(initialState, {
         if (!(payload.event_id in state.events) && get(payload, 'cancelled_items.length', 0) < 1)
             return state;
 
-        let events = cloneDeep(state.events);
+        return produce(state, (draft) => {
+            let events = draft.events;
 
-        // First mark the original Event as cancelled
-        markEventCancelled(
-            events,
-            payload.event_id,
-            payload.etag,
-            payload.reason,
-            payload.occur_status,
-            payload.actionedDate
-        );
-
-        // Now mark all associated Events that are also cancelled
-        (get(payload, 'cancelled_items') || []).forEach(
-            (event) => markEventCancelled(
+            // First mark the original Event as cancelled
+            markEventCancelled(
                 events,
-                event._id,
-                event._etag,
+                payload.event_id,
+                payload.etag,
                 payload.reason,
                 payload.occur_status,
                 payload.actionedDate
-            )
-        );
+            );
 
-        return {
-            ...state,
-            events,
-        };
+            // Now mark all associated Events that are also cancelled
+            (get(payload, 'cancelled_items') || []).forEach(
+                (event) => markEventCancelled(
+                    events,
+                    event._id,
+                    event._etag,
+                    payload.reason,
+                    payload.occur_status,
+                    payload.actionedDate
+                )
+            );
+        });
     },
 
     [EVENTS.ACTIONS.SET_EVENT_PLANNINGS]: (state, payload) => {
         // If the event is not loaded, disregard this action
         if (!(payload.event_id in state.events)) return state;
 
-        let events = cloneDeep(state.events);
-        let event = events[payload.event_id];
+        return produce(state, (draft) => {
+            let events = draft.events;
+            let event = events[payload.event_item];
 
-        event.planning_ids = payload.planning_ids;
-
-        return {
-            ...state,
-            events,
-        };
+            event.planning_ids = payload.planning_ids;
+        });
     },
 
-    [EVENTS.ACTIONS.LOCK_EVENT]: (state, payload) => {
-        let events = cloneDeep(state.events);
-        const newEvent = payload.event;
-        let event = get(events, newEvent._id, payload.event);
+    [EVENTS.ACTIONS.LOCK_EVENT]: (state, payload) => (
+        produce(state, (draft) => {
+            let events = draft.events;
+            const newEvent = payload.event;
+            let event = get(events, newEvent._id, payload.event);
 
-        event.lock_action = newEvent.lock_action;
-        event.lock_user = newEvent.lock_user;
-        event.lock_time = newEvent.lock_time;
-        event.lock_session = newEvent.lock_session;
-        event._etag = newEvent._etag;
-
-        return {
-            ...state,
-            events,
-        };
-    },
+            event.lock_action = newEvent.lock_action;
+            event.lock_user = newEvent.lock_user;
+            event.lock_time = newEvent.lock_time;
+            event.lock_session = newEvent.lock_session;
+            event._etag = newEvent._etag;
+        })
+    ),
 
     [EVENTS.ACTIONS.UNLOCK_EVENT]: (state, payload) => {
         // If the event is not loaded, disregard this action
         if (!(payload.event._id in state.events)) return state;
 
-        let events = cloneDeep(state.events);
-        const newEvent = payload.event;
-        let event = events[newEvent._id];
+        return produce(state, (draft) => {
+            let events = draft.events;
+            const newEvent = payload.event;
+            let event = events[newEvent._id];
 
-        removeLock(event, newEvent._etag);
-
-        return {
-            ...state,
-            events,
-        };
+            removeLock(event, newEvent._etag);
+        });
     },
 
     [EVENTS.ACTIONS.MARK_EVENT_POSTPONED]: (state, payload) => {
         // If the event is not loaded, disregard this action
         if (!(payload.event._id in state.events)) return state;
 
-        let events = cloneDeep(state.events);
-        let event = events[payload.event._id];
+        return produce(state, (draft) => {
+            let events = draft.events;
+            let event = events[payload.event._id];
 
-        if (get(payload, 'reason.length', 0) > 0) {
-            event.state_reason = payload.reason;
-        }
+            if (get(payload, 'reason.length', 0) > 0) {
+                event.state_reason = payload.reason;
+            }
 
-        if (get(payload, 'actionedDate')) {
-            event.actioned_date = payload.actionedDate;
-        }
+            if (get(payload, 'actionedDate')) {
+                event.actioned_date = payload.actionedDate;
+            }
 
-        event.state = WORKFLOW_STATE.POSTPONED;
-
-        return {
-            ...state,
-            events,
-        };
+            event.state = WORKFLOW_STATE.POSTPONED;
+        });
     },
 
     [EVENTS.ACTIONS.SPIKE_EVENT]: (state, payload) => {
@@ -232,14 +213,11 @@ const eventsReducer = createReducer<IEventState>(initialState, {
 
         // Otherwise iterate over the items and mark them
         // with their new etag and spike state
-        let events = cloneDeep(state.events);
+        return produce(state, (draft) => {
+            let events = draft.events;
 
-        payload.items.forEach((event) => spikeEvent(events, event));
-
-        return {
-            ...state,
-            events,
-        };
+            payload.items.forEach((event) => spikeEvent(events, event));
+        });
     },
 
     [EVENTS.ACTIONS.UNSPIKE_EVENT]: (state, payload) => {
@@ -250,14 +228,11 @@ const eventsReducer = createReducer<IEventState>(initialState, {
 
         // Otherwise iterate over the items and mark them
         // with their new etag and spike state
-        let events = cloneDeep(state.events);
+        return produce(state, (draft) => {
+            let events = draft.events;
 
-        payload.items.forEach((event) => unspikeEvent(events, event));
-
-        return {
-            ...state,
-            events,
-        };
+            payload.items.forEach((event) => unspikeEvent(events, event));
+        });
     },
 
     [EVENTS.ACTIONS.MARK_EVENT_POSTED]: (state, payload) => (
@@ -291,19 +266,16 @@ const eventsReducer = createReducer<IEventState>(initialState, {
         }
     ),
 
-    [EVENTS.ACTIONS.EXPIRE_EVENTS]: (state, payload) => {
-        let events = cloneDeep(state.events);
+    [EVENTS.ACTIONS.EXPIRE_EVENTS]: (state, payload) => (
+        produce(state, (draft) => {
+            let events = draft.events;
 
-        payload.forEach((eventId) => {
-            if (events[eventId])
-                events[eventId].expired = true;
-        });
-
-        return {
-            ...state,
-            events,
-        };
-    },
+            payload.forEach((eventId) => {
+                if (events[eventId])
+                    events[eventId].expired = true;
+            });
+        })
+    ),
 
     [EVENTS.ACTIONS.RECEIVE_EVENT_TEMPLATES]: (state, payload) => ({
         ...state,
@@ -323,22 +295,20 @@ const onEventPostChanged = (state, payload) => {
 
     // Otherwise iterate over the items and mark them
     // with their new etag, state and pubstatus values
-    let events = cloneDeep(state.events);
 
-    payload.items.forEach((event) =>
-        updateEventPubstatus(
-            events,
-            event.id,
-            event.etag,
-            payload.state,
-            payload.pubstatus
-        )
-    );
+    return produce(state, (draft) => {
+        let events = draft.events;
 
-    return {
-        ...state,
-        events,
-    };
+        payload.items.forEach((event) =>
+            updateEventPubstatus(
+                events,
+                event.id,
+                event.etag,
+                payload.state,
+                payload.pubstatus
+            )
+        );
+    });
 };
 
 const updateEventPubstatus = (events, eventId, etag, state, pubstatus) => {

--- a/client/reducers/events.ts
+++ b/client/reducers/events.ts
@@ -70,9 +70,9 @@ export const unspikeEvent = (events, payload) => {
 };
 
 const eventsReducer = createReducer<IEventState>(initialState, {
-    [RESET_STORE]: () => (initialState),
+    [RESET_STORE]: () => ({...initialState}),
 
-    [INIT_STORE]: () => (initialState),
+    [INIT_STORE]: () => ({...initialState}),
 
     [EVENTS.ACTIONS.ADD_EVENTS]: (state, payload) => {
         const _events = modifyEventsBeingAdded(state, payload);

--- a/client/reducers/eventsplanning.ts
+++ b/client/reducers/eventsplanning.ts
@@ -32,9 +32,9 @@ const addOrReplaceFilters = (filters, filter) => {
 };
 
 const eventsPlanningReducer = createReducer<IEventsPlanningState>(initialState, {
-    [RESET_STORE]: () => (null),
+    [RESET_STORE]: () => ({...initialState}),
 
-    [INIT_STORE]: () => (initialState),
+    [INIT_STORE]: () => ({...initialState}),
 
     [EVENTS_PLANNING.ACTIONS.SET_EVENTS_PLANNING_LIST]: (state, payload) =>
         produce(state, (draft) => {

--- a/client/reducers/featuredPlanning.ts
+++ b/client/reducers/featuredPlanning.ts
@@ -266,8 +266,8 @@ function moveItemToUnselected(prevState: IFeaturedPlanningState, itemId: IPlanni
 }
 
 const featuredPlanningReducer = createReducer(initialState, {
-    [RESET_STORE]: () => null,
-    [INIT_STORE]: () => cloneDeep(initialState),
+    [RESET_STORE]: () => ({...initialState}),
+    [INIT_STORE]: () => ({...initialState}),
 
     // Locks
     [FEATURED_PLANNING.ACTIONS.SET_LOCK_USER]: (state, payload) => ({

--- a/client/reducers/locks.ts
+++ b/client/reducers/locks.ts
@@ -1,8 +1,8 @@
 import {ILockedItems, ILock, IWebsocketMessageData} from '../interfaces';
 import {createReducer} from './createReducer';
 import {RESET_STORE, INIT_STORE, LOCKS} from '../constants';
-import {cloneDeep} from 'lodash';
 import {getRelatedEventIdsForPlanning} from '../utils/planning';
+import {produce} from 'immer';
 
 const initialLockState: ILockedItems = {
     event: {},
@@ -75,11 +75,15 @@ export default createReducer(initialLockState, {
     ),
 
     [LOCKS.ACTIONS.SET_ITEM_AS_LOCKED]: (state: ILockedItems, payload: IWebsocketMessageData['ITEM_LOCKED']) => (
-        addLock(cloneDeep(state), payload)
+        produce(state, (draft) => {
+            addLock(draft, payload);
+        })
     ),
 
     [LOCKS.ACTIONS.SET_ITEM_AS_UNLOCKED]: (state: ILockedItems, payload: IWebsocketMessageData['ITEM_UNLOCKED']) => (
-        removeLock(cloneDeep(state), payload)
+        produce(state, (draft) => {
+            removeLock(draft, payload);
+        })
     ),
 
     [LOCKS.ACTIONS.RELOAD_SOFT_LOCKS_FOR_RELATED_EVENTS]: (state: ILockedItems, payload: {planning: IPlanningItem}) => {

--- a/client/reducers/locks.ts
+++ b/client/reducers/locks.ts
@@ -61,9 +61,9 @@ function addLock(state: ILockedItems, data: IWebsocketMessageData['ITEM_LOCKED']
 }
 
 export default createReducer(initialLockState, {
-    [RESET_STORE]: () => null,
+    [RESET_STORE]: () => ({...initialLockState}),
 
-    [INIT_STORE]: () => initialLockState,
+    [INIT_STORE]: () => ({...initialLockState}),
 
     [LOCKS.ACTIONS.RECEIVE]: (state: ILockedItems, payload: ILockedItems) => (
         {

--- a/client/reducers/modal.ts
+++ b/client/reducers/modal.ts
@@ -32,7 +32,7 @@ const modal = (state = initialState, action) => {
             previousState: undefined,
         };
     case 'RESET_STORE': {
-        return initialState;
+        return {...initialState};
     }
     default:
         return state;

--- a/client/reducers/planning.ts
+++ b/client/reducers/planning.ts
@@ -1,4 +1,4 @@
-import {cloneDeep, get, uniq, find} from 'lodash';
+import {get, uniq, find} from 'lodash';
 import {createReducer} from './createReducer';
 import {getItemType, planningUtils} from '../utils';
 import {
@@ -11,6 +11,7 @@ import {
     MAIN,
     ITEM_TYPE,
 } from '../constants';
+import {produce} from 'immer';
 
 const initialState = {
     plannings: {},
@@ -20,9 +21,6 @@ const initialState = {
     readOnly: true,
     planningHistoryItems: [],
 };
-
-let plannings;
-let plan;
 
 const planningReducer = createReducer(initialState, {
     [RESET_STORE]: () => ({...initialState}),
@@ -66,141 +64,120 @@ const planningReducer = createReducer(initialState, {
         planningHistoryItems: payload,
     }),
 
-    [PLANNING.ACTIONS.MARK_PLANNING_CANCELLED]: (state, payload) => {
-        plannings = cloneDeep(state.plannings);
-        plan = get(plannings, payload.planning_item, null);
+    [PLANNING.ACTIONS.MARK_PLANNING_CANCELLED]: (state, payload) => (
+        produce(state, (draft) => {
+            const plannings = draft.plannings;
+            const plan = get(plannings, payload.planning_item, null);
 
-        // If the planning item is not loaded, disregard this action
-        if (plan === null) return state;
+            // If the planning item is not loaded, disregard this action
+            if (plan === null) return;
 
-        markPlaning(plan, payload, 'cancelled');
-        plan.state = WORKFLOW_STATE.CANCELLED;
-        plan.coverages.forEach((coverage) => {
-            markCoverage(coverage, payload, 'cancelled');
-            get(coverage, 'scheduled_updates', []).forEach(
-                (s) => markCoverage(s, payload, 'cancelled')
-            );
-        });
-
-        return {
-            ...state,
-            plannings,
-        };
-    },
-
-    [PLANNING.ACTIONS.MARK_COVERAGE_CANCELLED]: (state, payload) => {
-        plannings = cloneDeep(state.plannings);
-        plan = get(plannings, payload.planning_item, null);
-
-        // If the planning item is not loaded, disregard this action
-        if (plan === null) return state;
-
-        if ('etag' in payload) {
-            plan._etag = payload.etag;
-        }
-
-        plan.coverages.forEach((coverage) => {
-            if (payload.ids.indexOf(coverage.coverage_id) !== -1) {
+            markPlaning(plan, payload, 'cancelled');
+            plan.state = WORKFLOW_STATE.CANCELLED;
+            plan.coverages.forEach((coverage) => {
                 markCoverage(coverage, payload, 'cancelled');
+                get(coverage, 'scheduled_updates', []).forEach(
+                    (s) => markCoverage(s, payload, 'cancelled')
+                );
+            });
+        })
+    ),
+
+    [PLANNING.ACTIONS.MARK_COVERAGE_CANCELLED]: (state, payload) => (
+        produce(state, (draft) => {
+            const plannings = draft.plannings;
+            const plan = get(plannings, payload.planning_item, null);
+
+            // If the planning item is not loaded, disregard this action
+            if (plan === null) return;
+
+            if ('etag' in payload) {
+                plan._etag = payload.etag;
             }
-        });
 
-        return {
-            ...state,
-            plannings,
-        };
-    },
+            plan.coverages.forEach((coverage) => {
+                if (payload.ids.indexOf(coverage.coverage_id) !== -1) {
+                    markCoverage(coverage, payload, 'cancelled');
+                }
+            });
+        })
+    ),
 
-    [PLANNING.ACTIONS.MARK_PLANNING_POSTPONED]: (state, payload) => {
-        plannings = cloneDeep(state.plannings);
-        plan = get(plannings, payload.planning_item, null);
+    [PLANNING.ACTIONS.MARK_PLANNING_POSTPONED]: (state, payload) => (
+        produce(state, (draft) => {
+            const plannings = draft.plannings;
+            const plan = get(plannings, payload.planning_item, null);
 
-        // If the planning item is not loaded, disregard this action
-        if (plan === null) return state;
+            // If the planning item is not loaded, disregard this action
+            if (plan === null) return;
 
-        markPlaning(plan, payload, 'postponed');
-        plan.state = WORKFLOW_STATE.POSTPONED;
-        plan.coverages.forEach((coverage) => markCoverage(coverage, payload, 'postponed'));
-
-        return {
-            ...state,
-            plannings,
-        };
-    },
+            markPlaning(plan, payload, 'postponed');
+            plan.state = WORKFLOW_STATE.POSTPONED;
+            plan.coverages.forEach((coverage) => markCoverage(coverage, payload, 'postponed'));
+        })
+    ),
 
     [PLANNING.ACTIONS.LOCK_PLANNING]: (state, payload) => {
         if (!(payload.plan._id in state.plannings)) return state;
 
-        plannings = cloneDeep(state.plannings);
-        const newPlan = payload.plan;
+        return produce(state, (draft) => {
+            const plannings = draft.plannings;
+            const newPlan = payload.plan;
 
-        plan = plannings[newPlan._id];
+            const plan = plannings[newPlan._id];
 
-        plan.lock_action = newPlan.lock_action;
-        plan.lock_user = newPlan.lock_user;
-        plan.lock_time = newPlan.lock_time;
-        plan.lock_session = newPlan.lock_session;
-        plan._etag = newPlan._etag;
-
-        return {
-            ...state,
-            plannings,
-        };
+            plan.lock_action = newPlan.lock_action;
+            plan.lock_user = newPlan.lock_user;
+            plan.lock_time = newPlan.lock_time;
+            plan.lock_session = newPlan.lock_session;
+            plan._etag = newPlan._etag;
+        });
     },
 
     [PLANNING.ACTIONS.UNLOCK_PLANNING]: (state, payload) => {
         // If the planning is not loaded, disregard this action
         if (!(payload.plan._id in state.plannings)) return state;
 
-        plannings = cloneDeep(state.plannings);
-        const newPlan = payload.plan;
+        return produce(state, (draft) => {
+            const plannings = draft.plannings;
+            const newPlan = payload.plan;
 
-        plan = plannings[newPlan._id];
+            const plan = plannings[newPlan._id];
 
-        delete plan.lock_action;
-        delete plan.lock_user;
-        delete plan.lock_time;
-        delete plan.lock_session;
-        plan._etag = newPlan._etag;
-
-        return {
-            ...state,
-            plannings,
-        };
+            delete plan.lock_action;
+            delete plan.lock_user;
+            delete plan.lock_time;
+            delete plan.lock_session;
+            plan._etag = newPlan._etag;
+        });
     },
 
     [PLANNING.ACTIONS.SPIKE_PLANNING]: (state, payload) => {
         // If the planning is not loaded, disregard this action
         if (!(payload.id in state.plannings)) return state;
 
-        const plannings = cloneDeep(state.plannings);
-        const plan = plannings[payload.id];
+        return produce(state, (draft) => {
+            const plannings = draft.plannings;
+            const plan = plannings[payload.id];
 
-        plan._etag = payload.etag;
-        plan.state = payload.state;
-        plan.revert_state = payload.revert_state;
-
-        return {
-            ...state,
-            plannings,
-        };
+            plan._etag = payload.etag;
+            plan.state = payload.state;
+            plan.revert_state = payload.revert_state;
+        });
     },
 
     [PLANNING.ACTIONS.UNSPIKE_PLANNING]: (state, payload) => {
         // If the planning is not loaded, disregard this action
         if (!(payload.id in state.plannings)) return state;
 
-        const plannings = cloneDeep(state.plannings);
-        const plan = plannings[payload.id];
+        return produce(state, (draft) => {
+            const plannings = draft.plannings;
+            const plan = plannings[payload.id];
 
-        plan._etag = payload.etag;
-        plan.state = payload.state;
-        delete plan.revert_state;
-
-        return {
-            ...state,
-            plannings,
-        };
+            plan._etag = payload.etag;
+            plan.state = payload.state;
+            delete plan.revert_state;
+        });
     },
 
     [ASSIGNMENTS.ACTIONS.REMOVE_ASSIGNMENT]: (state, payload) => {
@@ -209,23 +186,21 @@ const planningReducer = createReducer(initialState, {
             return state;
         }
 
-        let plannings = cloneDeep(state.plannings);
-        let plan = plannings[payload.planning];
+        return produce(state, (draft) => {
+            const plannings = draft.plannings;
+            const plan = plannings[payload.planning];
 
-        plan._etag = payload.planning_etag;
+            plan._etag = payload.planning_etag;
 
-        const coverage = find(get(plan, 'coverages', []), (c) => c.coverage_id === payload.coverage);
+            const coverage = find(get(plan, 'coverages', []), (c) => c.coverage_id === payload.coverage);
 
-        if (coverage) {
-            delete coverage.assigned_to;
-            coverage.workflow_status = WORKFLOW_STATE.DRAFT;
-        }
-
-        return {
-            ...state,
-            plannings,
-        };
+            if (coverage) {
+                delete coverage.assigned_to;
+                coverage.workflow_status = WORKFLOW_STATE.DRAFT;
+            }
+        });
     },
+
     [MAIN.ACTIONS.PREVIEW]: (state, payload) => {
         if (getItemType(payload) === ITEM_TYPE.PLANNING) {
             return {
@@ -237,19 +212,16 @@ const planningReducer = createReducer(initialState, {
         }
     },
 
-    [PLANNING.ACTIONS.EXPIRE_PLANNING]: (state, payload) => {
-        let plannings = cloneDeep(state.plannings);
+    [PLANNING.ACTIONS.EXPIRE_PLANNING]: (state, payload) => (
+        produce(state, (draft) => {
+            const plannings = draft.plannings;
 
-        payload.forEach((planId) => {
-            if (plannings[planId])
-                plannings[planId].expired = true;
-        });
-
-        return {
-            ...state,
-            plannings,
-        };
-    },
+            payload.forEach((planId) => {
+                if (plannings[planId])
+                    plannings[planId].expired = true;
+            });
+        })
+    ),
 });
 
 const markPlaning = (plan, payload, action) => {

--- a/client/reducers/planning.ts
+++ b/client/reducers/planning.ts
@@ -25,9 +25,9 @@ let plannings;
 let plan;
 
 const planningReducer = createReducer(initialState, {
-    [RESET_STORE]: () => (initialState),
+    [RESET_STORE]: () => ({...initialState}),
 
-    [INIT_STORE]: () => (initialState),
+    [INIT_STORE]: () => ({...initialState}),
 
     [PLANNING.ACTIONS.SET_LIST]: (state, payload) => (
         {

--- a/client/reducers/tests/assignment_test.ts
+++ b/client/reducers/tests/assignment_test.ts
@@ -12,7 +12,7 @@ describe('assignment', () => {
 
     beforeEach(() => {
         initialState = cloneDeep(testData.assignmentInitialState);
-        state = assignment({}, {type: null});
+        state = assignment(initialState, {type: null});
         assignments = cloneDeep(testData.assignments);
     });
 

--- a/client/reducers/tests/locks_test.ts
+++ b/client/reducers/tests/locks_test.ts
@@ -114,7 +114,7 @@ describe('lock reducers', () => {
             {type: 'RESET_STORE'}
         );
 
-        expect(result).toBe(null);
+        expect(result).toEqual(initialState);
 
         result = locks(
             null,

--- a/client/utils/index.ts
+++ b/client/utils/index.ts
@@ -35,6 +35,7 @@ import {
     QUEUE_ITEM_PREFIX,
     FEATURED_PLANNING,
     TO_BE_CONFIRMED_FIELD,
+    INITIAL_STATE,
 } from '../constants';
 import * as testData from './testData';
 import {default as lockUtils} from './locks';
@@ -239,11 +240,15 @@ export const createStore = (params = {}, app = planningApp) => {
     }
 
     // return the store
-    return _createStore(
+    const _store = _createStore(
         app,
         initialState,
         _compose(applyMiddleware(...middlewares))
     );
+
+    _store.dispatch({type: INITIAL_STATE});
+
+    return _store;
 };
 
 /**

--- a/client/utils/notifications.ts
+++ b/client/utils/notifications.ts
@@ -1,4 +1,3 @@
-import {WS_NOTIFICATION} from '../constants';
 import * as actions from '../actions';
 import {forEach} from 'lodash';
 
@@ -10,13 +9,6 @@ import {forEach} from 'lodash';
 export const registerNotifications = ($scope, store) => {
     forEach(actions.notifications, (func, event) => {
         $scope.$on(event, (_e, data) => {
-            store.dispatch({
-                type: WS_NOTIFICATION,
-                payload: {
-                    event,
-                    data,
-                },
-            });
             store.dispatch(func()(_e, data));
         });
     });

--- a/e2e/cypress/support/common/ui/actionMenu.ts
+++ b/e2e/cypress/support/common/ui/actionMenu.ts
@@ -28,7 +28,7 @@ export class ActionMenu {
     get menuButton() {
         return this.parent
             .find('.icon-dots-vertical')
-            .first()
+            .parent()
             .should('exist');
     }
 
@@ -39,7 +39,6 @@ export class ActionMenu {
     open() {
         cy.log('Common.UI.ActionMenu.open');
         this.menuButton.click();
-        // this.menuButton.click({force: true});
         this.popup.waitTillOpen();
         return this;
     }

--- a/e2e/cypress/support/planning/searchFilters.ts
+++ b/e2e/cypress/support/planning/searchFilters.ts
@@ -94,6 +94,7 @@ export class SearchFilters extends Modal {
             .find('.side-panel__header')
             .should('exist')
             .find('.icon-pencil')
+            .parent()
             .should('exist')
             .click();
     }


### PR DESCRIPTION
### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

### Front-end checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)

Resolves: #[issue-number]

