### PR TITLE
convert get_related_planning_for_events to async

### DIFF
--- a/server/planning/assignments/assignments.py
+++ b/server/planning/assignments/assignments.py
@@ -76,7 +76,7 @@ from planning.utils import (
     get_event_formatted_dates,
     get_formatted_contacts,
     update_event_item_with_translations_value,
-    get_related_planning_for_events,
+    get_related_planning_for_events_async,
     get_related_event_ids_for_planning,
     get_first_related_event_id_for_planning,
     get_first_event_item_for_planning_id,
@@ -1075,7 +1075,7 @@ class AssignmentsService(AsyncBaseService):
 
         event = deepcopy(original.to_dict())
         event.update(updates)
-        plannings = get_related_planning_for_events([event[ID_FIELD]], "primary")
+        plannings = await get_related_planning_for_events_async([event[ID_FIELD]], "primary")
 
         if not plannings:
             # If this Event has no associated Planning items

--- a/server/planning/commands/flag_expired_items.py
+++ b/server/planning/commands/flag_expired_items.py
@@ -15,7 +15,7 @@ from superdesk.lock import lock, unlock, remove_locks
 from superdesk.notification import push_notification
 from .async_cli import planning_cli
 
-from planning.utils import get_related_planning_for_events, get_related_event_ids_for_planning
+from planning.utils import get_related_planning_for_events_async, get_related_event_ids_for_planning
 
 
 log_msg_context: ContextVar[str] = ContextVar("log_msg", default="")
@@ -98,7 +98,7 @@ async def flag_expired_events(expiry_datetime: datetime):
     async for items in events_service.get_expired_items(expiry_datetime):
         events.update({item[ID_FIELD]: item for item in items})
 
-    set_event_plans(events)
+    await set_event_plans(events)
 
     for event_id, event in events.items():
         if event.get("lock_user"):
@@ -166,7 +166,7 @@ async def flag_expired_planning(expiry_datetime: datetime):
     logger.info(f"{log_msg} {len(plans_expired)} Planning items expired: {list(plans_expired)}")
 
 
-def set_event_plans(events: dict[str, dict[str, Any]]) -> None:
+async def set_event_plans(events: dict[str, dict[str, Any]]) -> None:
     """
     Populates each event in the given dictionary with its related planning items.
 
@@ -178,7 +178,7 @@ def set_event_plans(events: dict[str, dict[str, Any]]) -> None:
         - The `events` dictionary is modified in place.
         - Each event gains a `_plans` key containing a list of related planning items.
     """
-    for plan in get_related_planning_for_events(list(events.keys()), "primary"):
+    for plan in await get_related_planning_for_events_async(list(events.keys()), "primary"):
         for related_event_id in get_related_event_ids_for_planning(plan, "primary"):
             event = events[related_event_id]
             if "_plans" not in event:

--- a/server/planning/content_api/resources/event.py
+++ b/server/planning/content_api/resources/event.py
@@ -17,7 +17,7 @@ from superdesk.core.resources import (
 from superdesk.core.resources.service import AsyncResourceService
 
 from content_api import MONGO_PREFIX, ELASTIC_PREFIX
-from planning.utils import get_related_planning_for_events
+from planning.utils import get_related_planning_for_events_async
 
 from .planning import ContentAPIPlanningService
 from ..types import ContentAPIEventResource
@@ -45,7 +45,7 @@ class ContentAPIEventService(AsyncResourceService[ContentAPIEventResource]):
             await self.create([formatted_item])
 
         # Check for linked planning items to the event and update them as well
-        related_planning_items = get_related_planning_for_events([event_id])
+        related_planning_items = await get_related_planning_for_events_async([event_id])
         for planning_item in related_planning_items:
             await ContentAPIPlanningService().publish_async(planning_item, subscribers)
 

--- a/server/planning/events/events.py
+++ b/server/planning/events/events.py
@@ -87,7 +87,7 @@ from planning.common import (
 )
 from planning.utils import (
     get_planning_event_link_method,
-    get_related_planning_for_events,
+    get_related_planning_for_events_async,
     get_related_event_ids_for_planning,
 )
 from .events_schema import events_schema
@@ -222,13 +222,13 @@ class EventsService(AsyncBaseService):
 
     async def on_fetched_async(self, docs):
         for doc in docs["_items"]:
-            self._enhance_event_item(doc)
+            await self._enhance_event_item(doc)
 
     async def on_fetched_item_async(self, doc):
-        self._enhance_event_item(doc)
+        await self._enhance_event_item(doc)
 
-    def _enhance_event_item(self, doc):
-        plannings = get_related_planning_for_events([doc[ID_FIELD]])
+    async def _enhance_event_item(self, doc):
+        plannings = await get_related_planning_for_events_async([doc[ID_FIELD]])
 
         if len(plannings):
             doc["planning_ids"] = [planning.get("_id") for planning in plannings]
@@ -257,10 +257,10 @@ class EventsService(AsyncBaseService):
             )
         else:
             # Get associated planning items
-            return get_related_planning_for_events([item[ID_FIELD]], event_link_type)
+            return await get_related_planning_for_events_async([item[ID_FIELD]], event_link_type)
 
-    def on_locked_event(self, doc, user_id):
-        self._enhance_event_item(doc)
+    async def on_locked_event(self, doc, user_id):
+        await self._enhance_event_item(doc)
 
     async def set_ingest_provider_sequence_async(self, item, provider):
         """Sets the value of ingest_provider_sequence in item.
@@ -636,7 +636,7 @@ class EventsService(AsyncBaseService):
             updates["location"] = original["location"]
 
         updates[ID_FIELD] = original[ID_FIELD]
-        self._enhance_event_item(updates)
+        await self._enhance_event_item(updates)
 
     async def on_deleted_async(self, doc):
         push_notification(
@@ -788,7 +788,7 @@ class EventsService(AsyncBaseService):
             if event["dates"]["start"] < updates["actioned_date"]:
                 return
 
-        for plan in get_related_planning_for_events([event[ID_FIELD]], "primary"):
+        for plan in await get_related_planning_for_events_async([event[ID_FIELD]], "primary"):
             if plan.get("state") != WORKFLOW_STATE.CANCELLED and len(plan.get("coverages", [])) > 0:
                 await get_resource_service("planning_cancel").patch_async(
                     plan[ID_FIELD],

--- a/server/planning/events/events_cancel.py
+++ b/server/planning/events/events_cancel.py
@@ -33,7 +33,7 @@ from planning.common import (
     remove_lock_information,
     set_actioned_date_to_event,
 )
-from planning.utils import get_related_planning_for_events
+from planning.utils import get_related_planning_for_events_async
 from planning import signals
 
 
@@ -76,7 +76,7 @@ async def cancel_event_plannings(updates: dict[str, Any], original: dict[str, An
     planning_history_service = PlanningHistoryAsyncService()
     reason = updates.get("reason", None)
 
-    for plan in get_related_planning_for_events([original[ID_FIELD]], "primary"):
+    for plan in await get_related_planning_for_events_async([original[ID_FIELD]], "primary"):
         if plan.get("state") != WORKFLOW_STATE.CANCELLED:
             request.view_args["event_cancellation"] = True
             cancelled_plan = await planning_cancel_service.patch_async(plan[ID_FIELD], {"reason": reason})

--- a/server/planning/events/events_history_async_service.py
+++ b/server/planning/events/events_history_async_service.py
@@ -8,7 +8,7 @@ from planning.types import EventResourceModel
 from planning.types import EventsHistoryResourceModel
 from superdesk.core.types import SearchRequest
 from superdesk.resource_fields import ID_FIELD
-from planning.utils import get_related_planning_for_events
+from planning.utils import get_related_planning_for_events_async
 from planning.history_async_service import HistoryAsyncService
 from planning.item_lock import LOCK_ACTION
 
@@ -30,7 +30,7 @@ class EventsHistoryAsyncService(HistoryAsyncService[EventsHistoryResourceModel])
             if isinstance(item, EventResourceModel):
                 item = item.to_dict()
 
-            planning_items = get_related_planning_for_events([item[ID_FIELD]], "primary")
+            planning_items = await get_related_planning_for_events_async([item[ID_FIELD]], "primary")
             if len(planning_items) > 0:
                 item["created_from_planning"] = planning_items[0].get("_id")
                 created_from_planning.append(item)

--- a/server/planning/events/events_post.py
+++ b/server/planning/events/events_post.py
@@ -33,7 +33,7 @@ from planning.common import (
 from planning.validate import validate_docs
 from planning.events.events_utils import get_recurring_timeline, get_update_method
 from planning.types import EventsHistoryResourceModel
-from planning.utils import try_cast_object_id, get_related_planning_for_events
+from planning.utils import try_cast_object_id, get_related_planning_for_events_async
 from planning.content_profiles.utils import is_post_planning_with_event_enabled, is_cancel_planning_with_event_enabled
 
 
@@ -216,7 +216,7 @@ class EventsPostService(AsyncBaseService):
         updates["version"] = version
 
         await events_history_service._save_history(event, updates, "post")
-        plannings = get_related_planning_for_events([event[ID_FIELD]], "primary")
+        plannings = await get_related_planning_for_events_async([event[ID_FIELD]], "primary")
 
         event["plans"] = [p.get("_id") for p in plannings]
         await self.publish_event(event, version)

--- a/server/planning/events/events_postpone.py
+++ b/server/planning/events/events_postpone.py
@@ -31,7 +31,7 @@ from planning.events.events_utils import (
     pre_update_event_actions,
 )
 from planning.planning.planning_postpone import process_postpone_planning_item
-from planning.utils import get_related_planning_for_events
+from planning.utils import get_related_planning_for_events_async
 
 
 def set_event_postponed(updates):
@@ -44,7 +44,7 @@ def set_event_postponed(updates):
 async def postpone_event_plannings(updates: dict[str, Any], original: dict[str, Any]):
     reason = updates.get("reason", None)
 
-    for plan in get_related_planning_for_events([original[ID_FIELD]], "primary"):
+    for plan in await get_related_planning_for_events_async([original[ID_FIELD]], "primary"):
         if plan.get("state") != WORKFLOW_STATE.CANCELLED:
             updated_plan = await process_postpone_planning_item({"reason": reason}, plan)
             await signals.planning_postponed.send(updated_plan, plan)

--- a/server/planning/events/events_reschedule.py
+++ b/server/planning/events/events_reschedule.py
@@ -36,7 +36,7 @@ from planning.events.events_utils import (
 )
 from planning.planning.planning_history_async_service import PlanningHistoryAsyncService
 from planning.types import EventsHistoryResourceModel
-from planning.utils import get_related_planning_for_events, event_has_planning_items
+from planning.utils import get_related_planning_for_events_async, event_has_planning_items
 
 from superdesk.core import get_current_app
 from superdesk.resource_fields import ID_FIELD
@@ -80,7 +80,7 @@ async def reschedule_event_plannings(original: dict[str, Any], reason: str, plan
     planning_history_service = PlanningHistoryAsyncService()
 
     plan_updates = {"reason": reason, "state": state}
-    for plan in plans or get_related_planning_for_events([original[ID_FIELD]], "primary"):
+    for plan in plans or await get_related_planning_for_events_async([original[ID_FIELD]], "primary"):
         if plan.get("state") != WORKFLOW_STATE.CANCELLED:
             updated_plan = await planning_reschedule_service.patch_async(plan[ID_FIELD], plan_updates)
             await planning_history_service.on_reschedule(updated_plan, plan)
@@ -315,7 +315,7 @@ async def reschedule_recurring_event(updates: dict[str, Any], original: dict[str
         await app.on_inserted_events.call_async(new_events)
 
     for event in deleted_events.values():
-        event_plans = get_related_planning_for_events([event[ID_FIELD]], "primary")
+        event_plans = await get_related_planning_for_events_async([event[ID_FIELD]], "primary")
         is_original = event[ID_FIELD] == original[ID_FIELD]
         if len(event_plans) > 0 or event.get("pubstatus", None) is not None:
             if is_original:

--- a/server/planning/events/events_service.py
+++ b/server/planning/events/events_service.py
@@ -46,7 +46,7 @@ from planning.core.service import BasePlanningAsyncService
 from planning.utils import (
     get_planning_event_link_method,
     get_related_event_ids_for_planning,
-    get_related_planning_for_events,
+    get_related_planning_for_events_async,
 )
 
 from .events_sync import sync_event_metadata_with_planning_items
@@ -361,7 +361,7 @@ class EventsAsyncService(BasePlanningAsyncService[EventResourceModel]):
             updates["location"] = original.location
 
         updates[ID_FIELD] = original.id
-        self._enhance_event_item(updates)
+        await self._enhance_event_item(updates)
 
     async def delete_event_files(self, updates: dict[str, Any], event_files: list[ObjectId]):
         files = [f for f in event_files if f not in (updates or {}).get("files", [])]
@@ -626,7 +626,7 @@ class EventsAsyncService(BasePlanningAsyncService[EventResourceModel]):
             if event.dates.start < updates["actioned_date"]:
                 return
 
-        for plan in get_related_planning_for_events([event.id], "primary"):
+        for plan in await get_related_planning_for_events_async([event.id], "primary"):
             if plan.get("state") != WorkflowState.CANCELLED and len(plan.get("coverages", [])) > 0:
                 await get_resource_service("planning_cancel").patch_async(
                     plan[ID_FIELD],
@@ -837,8 +837,8 @@ class EventsAsyncService(BasePlanningAsyncService[EventResourceModel]):
 
         await signals.planning_updated.send(updates, planning_item)
 
-    def _enhance_event_item(self, doc: dict[str, Any]):
-        plannings = get_related_planning_for_events([doc[ID_FIELD]])
+    async def _enhance_event_item(self, doc: dict[str, Any]):
+        plannings = await get_related_planning_for_events_async([doc[ID_FIELD]])
 
         if len(plannings):
             doc["planning_ids"] = [planning.get("_id") for planning in plannings]

--- a/server/planning/events/events_spike.py
+++ b/server/planning/events/events_spike.py
@@ -26,7 +26,7 @@ from planning.types.assignment import AssignmentResourceModel
 from planning.utils import (
     event_has_planning_items,
     get_first_related_event_id_for_planning,
-    get_related_planning_for_events,
+    get_related_planning_for_events_async,
 )
 from superdesk.errors import SuperdeskApiError
 from superdesk.notification import push_notification
@@ -39,7 +39,7 @@ async def post_spike_event_actions(original: dict[str, Any]) -> None:
     # Spike associated planning
     spiked_items = []
 
-    for planning in get_related_planning_for_events([original[ID_FIELD]], "primary"):
+    for planning in await get_related_planning_for_events_async([original[ID_FIELD]], "primary"):
         if planning["state"] == WORKFLOW_STATE.DRAFT:
             await process_spike_planning_item({"state": "spiked"}, planning)
             spiked_items.append(str(planning[ID_FIELD]))
@@ -103,8 +103,8 @@ def validate_event_states(event: dict[str, Any]) -> None:
         raise SuperdeskApiError.badRequestError(message="Spike failed. Event is already spiked.")
 
 
-def validate_spike_event(event: dict[str, Any]) -> None:
-    for planning in get_related_planning_for_events([event[ID_FIELD]], "primary"):
+async def validate_spike_event(event: dict[str, Any]) -> None:
+    for planning in await get_related_planning_for_events_async([event[ID_FIELD]], "primary"):
         if planning.get(LOCK_USER) or planning.get(LOCK_SESSION):
             raise SuperdeskApiError.forbiddenError(
                 message="Spike failed. One or more related planning items are locked."
@@ -138,7 +138,7 @@ async def validate_recurring_event(original: dict[str, Any], recurrence_id: str)
 
 
 async def spike_single_event(updates: dict[str, Any], original: dict[str, Any]) -> None:
-    validate_spike_event(original)
+    await validate_spike_event(original)
     remove_lock_information(updates)
     spike_event(updates, original)
 

--- a/server/planning/events/events_sync/__init__.py
+++ b/server/planning/events/events_sync/__init__.py
@@ -16,7 +16,7 @@ from typing import Dict, Optional, List, cast
 from superdesk import get_resource_service
 
 from planning.utils import parse_date
-from planning.utils import get_related_planning_for_events
+from planning.utils import get_related_planning_for_events_async
 from planning.content_profiles.utils import AllContentProfileData
 from planning.common import get_config_event_fields_to_sync_with_planning
 from planning.types import Event, EmbeddedPlanningDict, StringFieldTranslation
@@ -154,7 +154,7 @@ async def sync_event_metadata_with_planning_items(
             await planning_service.patch_async(sync_data.planning.original["_id"], sync_data.planning.updates)
 
     # Sync all the Planning items that were NOT provided in the ``embedded_planning`` field
-    for item in get_related_planning_for_events([event_updated["_id"]], "primary", processed_planning_ids):
+    for item in await get_related_planning_for_events_async([event_updated["_id"]], "primary", processed_planning_ids):
         translated_fields = get_translated_fields(item.get("translations") or [])
         sync_data = SyncData(
             event=event_sync_data,

--- a/server/planning/planning/planning.py
+++ b/server/planning/planning/planning.py
@@ -87,6 +87,7 @@ from .planning_schema import planning_schema
 from planning.utils import (
     get_planning_event_link_method,
     get_related_planning_for_events,
+    get_related_planning_for_events_async,
     get_related_event_links_for_planning,
     get_related_event_ids_for_planning,
     get_first_related_event_id_for_planning,
@@ -480,10 +481,10 @@ class PlanningService(AsyncBaseService):
         added_agendas = list(set(updated_agendas) - set(existing_agendas))
         return added_agendas, removed_agendas
 
-    def _get_event_links(self, event_id) -> List[str]:
-        return [str(link["_id"]) for link in get_related_planning_for_events([event_id])]
+    async def _get_event_links(self, event_id) -> List[str]:
+        return [str(link["_id"]) for link in await get_related_planning_for_events_async([event_id])]
 
-    def _notify_related_events_changed(self, updates, original) -> bool:
+    async def _notify_related_events_changed(self, updates, original) -> bool:
         if "related_events" not in updates:
             return False
 
@@ -503,7 +504,7 @@ class PlanningService(AsyncBaseService):
                 event=str(_id),
                 planning=str(original.get(ID_FIELD)),
                 action="delete" if _id in removed_ids else "create",
-                links=self._get_event_links(_id),
+                links=await self._get_event_links(_id),
             )
 
         return len(changed_ids) > 0
@@ -554,7 +555,7 @@ class PlanningService(AsyncBaseService):
         user_id = str(updates.get("version_creator", ""))
         doc = deepcopy(original)
         doc.update(updates)
-        related_events_changed = self._notify_related_events_changed(updates, original)
+        related_events_changed = await self._notify_related_events_changed(updates, original)
 
         push_notification(
             "planning:updated",
@@ -623,7 +624,7 @@ class PlanningService(AsyncBaseService):
             # Get associated event
             all_items = await (await events_service.find_async(where={"_id": event_id})).to_list()
             # Get all associated planning items
-            return chain(all_items, get_related_planning_for_events([event_id], event_link_type))
+            return chain(all_items, await get_related_planning_for_events_async([event_id], event_link_type))
 
     async def remove_coverages(self, updates, original):
         if "coverages" not in updates:
@@ -1512,7 +1513,7 @@ class PlanningService(AsyncBaseService):
 
     async def on_event_converted_to_recurring(self, updates, original):
         event_id = original[ID_FIELD]
-        for item in get_related_planning_for_events([original[ID_FIELD]]):
+        for item in await get_related_planning_for_events_async([original[ID_FIELD]]):
             related_events = get_related_event_links_for_planning(item)
 
             # Set the ``recurrence_id`` in the ``planning.related_events`` field

--- a/server/planning/planning/planning_service.py
+++ b/server/planning/planning/planning_service.py
@@ -54,7 +54,7 @@ from planning.types import (
 )
 from planning.utils import (
     get_related_event_links_for_planning,
-    get_related_planning_for_events,
+    get_related_planning_for_events_async,
     get_planning_event_link_method,
     get_first_related_event_id_for_planning,
     get_related_event_ids_for_planning,
@@ -158,7 +158,7 @@ class PlanningAsyncService(BasePlanningAsyncService[PlanningResourceModel]):
             yield items
 
     async def on_event_converted_to_recurring(self, updates: dict[str, Any], original: EventResourceModel):
-        for item in get_related_planning_for_events([original.id]):
+        for item in await get_related_planning_for_events_async([original.id]):
             related_events = get_related_event_links_for_planning(item)
 
             # Set the ``recurrence_id`` in the ``planning.related_events`` field

--- a/server/planning/planning_article_export.py
+++ b/server/planning/planning_article_export.py
@@ -32,7 +32,7 @@ from planning.common import (
 )
 from planning.events import EventsAsyncService
 from planning.agendas_async import AgendasAsyncService
-from planning.utils import get_related_planning_for_events, get_first_related_event_id_for_planning
+from planning.utils import get_related_planning_for_events_async, get_first_related_event_id_for_planning
 from planning.archive import create_item_from_template
 
 
@@ -79,7 +79,7 @@ async def get_items(ids, resource_type):
             if event_id:
                 item["event"] = await events_service.find_by_id_raw(event_id)
         elif item_type == "event":
-            item["plannings"] = get_related_planning_for_events([item["_id"]], "primary")
+            item["plannings"] = await get_related_planning_for_events_async([item["_id"]], "primary")
             item["coverages"] = []
             for plan in item["plannings"]:
                 item["coverages"].extend(plan.get("coverages") or [])

--- a/server/planning/utils.py
+++ b/server/planning/utils.py
@@ -11,6 +11,7 @@
 import arrow
 import pytz
 import logging
+
 from datetime import datetime
 
 from bson.objectid import ObjectId
@@ -152,6 +153,7 @@ def get_related_planning_for_events(
     link_type: Optional[PLANNING_RELATED_EVENT_LINK_TYPE] = None,
     exclude_planning_ids: Optional[List[str]] = None,
 ) -> List[Planning]:
+    """Deprecated: use get_related_planning_for_events_async in async contexts."""
     related_events_filters: List[Dict[str, Any]] = [{"terms": {"related_events._id": event_ids}}]
     if link_type is not None:
         related_events_filters.append({"term": {"related_events.link_type": link_type}})
@@ -172,6 +174,33 @@ def get_related_planning_for_events(
     req.args = {"source": json.dumps({"query": {"bool": bool_query}})}
 
     return [cast_item(item) for item in get_resource_service("planning").get(req=req, lookup=None)]
+
+
+async def get_related_planning_for_events_async(
+    event_ids: List[str],
+    link_type: Optional[PLANNING_RELATED_EVENT_LINK_TYPE] = None,
+    exclude_planning_ids: Optional[List[str]] = None,
+) -> List[Planning]:
+    related_events_filters: List[Dict[str, Any]] = [{"terms": {"related_events._id": event_ids}}]
+    if link_type is not None:
+        related_events_filters.append({"term": {"related_events.link_type": link_type}})
+
+    bool_query: Dict[str, Any] = {
+        "filter": {
+            "nested": {
+                "path": "related_events",
+                "query": {"bool": {"filter": related_events_filters}},
+            },
+        }
+    }
+
+    if len(exclude_planning_ids or []) > 0:
+        bool_query["must_not"] = {"terms": {"_id": exclude_planning_ids}}
+
+    req = ParsedRequest()
+    req.args = {"source": json.dumps({"query": {"bool": bool_query}})}
+
+    return [cast_item(item) async for item in await get_resource_service("planning").get_async(req=req, lookup=None)]
 
 
 def event_has_planning_items(event_id: str, link_type: Optional[PLANNING_RELATED_EVENT_LINK_TYPE] = None) -> bool:


### PR DESCRIPTION
add async implementation and switch to async
where possible.

SDESK-7844

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

### Front-end checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)

Resolves: #[issue-number]

