### PR TITLE
fix assignment links for published items

### DIFF
--- a/server/features/assignments.feature
+++ b/server/features/assignments.feature
@@ -1460,7 +1460,10 @@ Feature: Assignments
                 "desk": "#desks._id#",
                 "user": "#CONTEXT_USER_ID#",
                 "state": "completed"
-            }
+            },
+            "linked_items": [
+                {"_id": "#archive._id#", "_type": "published"}
+            ]
         }
         """
 

--- a/server/planning/assignments/assignments.py
+++ b/server/planning/assignments/assignments.py
@@ -120,10 +120,10 @@ class AssignmentsService(AsyncBaseService):
         assignment_archive_map: dict[str, tuple[list[str], list[dict]]] = {}
         async for item in await self.get_archive_links_for_assignments([doc.get(ID_FIELD) for doc in docs]):
             linked_item_ids, linked_items = assignment_archive_map.setdefault(str(item.get("assignment_id")), ([], []))
-            linked_item_ids.append(str(item.get("_id")))
+            linked_item_ids.append(str(item.get("guid")))
             linked_items.append(
                 {
-                    "_id": item.get("_id"),
+                    "_id": item.get("guid"),
                     "_type": item.get("_type"),
                     "event_id": item.get("event_id"),
                 }
@@ -156,7 +156,7 @@ class AssignmentsService(AsyncBaseService):
             "source": json.dumps(query),
             "repo": repos,
             "run_signals": False,
-            "projections": json.dumps(["_id", "_type", "event_id", "assignment_id"]),
+            "projections": json.dumps(["_id", "guid", "_type", "event_id", "assignment_id"]),
             "aggs": None,
         }
         return await get_resource_service("search").get_async(req=req, lookup=None, signals=False)

--- a/server/planning/assignments/assignments_test.py
+++ b/server/planning/assignments/assignments_test.py
@@ -86,9 +86,9 @@ class AssignmentsTestCase(TestCase):
         await assignment_service.delete_action_async(lookup={"_id": ObjectId("5b20652a1d41c812e24aa49e")})
         self.assertIsNone(delivery_service.find_one(req=None, item_id="item1"))
 
-    async def test_get_archive_items_for_assignments_excludes_body(self):
+    async def test_get_archive_links_for_assignments_excludes_body(self):
         assignment_service = get_resource_service("assignments")
-        cursor = await assignment_service.get_archive_items_for_assignments([self.assignment_item["_id"]])
+        cursor = await assignment_service.get_archive_links_for_assignments([self.assignment_item["_id"]])
 
         # Test that aggregations were not generated
         self.assertNotIn("aggregations", cursor.hits)
@@ -99,7 +99,8 @@ class AssignmentsTestCase(TestCase):
         self.assertEqual(
             item,
             {
-                "_id": self.archive_item["_id"],
+                "_id": self.archive_item["guid"],
+                "guid": self.archive_item["guid"],
                 "_type": "archive",
                 "event_id": self.archive_item["event_id"],
                 "assignment_id": self.assignment_item["_id"],


### PR DESCRIPTION
STT-1516

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

### Front-end checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)

Resolves: #[issue-number]

