### PR TITLE
fix creation of multiple assignments for coverage

### DIFF
--- a/client/api/planning.ts
+++ b/client/api/planning.ts
@@ -152,11 +152,63 @@ function create(updates: Partial<IPlanningItem>): Promise<IPlanningItem> {
     return superdeskApi.dataApi.create<IPlanningItem>('planning', updates);
 }
 
+/**
+ * Preserves full assignment objects when coverage updates contain only partial assignment data.
+ * This prevents duplicate assignments from being created on the server.
+ * When auto-save sends only changed fields (e.g., desk), we need to merge them with original
+ * assignment data (including assignment_id) to ensure complete assignment info is sent.
+ */
+function preserveAssignmentFieldsInCoverages(
+    original: IPlanningItem,
+    updates: Partial<IPlanningItem>
+): Partial<IPlanningItem> {
+    if (!updates.coverages || !original.coverages) {
+        return updates;
+    }
+
+    const result = cloneDeep(updates);
+    const originalCoverages = original.coverages;
+
+    // For each coverage being updated, ensure full assignment object is preserved
+    result.coverages.forEach((updatedCoverage, index) => {
+        const originalCoverage = originalCoverages[index];
+
+        // If the original coverage had an assignment and the updated one has partial assignment data
+        if (originalCoverage?.assigned_to && updatedCoverage?.assigned_to) {
+            // Merge the original assignment with the updated one, giving precedence to updated values
+            // This preserves assignment_id, state, assignor_desk, assigned_date_desk, etc.
+            updatedCoverage.assigned_to = {
+                ...originalCoverage.assigned_to,
+                ...updatedCoverage.assigned_to,
+            };
+        }
+
+        // Also handle scheduled updates if present
+        if (updatedCoverage?.scheduled_updates && originalCoverage?.scheduled_updates) {
+            updatedCoverage.scheduled_updates.forEach((scheduledUpdate, updateIndex) => {
+                const originalUpdate = originalCoverage.scheduled_updates?.[updateIndex];
+
+                if (originalUpdate?.assigned_to && scheduledUpdate?.assigned_to) {
+                    scheduledUpdate.assigned_to = {
+                        ...originalUpdate.assigned_to,
+                        ...scheduledUpdate.assigned_to,
+                    };
+                }
+            });
+        }
+    });
+
+    return result;
+}
+
 function update(original: IPlanningItem, updates: Partial<IPlanningItem>): Promise<IPlanningItem> {
+    // Preserve full assignment objects to prevent duplicate assignments
+    const updatesWithPreservedAssignments = preserveAssignmentFieldsInCoverages(original, updates);
+
     return superdeskApi.dataApi.patch<IPlanningItem>(
         'planning',
         original,
-        planningUtils.modifyForServer(updates)
+        planningUtils.modifyForServer(updatesWithPreservedAssignments)
     );
 }
 

--- a/client/components/Coverages/CoverageAddAdvancedModal.tsx
+++ b/client/components/Coverages/CoverageAddAdvancedModal.tsx
@@ -213,10 +213,10 @@ class CoverageAddAdvancedModalComponent extends React.Component<IProps, IState> 
                         (val) => val.coverage_id === coverage.coverage_id
                     );
 
-                newCoverage.assigned_to = {
+                newCoverage.assigned_to = Object.assign({}, newCoverage.assigned_to || {}, {
                     user: get(coverage, 'user._id'),
                     desk: get(coverage, 'desk._id'),
-                };
+                });
 
                 if (coverage.coverage_id != null && coverage.enabled !== true) {
                     newCoverage.workflow_status = 'spiked';


### PR DESCRIPTION
it was creating new assignment when there was `assignment_id` missing in the client payload.

STT-1533

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

### Front-end checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)

Resolves: #[issue-number]

