### PR TITLE
[SDESK-7855] Improve stability of expiry commands, use bulk_update

### DIFF
--- a/server/planning/commands/delete_spiked_items.py
+++ b/server/planning/commands/delete_spiked_items.py
@@ -21,6 +21,7 @@ from superdesk.lock import lock, unlock, remove_locks
 from planning.common import WORKFLOW_STATE
 from planning.events.events_utils import get_recurring_timeline
 from .async_cli import planning_cli
+from .utils import iterate_expired_items
 
 
 log_msg_context: ContextVar[str] = ContextVar("log_msg", default="")
@@ -83,10 +84,12 @@ async def delete_spiked_events(expiry_datetime):
     events_deleted = set()
     series_to_delete = dict()
 
+    base_query = {"must": [{"term": {"state": WORKFLOW_STATE.SPIKED}}]}
+
     # Obtain the full list of Events that we're to process first
     # As subsequent queries will change the list of returned items
     events = dict()
-    async for items in events_service.get_expired_items(expiry_datetime, spiked_events_only=True):
+    async for items in iterate_expired_items("event", expiry_datetime, base_query):
         events.update({item[ID_FIELD]: item for item in items})
 
     for event_id, event in events.items():
@@ -134,7 +137,10 @@ async def delete_spiked_planning(expiry_datetime):
     # Obtain the full list of Planning items that we're to process first
     # As subsequent queries will change the list of returnd items
     plans = dict()
-    async for items in planning_service.get_expired_items(expiry_datetime, spiked_planning_only=True):
+
+    base_query = {"must": [{"term": {"state": WORKFLOW_STATE.SPIKED}}]}
+
+    async for items in iterate_expired_items("planning", expiry_datetime, base_query):
         plans.update({item[ID_FIELD]: item for item in items})
 
     plans_deleted = set()

--- a/server/planning/commands/flag_expired_items.py
+++ b/server/planning/commands/flag_expired_items.py
@@ -140,11 +140,15 @@ async def flag_expired_items(resource_type: Literal["event", "planning"], expiry
 
             items_expired.add(item_id)
 
-        await get_current_async_app().resources.bulk_update_resources([
-            ("events", events_to_expire, updates.copy()),
-            ("planning", planning_to_expire, updates.copy()),
-        ])
-        logger.info(f"{log_msg} {len(events_to_expire)} Events expired, {len(planning_to_expire)} Planning items expired")
+        await get_current_async_app().resources.bulk_update_resources(
+            [
+                ("events", events_to_expire, updates.copy()),
+                ("planning", planning_to_expire, updates.copy()),
+            ]
+        )
+        logger.info(
+            f"{log_msg} {len(events_to_expire)} Events expired, {len(planning_to_expire)} Planning items expired"
+        )
 
     if len(events_in_use) > 0:
         logger.info(f"{log_msg} Skipping {len(events_in_use)} Events in use: {list(events_in_use)}")
@@ -175,11 +179,7 @@ def get_event_plans(events: list[dict[str, Any]]) -> dict[str, list[dict]]:
     plans: dict[str, list[dict]] = {}
     event_ids = [event[ID_FIELD] for event in events]
 
-    projection = {
-        "_planning_schedule": 1,
-        "planning_date": 1,
-        "related_events": 1
-    }
+    projection = {"_planning_schedule": 1, "planning_date": 1, "related_events": 1}
     for plan in get_related_planning_for_events(event_ids, "primary", projection=projection):
         for related_event_id in get_related_event_ids_for_planning(plan, "primary"):
             plans.setdefault(related_event_id, []).append(plan)

--- a/server/planning/commands/flag_expired_items.py
+++ b/server/planning/commands/flag_expired_items.py
@@ -1,21 +1,24 @@
 from datetime import timedelta, datetime
 from bson.objectid import ObjectId
 from contextvars import ContextVar
-from typing import Any
+from typing import Any, Literal
 
-from planning.events import EventsAsyncService
-from planning.planning import PlanningAsyncService
-from superdesk.core import get_app_config
+from superdesk.core import get_config, get_current_async_app
+from superdesk.core.utils import str_to_date
 from superdesk.resource_fields import ID_FIELD
 from superdesk import get_resource_service
 from superdesk.logging import logger
 from superdesk.utc import utcnow
 from superdesk.celery_task_utils import get_lock_id
-from superdesk.lock import lock, unlock, remove_locks
+from superdesk.lock import lock, unlock
 from superdesk.notification import push_notification
+
+from planning.common import remove_lock_information
+from planning.search.queries import elastic
 from .async_cli import planning_cli
 
 from planning.utils import get_related_planning_for_events, get_related_event_ids_for_planning
+from .utils import iterate_expired_items
 
 
 log_msg_context: ContextVar[str] = ContextVar("log_msg", default="")
@@ -31,6 +34,10 @@ async def flag_expired_items_command():
 
         $ python manage.py planning:flag_expired
 
+    .. versionchanged:: 3.1
+        - Removes any lock information from the item (locks would already be too old).
+        - Uses bulk update operations in batches to improve performance
+
     """
     return await flag_expired_items_handler()
 
@@ -42,7 +49,7 @@ async def flag_expired_items_handler():
 
     logger.info(f"{log_msg} Starting to remove expired content at.")
 
-    expire_interval = get_app_config("PLANNING_EXPIRY_MINUTES", 0)
+    expire_interval = get_config(int, "PLANNING_EXPIRY_MINUTES", 0)
     if expire_interval == 0:
         logger.info(f"{log_msg} PLANNING_EXPIRY_MINUTES=0, not flagging items as expired")
         return
@@ -55,118 +62,104 @@ async def flag_expired_items_handler():
     expiry_datetime = now - timedelta(minutes=expire_interval)
 
     try:
-        await flag_expired_events(expiry_datetime)
-    except Exception as e:
-        logger.exception(e)
+        try:
+            await flag_expired_items("event", expiry_datetime)
+        except Exception as e:
+            logger.exception(e)
 
-    try:
-        await flag_expired_planning(expiry_datetime)
-    except Exception as e:
-        logger.exception(e)
-
-    unlock(lock_name)
+        try:
+            await flag_expired_items("planning", expiry_datetime)
+        except Exception as e:
+            logger.exception(e)
+    finally:
+        unlock(lock_name)
 
     logger.info(f"{log_msg} Completed flagging expired items.")
-    remove_locks()
     logger.info(f"{log_msg} Starting to remove expired planning versions.")
     await remove_expired_published_planning()
     logger.info(f"{log_msg} Completed removing expired planning versions.")
 
 
-async def flag_expired_events(expiry_datetime: datetime):
+async def flag_expired_items(resource_type: Literal["event", "planning"], expiry_datetime: datetime):
     """
-    Flags events and related plans as `expired` if their schedules are before or equal to the provided expiry_datetime.
+    Flags items and related plans as `expired` if their schedules are before or equal to the provided expiry_datetime.
 
-    - Events locked by users are skipped.
+    - Item locks will be removed.
     - Events with schedules extending beyond expiry_datetime are considered "in use" and not flagged.
     - Expired events and their related plans are updated with {"expired": True}.
     - Notifications are pushed for expired events and plans.
     """
+
     log_msg = log_msg_context.get()
     logger.info(f"{log_msg} Starting to flag expired events")
-    events_service = EventsAsyncService()
-    planning_service = PlanningAsyncService()
 
-    locked_events = set()
+    processing_events = resource_type == "event"
     events_in_use = set()
-    events_expired = set()
+    items_expired = set()
     plans_expired = set()
 
-    # Obtain the full list of Events that we're to process first
-    # As subsequent queries will change the list of returned items
-    events = dict()
-    async for items in events_service.get_expired_items(expiry_datetime):
-        events.update({item[ID_FIELD]: item for item in items})
+    projection = [] if not processing_events else ["dates"]
+    base_query = {"must_not": [elastic.term("expired", True)]}
 
-    set_event_plans(events)
+    if resource_type == "planning":
+        # Skip Planning items with a primary link to an Event,
+        # as this will be processed when processing the Event
+        base_query["must_not"].append(
+            elastic.nested(
+                "related_events",
+                elastic.term("related_events.link_type", "primary"),
+            )
+        )
 
-    for event_id, event in events.items():
-        if event.get("lock_user"):
-            locked_events.add(event_id)
-        elif is_event_in_use(event, expiry_datetime):
-            events_in_use.add(event_id)
-        else:
-            events_expired.add(event_id)
-            await events_service.system_update(event_id, {"expired": True})
-            for plan in event.get("_plans", []):
-                plan_id = plan[ID_FIELD]
-                await planning_service.system_update(plan_id, {"expired": True})
-                plans_expired.add(plan_id)
+    # We can safely remove the lock, as the lock would be too old now anyway
+    updates = remove_lock_information({"expired": True})
 
-    if len(locked_events) > 0:
-        logger.info(f"{log_msg} Skipping {len(locked_events)} locked Events: {list(locked_events)}")
+    async for items in iterate_expired_items(resource_type, expiry_datetime, base_query, projection):
+        plans = get_event_plans(items) if processing_events else {}
+        events_to_expire: set[str] = set()
+        planning_to_expire: set[str] = set()
+
+        for item in items:
+            item_id = item[ID_FIELD]
+
+            if not processing_events:
+                planning_to_expire.add(item_id)
+            else:
+                item_plans = plans.get(item_id, [])
+                if is_event_in_use(item, item_plans, expiry_datetime):
+                    # This Event is linked to a Planning item that's not eligible for expiry yet
+                    # Skipping this one
+                    events_in_use.add(item_id)
+                    continue
+
+                events_to_expire.add(item_id)
+                for plan in item_plans:
+                    plan_id = plan[ID_FIELD]
+                    planning_to_expire.add(plan_id)
+                    plans_expired.add(plan_id)
+
+            items_expired.add(item_id)
+
+        await get_current_async_app().resources.bulk_update_resources([
+            ("events", events_to_expire, updates.copy()),
+            ("planning", planning_to_expire, updates.copy()),
+        ])
+        logger.info(f"{log_msg} {len(events_to_expire)} Events expired, {len(planning_to_expire)} Planning items expired")
 
     if len(events_in_use) > 0:
         logger.info(f"{log_msg} Skipping {len(events_in_use)} Events in use: {list(events_in_use)}")
 
-    if len(events_expired) > 0:
-        push_notification("events:expired", items=list(events_expired))
+    if len(items_expired) > 0:
+        push_resource_name = "events" if processing_events else "planning"
+        push_notification(f"{push_resource_name}:expired", items=list(items_expired))
 
     if len(plans_expired) > 0:
         push_notification("planning:expired", items=list(plans_expired))
 
-    logger.info(f"{log_msg} {len(events_expired)} Events expired: {list(events_expired)}")
+    logger.info(f"{log_msg} {len(items_expired)} Events expired")
 
 
-async def flag_expired_planning(expiry_datetime: datetime):
-    """
-    Flags planning items as expired if their schedule has passed the provided expiry_datetime.
-
-    - It skips planning items that are locked by users.
-    - All other planning items are marked as expired by setting the `expired` field to `True`.
-    - A notification is pushed with the items' ids that have been flagged as expired.
-    """
-
-    log_msg = log_msg_context.get()
-    logger.info(f"{log_msg} Starting to flag expired planning items")
-    planning_service = PlanningAsyncService()
-
-    # Obtain the full list of Planning items that we're to process first
-    # As subsequent queries will change the list of returned items
-    plans = dict()
-    async for items in planning_service.get_expired_items(expiry_datetime):
-        plans.update({item[ID_FIELD]: item for item in items})
-
-    locked_plans = set()
-    plans_expired = set()
-
-    for plan_id, plan in plans.items():
-        if plan.get("lock_user"):
-            locked_plans.add(plan_id)
-        else:
-            await planning_service.system_update(plan[ID_FIELD], {"expired": True})
-            plans_expired.add(plan_id)
-
-    if len(locked_plans) > 0:
-        logger.info(f"{log_msg} Skipping {len(locked_plans)} locked Planning items: {list(locked_plans)}")
-
-    if len(plans_expired) > 0:
-        push_notification("planning:expired", items=list(plans_expired))
-
-    logger.info(f"{log_msg} {len(plans_expired)} Planning items expired: {list(plans_expired)}")
-
-
-def set_event_plans(events: dict[str, dict[str, Any]]) -> None:
+def get_event_plans(events: list[dict[str, Any]]) -> dict[str, list[dict]]:
     """
     Populates each event in the given dictionary with its related planning items.
 
@@ -178,23 +171,30 @@ def set_event_plans(events: dict[str, dict[str, Any]]) -> None:
         - The `events` dictionary is modified in place.
         - Each event gains a `_plans` key containing a list of related planning items.
     """
-    for plan in get_related_planning_for_events(list(events.keys()), "primary"):
+
+    plans: dict[str, list[dict]] = {}
+    event_ids = [event[ID_FIELD] for event in events]
+
+    projection = {
+        "_planning_schedule": 1,
+        "planning_date": 1,
+        "related_events": 1
+    }
+    for plan in get_related_planning_for_events(event_ids, "primary", projection=projection):
         for related_event_id in get_related_event_ids_for_planning(plan, "primary"):
-            event = events[related_event_id]
-            if "_plans" not in event:
-                event["_plans"] = []
-            event["_plans"].append(plan)
+            plans.setdefault(related_event_id, []).append(plan)
+    return plans
 
 
-def is_event_in_use(event: dict[str, Any], expiry_datetime: datetime) -> bool:
+def is_event_in_use(event: dict[str, Any], plans: list[dict], expiry_datetime: datetime) -> bool:
     """
     Checks if an event is considered 'in use' by comparing its latest
     scheduled date to the provided expiry_datetime.
     """
-    return get_latest_scheduled_date(event) > expiry_datetime
+    return get_latest_scheduled_date(event, plans) > expiry_datetime
 
 
-def get_latest_scheduled_date(event: dict[str, Any]) -> datetime:
+def get_latest_scheduled_date(event: dict[str, Any], plans: list[dict]) -> datetime:
     """
     Calculates the latest scheduled date for a given event, considering:
     - The event's own end date
@@ -204,10 +204,10 @@ def get_latest_scheduled_date(event: dict[str, Any]) -> datetime:
     Returns:
         datetime: The latest scheduled datetime.
     """
-    latest_scheduled = datetime.strptime(event["dates"]["end"], "%Y-%m-%dT%H:%M:%S%z")
+    latest_scheduled = str_to_date(event["dates"]["end"])
 
     # Check related plans' planning dates
-    for plan in event.get("_plans", []):
+    for plan in plans:
         planning_date = plan.get("planning_date", latest_scheduled)
 
         # First check the Planning item's planning date
@@ -220,7 +220,7 @@ def get_latest_scheduled_date(event: dict[str, Any]) -> datetime:
         for planning_schedule in plan.get("_planning_schedule", []):
             scheduled = planning_schedule.get("scheduled")
             if scheduled and isinstance(scheduled, str):
-                scheduled = datetime.strptime(scheduled, "%Y-%m-%dT%H:%M:%S%z")
+                scheduled = str_to_date(scheduled)
 
             if scheduled and (latest_scheduled < scheduled):
                 latest_scheduled = scheduled
@@ -234,10 +234,10 @@ async def remove_expired_published_planning():
     Expiry of the planning versions mirrors the expiry of items within the publish queue in Superdesk so it uses the
     same configuration value
     """
-    expire_interval = get_app_config("PUBLISH_QUEUE_EXPIRY_MINUTES", 0)
+    expire_interval = get_config(int, "PUBLISH_QUEUE_EXPIRY_MINUTES", 0)
     if expire_interval:
         expire_time = utcnow() - timedelta(minutes=expire_interval)
-        logger.info("Removing planning history items created before {}".format(str(expire_time)))
+        logger.info(f"Removing published_planning items created before {expire_time}")
 
         await get_resource_service("published_planning").delete_async(
             {"_id": {"$lte": ObjectId.from_datetime(expire_time)}}

--- a/server/planning/commands/flag_expired_items.py
+++ b/server/planning/commands/flag_expired_items.py
@@ -91,7 +91,7 @@ async def flag_expired_items(resource_type: Literal["event", "planning"], expiry
     """
 
     log_msg = log_msg_context.get()
-    logger.info(f"{log_msg} Starting to flag expired events")
+    logger.info(f"{log_msg} Starting to flag expired {resource_type}s")
 
     processing_events = resource_type == "event"
     events_in_use = set()
@@ -140,12 +140,15 @@ async def flag_expired_items(resource_type: Literal["event", "planning"], expiry
 
             items_expired.add(item_id)
 
-        await get_current_async_app().resources.bulk_update_resources(
-            [
-                ("events", events_to_expire, updates.copy()),
-                ("planning", planning_to_expire, updates.copy()),
-            ]
-        )
+        resource_updates: list[tuple[str, set[str], dict]] = []
+        if events_to_expire:
+            resource_updates.append(("events", events_to_expire, updates.copy()))
+        if planning_to_expire:
+            resource_updates.append(("planning", planning_to_expire, updates.copy()))
+
+        if resource_updates:
+            await get_current_async_app().resources.bulk_update_resources(resource_updates)
+
         logger.info(
             f"{log_msg} {len(events_to_expire)} Events expired, {len(planning_to_expire)} Planning items expired"
         )
@@ -160,7 +163,7 @@ async def flag_expired_items(resource_type: Literal["event", "planning"], expiry
     if len(plans_expired) > 0:
         push_notification("planning:expired", items=list(plans_expired))
 
-    logger.info(f"{log_msg} {len(items_expired)} Events expired")
+    logger.info(f"{log_msg} {len(items_expired)} {resource_type}s expired")
 
 
 def get_event_plans(events: list[dict[str, Any]]) -> dict[str, list[dict]]:

--- a/server/planning/commands/utils.py
+++ b/server/planning/commands/utils.py
@@ -44,15 +44,17 @@ async def iterate_expired_items(
                 )
             ),
         )
-        query.filter.extend([
-            elastic.field_range(
-                elastic.ElasticRangeParams(
-                    field="planning_date",
-                    lt=date_to_str(expiry_datetime),
-                    time_zone="UTC",
+        query.filter.extend(
+            [
+                elastic.field_range(
+                    elastic.ElasticRangeParams(
+                        field="planning_date",
+                        lt=date_to_str(expiry_datetime),
+                        time_zone="UTC",
+                    )
                 )
-            )
-        ])
+            ]
+        )
 
     query_dict = query.build()
 

--- a/server/planning/commands/utils.py
+++ b/server/planning/commands/utils.py
@@ -1,0 +1,90 @@
+from typing import Literal, AsyncGenerator
+from datetime import datetime
+
+from planning.events import EventsAsyncService
+from planning.planning import PlanningAsyncService
+from superdesk.core import get_config
+from superdesk.core.utils import date_to_str
+from planning.search.queries import elastic
+
+
+async def iterate_expired_items(
+    resource_type: Literal["event", "planning"],
+    expiry_datetime: datetime,
+    base_query: dict | None = None,
+    projection: list[str] | None = None,
+) -> AsyncGenerator[list[dict], None]:
+    if projection and "_updated" not in projection:
+        projection.append("_updated")
+
+    resource_service = EventsAsyncService() if resource_type == "event" else PlanningAsyncService()
+
+    query = elastic.ElasticQuery()
+    query.sort = [{"_updated": "asc"}]
+    query.size = get_config(int, "MAX_EXPIRY_QUERY_LIMIT")
+    query.extend_query(base_query or {})
+
+    if resource_type == "event":
+        query.filter.append(
+            elastic.field_range(
+                elastic.ElasticRangeParams(
+                    field="dates.end",
+                    lt=date_to_str(expiry_datetime),
+                    time_zone="UTC",
+                )
+            )
+        )
+    elif resource_type == "planning":
+        query.must_not.append(
+            elastic.field_range(
+                elastic.ElasticRangeParams(
+                    field="_planning_schedule.scheduled",
+                    gt=date_to_str(expiry_datetime),
+                    time_zone="UTC",
+                )
+            ),
+        )
+        query.filter.extend([
+            elastic.field_range(
+                elastic.ElasticRangeParams(
+                    field="planning_date",
+                    lt=date_to_str(expiry_datetime),
+                    time_zone="UTC",
+                )
+            )
+        ])
+
+    query_dict = query.build()
+
+    total_received = 0
+    total_items = -1
+    last_item_query = elastic.date_range(
+        elastic.ElasticRangeParams(
+            field="_updated",
+            gt=date_to_str(expiry_datetime),
+            time_zone="UTC",
+        )
+    )
+
+    for i in range(get_config(int, "MAX_EXPIRY_LOOPS")):
+        results = await resource_service.search(query_dict, projection=projection)
+        items = await results.to_list_raw()
+        results_count = len(items)
+
+        # If the total_items has not been set, then this is the first query
+        # In which case we need to store the total hits from the search
+        if total_items < 0:
+            total_items = results_count
+
+        # If the last query doesn't contain any results, return here
+        if results_count == 0:
+            break
+
+        total_received += results_count
+
+        # Yield the results for iteration by the callee
+        yield items
+        last_item_query["range"]["_updated"]["gt"] = items[-1]["_updated"]
+
+        if i == 0:
+            query_dict["query"]["bool"]["must"].append(last_item_query)

--- a/server/planning/commands/utils.py
+++ b/server/planning/commands/utils.py
@@ -14,7 +14,7 @@ async def iterate_expired_items(
     base_query: dict | None = None,
     projection: list[str] | None = None,
 ) -> AsyncGenerator[list[dict], None]:
-    if projection and "_updated" not in projection:
+    if projection is not None and "_updated" not in projection:
         projection.append("_updated")
 
     resource_service = EventsAsyncService() if resource_type == "event" else PlanningAsyncService()
@@ -89,4 +89,4 @@ async def iterate_expired_items(
         last_item_query["range"]["_updated"]["gt"] = items[-1]["_updated"]
 
         if i == 0:
-            query_dict["query"]["bool"]["must"].append(last_item_query)
+            query_dict["query"]["bool"].setdefault("must", []).append(last_item_query)

--- a/server/planning/common.py
+++ b/server/planning/common.py
@@ -248,8 +248,9 @@ def get_config_event_related_item_search_provider_name() -> Optional[str]:
     return get_app_config("EVENT_RELATED_ITEM_SEARCH_PROVIDER_NAME")
 
 
-def remove_lock_information(item):
+def remove_lock_information(item: dict) -> dict:
     item.update({LOCK_USER: None, LOCK_SESSION: None, LOCK_TIME: None, LOCK_ACTION: None})
+    return item
 
 
 def get_default_coverage_status_qcode_on_ingest():

--- a/server/planning/events/events.py
+++ b/server/planning/events/events.py
@@ -22,7 +22,6 @@ from datetime import datetime, timedelta
 from dateutil import parser
 
 from eve.methods.common import resolve_document_etag
-from eve.utils import date_to_str
 from dateutil.rrule import (
     rrule,
     YEARLY,
@@ -47,14 +46,13 @@ from superdesk.errors import SuperdeskApiError
 from superdesk.metadata.utils import generate_guid
 from superdesk.metadata.item import GUID_NEWSML
 from superdesk.notification import push_notification
-from superdesk.utc import get_date, utcnow, utc_to_local
+from superdesk.utc import get_date, utcnow
 from superdesk.users.services import current_user_has_privilege
 from superdesk.publish_async.utils import get_next_sequence_number
 from apps.auth import get_user, get_user_id
 from apps.archive.common import get_auth, update_dates_for
 
 from planning.events.events_reschedule import reschedule_single_event
-from planning.events.events_utils import get_recurring_timeline
 from planning.events.events_history_async_service import EventsHistoryAsyncService
 from planning.types import (
     EmbeddedCoverageItem,
@@ -66,7 +64,6 @@ from planning.types import (
 from planning.common import (
     TEMP_ID_PREFIX,
     UPDATE_SINGLE,
-    UPDATE_FUTURE,
     get_max_recurrent_events,
     WORKFLOW_STATE,
     ITEM_STATE,
@@ -875,48 +872,6 @@ class EventsService(AsyncBaseService):
         await planning_service.system_update_async(plan_id, updates, planning_item)
         app = get_current_app().as_any()
         await app.on_updated_planning.call_async(updates, planning_item)
-
-    async def get_expired_items(self, expiry_datetime, spiked_events_only=False):
-        """Get the expired items
-
-        Where end date is in the past
-        """
-        query = {
-            "query": {"bool": {"must_not": [{"term": {"expired": True}}]}},
-            "filter": {"range": {"dates.end": {"lte": date_to_str(expiry_datetime)}}},
-            "sort": [{"dates.start": "asc"}],
-            "size": get_max_recurrent_events(),
-        }
-
-        if spiked_events_only:
-            query["query"] = {"bool": {"must": [{"term": {"state": WORKFLOW_STATE.SPIKED}}]}}
-
-        total_received = 0
-        total_events = -1
-
-        while total_received + get_max_recurrent_events() < 10000:  # 10k is max elastic limit
-            query["from"] = total_received
-
-            results = await self.search_async(query)
-
-            # If the total_events has not been set, then this is the first query
-            # In which case we need to store the total hits from the search
-            if total_events < 0:
-                total_events = await results.count()
-
-                # If the search doesn't contain any results, return here
-                if total_events < 1:
-                    break
-
-            # If the last query doesn't contain any results, return here
-            items = await results.to_list()
-            if not len(items):
-                break
-
-            total_received += len(items)
-
-            # Yield the results for iteration by the callee
-            yield items
 
     async def delete_event_files(self, updates, original):
         files = [f for f in original.get("files", []) if f not in (updates or {}).get("files", [])]

--- a/server/planning/events/events_service.py
+++ b/server/planning/events/events_service.py
@@ -3,19 +3,19 @@ import itertools
 
 from copy import deepcopy
 from bson import ObjectId
-from typing import Any, AsyncGenerator, cast
-from datetime import datetime, timedelta
+from typing import Any, cast
+from datetime import timedelta
 from apps.archive.common import get_auth
 from apps.auth import get_user, get_user_id
 
 from superdesk.utc import utcnow
-from superdesk.core import get_app_config
+from superdesk.core import get_config
 from superdesk import get_resource_service
 from superdesk.resource_fields import ID_FIELD
 from superdesk.errors import SuperdeskApiError
 from superdesk.metadata.item import GUID_NEWSML
 from superdesk.notification import push_notification
-from superdesk.core.utils import date_to_str, generate_guid
+from superdesk.core.utils import generate_guid
 
 
 from planning import signals
@@ -59,65 +59,6 @@ from .events_utils import (
 
 class EventsAsyncService(BasePlanningAsyncService[EventResourceModel]):
     resource_name = "events"
-
-    async def get_expired_items(
-        self, expiry_datetime: datetime, spiked_events_only: bool = False
-    ) -> AsyncGenerator[list[dict[str, Any]], None]:
-        """
-        Retrieve "expired" events which are those whose end date is on or before `expiry_datetime` and
-        are not already marked as expired.
-
-        By default, items returned are:
-        - Not already marked as expired (expired=True).
-        - Have an end date `<= expiry_datetime`.
-
-        If `spiked_events_only` is True, only spiked events are returned, still filtered by
-        end date `<= expiry_datetime`.
-
-        Results are sorted by start date and fetched in batches.
-        """
-        query: dict[str, Any] = {
-            "query": {
-                "bool": {
-                    "must_not": [{"term": {"expired": True}}],
-                    "filter": {"range": {"dates.end": {"lte": date_to_str(expiry_datetime)}}},
-                },
-            },
-            "sort": [{"dates.start": "asc"}],
-            "size": get_max_recurrent_events(),
-        }
-
-        if spiked_events_only:
-            del query["query"]["bool"]["must_not"]
-            query["query"]["bool"]["must"] = [{"term": {"state": WorkflowState.SPIKED}}]
-
-        total_received = 0
-        total_events = -1
-
-        while True:
-            query["from"] = total_received
-
-            results = await self.search(query)
-            items = await results.to_list_raw()
-            results_count = len(items)
-
-            # If the total_events has not been set, then this is the first query
-            # In which case we need to store the total hits from the search
-            if total_events < 0:
-                total_events = results_count
-
-                # If the search doesn't contain any results, return here
-                if total_events < 1:
-                    break
-
-            # If the last query doesn't contain any results, return here
-            if results_count == 0:
-                break
-
-            total_received += results_count
-
-            # Yield the results for iteration by the callee
-            yield items
 
     def _extract_embedded_planning(
         self, docs: list[EventResourceModel]
@@ -177,7 +118,7 @@ class EventsAsyncService(BasePlanningAsyncService[EventResourceModel]):
             event.id = event.guid
 
             if not event.language:
-                event.language = event.languages[0] if len(event.languages) > 0 else get_app_config("DEFAULT_LANGUAGE")
+                event.language = event.languages[0] if len(event.languages) > 0 else get_config(str, "DEFAULT_LANGUAGE")
 
             # overwrite expiry date if needed
             self._overwrite_event_expiry_date(event)
@@ -703,7 +644,7 @@ class EventsAsyncService(BasePlanningAsyncService[EventResourceModel]):
             assert event.dates is not None
             assert event.dates.end is not None
 
-            expiry_minutes = get_app_config("PLANNING_EXPIRY_MINUTES", None)
+            expiry_minutes = get_config(int, "PLANNING_EXPIRY_MINUTES", 0)
             event.expiry = event.dates.end + timedelta(minutes=expiry_minutes or 0)
 
     def set_recurring_mode(self, event: EventResourceModel):

--- a/server/planning/planning/planning.py
+++ b/server/planning/planning/planning.py
@@ -21,7 +21,7 @@ from io import BytesIO
 from lxml import etree
 from bson import ObjectId
 from eve.methods.common import resolve_document_etag
-from eve.utils import ParsedRequest, date_to_str
+from eve.utils import ParsedRequest
 
 from superdesk.core import json, get_current_app, get_app_config
 from superdesk.eve_async.service import AsyncBaseService
@@ -1439,76 +1439,6 @@ class PlanningService(AsyncBaseService):
                     session=session_id,
                     user=user_id,
                 )
-
-    async def get_expired_items(self, expiry_datetime, spiked_planning_only=False):
-        """Get the expired items
-
-        Where planning_date is in the past
-        """
-        nested_filter = {
-            "nested": {
-                "path": "_planning_schedule",
-                "filter": {"range": {"_planning_schedule.scheduled": {"gt": date_to_str(expiry_datetime)}}},
-            }
-        }
-        range_filter = {"range": {"planning_date": {"gt": date_to_str(expiry_datetime)}}}
-        query = {
-            "query": {
-                "bool": {
-                    "must_not": [
-                        {
-                            "nested": {
-                                "path": "related_events",
-                                "query": {"term": {"related_events.link_type": "primary"}},
-                            },
-                        },
-                        {"term": {"expired": True}},
-                        nested_filter,
-                        range_filter,
-                    ]
-                }
-            }
-        }
-
-        if spiked_planning_only:
-            query = {
-                "query": {
-                    "bool": {
-                        "must_not": [nested_filter, range_filter],
-                        "must": [{"term": {"state": WORKFLOW_STATE.SPIKED}}],
-                    }
-                }
-            }
-
-        query["sort"] = [{"planning_date": "asc"}]
-        query["size"] = 200
-
-        total_received = 0
-        total_items = -1
-
-        while True:
-            query["from"] = total_received
-
-            results = await self.search_async(query)
-
-            # If the total_items has not been set, then this is the first query
-            # In which case we need to store the total hits from the search
-            if total_items < 0:
-                total_items = await results.count()
-
-                # If the search doesn't contain any results, return here
-                if total_items < 1:
-                    break
-
-            # If the last query doesn't contain any results, return here
-            items = await results.to_list()
-            if not len(items):
-                break
-
-            total_received += len(items)
-
-            # Yield the results for iteration by the callee
-            yield items
 
     async def on_event_converted_to_recurring(self, updates, original):
         event_id = original[ID_FIELD]

--- a/server/planning/planning/planning_service.py
+++ b/server/planning/planning/planning_service.py
@@ -5,12 +5,12 @@ from lxml import etree
 from copy import deepcopy
 from bson import ObjectId
 from datetime import datetime
-from superdesk.core.types import SearchRequest
 from typing_extensions import assert_never
-from typing import AsyncGenerator, Any, cast
+from typing import Any, cast
 
 from apps.auth import get_user, get_auth
 
+from superdesk.core.types import SearchRequest
 from superdesk.core import get_current_app
 from superdesk.utc import utcnow, utc_to_local
 from superdesk.errors import SuperdeskApiError
@@ -18,7 +18,7 @@ from superdesk.resource_fields import ID_FIELD
 from superdesk.metadata.item import GUID_NEWSML
 from superdesk.notification import push_notification
 from superdesk import get_resource_service, get_app_config
-from superdesk.core.utils import date_to_str, generate_guid
+from superdesk.core.utils import generate_guid
 
 from planning.planning_notifications import PlanningNotifications
 from planning.content_profiles.utils import is_field_enabled
@@ -75,87 +75,6 @@ class PlanningAsyncService(BasePlanningAsyncService[PlanningResourceModel]):
             if getattr(updates, field) != getattr(original, field):
                 return True
         return False
-
-    async def get_expired_items(
-        self, expiry_datetime: datetime, spiked_planning_only: bool = False
-    ) -> AsyncGenerator[list[dict[str, Any]], None]:
-        """
-        Retrieve "expired" items which are those whose planning_date is before `expiry_datetime` and
-        have no future schedules or primary-linked events, and are not already expired.
-
-        By default, items are filtered to exclude:
-        - Items linked to a primary event or,
-        - Items already expired or,
-        - Items with future scheduling or a planning_date beyond `expiry_datetime`.
-
-        If `spiked_planning_only` is True, only spiked items are returned, still excluding
-        those with future schedules or planning_dates.
-        """
-        nested_filter = {
-            "nested": {
-                "path": "_planning_schedule",
-                "query": {"range": {"_planning_schedule.scheduled": {"gt": date_to_str(expiry_datetime)}}},
-            }
-        }
-        range_filter = {"range": {"planning_date": {"gt": date_to_str(expiry_datetime)}}}
-        query: dict[str, Any] = {
-            "query": {
-                "bool": {
-                    "must_not": [
-                        {
-                            "nested": {
-                                "path": "related_events",
-                                "query": {"term": {"related_events.link_type": "primary"}},
-                            },
-                        },
-                        {"term": {"expired": True}},
-                        nested_filter,
-                        range_filter,
-                    ]
-                }
-            }
-        }
-
-        if spiked_planning_only:
-            query = {
-                "query": {
-                    "bool": {
-                        "must_not": [nested_filter, range_filter],
-                        "must": [{"term": {"state": WORKFLOW_STATE.SPIKED}}],
-                    }
-                }
-            }
-
-        query["sort"] = [{"planning_date": "asc"}]
-        query["size"] = 200
-
-        total_received = 0
-        total_items = -1
-
-        while True:
-            query["from"] = total_received
-
-            results = await self.search(query)
-            items = await results.to_list_raw()
-            results_count = len(items)
-
-            # If the total_items has not been set, then this is the first query
-            # In which case we need to store the total hits from the search
-            if total_items < 0:
-                total_items = results_count
-
-                # If the search doesn't contain any results, return here
-                if total_items < 1:
-                    break
-
-            # If the last query doesn't contain any results, return here
-            if results_count == 0:
-                break
-
-            total_received += results_count
-
-            # Yield the results for iteration by the callee
-            yield items
 
     async def on_event_converted_to_recurring(self, updates: dict[str, Any], original: EventResourceModel):
         for item in get_related_planning_for_events([original.id]):

--- a/server/planning/search/queries/elastic.py
+++ b/server/planning/search/queries/elastic.py
@@ -33,6 +33,7 @@ class ElasticQuery:
 
         self.extra: Dict[str, Any] = {}
         self.multilingual_fields: Set[str] = set()
+        self.size: int | None = None
 
     def build(self) -> Dict[str, Any]:
         query: Dict[str, Any] = {"query": {"bool": {}}}
@@ -52,12 +53,22 @@ class ElasticQuery:
         if len(self.sort):
             query["sort"] = self.sort
 
+        if self.size is not None:
+            query["size"] = self.size
+
         return query
 
     def extend_query(self, query: Dict[str, Any]):
         def _extend(key: str):
-            conditions = ((query.get("query") or {}).get("bool") or {}).get(key) or []
-            if len(conditions):
+            try:
+                conditions = query["query"]["bool"][key]
+            except KeyError:
+                try:
+                    conditions = query["bool"][key]
+                except KeyError:
+                    conditions = query.get(key, None)
+
+            if conditions:
                 self.__dict__[key].extend(conditions)
 
         _extend("must")

--- a/server/planning/utils.py
+++ b/server/planning/utils.py
@@ -151,7 +151,7 @@ def get_related_planning_for_events(
     event_ids: List[str],
     link_type: Optional[PLANNING_RELATED_EVENT_LINK_TYPE] = None,
     exclude_planning_ids: Optional[List[str]] = None,
-    projection: dict | str | None = None
+    projection: dict | str | None = None,
 ) -> List[Planning]:
     related_events_filters: List[Dict[str, Any]] = [{"terms": {"related_events._id": event_ids}}]
     if link_type is not None:

--- a/server/planning/utils.py
+++ b/server/planning/utils.py
@@ -151,6 +151,7 @@ def get_related_planning_for_events(
     event_ids: List[str],
     link_type: Optional[PLANNING_RELATED_EVENT_LINK_TYPE] = None,
     exclude_planning_ids: Optional[List[str]] = None,
+    projection: dict | str | None = None
 ) -> List[Planning]:
     related_events_filters: List[Dict[str, Any]] = [{"terms": {"related_events._id": event_ids}}]
     if link_type is not None:
@@ -170,6 +171,8 @@ def get_related_planning_for_events(
 
     req = ParsedRequest()
     req.args = {"source": json.dumps({"query": {"bool": bool_query}})}
+    if projection:
+        req.projection = json.dumps(projection) if isinstance(projection, dict) else projection
 
     return [cast_item(item) for item in get_resource_service("planning").get(req=req, lookup=None)]
 


### PR DESCRIPTION
### Purpose
The expiry command was attempting to expire all items in one loop. This caused Elasticsearch to raise an  exception after 10,000 items.

### What has changed
* Process expiry items in batches (applying `MAX_EXPIRY_QUERY_LIMIT` and `MAX_EXPIRY_LOOPS` configs)
* Use `bulk_update` to reduce number of calls to the DB
* Use projection to reduce size of DB responses
* Remove duplicate `get_expired_items` code (reducing 4 functions down to 1)
* Remove locks on ALL expired items (shouldn't be an issue, as the Event or Planning would have happened 30+ days ago).

Resolves: [SDESK-7855](https://sofab.atlassian.net/browse/SDESK-7855)
Depends on: https://github.com/superdesk/superdesk-core/pull/3132



[SDESK-7855]: https://sofab.atlassian.net/browse/SDESK-7855?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ