### PR TITLE
[STT-1516] Improve web request performance for Assignments resource

### DIFF
--- a/server/features/assignments.feature
+++ b/server/features/assignments.feature
@@ -2683,3 +2683,61 @@ Feature: Assignments
             }
         }]}
         """
+
+    @auth
+    @planning_cvs
+    Scenario: Assignments enhanced with Archive details
+        When we post to "/archive" with success
+        """
+        [{
+            "type": "text",
+            "headline": "test headline",
+            "slugline": "test slugline",
+            "task": {
+                "desk": "#desks._id#",
+                "stage": "#desks.incoming_stage#"
+            }
+        }]
+        """
+        When we post to "/planning" with success
+        """
+        [{
+            "item_class": "item class value",
+            "slugline": "test slugline",
+            "planning_date": "2016-01-02",
+            "coverages": [{
+                "planning": {
+                    "ednote": "test coverage, I want 250 words",
+                    "slugline": "test slugline"
+                },
+                "assigned_to": {
+                    "desk": "#desks._id#",
+                    "user": "#CONTEXT_USER_ID#"
+                },
+                "workflow_status": "active"
+            }]
+        }]
+        """
+        Then we store assignment id in "assignmentId" from coverage 0
+        When we post to "assignments/link" with success
+        """
+        [{
+            "assignment_id": "#assignmentId#",
+            "item_id": "#archive._id#",
+            "reassign": true
+        }]
+        """
+        When we get "assignments"
+        Then we get list with 1 items
+        """
+        {"_items": [{
+            "_id": "#assignmentId#",
+            "item_ids": ["#archive._id#"],
+            "linked_items": [{
+                "_id": "#archive._id#",
+                "_type": "#archive._type#",
+                "event_id": "#archive.event_id#",
+                "body_html": "__no_value__"
+            }]
+        }]}
+        """

--- a/server/planning/assignments/assignments.py
+++ b/server/planning/assignments/assignments.py
@@ -118,7 +118,7 @@ class AssignmentsService(AsyncBaseService):
     async def _enhance_assignments(self, docs):
         """Populate `item_ids` with ids for all linked Archive items for an Assignment"""
         assignment_archive_map: dict[str, tuple[list[str], list[dict]]] = {}
-        async for item in await self.get_archive_items_for_assignments([doc.get(ID_FIELD) for doc in docs]):
+        async for item in await self.get_archive_links_for_assignments([doc.get(ID_FIELD) for doc in docs]):
             linked_item_ids, linked_items = assignment_archive_map.setdefault(str(item.get("assignment_id")), ([], []))
             linked_item_ids.append(str(item.get("_id")))
             linked_items.append(
@@ -139,7 +139,7 @@ class AssignmentsService(AsyncBaseService):
             except KeyError:
                 pass
 
-    async def get_archive_items_for_assignments(self, assignment_ids):
+    async def get_archive_links_for_assignments(self, assignment_ids):
         """
         Given an array of assignment id's return the matching items
         :param assignment_ids:
@@ -159,7 +159,7 @@ class AssignmentsService(AsyncBaseService):
             "projections": json.dumps(["_id", "_type", "event_id", "assignment_id"]),
             "aggs": None,
         }
-        return await get_resource_service("search").get_async(req=req, lookup=None)
+        return await get_resource_service("search").get_async(req=req, lookup=None, signals=False)
 
     async def get_archive_items_for_assignment(self, assignment):
         """Using the `search` resource service, retrieve the list of Archive items linked to the provided Assignment."""

--- a/server/planning/assignments/assignments.py
+++ b/server/planning/assignments/assignments.py
@@ -117,23 +117,27 @@ class AssignmentsService(AsyncBaseService):
 
     async def _enhance_assignments(self, docs):
         """Populate `item_ids` with ids for all linked Archive items for an Assignment"""
-        items = await (await self.get_archive_items_for_assignments([str(doc.get(ID_FIELD)) for doc in docs])).to_list()
-        for doc in docs:
-            linked_items = [
+        assignment_archive_map: dict[str, tuple[list[str], list[dict]]] = {}
+        async for item in await self.get_archive_items_for_assignments([doc.get(ID_FIELD) for doc in docs]):
+            linked_item_ids, linked_items = assignment_archive_map.setdefault(str(item.get("assignment_id")), ([], []))
+            linked_item_ids.append(str(item.get("_id")))
+            linked_items.append(
                 {
                     "_id": item.get("_id"),
                     "_type": item.get("_type"),
                     "event_id": item.get("event_id"),
                 }
-                for item in items
-                if str(item.get("assignment_id")) == str(doc.get("_id"))
-            ]
+            )
 
-            if len(linked_items):
-                doc["item_ids"] = [item["_id"] for item in linked_items]
-                doc["linked_items"] = linked_items
-
+        for doc in docs:
             self.set_type(doc, doc)
+
+            try:
+                linked_item_ids, linked_items = assignment_archive_map[str(doc.get("_id"))]
+                doc["item_ids"] = linked_item_ids
+                doc["linked_items"] = linked_items
+            except KeyError:
+                pass
 
     async def get_archive_items_for_assignments(self, assignment_ids):
         """
@@ -148,7 +152,13 @@ class AssignmentsService(AsyncBaseService):
 
         req = ParsedRequest()
         repos = "archive,published,archived"
-        req.args = {"source": json.dumps(query), "repo": repos}
+        req.args = {
+            "source": json.dumps(query),
+            "repo": repos,
+            "run_signals": False,
+            "projections": json.dumps(["_id", "_type", "event_id", "assignment_id"]),
+            "aggs": None,
+        }
         return await get_resource_service("search").get_async(req=req, lookup=None)
 
     async def get_archive_items_for_assignment(self, assignment):

--- a/server/planning/assignments/assignments_test.py
+++ b/server/planning/assignments/assignments_test.py
@@ -5,7 +5,9 @@ from bson import ObjectId
 
 
 class AssignmentsTestCase(TestCase):
-    users = [{"_id": ObjectId(), "username": "u1"}, {"_id": ObjectId(), "username": "u2"}]
+    users = [{"_id": ObjectId(), "username": "u1", "user_type": "administrator"}, {"_id": ObjectId(), "username": "u2"}]
+    desks = [{"_id": ObjectId(), "name": "desk1", "members": [{"user": users[0]["_id"]}]}]
+    stages = [{"_id": ObjectId(), "name": "working stage", "desk": desks[0]["_id"]}]
 
     auth = [
         {"_id": ObjectId(), "user": users[0]["_id"]},
@@ -15,11 +17,14 @@ class AssignmentsTestCase(TestCase):
     archive_item = {
         "_id": "item1",
         "guid": "item1",
+        "event_id": "abcd123",
         "type": "text",
         "headline": "test headline",
         "slugline": "test slugline",
-        "task": {"desk": "desk1", "stage": "stage1"},
+        "task": {"desk": desks[0]["_id"], "stage": stages[0]["_id"], "user": users[0]["_id"]},
         "assignment_id": ObjectId("5b20652a1d41c812e24aa49e"),
+        "state": "in_progress",
+        "version": 1,
     }
 
     assignment_item = {
@@ -30,7 +35,7 @@ class AssignmentsTestCase(TestCase):
         "assigned_to": {
             "state": "in_progress",
             "user": "aaaaaaaaaaaaaaaaaaaaaaaa",
-            "desk": "desk1",
+            "desk": desks[0]["_id"],
         },
         "lock_user": users[0]["_id"],
         "lock_session": auth[0]["_id"],
@@ -43,7 +48,7 @@ class AssignmentsTestCase(TestCase):
         "coverages": [
             {
                 "coverage_id": "cov1",
-                "assigned_to": {"user": "aaaaaaaaaaaaaaaaaaaaaaaa", "desk": "desk1"},
+                "assigned_to": {"user": "aaaaaaaaaaaaaaaaaaaaaaaa", "desk": desks[0]["_id"]},
             }
         ],
         "lock_user": users[0]["_id"],
@@ -61,21 +66,42 @@ class AssignmentsTestCase(TestCase):
 
     async def asyncSetUp(self):
         await super().asyncSetUp()
-        async with self.app.app_context():
-            self.app.data.insert("users", self.users)
-            self.app.data.insert("auth", self.auth)
-            self.app.data.insert("archive", [self.archive_item])
-            self.app.data.insert("assignments", [self.assignment_item])
-            self.app.data.insert("planning", [self.planning_item])
-            self.app.data.insert("delivery", [self.delivery_item])
+        self.app.data.insert("users", self.users)
+        self.app.data.insert("desks", self.desks)
+        self.app.data.insert("stages", self.stages)
+        self.app.data.insert("auth", self.auth)
+        self.app.data.insert("archive", [self.archive_item])
+        self.app.data.insert("assignments", [self.assignment_item])
+        self.app.data.insert("planning", [self.planning_item])
+        self.app.data.insert("delivery", [self.delivery_item])
+
+        g.user = self.users[0]
+        g.auth = self.auth[0]
 
     async def test_delivery_record_deleted(self):
-        async with self.app.app_context():
-            g.user = self.users[0]
-            g.auth = self.auth[0]
-            delivery_service = get_resource_service("delivery")
-            assignment_service = get_resource_service("assignments")
+        delivery_service = get_resource_service("delivery")
+        assignment_service = get_resource_service("assignments")
 
-            self.assertIsNotNone(await delivery_service.find_one_async(req=None, item_id="item1"))
-            await assignment_service.delete_action_async(lookup={"_id": ObjectId("5b20652a1d41c812e24aa49e")})
-            self.assertIsNone(delivery_service.find_one(req=None, item_id="item1"))
+        self.assertIsNotNone(await delivery_service.find_one_async(req=None, item_id="item1"))
+        await assignment_service.delete_action_async(lookup={"_id": ObjectId("5b20652a1d41c812e24aa49e")})
+        self.assertIsNone(delivery_service.find_one(req=None, item_id="item1"))
+
+    async def test_get_archive_items_for_assignments_excludes_body(self):
+        assignment_service = get_resource_service("assignments")
+        cursor = await assignment_service.get_archive_items_for_assignments([self.assignment_item["_id"]])
+
+        # Test that aggregations were not generated
+        self.assertNotIn("aggregations", cursor.hits)
+
+        # Test that the item only contains the expected fields
+        self.assertEqual(await cursor.count(), 1)
+        item = await cursor.next()
+        self.assertEqual(
+            item,
+            {
+                "_id": self.archive_item["_id"],
+                "_type": "archive",
+                "event_id": self.archive_item["event_id"],
+                "assignment_id": self.assignment_item["_id"],
+            },
+        )


### PR DESCRIPTION
### Purpose
While processing a web request for Assignments, we're getting the list of linked content items (archive, publised etc). The issue is we're retrieving the entire content items from the DB when we only need just a couple fields, which increases the processing required for the elasticsearch json response.

### What has changed
When enhancing Assignment items on fetch:
* Disable aggregations, as they are not needed
* Use projection to define what fields we need
* Tell `search` endpoint not to run it's on fetched signals.

Depends on: https://github.com/superdesk/superdesk-core/pull/3091
Resolves: [STT-1516](https://sofab.atlassian.net/browse/STT-1516)



[STT-1516]: https://sofab.atlassian.net/browse/STT-1516?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ