### PR TITLE
Tweak language field coverage advanced modal

### DIFF
--- a/client/components/Coverages/CoverageAddAdvancedModal.tsx
+++ b/client/components/Coverages/CoverageAddAdvancedModal.tsx
@@ -8,6 +8,7 @@ import {IDesk, IUser} from 'superdesk-api';
 import {gettext, planningUtils, getUsersForDesk, getDesksForUser} from '../../utils';
 import {getUserInterfaceLanguageFromCV} from '../../utils/users';
 import {getVocabularyItemFieldTranslated} from '../../utils/vocabularies';
+import {planningApi} from '../../superdeskApi';
 
 import * as selectors from '../../selectors';
 import * as actions from '../../actions';
@@ -15,8 +16,10 @@ import * as actions from '../../actions';
 import {Button, Checkbox, Modal, Spacer, Tooltip} from 'superdesk-ui-framework/react';
 import {CoverageEditableFields} from './CoverageFieldsRow';
 
+import {IVocabularyItem} from 'superdesk-api';
+
 type IReduxStateProps = {
-    languages: Array<any>;
+    allLanguages: Array<{value: IVocabularyItem}>;
 };
 
 interface IReduxDispatchProps {
@@ -76,6 +79,35 @@ class CoverageAddAdvancedModalComponent extends React.Component<IProps, IState> 
         };
     }
 
+    getDefaultLanguage() {
+        const {multilingual} = planningApi.contentProfiles;
+        const profile = planningApi.contentProfiles.get('planning');
+
+        if (!multilingual.isEnabled(profile)) {
+            return null;
+        }
+
+        return planningApi.contentProfiles.getDefaultLanguage(profile) ?? null;
+    }
+
+    getFilteredLanguages() {
+        const {allLanguages} = this.props;
+        const {multilingual} = planningApi.contentProfiles;
+
+        const planningProfile = planningApi.contentProfiles.get('planning');
+        const isMultilingual = multilingual.isEnabled(planningProfile);
+
+        // If `multilingual` is not enabled, return all languages
+        // If `multilingual` is enabled, filter to only configured languages
+        if (!isMultilingual) {
+            return allLanguages;
+        }
+
+        const planningProfileLanguages = multilingual.getLanguages(planningProfile);
+
+        return allLanguages.filter((language) => planningProfileLanguages.includes(language.value.qcode));
+    }
+
     componentDidMount() {
         const {value, users, desks, newsCoverageStatus} = this.props;
         const coverages = [];
@@ -108,7 +140,7 @@ class CoverageAddAdvancedModalComponent extends React.Component<IProps, IState> 
                     qcode: contentType.qcode,
                     workflow_status: 'draft',
                     planning: {
-                        language: null,
+                        language: this.getDefaultLanguage(),
                     },
                     desk: null,
                     filteredDesks: desks,
@@ -130,15 +162,18 @@ class CoverageAddAdvancedModalComponent extends React.Component<IProps, IState> 
 
     duplicate = (index, coverage) => {
         const coveragesCopy = cloneDeep(this.state.coverages);
-        const coverageToAdd = {
+        const coverageToAdd: Partial<ICoverageLineItem> = {
             enabled: false,
             qcode: coverage.qcode,
             desk: null,
             user: null,
+            planning: {
+                language: this.getDefaultLanguage(),
+            } as any,
             status: planningUtils.getDefaultCoverageStatus(this.props.newsCoverageStatus),
             filteredDesks: this.props.desks,
             filteredUsers: this.props.users,
-        } satisfies Partial<ICoverageLineItem>;
+        };
 
         coveragesCopy.splice(index + 1, 0, coverageToAdd);
         this.setState({coverages: coveragesCopy});
@@ -156,17 +191,25 @@ class CoverageAddAdvancedModalComponent extends React.Component<IProps, IState> 
     }
 
     onDeskChange = (selected, desk) => {
+        const deskLanguage = desk?.desk_language;
         const updates: Partial<ICoverageLineItem> = {
             desk: desk,
             filteredUsers: getUsersForDesk(desk, this.props.users),
+            user: null,
         };
 
-        // Set language if desk has a default language that matches event languages
-        if (desk?.desk_language && this.props.eventLanguages?.includes(desk.desk_language)) {
-            updates.planning = {
-                ...(selected.planning ?? {}),
-                language: desk.desk_language,
-            };
+        // If desk has a language, check if it's available in the planning profile
+        // and set it as the coverage language
+        if (deskLanguage != null) {
+            const filteredLanguages = this.getFilteredLanguages();
+            const deskLanguageAvailable = filteredLanguages.some((lang) => lang.value.qcode === deskLanguage);
+
+            if (deskLanguageAvailable) {
+                updates.planning = {
+                    ...(selected.planning ?? {}),
+                    language: deskLanguage,
+                };
+            }
         }
 
         this.updateCoverage(selected, updates);
@@ -310,7 +353,7 @@ class CoverageAddAdvancedModalComponent extends React.Component<IProps, IState> 
                                     <CoverageEditableFields
                                         index={index}
                                         coverage={coverage}
-                                        languages={this.props.languages}
+                                        languages={this.getFilteredLanguages()}
                                         eventLanguages={this.props.eventLanguages}
                                         handleDeskChange={this.onDeskChange}
                                         handleUserChange={this.onUserChange}
@@ -333,7 +376,7 @@ const mapDispatchToProps = (dispatch): IReduxDispatchProps => ({
 });
 
 const mapStateToProps = (state) => ({
-    languages: selectors.vocabs.getLanguages(state),
+    allLanguages: selectors.vocabs.getLanguagesForTreeSelectInput(state),
 });
 
 export const CoverageAddAdvancedModal = connect<IReduxStateProps, IReduxDispatchProps, IOwnProps>(

--- a/client/components/Coverages/CoverageAddAdvancedModal.tsx
+++ b/client/components/Coverages/CoverageAddAdvancedModal.tsx
@@ -2,7 +2,12 @@ import React from 'react';
 import {connect} from 'react-redux';
 import {cloneDeep, get} from 'lodash';
 
-import {IG2ContentType, IPlanningNewsCoverageStatus, IPlanningCoverageItem} from '../../interfaces';
+import {
+    IG2ContentType,
+    IPlanningNewsCoverageStatus,
+    IPlanningCoverageItem,
+    ICoveragePlanningDetails,
+} from '../../interfaces';
 import {IDesk, IUser} from 'superdesk-api';
 
 import {gettext, planningUtils, getUsersForDesk, getDesksForUser} from '../../utils';
@@ -44,7 +49,6 @@ interface IOwnProps {
     users: Array<IUser>;
     contentTypes: Array<IG2ContentType>;
     newsCoverageStatus: Array<IPlanningNewsCoverageStatus>;
-    eventLanguages?: Array<string>;
 
     onSave(field: string, value: Array<DeepPartial<ICoverageLineItem>>): void;
     onCancel(): void;
@@ -57,6 +61,7 @@ interface IState {
     advancedMode: boolean;
     coverages: Array<Partial<ICoverageLineItem>>;
     isDirty: boolean;
+    filteredLanguages: Array<{value: IVocabularyItem}>;
 }
 
 class CoverageAddAdvancedModalComponent extends React.Component<IProps, IState> {
@@ -76,6 +81,7 @@ class CoverageAddAdvancedModalComponent extends React.Component<IProps, IState> 
             advancedMode: !!props.coverageAddAdvancedMode,
             coverages: [],
             isDirty: false,
+            filteredLanguages: this.getFilteredLanguages(props.allLanguages),
         };
     }
 
@@ -90,8 +96,7 @@ class CoverageAddAdvancedModalComponent extends React.Component<IProps, IState> 
         return planningApi.contentProfiles.getDefaultLanguage(profile) ?? null;
     }
 
-    getFilteredLanguages() {
-        const {allLanguages} = this.props;
+    getFilteredLanguages(allLanguages: Array<{value: IVocabularyItem}>) {
         const {multilingual} = planningApi.contentProfiles;
 
         const planningProfile = planningApi.contentProfiles.get('planning');
@@ -106,6 +111,19 @@ class CoverageAddAdvancedModalComponent extends React.Component<IProps, IState> 
         const planningProfileLanguages = multilingual.getLanguages(planningProfile);
 
         return allLanguages.filter((language) => planningProfileLanguages.includes(language.value.qcode));
+    }
+
+    componentDidUpdate(prevProps: IProps) {
+        if (prevProps.allLanguages !== this.props.allLanguages) {
+            const nextFilteredLanguages = this.getFilteredLanguages(this.props.allLanguages);
+
+            if (this.state.filteredLanguages !== nextFilteredLanguages) {
+                // eslint-disable-next-line react/no-did-update-set-state
+                this.setState({
+                    filteredLanguages: nextFilteredLanguages,
+                });
+            }
+        }
     }
 
     componentDidMount() {
@@ -169,7 +187,7 @@ class CoverageAddAdvancedModalComponent extends React.Component<IProps, IState> 
             user: null,
             planning: {
                 language: this.getDefaultLanguage(),
-            } as any,
+            } as ICoveragePlanningDetails,
             status: planningUtils.getDefaultCoverageStatus(this.props.newsCoverageStatus),
             filteredDesks: this.props.desks,
             filteredUsers: this.props.users,
@@ -201,8 +219,9 @@ class CoverageAddAdvancedModalComponent extends React.Component<IProps, IState> 
         // If desk has a language, check if it's available in the planning profile
         // and set it as the coverage language
         if (deskLanguage != null) {
-            const filteredLanguages = this.getFilteredLanguages();
-            const deskLanguageAvailable = filteredLanguages.some((lang) => lang.value.qcode === deskLanguage);
+            const deskLanguageAvailable = this.state.filteredLanguages.some(
+                (lang) => lang.value.qcode === deskLanguage
+            );
 
             if (deskLanguageAvailable) {
                 updates.planning = {
@@ -353,8 +372,7 @@ class CoverageAddAdvancedModalComponent extends React.Component<IProps, IState> 
                                     <CoverageEditableFields
                                         index={index}
                                         coverage={coverage}
-                                        languages={this.getFilteredLanguages()}
-                                        eventLanguages={this.props.eventLanguages}
+                                        languages={this.state.filteredLanguages}
                                         handleDeskChange={this.onDeskChange}
                                         handleUserChange={this.onUserChange}
                                         updateCoverage={this.updateCoverage}

--- a/client/components/Coverages/CoverageAddAdvancedModal.tsx
+++ b/client/components/Coverages/CoverageAddAdvancedModal.tsx
@@ -61,7 +61,6 @@ interface IState {
     advancedMode: boolean;
     coverages: Array<Partial<ICoverageLineItem>>;
     isDirty: boolean;
-    filteredLanguages: Array<{value: IVocabularyItem}>;
 }
 
 class CoverageAddAdvancedModalComponent extends React.Component<IProps, IState> {
@@ -81,7 +80,6 @@ class CoverageAddAdvancedModalComponent extends React.Component<IProps, IState> 
             advancedMode: !!props.coverageAddAdvancedMode,
             coverages: [],
             isDirty: false,
-            filteredLanguages: this.getFilteredLanguages(props.allLanguages),
         };
     }
 
@@ -102,8 +100,6 @@ class CoverageAddAdvancedModalComponent extends React.Component<IProps, IState> 
         const planningProfile = planningApi.contentProfiles.get('planning');
         const isMultilingual = multilingual.isEnabled(planningProfile);
 
-        // If `multilingual` is not enabled, return all languages
-        // If `multilingual` is enabled, filter to only configured languages
         if (!isMultilingual) {
             return allLanguages;
         }
@@ -111,19 +107,6 @@ class CoverageAddAdvancedModalComponent extends React.Component<IProps, IState> 
         const planningProfileLanguages = multilingual.getLanguages(planningProfile);
 
         return allLanguages.filter((language) => planningProfileLanguages.includes(language.value.qcode));
-    }
-
-    componentDidUpdate(prevProps: IProps) {
-        if (prevProps.allLanguages !== this.props.allLanguages) {
-            const nextFilteredLanguages = this.getFilteredLanguages(this.props.allLanguages);
-
-            if (this.state.filteredLanguages !== nextFilteredLanguages) {
-                // eslint-disable-next-line react/no-did-update-set-state
-                this.setState({
-                    filteredLanguages: nextFilteredLanguages,
-                });
-            }
-        }
     }
 
     componentDidMount() {
@@ -372,7 +355,7 @@ class CoverageAddAdvancedModalComponent extends React.Component<IProps, IState> 
                                     <CoverageEditableFields
                                         index={index}
                                         coverage={coverage}
-                                        languages={this.state.filteredLanguages}
+                                        languages={this.getFilteredLanguages(this.props.allLanguages)}
                                         handleDeskChange={this.onDeskChange}
                                         handleUserChange={this.onUserChange}
                                         updateCoverage={this.updateCoverage}

--- a/client/components/Coverages/CoverageAddAdvancedModal.tsx
+++ b/client/components/Coverages/CoverageAddAdvancedModal.tsx
@@ -100,6 +100,7 @@ class CoverageAddAdvancedModalComponent extends React.Component<IProps, IState> 
         const planningProfile = planningApi.contentProfiles.get('planning');
         const isMultilingual = multilingual.isEnabled(planningProfile);
 
+        // If `multilingual` is enabled, filter to only configured languages
         if (!isMultilingual) {
             return allLanguages;
         }

--- a/client/components/Coverages/CoverageAddButton/AddCoveragesWrapper.tsx
+++ b/client/components/Coverages/CoverageAddButton/AddCoveragesWrapper.tsx
@@ -192,7 +192,6 @@ class AddCoveragesWrapperComponent extends React.Component<IProps, IState> {
                         users={this.props.users}
                         desks={this.props.desks}
                         coverageAddAdvancedMode={this.props.coverageAddAdvancedMode}
-                        eventLanguages={this.props.eventLanguages}
                     />
                 )}
             </React.Fragment>

--- a/client/components/Coverages/CoverageFieldsRow.tsx
+++ b/client/components/Coverages/CoverageFieldsRow.tsx
@@ -5,14 +5,14 @@ import {getUserInterfaceLanguageFromCV} from '../../utils/users';
 import {gettext} from '../../utils';
 import {superdeskApi} from '../../superdeskApi';
 import {IPlanningNewsCoverageStatus} from '../../interfaces';
-import {IDesk, IUser} from 'superdesk-api';
+import {IDesk, IUser, IVocabularyItem} from 'superdesk-api';
 import {ICoverageLineItem} from './CoverageAddAdvancedModal';
 
 interface IProps {
     index: number;
     coverage: Partial<ICoverageLineItem>;
     newsCoverageStatus: Array<IPlanningNewsCoverageStatus>;
-    languages: Array<any>;
+    languages: Array<{value: IVocabularyItem}>;
     eventLanguages?: Array<string>;
     handleDeskChange: (coverage: Partial<ICoverageLineItem>, desk: IDesk) => void;
     handleUserChange: (coverage: Partial<ICoverageLineItem>, user: IUser) => void;
@@ -34,93 +34,89 @@ export const CoverageEditableFields = ({
     const {SelectUser} = superdeskApi.components;
 
     return (
-        <>
-            <Spacer
-                h
-                gap="8"
-                noWrap
-                alignItems="end"
-                style={{padding: 'var(--gap-1)'}}
-                justifyContent="space-between"
+        <Spacer
+            h
+            gap="8"
+            noWrap
+            alignItems="end"
+            style={{padding: 'var(--gap-1)'}}
+            justifyContent="space-between"
+        >
+            <Select
+                fullWidth
+                label={gettext('Desk')}
+                value={coverage.desk?._id}
+                onChange={(newDeskId) => {
+                    handleDeskChange(
+                        coverage,
+                        coverage.filteredDesks.find(({_id}) => _id === newDeskId),
+                    );
+                }}
             >
-                <Select
-                    fullWidth
-                    label={gettext('Desk')}
-                    value={coverage.desk?._id}
-                    onChange={(newDeskId) => {
-                        handleDeskChange(
-                            coverage,
-                            coverage.filteredDesks.find(({_id}) => _id === newDeskId),
-                        );
+                <Option>{gettext('Select a desk')}</Option>
+                {coverage.filteredDesks.map((desk) => (
+                    <Option key={desk._id} value={desk._id}>{desk.name}</Option>
+                ))}
+            </Select>
+            <div style={{width: '100%'}}>
+                <SelectUser
+                    key={`${coverage.desk?._id}-${index}`}
+                    deskId={coverage.desk?._id ?? undefined}
+                    selectedUserId = {coverage.user?._id}
+                    onSelect={(user) => {
+                        handleUserChange(coverage, user);
                     }}
-                >
-                    <Option>{gettext('Select a desk')}</Option>
-                    {coverage.filteredDesks.map((desk) => (
-                        <Option key={desk._id} value={desk._id}>{desk.name}</Option>
-                    ))}
-                </Select>
-                <div style={{width: '100%'}}>
-                    <SelectUser
-                        key={`${coverage.desk?._id}-${index}`}
-                        deskId={coverage.desk?._id ?? undefined}
-                        selectedUserId = {coverage.user?._id}
-                        onSelect={(user) => {
-                            handleUserChange(coverage, user);
-                        }}
-                        autoFocus={false}
-                        horizontalSpacing={true}
-                        clearable={true}
-                    />
-                </div>
-                <Select
-                    fullWidth
-                    value={coverage.planning?.language}
-                    label={gettext('Language')}
-                    onChange={(value) => {
-                        updateCoverage(
-                            coverage,
-                            {
-                                planning: {
-                                    ...(coverage.planning ?? {}),
-                                    language: value,
-                                }
-                            } as ICoverageLineItem,
-                        );
-                    }}
-                >
-                    {languages.map((cov) => (
-                        <Option key={cov.qcode} value={cov.qcode}>
-                            {getVocabularyItemFieldTranslated(cov, 'name', language)}
-                        </Option>
-                    ))}
-                </Select>
-                <Select
-                    fullWidth
-                    label={gettext('Status')}
-                    value={coverage.status?.qcode}
-                    onChange={(value) => {
-                        const status = newsCoverageStatus.find((s) => s.qcode === value);
-
-                        updateCoverage(coverage, {status: status});
-                    }}
-                >
-                    <Option>{gettext('Select a status')}</Option>
-                    {newsCoverageStatus.map((cov) => (
-                        <Option key={cov.qcode} value={cov.qcode}>
-                            {getVocabularyItemFieldTranslated(cov, 'label', language)}
-                        </Option>
-                    ))}
-                </Select>
-            </Spacer>
-            <div className="sd-list-item__action-menu sd-list-item__action-menu--direction-row">
-                <IconButton
-                    ariaValue={gettext('Duplicate')}
-                    icon="plus-sign"
-                    onClick={() => {
-                        duplicateCoverage(index, coverage);
-                    }}
+                    autoFocus={false}
+                    horizontalSpacing={true}
+                    clearable={true}
                 />
             </div>
-        </>
+            <Select
+                fullWidth
+                value={coverage.planning?.language}
+                label={gettext('Language')}
+                onChange={(value) => {
+                    updateCoverage(
+                        coverage,
+                        {
+                            planning: {
+                                ...(coverage.planning ?? {}),
+                                language: value,
+                            }
+                        } as ICoverageLineItem,
+                    );
+                }}
+            >
+                {languages.map((lang) => (
+                    <Option key={lang.value.qcode} value={lang.value.qcode}>
+                        {getVocabularyItemFieldTranslated(lang.value, 'name', language)}
+                    </Option>
+                ))}
+            </Select>
+            <Select
+                fullWidth
+                label={gettext('Status')}
+                value={coverage.status?.qcode}
+                onChange={(value) => {
+                    const status = newsCoverageStatus.find((s) => s.qcode === value);
+
+                    updateCoverage(coverage, {status: status});
+                }}
+            >
+                <Option>{gettext('Select a status')}</Option>
+                {newsCoverageStatus.map((cov) => (
+                    <Option key={cov.qcode} value={cov.qcode}>
+                        {getVocabularyItemFieldTranslated(cov, 'label', language)}
+                    </Option>
+                ))}
+            </Select>
+            <IconButton
+                ariaValue={gettext('Duplicate')}
+                icon="plus-sign"
+                onClick={() => {
+                    duplicateCoverage(index, coverage);
+                }}
+            />
+        </Spacer>
     );
 };

--- a/client/components/Coverages/CoverageFieldsRow.tsx
+++ b/client/components/Coverages/CoverageFieldsRow.tsx
@@ -13,7 +13,6 @@ interface IProps {
     coverage: Partial<ICoverageLineItem>;
     newsCoverageStatus: Array<IPlanningNewsCoverageStatus>;
     languages: Array<{value: IVocabularyItem}>;
-    eventLanguages?: Array<string>;
     handleDeskChange: (coverage: Partial<ICoverageLineItem>, desk: IDesk) => void;
     handleUserChange: (coverage: Partial<ICoverageLineItem>, user: IUser) => void;
     updateCoverage: (coverage: Partial<ICoverageLineItem>, updates: Partial<ICoverageLineItem>) => void;


### PR DESCRIPTION
### Purpose
- Make available languages in dropdown either ones configured in planning profile, if it's multilingual or if not, all languages are available
- When switching desk, if desk language matches any of the available languages, change the language
- Set user to `null` on desk change, making it consistent with how editor works

Resolves: #[SDBELGA-1011]



[SDBELGA-1011]: https://sofab.atlassian.net/browse/SDBELGA-1011?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ