### PR TITLE
[STT-1514] fix: Update PlanningAutosave when Assignment changes

### DIFF
--- a/server/features/assignments.feature
+++ b/server/features/assignments.feature
@@ -17,14 +17,16 @@ Feature: Assignments
         }
         ]
         """
-        And "desks"
-        """
-        [{"name": "Sports", "content_expiry": 60, "members": [{"user": "#CONTEXT_USER_ID#"}]}]
-        """
         And "users"
         """
         [{"_id": "507f191e810c19729de87034", "name":"testfoo", "email":"foo@122d.com", "username":"johnfoo"}]
         """
+        When we post to "desks"
+        """
+        [{"name": "Sports", "content_expiry": 60, "members": [{"user": "#CONTEXT_USER_ID#"}]}]
+        """
+        Then we get OK response
+        And we store "SPORTS_DESK_ID" with value "#desks._id#" to context
 
     @auth
     Scenario: Empty planning list
@@ -2580,6 +2582,104 @@ Feature: Assignments
             "assigned_to": {
                 "desk": "#desks._id#",
                 "user": "#CONTEXT_USER_ID#"
+            }
+        }]}
+        """
+
+    @auth
+    @planning_cvs
+    Scenario: Assignment reassign also update Planning autosave
+        Given we have sessions "/sessions"
+        When we post to "desks"
+        """
+        [{"name": "News", "content_expiry": 60, "members": [{"user": "#CONTEXT_USER_ID#"}]}]
+        """
+        Then we get OK response
+        And we store "NEWS_DESK_ID" with value "#desks._id#" to context
+        When we post to "planning"
+        """
+        [{
+            "item_class": "item class value",
+            "headline": "test headline",
+            "slugline": "test slugline",
+            "planning_date": "2016-01-02",
+            "coverages": [{
+                "planning": {
+                    "ednote": "test coverage, I want 250 words",
+                    "headline": "test headline",
+                    "slugline": "test slugline",
+                    "g2_content_type" : "text"
+                },
+                "assigned_to": {
+                    "desk": "#SPORTS_DESK_ID#",
+                    "user": "#CONTEXT_USER_ID#",
+                    "state": "assigned"
+                },
+                "workflow_status": "active"
+            }]
+        }]
+        """
+        Then we get OK response
+        Then we store coverage id in "coverageId" from coverage 0
+        Then we store assignment id in "assignmentId" from coverage 0
+        When we post to "/planning/#planning._id#/lock"
+        """
+        {"lock_action": "edit"}
+        """
+        Then we get OK response
+        When we post to "planning_autosave"
+        """
+        {
+            "_id": "#planning._id#",
+            "item_class": "item class value",
+            "headline": "test headline",
+            "slugline": "test slugline",
+            "planning_date": "2016-01-02",
+            "coverages": [{
+                "coverage_id": "#coverageId#",
+                "planning": {
+                    "ednote": "test coverage, I want 250 words",
+                    "headline": "test headline",
+                    "slugline": "test slugline",
+                    "g2_content_type" : "text"
+                },
+                "assigned_to": {
+                    "desk": "#SPORTS_DESK_ID#",
+                    "user": "#CONTEXT_USER_ID#",
+                    "state": "assigned",
+                    "assignment_id": "#assignmentId#"
+                },
+                "workflow_status": "active"
+            }],
+            "lock_user": "#CONTEXT_USER_ID#",
+            "lock_session": "#SESSION_ID#",
+            "lock_action": "edit",
+            "lock_time": "#DATE#"
+        }
+        """
+        Then we get OK response
+        When we post to "/assignments/#assignmentId#/lock"
+        """
+        {"lock_action": "reassign"}
+        """
+        Then we get OK response
+        When we patch "/assignments/#assignmentId#"
+        """
+        {"assigned_to": {
+            "desk": "#NEWS_DESK_ID#",
+            "user": "507f191e810c19729de87034"
+        }}
+        """
+        Then we get OK response
+        When we get "/planning_autosave/#planning._id#"
+        Then we get existing resource
+        """
+        {"coverages": [{
+            "coverage_id": "#coverageId#",
+            "assigned_to": {
+                "assignment_id": "#assignmentId#",
+                "desk": "#NEWS_DESK_ID#",
+                "user": "507f191e810c19729de87034"
             }
         }]}
         """

--- a/server/planning/assignments/assignments.py
+++ b/server/planning/assignments/assignments.py
@@ -309,7 +309,7 @@ class AssignmentsService(AsyncBaseService):
         # then re-publish the Planning item (So updated Assignment details are published to subscribers)
         current_request = get_current_app().get_current_request()
         assignee_details_changed = self.assignee_details_changed(updates, original)
-        if assignee_details_changed and (current_request is None or "/assignments" in current_request.path):
+        if assignee_details_changed and (current_request is None or "/planning" not in current_request.path):
             await self.publish_planning(original.get("planning_item"))
 
     def assignee_details_changed(self, updates: Dict[str, Any], original: Dict[str, Any]) -> bool:

--- a/server/planning/assignments/assignments.py
+++ b/server/planning/assignments/assignments.py
@@ -305,21 +305,24 @@ class AssignmentsService(AsyncBaseService):
         self.notify("assignments:updated", updates, original)
         await self.send_assignment_notification(updates, original)
 
-        # If Desk, User and/or State was changed, then re-publish the Planning item
-        # So that the newly appointed assignee's/state will be pushed to subscribers
-        if self.assignee_details_changed(updates, original):
+        # If Assignee details have changed, and the current request comes from an Assignment API endpoint
+        # then re-publish the Planning item (So updated Assignment details are published to subscribers)
+        current_request = get_current_app().get_current_request()
+        assignee_details_changed = self.assignee_details_changed(updates, original)
+        if assignee_details_changed and (current_request is None or "/assignments" in current_request.path):
             await self.publish_planning(original.get("planning_item"))
 
     def assignee_details_changed(self, updates: Dict[str, Any], original: Dict[str, Any]) -> bool:
-        if "assigned_to" not in updates:
-            return False
+        if "assigned_to" in updates:
+            original_assigned_to = original.get("assigned_to") or {}
+            updated_assigned_to = updates["assigned_to"] or {}
 
-        original_assigned_to = original.get("assigned_to") or {}
-        updated_assigned_to = updates["assigned_to"] or {}
+            for field in {"user", "desk", "state", "contact", "coverage_provider"}:
+                if original_assigned_to.get(field) != updated_assigned_to.get(field):
+                    return True
 
-        for field in ["user", "desk", "state"]:
-            if original_assigned_to.get(field) != updated_assigned_to.get(field):
-                return True
+        if "priority" in updates and updates["priority"] != original.get("priority"):
+            return True
 
         return False
 

--- a/server/planning/common.py
+++ b/server/planning/common.py
@@ -817,18 +817,22 @@ def _sync_coverage_assigned_to(coverages, lookup_field, id_field):
         if not assignment:
             continue
 
-        assignment.setdefault("assigned_to", {})
-        coverage["assigned_to"]["assignment_id"] = assignment[ID_FIELD]
-        coverage["assigned_to"]["desk"] = assignment["assigned_to"].get("desk")
-        coverage["assigned_to"]["user"] = assignment["assigned_to"].get("user")
-        coverage["assigned_to"]["contact"] = assignment["assigned_to"].get("contact")
-        coverage["assigned_to"]["state"] = assignment["assigned_to"].get("state")
-        coverage["assigned_to"]["assignor_user"] = assignment["assigned_to"].get("assignor_user")
-        coverage["assigned_to"]["assignor_desk"] = assignment["assigned_to"].get("assignor_desk")
-        coverage["assigned_to"]["assigned_date_desk"] = assignment["assigned_to"].get("assigned_date_desk")
-        coverage["assigned_to"]["assigned_date_user"] = assignment["assigned_to"].get("assigned_date_user")
-        coverage["assigned_to"]["coverage_provider"] = assignment["assigned_to"].get("coverage_provider")
-        coverage["assigned_to"]["priority"] = assignment.get("priority")
+        copy_assignment_details_to_coverage(assignment, coverage)
+
+
+def copy_assignment_details_to_coverage(assignment: dict, coverage: dict) -> None:
+    assignment.setdefault("assigned_to", {})
+    coverage["assigned_to"]["assignment_id"] = assignment[ID_FIELD]
+    coverage["assigned_to"]["desk"] = assignment["assigned_to"].get("desk")
+    coverage["assigned_to"]["user"] = assignment["assigned_to"].get("user")
+    coverage["assigned_to"]["contact"] = assignment["assigned_to"].get("contact")
+    coverage["assigned_to"]["state"] = assignment["assigned_to"].get("state")
+    coverage["assigned_to"]["assignor_user"] = assignment["assigned_to"].get("assignor_user")
+    coverage["assigned_to"]["assignor_desk"] = assignment["assigned_to"].get("assignor_desk")
+    coverage["assigned_to"]["assigned_date_desk"] = assignment["assigned_to"].get("assigned_date_desk")
+    coverage["assigned_to"]["assigned_date_user"] = assignment["assigned_to"].get("assigned_date_user")
+    coverage["assigned_to"]["coverage_provider"] = assignment["assigned_to"].get("coverage_provider")
+    coverage["assigned_to"]["priority"] = assignment.get("priority")
 
 
 def sync_assignment_details_to_coverages(doc):

--- a/server/planning/planning/__init__.py
+++ b/server/planning/planning/__init__.py
@@ -128,6 +128,7 @@ def init_app(app):
     app.on_updated_planning_reschedule += planning_history_service.on_reschedule
 
     app.on_locked_planning += planning_service.on_locked_planning
+    app.on_updated_assignments += PlanningAutosaveAsyncService().on_assignment_updated
 
     superdesk.privilege(
         name="planning_planning_management",

--- a/server/planning/planning/planning_autosave_service.py
+++ b/server/planning/planning/planning_autosave_service.py
@@ -1,7 +1,9 @@
 import logging
 
+from superdesk.core import get_current_app
+
 from planning.autosave_service import AutosaveAsyncService
-from planning.common import WORKFLOW_STATE
+from planning.common import WORKFLOW_STATE, copy_assignment_details_to_coverage
 
 logger = logging.getLogger(__name__)
 
@@ -33,3 +35,49 @@ class PlanningAutosaveAsyncService(AutosaveAsyncService):
             coverage_update["workflow_status"] = WORKFLOW_STATE.DRAFT
 
         await self.system_update(planning_id, {"coverages": coverages})
+
+    async def on_assignment_updated(self, updates: dict, original: dict) -> None:
+        """Update the Planning Autosave upon changes to any associated Assignment.
+
+        This makes sure that the Coverage's Assignee details (user, desk etc) are kept in sync with the Assignment.
+
+        :param updates: The Assignment updates that were made
+        :param original: The original Assignment document
+        """
+
+        if "assigned_to" not in updates and "priority" not in updates:
+            # Relevant Assignment data was not updated, no need to update the Planning autosave
+            return
+
+        current_request = get_current_app().get_current_request()
+        if current_request and "/planning" in current_request.path:
+            # This request came from the Planning endpoint itself,
+            # no need to respond to an Assignment update here
+            return
+
+        planning_id = original.get("planning_item")
+        planning_autosave = await self.find_by_id_raw(item_id=planning_id)
+        if not planning_autosave:
+            # Item is not currently being edited (No current autosave item)
+            return
+
+        # There is a current autosave, we need to update it now
+        coverages = planning_autosave.get("coverages")
+        assignment = original.copy()
+        assignment.update(updates)
+
+        coverage_to_update = next(
+            (
+                coverage
+                for coverage in coverages
+                if str((coverage.get("assigned_to") or {}).get("assignment_id")) == str(assignment["_id"])
+            ),
+            None,
+        )
+
+        if not coverage_to_update:
+            logger.warning("Coverage not found for Assignment", extra={"assignment_id": assignment["_id"]})
+            return
+
+        copy_assignment_details_to_coverage(assignment, coverage_to_update)
+        await self.system_update(planning_autosave["_id"], updates={"coverages": coverages})


### PR DESCRIPTION
### Purpose
There is a bug where if a user has a Planning item locked for editing (but not currently open in the browser), and a change occurs with the associated Assignment, upon re-opening the Planning item in the editor, the old assignee details are loaded.

### What has changed
* Add Assignment updated hook to PlanningAutosave service, and update if necessary
* When updating Assignment, only re-post the associated Planning item if the http request didn't come from a Planning endpoint (this could have caused double publishing)

Resolves: [STT-1514](https://sofab.atlassian.net/browse/STT-1514)



[STT-1514]: https://sofab.atlassian.net/browse/STT-1514?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ