### PR TITLE
[STT-1514] - Sync planning editor coverages after assignment updates

### DIFF
--- a/client/actions/assignments/notifications.ts
+++ b/client/actions/assignments/notifications.ts
@@ -1,16 +1,20 @@
 import {get, cloneDeep} from 'lodash';
 
-import {IWebsocketMessageData} from '../../interfaces';
+import {
+    IWebsocketMessageData, EDITOR_TYPE, IEventOrPlanningItem, IPlanningItem, IPlanningAppState} from '../../interfaces';
 
 import {planningApi, superdeskApi} from '../../superdeskApi';
-import {ASSIGNMENTS, WORKSPACE, MODALS} from '../../constants';
-import {lockUtils, assignmentUtils, gettext, isExistingItem} from '../../utils';
+import {ASSIGNMENTS, WORKSPACE, MODALS, ITEM_TYPE} from '../../constants';
+import {lockUtils, assignmentUtils, gettext, isExistingItem, getAutosaveItem} from '../../utils';
 
+import {editors as editorsActions} from '../../actions';
 import * as selectors from '../../selectors';
 import assignments from './index';
 import main from '../main';
 import {hideModal, showModal} from '../index';
 import planningApis from '../planning/api';
+
+type GetStateFunc = () => IPlanningAppState;
 
 const _notifyAssignmentEdited = (assignmentId) => (
     (dispatch, getState, {notify}) => {
@@ -85,7 +89,7 @@ const onAssignmentUpdated = (_e, data) => (
         const currentDesk = assignmentUtils.getCurrentSelectedDeskId(desks, getState());
         let querySearchSettings = selectors.getAssignmentSearch(getState());
 
-        dispatch(_updatePlannigRelatedToAssignment(data));
+        dispatch(updatePlannigRelatedToAssignment(data));
 
         // Updates my assignments count
         dispatch(
@@ -175,15 +179,61 @@ const onAssignmentUpdated = (_e, data) => (
     }
 );
 
-const _updatePlannigRelatedToAssignment = (data) => (
-    (dispatch, getState) => {
-        const plans = selectors.planning.storedPlannings(getState());
+/**
+ * Synchronizes editor state with updated planning coverages after assignment changes
+ * When assignments are modified (desk changed, state changed to in-progress, etc.), the planning
+ * editor's coverage data becomes stale. This action refreshes the editor form and autosave with
+ * the latest coverage information from the server.
+ * @param {string} planningId - The planning item ID
+ * @param {IPlanningItem[]} loadedPlannings - Planning items freshly loaded from server
+ * @returns {Function} Thunk action that syncs the editor if the planning item is currently being edited
+ */
+const syncEditorWithUpdatedPlanning = (planningId: string, loadedPlannings: IPlanningItem[]) => (
+    (dispatch, getState: GetStateFunc) => {
+        const currentState = getState();
+        const editorSelectors = selectors.editors.editorSelectors[EDITOR_TYPE.INLINE];
+        const editorDiff = cloneDeep(editorSelectors.getEditorDiff(currentState));
+
+        // only update if this planning item is currently being edited
+        if (editorDiff?._id === planningId && loadedPlannings.length > 0) {
+            const updatedDiff = {
+                ...editorDiff,
+                coverages: loadedPlannings[0]?.coverages || []
+            };
+
+            dispatch(editorsActions.setFormDiff(EDITOR_TYPE.INLINE, updatedDiff));
+
+            const autosaves = selectors.forms.autosaves(currentState);
+            const autosaveItem = getAutosaveItem(
+                autosaves,
+                ITEM_TYPE.PLANNING,
+                planningId
+            );
+
+            return planningApi.autosave.save(autosaveItem, updatedDiff as IEventOrPlanningItem);
+        }
+
+        return Promise.resolve();
+    }
+);
+
+/**
+ * Updates planning item when its related assignment changes
+ * Reloads the planning item's coverages from the server and synchronizes them with the editor
+ * if the planning item is currently being edited. Also updates the item history.
+ * @param {object} data - Assignment notification data containing planning and coverage IDs
+ * @returns {Function} Thunk action that performs the update
+ */
+const updatePlannigRelatedToAssignment = (data) => (
+    async(dispatch, getState: GetStateFunc) => {
+        const state = getState();
+        const plans = selectors.planning.storedPlannings(state);
 
         if (!get(data, 'planning')) {
             return Promise.resolve();
         }
 
-        let planningItem = cloneDeep(get(plans, data.planning, {}));
+        const planningItem = cloneDeep(get(plans, data.planning, {}));
 
         if (!isExistingItem(planningItem)) {
             return Promise.resolve();
@@ -196,7 +246,9 @@ const _updatePlannigRelatedToAssignment = (data) => (
             return Promise.resolve();
         }
 
-        dispatch(planningApis.loadPlanningByIds([data.planning]));
+        const loadedPlannings = await dispatch(planningApis.loadPlanningByIds([data.planning]));
+
+        dispatch(syncEditorWithUpdatedPlanning(data.planning, loadedPlannings));
         dispatch(main.fetchItemHistory(planningItem));
     }
 );
@@ -319,7 +371,7 @@ const onAssignmentRemoved = (_e, data) => (
                 )
             );
 
-            return dispatch(_updatePlannigRelatedToAssignment(data));
+            return dispatch(updatePlannigRelatedToAssignment(data));
         }
 
         return Promise.resolve();

--- a/client/actions/assignments/notifications.ts
+++ b/client/actions/assignments/notifications.ts
@@ -89,7 +89,7 @@ const onAssignmentUpdated = (_e, data) => (
         const currentDesk = assignmentUtils.getCurrentSelectedDeskId(desks, getState());
         let querySearchSettings = selectors.getAssignmentSearch(getState());
 
-        dispatch(updatePlannigRelatedToAssignment(data));
+        dispatch(updatePlanningRelatedToAssignment(data));
 
         // Updates my assignments count
         dispatch(
@@ -224,32 +224,26 @@ const syncEditorWithUpdatedPlanning = (planningId: string, loadedPlannings: IPla
  * @param {object} data - Assignment notification data containing planning and coverage IDs
  * @returns {Function} Thunk action that performs the update
  */
-const updatePlannigRelatedToAssignment = (data) => (
+const updatePlanningRelatedToAssignment = (data) => (
     async(dispatch, getState: GetStateFunc) => {
         const state = getState();
         const plans = selectors.planning.storedPlannings(state);
 
-        if (!get(data, 'planning')) {
-            return Promise.resolve();
-        }
+        if (!get(data, 'planning')) return;
 
         const planningItem = cloneDeep(get(plans, data.planning, {}));
 
-        if (!isExistingItem(planningItem)) {
-            return Promise.resolve();
-        }
+        if (!isExistingItem(planningItem)) return;
 
         let coverages = get(planningItem, 'coverages') || [];
         let coverage = coverages.find((cov) => cov.coverage_id === data.coverage);
 
-        if (!coverage) {
-            return Promise.resolve();
-        }
+        if (!coverage) return;
 
         const loadedPlannings = await dispatch(planningApis.loadPlanningByIds([data.planning]));
 
-        dispatch(syncEditorWithUpdatedPlanning(data.planning, loadedPlannings));
-        dispatch(main.fetchItemHistory(planningItem));
+        await dispatch(syncEditorWithUpdatedPlanning(data.planning, loadedPlannings));
+        await dispatch(main.fetchItemHistory(planningItem));
     }
 );
 
@@ -371,7 +365,7 @@ const onAssignmentRemoved = (_e, data) => (
                 )
             );
 
-            return dispatch(updatePlannigRelatedToAssignment(data));
+            return dispatch(updatePlanningRelatedToAssignment(data));
         }
 
         return Promise.resolve();

--- a/client/actions/assignments/tests/notification_test.ts
+++ b/client/actions/assignments/tests/notification_test.ts
@@ -390,7 +390,11 @@ describe('actions.assignments.notification', () => {
                 .then(() => {
                     expect(planningApi.locks.setItemAsUnlocked.callCount).toBe(1);
                     expect(assignmentsApi.fetchAssignmentById.callCount).toBe(1);
-                    expect(store.dispatch.args[5]).toEqual([{
+
+                    // find the UNLOCK_ASSIGNMENT dispatch call instead of relying on hardcoded dispatch index
+                    const unlockDispatch = store.dispatch.args.find((args) => args[0]?.type === 'UNLOCK_ASSIGNMENT');
+
+                    expect(unlockDispatch).toEqual([{
                         type: 'UNLOCK_ASSIGNMENT',
                         payload: {
                             assignment: {

--- a/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx
+++ b/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx
@@ -53,14 +53,7 @@ const mapStateToProps = (state) => ({
 });
 
 class CoverageFormHeaderComponent extends React.PureComponent<IProps> {
-    constructor(props: IProps) {
-        super(props);
-
-        this.showAssignmentModal = this.showAssignmentModal.bind(this);
-        this.removeAssignment = this.removeAssignment.bind(this);
-    }
-
-    showAssignmentModal(event) {
+    showAssignmentModal = (event) => {
         onEventCapture(event);
 
         this.props.showEditCoverageAssignmentModal({
@@ -80,7 +73,7 @@ class CoverageFormHeaderComponent extends React.PureComponent<IProps> {
         });
     }
 
-    removeAssignment() {
+    removeAssignment = () => {
         const {value} = this.props;
 
         const remove = () => {

--- a/client/components/UI/List/Border.tsx
+++ b/client/components/UI/List/Border.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import classNames from 'classnames';
 
 interface IProps {
-    state: false | 'success' | 'error' | 'locked' | 'active' | 'idle';
+    state?: false | 'success' | 'error' | 'locked' | 'active' | 'idle';
 }
 
 /**


### PR DESCRIPTION
### Purpose
This pull request improves the synchronization between assignment changes and planning editor state, refactors some React component methods for clarity, and makes a minor type adjustment for a UI component. The most significant changes are in how planning coverages are updated in the editor when assignments are modified.

### What has changed
* Introduced `syncEditorWithUpdatedPlanning` thunk to refresh the planning editor's coverage data and autosave when assignments are updated, ensuring the editor reflects the latest server state.
* Replaced `_updatePlannigRelatedToAssignment` with `updatePlannigRelatedToAssignment`, which loads updated planning items from the server, synchronizes them with the editor if being edited, and updates the item history. [[1]](diffhunk://#diff-d829a8d7efa188fa8e1891bfd2d180955cc7ae16404dda2fe5b5dc7d4b819a24L178-R236) [[2]](diffhunk://#diff-d829a8d7efa188fa8e1891bfd2d180955cc7ae16404dda2fe5b5dc7d4b819a24L199-R251)
* Updated all usages to dispatch the new `updatePlannigRelatedToAssignment` instead of the old function, ensuring consistent behavior on assignment updates and removals. [[1]](diffhunk://#diff-d829a8d7efa188fa8e1891bfd2d180955cc7ae16404dda2fe5b5dc7d4b819a24L88-R92) [[2]](diffhunk://#diff-d829a8d7efa188fa8e1891bfd2d180955cc7ae16404dda2fe5b5dc7d4b819a24L322-R374)

**Minor improvements:**

* Converted `showAssignmentModal` and `removeAssignment` methods in `CoverageFormHeaderComponent` to arrow functions, improving readability and removing the need for explicit binding in the constructor. [[1]](diffhunk://#diff-0c6d23bac9081939cd8d3448abae3cf2d808b76d781a48ae1c2d1eca19cd084fL56-R56) [[2]](diffhunk://#diff-0c6d23bac9081939cd8d3448abae3cf2d808b76d781a48ae1c2d1eca19cd084fL83-R76)
* Made the `state` prop in `Border` component optional to avoid editor warning

### Steps to test
- Create a Planning item with Coverage and assign to a Desk A (leave the Planning item open)
- Start working on the Assignment, save the respective article and close it 
- Go back to the Planning item, check the Coverage and click on Reassign

**Expected behavior**: Coverage can not be reassigned with the assignment being already in progress

[STT-1514]


[STT-1514]: https://sofab.atlassian.net/browse/STT-1514?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ