### PR TITLE
fix time shift in coverage due time

### DIFF
--- a/client/components/UI/Form/TimeInput/index.tsx
+++ b/client/components/UI/Form/TimeInput/index.tsx
@@ -212,8 +212,8 @@ export class TimeInput extends React.Component {
             return;
         }
 
-        let newTime;
-        let newMoment;
+        let newTime: moment.Moment;
+        let newMoment: moment.Moment;
 
         if (remoteTimeZone) {
             newTime = moment.tz(newValue, appConfig.planning.timeformat, true, remoteTimeZone);
@@ -227,6 +227,7 @@ export class TimeInput extends React.Component {
                 moment();
         }
 
+        newMoment.local(); // Ensure we are in local time to set hours/minutes correctly
         newMoment.hour(newTime.hour());
         newMoment.minute(newTime.minute());
         newMoment.second(0);

--- a/client/utils/events.tsx
+++ b/client/utils/events.tsx
@@ -1069,11 +1069,11 @@ function getFlattenedEventsByDate(events: Array<IEventItem>, startDate: moment.M
     return flatten(sortBy(eventsList, [(e) => (e.date)]).map((e) => e.events.map((k) => [e.date, k._id])));
 }
 
-const getStartDate = (event: IEventItem) => (
+export const getStartDate = (event: IEventItem) => (
     event.dates?.all_day ? moment.utc(event.dates.start) : moment(event.dates?.start)
 );
 
-const getEndDate = (event: IEventItem) => (
+export const getEndDate = (event: IEventItem) => (
     (event.dates?.all_day || event.dates?.no_end_time) ? moment.utc(event.dates.end) : moment(event.dates?.end)
 );
 

--- a/client/utils/planning.tsx
+++ b/client/utils/planning.tsx
@@ -1646,7 +1646,7 @@ function defaultCoverageValues(
             });
 
             if (appConfig.long_event_duration_threshold === 0) {
-                newCoverage.planning.scheduled = moment(eventItem?.dates?.end || moment());
+                newCoverage.planning.scheduled = getCoverageTimeFromEvent(eventItem);
             } else if (duration.hours() > appConfig.long_event_duration_threshold) {
                 delete newCoverage.planning.scheduled;
                 delete newCoverage.planning._scheduledTime;
@@ -1666,6 +1666,13 @@ function getCoverageTimeForAllDay(date: IDateTime): moment.Moment {
     return moment([allDay.year(), allDay.month(), allDay.date(), 11, 0, 0]); // will add 1h later
 }
 
+function getCoverageTimeFromEvent(eventItem: IEventItem): moment.Moment {
+    const endDate = getEndDate(eventItem);
+
+    return eventItem.dates?.all_day || eventItem.dates?.no_end_time ?
+        getCoverageTimeForAllDay(endDate) : moment(endDate);
+}
+
 function getDefaultCoverageDueDate(
     planningItem: IPlanningItem,
     eventItem?: IEventItem,
@@ -1680,10 +1687,7 @@ function getDefaultCoverageDueDate(
             coverageTime = moment(planningItem.planning_date);
         }
     } else if (eventItem) {
-        const endDate = getEndDate(eventItem);
-
-        coverageTime = eventItem.dates?.all_day || eventItem.dates?.no_end_time ?
-            getCoverageTimeForAllDay(endDate) : moment(endDate);
+        coverageTime = getCoverageTimeFromEvent(eventItem);
     }
 
     if (!coverageTime) {

--- a/client/utils/planning.tsx
+++ b/client/utils/planning.tsx
@@ -70,6 +70,7 @@ import {isItemAction, isMenuDivider} from '../helpers';
 import {confirmAddingRelatedItems} from './confirmAddingRelatedItems';
 import {getOpenEditorType} from './editor';
 import {coverageProfiles} from '../selectors/coverageProfiles';
+import {getEndDate} from './events';
 
 export const isCoverageAssigned = (coverage: IPlanningCoverageItem) => coverage.assigned_to?.desk != null;
 
@@ -1667,10 +1668,13 @@ function getDefaultCoverageDueDate(
     const primaryEventIds = getRelatedEventIdsForPlanning(planningItem, 'primary');
 
     if (primaryEventIds.length === 0) {
-        coverageTime = moment(planningItem?.planning_date || moment());
+        coverageTime = moment(planningItem?.planning_date) || moment();
     } else if (eventItem) {
-        coverageTime = moment(eventItem?.dates?.end || moment());
+        coverageTime = moment(getEndDate(eventItem)) || moment();
     }
+
+    // Convert to local time for further calculations
+    coverageTime.local();
 
     if (!coverageTime) {
         return coverageTime;

--- a/client/utils/planning.tsx
+++ b/client/utils/planning.tsx
@@ -1660,24 +1660,34 @@ function defaultCoverageValues(
     return newCoverage;
 }
 
+function getCoverageTimeForAllDay(date: IDateTime): moment.Moment {
+    const allDay = moment.utc(date);
+
+    return moment([allDay.year(), allDay.month(), allDay.date(), 11, 0, 0]); // will add 1h later
+}
+
 function getDefaultCoverageDueDate(
     planningItem: IPlanningItem,
     eventItem?: IEventItem,
 ): moment.Moment | null {
-    let coverageTime: moment.Moment = null;
+    let coverageTime: moment.Moment;
     const primaryEventIds = getRelatedEventIdsForPlanning(planningItem, 'primary');
 
     if (primaryEventIds.length === 0) {
-        coverageTime = moment(planningItem?.planning_date) || moment();
+        if (planningItem.all_day && appConfig.planning?.all_day) {
+            coverageTime = getCoverageTimeForAllDay(planningItem.planning_date);
+        } else if (planningItem.planning_date) {
+            coverageTime = moment(planningItem.planning_date);
+        }
     } else if (eventItem) {
-        coverageTime = moment(getEndDate(eventItem)) || moment();
+        const endDate = getEndDate(eventItem);
+
+        coverageTime = eventItem.dates?.all_day || eventItem.dates?.no_end_time ?
+            getCoverageTimeForAllDay(endDate) : moment(endDate);
     }
 
-    // Convert to local time for further calculations
-    coverageTime.local();
-
     if (!coverageTime) {
-        return coverageTime;
+        return null;
     }
 
     coverageTime.add(1, 'hour');

--- a/client/utils/tests/planning_test.ts
+++ b/client/utils/tests/planning_test.ts
@@ -1106,7 +1106,7 @@ describe('PlanningUtils', () => {
 
             let coverage = planningUtils.defaultCoverageValues(newsCoverageStatus, plan, null);
 
-            expect(get(coverage, 'planning.scheduled').format()).toBe(planned.add(1, 'hour').format());
+            expect(coverage.planning.scheduled.toISOString()).toBe(planned.add(1, 'hour').toISOString());
 
             planned = moment('2119-03-15T09:33:00+11:00');
             plan.planning_date = planned;
@@ -1116,10 +1116,10 @@ describe('PlanningUtils', () => {
                 null
             );
 
-            expect((get(coverage, 'planning.scheduled').format())).toBe(
+            expect(coverage.planning.scheduled.toISOString()).toBe(
                 planned.add(2, 'hour')
                     .startOf('hour')
-                    .format()
+                    .toISOString()
             );
         });
         it('set coverage time from event', () => {
@@ -1140,7 +1140,7 @@ describe('PlanningUtils', () => {
 
             let coverage = planningUtils.defaultCoverageValues(newsCoverageStatus, plan, event);
 
-            expect(get(coverage, 'planning.scheduled').format()).toBe(eventEnd.add(1, 'hour').format());
+            expect(coverage.planning.scheduled.toISOString()).toBe(eventEnd.add(1, 'hour').toISOString());
 
             eventEnd = moment('2119-03-17T09:33:00+11:00');
             event.dates.end = eventEnd;
@@ -1151,8 +1151,7 @@ describe('PlanningUtils', () => {
                 event
             );
 
-            expect(get(coverage, 'planning.scheduled').format())
-                .toBe(eventEnd.add(1, 'hour').format());
+            expect(coverage.planning.scheduled.toISOString()).toBe(eventEnd.add(1, 'hour').toISOString());
         });
         it('no coverage schedule date for long event', () => {
             const newsCoverageStatus = [{qcode: 'ncostat:int'}];


### PR DESCRIPTION
when using all day planning or all day events it was getting initial value in UTC and then setting hours would work in UTC mode, avoiding that with local mode.

[STT-1503]

[STT-1503]: https://sofab.atlassian.net/browse/STT-1503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ