### PR TITLE
Fix planning item fetching

### DIFF
--- a/client/api/search.ts
+++ b/client/api/search.ts
@@ -7,6 +7,7 @@ import {appConfig} from 'appConfig';
 import planningApi from '../actions/planning/api';
 import eventsApi from '../actions/events/api';
 import {partition} from 'lodash';
+import {MAIN} from '../constants';
 
 export function cvsToString(
     items?: Array<{[key: string]: any}>,
@@ -48,7 +49,7 @@ export function convertCommonParams(params: ISearchParams): Partial<ISearchAPIPa
         lock_state: params.lock_state,
         directly_locked: params.directly_locked,
         page: params.page ?? 1,
-        max_results: params.max_results ?? 50,
+        max_results: params.max_results ?? MAIN.PAGE_SIZE,
         recurrence_id: params.recurrence_id,
         place: cvsToString(params.place),
         only_future: params.only_future,

--- a/client/constants/main.ts
+++ b/client/constants/main.ts
@@ -51,7 +51,7 @@ export const MAIN = {
         EVENTS: 'EVENTS',
         PLANNING: 'PLANNING',
     },
-    PAGE_SIZE: 50,
+    PAGE_SIZE: 100,
     PREVIEW: 'preview',
     EDIT: 'edit',
     JUMP: {


### PR DESCRIPTION
### Purpose
We sort items only by date on the backend and don't support custom sorting there, so if a customer repo has custom sorting applied, we would fetch 50 items per page, but they will be the first 50 which might not be in the correct order. Thus this PR tries to fix this by setting page limit to 100, so if those items they originally wanted are in the 100 fetched items, we get them and sort them on the frontend.

Resolves: #[STT-1558]



[STT-1558]: https://sofab.atlassian.net/browse/STT-1558?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ