### PR TITLE
fix issues with planning drop in event form

### DIFF
--- a/client/actions/events/api.ts
+++ b/client/actions/events/api.ts
@@ -8,6 +8,7 @@ import {
     IPlanningItem,
     IEventTemplate,
     IEventUpdateMethod,
+    IPlanningRelatedEventLinkType,
 } from '../../interfaces';
 import {appConfig} from 'appConfig';
 
@@ -577,20 +578,14 @@ function updateLinkedPlanningsForEvent(
         const toUnlink: Array<IPlanningItem> = currentlyLinked
             .filter((item) => associatedPlannings.find(({_id}) => _id === item._id) == null);
         const associatedPlanningIds = associatedPlannings.map(({_id}) => _id);
+        const defaultLinkType = appConfig.planning_event_link_method === 'one_primary' ? 'primary' : 'secondary';
 
         return planningApi.planning.getByIds(associatedPlanningIds, undefined)
             .then((allPlanningItems) => Promise.all([
                 ...toLink.map((oldPlanning) => {
                     const planningItem = allPlanningItems.find((x) => x._id === oldPlanning._id);
-                    const linkType = oldPlanning._temporary?.link_type;
-
-                    if (linkType == null) {
-                        superdeskApi.utilities.logger.error(
-                            new Error('linkType expected but not found'),
-                        );
-
-                        return Promise.resolve(planningItem);
-                    }
+                    // TODO: does not handle one primary many secondary
+                    const linkType = oldPlanning._temporary?.link_type ?? defaultLinkType;
 
                     const patch: Partial<IPlanningItem> = {
                         related_events: [

--- a/client/actions/events/api.ts
+++ b/client/actions/events/api.ts
@@ -570,6 +570,8 @@ function updateLinkedPlanningsForEvent(
      * missing items will be linked, extra items unlinked
      */
     associatedPlannings: Array<IPlanningItem>,
+
+    linkTypeMap: Map<string, IPlanningRelatedEventLinkType>,
 ): Promise<Array<IPlanningItem>> {
     return planningApi.events.getLinkedPlanningItems(eventId).then((currentlyLinked) => {
         const currentLinkedIds = new Set(currentlyLinked.map((item) => item._id));
@@ -578,14 +580,13 @@ function updateLinkedPlanningsForEvent(
         const toUnlink: Array<IPlanningItem> = currentlyLinked
             .filter((item) => associatedPlannings.find(({_id}) => _id === item._id) == null);
         const associatedPlanningIds = associatedPlannings.map(({_id}) => _id);
-        const defaultLinkType = appConfig.planning_event_link_method === 'one_primary' ? 'primary' : 'secondary';
 
         return planningApi.planning.getByIds(associatedPlanningIds, undefined)
             .then((allPlanningItems) => Promise.all([
                 ...toLink.map((oldPlanning) => {
                     const planningItem = allPlanningItems.find((x) => x._id === oldPlanning._id);
                     // TODO: does not handle one primary many secondary
-                    const linkType = oldPlanning._temporary?.link_type ?? defaultLinkType;
+                    const linkType = oldPlanning._temporary?.link_type ?? linkTypeMap.get(oldPlanning._id);
 
                     const patch: Partial<IPlanningItem> = {
                         related_events: [
@@ -667,9 +668,35 @@ const save = (original, updates) => (
                 if (!haveLinksChanged) {
                     return [updatedEvent];
                 } else {
+                    // Build a map of planning IDs to their link types for new links
+                    const linkTypeMap = new Map<string, IPlanningRelatedEventLinkType>();
+                    const originalPlanningIds = new Set(
+                        (originalEvent.associated_plannings ?? []).map((p) => p._id)
+                    );
+
+                    // Only calculate link type for newly added planning items
+                    let primaryCount = 0;
+
+                    (updates.associated_plannings ?? []).forEach((planning) => {
+                        const isNewLink = !originalPlanningIds.has(planning._id);
+
+                        if (isNewLink) {
+                            // For methods that support primary links, make the first new one primary
+                            if ((appConfig.planning_event_link_method === 'one_primary' ||
+                                appConfig.planning_event_link_method === 'one_primary_many_secondary') &&
+                                primaryCount === 0) {
+                                linkTypeMap.set(planning._id, 'primary');
+                                primaryCount++;
+                            } else {
+                                linkTypeMap.set(planning._id, 'secondary');
+                            }
+                        }
+                    });
+
                     return updateLinkedPlanningsForEvent(
                         updatedEvent._id,
                         updates.associated_plannings,
+                        linkTypeMap,
                     ).then((updatedPlannings) => {
                         // Update associated events, so if a link has been added/removed etags are updated
                         // after the change in planning items

--- a/client/api/editor/item_events.ts
+++ b/client/api/editor/item_events.ts
@@ -71,7 +71,7 @@ export function getEventsInstance(type: EDITOR_TYPE): IEditorAPI['item']['events
             .dom.fields.related_plannings?.current as {relatedItemRefs: Array<RelatedPlanningItem>};
 
         return Object.values(embeddedEditorRef.relatedItemRefs ?? [])
-            .find((x) => x.props.item._id === planId)?.containerNode;
+            .find((x) => x != null && x.props.item._id === planId)?.containerNode;
     }
 
     function addPlanningItem(
@@ -114,12 +114,6 @@ export function getEventsInstance(type: EDITOR_TYPE): IEditorAPI['item']['events
 
         return toAddConfirmed.then(() => {
             for (const item of result.canBeAdded) {
-                if (isTemporaryId(item.planning._id)) {
-                    item.planning._temporary = {
-                        link_type: item.link_type,
-                    };
-                }
-
                 plans.push(item.planning);
             }
 

--- a/client/reducers/events.ts
+++ b/client/reducers/events.ts
@@ -152,7 +152,7 @@ const eventsReducer = createReducer<IEventState>(initialState, {
 
         return produce(state, (draft) => {
             let events = draft.events;
-            let event = events[payload.event_item];
+            let event = events[payload.event_id];
 
             event.planning_ids = payload.planning_ids;
         });


### PR DESCRIPTION
link type was lost before updating.

STT-1536

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

### Front-end checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)

Resolves: #[issue-number]

