### PR TITLE
Fix planning item filtering

### DIFF
--- a/client/utils/index.ts
+++ b/client/utils/index.ts
@@ -678,7 +678,7 @@ export const isDateInRange = (inputDate, startDate, endDate, allDay = false) => 
 
     if (allDay) {
         if (startDate && inputDate.isBefore(startDate, 'day') ||
-            endDate && inputDate.isSameOrAfter(endDate, 'day')
+            endDate && inputDate.isAfter(endDate, 'day') // when allDay is true, endDate should be inclusive
         ) {
             return false;
         }


### PR DESCRIPTION
### Purpose
Fix planning items disappearing when there's no coverages for them

### What has changed
When we have allDay true which for planning items is always, check if inputDate is only after the end, and not if it's the same.

Resolves: #[STT-1556](https://sofab.atlassian.net/browse/STT-1556?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ)

[STT-1556]: https://sofab.atlassian.net/browse/STT-1556?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ