### PR TITLE
Increase width of coverage content type column in advanced coverage m…

### DIFF
--- a/client/components/Coverages/CoverageAddAdvancedModal.tsx
+++ b/client/components/Coverages/CoverageAddAdvancedModal.tsx
@@ -303,7 +303,7 @@ class CoverageAddAdvancedModalComponent extends React.Component<IProps, IState> 
                                 <div className="sd-list-item__column">
                                     <i className={planningUtils.getCoverageIcon(coverage.qcode)} />
                                 </div>
-                                <div className="sd-list-item__column sd-overflow-ellipsis" style={{width: '10%'}}>
+                                <div className="sd-list-item__column sd-overflow-ellipsis" style={{width: '15%'}}>
                                     {this.getContentTypeName(this.contentTypes.get(coverage.qcode))}
                                 </div>
                                 {coverage.enabled && (


### PR DESCRIPTION
…odal

SDBELGA-10-12

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

### Front-end checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)

Resolves: #[issue-number]

