### PR TITLE
[STT-1560] Add configurable assignment state reset on reassignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,12 @@ Below sections include the config options that can be defined in settings.py.
 * ASSIGNMENT_MANUAL_REASSIGNMENT_ONLY
     * Default: False (preserves the current behavior where automatic user assignment occurs)
     * If true, Disables automatic user assignment for coverage, ensuring that assignments are updated only through explicit manual reassignment
+* ASSIGNMENT_RESET_STATE_ON_REASSIGNMENT
+    * Default: False
+    * Controls assignment state transitions when reassigning to a different user (or unassigning)
+    * If False: Preserves the current state (e.g., IN_PROGRESS remains IN_PROGRESS, ASSIGNED remains ASSIGNED)
+    * If True: Resets to ASSIGNED state on reassignment
+    * Does not affect desk moves or assignments in COMPLETED/CANCELLED states
 
 ### Authoring Config
 * PLANNING_CHECK_FOR_ASSIGNMENT_ON_PUBLISH

--- a/client/components/Assignments/AssignmentEditor.tsx
+++ b/client/components/Assignments/AssignmentEditor.tsx
@@ -88,7 +88,8 @@ export class AssignmentEditorComponent extends React.PureComponent<IProps> {
     }
 
     onUserChange = (value?: IUser) => {
-        this.props.onChange({[this.FIELDS.USER]: value?._id});
+        // use null explicitly to ensure unassigned user is sent to backend
+        this.props.onChange({[this.FIELDS.USER]: value?._id ?? null});
     }
 
     onContactChange = (contact: IContact) => {

--- a/server/features/planning_assignment_reassignment.feature
+++ b/server/features/planning_assignment_reassignment.feature
@@ -1,0 +1,590 @@
+Feature: Planning Assignment Reassignment State Management
+
+    Background: Initial setup
+        Given "desks"
+        """
+        [{"name": "Sports Desk", "members": [{"user": "#CONTEXT_USER_ID#"}]}]
+        """
+
+    @auth
+    @notification
+    @vocabulary
+    Scenario: User reassignment preserves IN_PROGRESS state by default (config OFF)
+        Given empty "planning"
+        When we post to "/archive"
+        """
+        [{
+            "guid": "test_content_preserve",
+            "type": "text",
+            "headline": "test headline",
+            "slugline": "test slugline",
+            "task": {
+                "desk": "#desks._id#",
+                "user": "#CONTEXT_USER_ID#"
+            }
+        }]
+        """
+        Then we get OK response
+        When we post to "/planning"
+        """
+        [{
+            "guid": "test_preserve_state",
+            "headline": "Test preserve state on reassignment",
+            "slugline": "test preserve state",
+            "planning_date": "2026-01-02"
+        }]
+        """
+        Then we get OK response
+        When we patch "/planning/#planning._id#"
+        """
+        {
+            "coverages": [{
+                "workflow_status": "active",
+                "planning": {
+                    "ednote": "test coverage",
+                    "slugline": "test slugline",
+                    "g2_content_type": "text"
+                },
+                "assigned_to": {
+                    "desk": "#desks._id#",
+                    "user": "#CONTEXT_USER_ID#"
+                }
+            }]
+        }
+        """
+        Then we get OK response
+        Then we store coverage id in "coverage1" from coverage 0
+        Then we store assignment id in "assignment1" from coverage 0
+        When we post to "assignments/link"
+        """
+        [{
+            "assignment_id": "#assignment1#",
+            "item_id": "#archive._id#",
+            "reassign": true
+        }]
+        """
+        Then we get OK response
+        When we get "assignments/#assignment1#"
+        Then we get existing resource
+        """
+        {
+            "assigned_to": {
+                "state": "in_progress",
+                "user": "#CONTEXT_USER_ID#"
+            }
+        }
+        """
+        When we patch "/planning/#planning._id#"
+        """
+        {
+            "coverages": [{
+                "coverage_id": "#coverage1#",
+                "workflow_status": "active",
+                "planning": {
+                    "ednote": "test coverage",
+                    "slugline": "test slugline",
+                    "g2_content_type": "text"
+                },
+                "assigned_to": {
+                    "desk": "#desks._id#",
+                    "user": "507f191e810c19729de870eb",
+                    "assignment_id": "#assignment1#"
+                }
+            }]
+        }
+        """
+        Then we get OK response
+        When we get "assignments/#assignment1#"
+        Then we get existing resource
+        """
+        {
+            "assigned_to": {
+                "state": "in_progress",
+                "desk": "#desks._id#",
+                "user": "507f191e810c19729de870eb"
+            }
+        }
+        """
+
+    @auth
+    @notification
+    @vocabulary
+    Scenario: User reassignment resets to ASSIGNED state when config enabled
+        Given empty "planning"
+        When we set config assignment reset state on reassignment to True
+        When we post to "/archive"
+        """
+        [{
+            "guid": "test_content_reset",
+            "type": "text",
+            "headline": "test headline",
+            "slugline": "test slugline",
+            "task": {
+                "desk": "#desks._id#",
+                "user": "#CONTEXT_USER_ID#"
+            }
+        }]
+        """
+        Then we get OK response
+        When we post to "/planning"
+        """
+        [{
+            "guid": "test_reset_state",
+            "headline": "Test reset state on reassignment",
+            "slugline": "test reset state",
+            "planning_date": "2026-01-02"
+        }]
+        """
+        Then we get OK response
+        When we patch "/planning/#planning._id#"
+        """
+        {
+            "coverages": [{
+                "workflow_status": "active",
+                "planning": {
+                    "ednote": "test coverage",
+                    "slugline": "test slugline",
+                    "g2_content_type": "text"
+                },
+                "assigned_to": {
+                    "desk": "#desks._id#",
+                    "user": "#CONTEXT_USER_ID#"
+                }
+            }]
+        }
+        """
+        Then we get OK response
+        Then we store coverage id in "coverage1" from coverage 0
+        Then we store assignment id in "assignment1" from coverage 0
+        When we post to "assignments/link"
+        """
+        [{
+            "assignment_id": "#assignment1#",
+            "item_id": "#archive._id#",
+            "reassign": true
+        }]
+        """
+        Then we get OK response
+        When we get "assignments/#assignment1#"
+        Then we get existing resource
+        """
+        {
+            "assigned_to": {
+                "state": "in_progress",
+                "user": "#CONTEXT_USER_ID#"
+            }
+        }
+        """
+        When we patch "/planning/#planning._id#"
+        """
+        {
+            "coverages": [{
+                "coverage_id": "#coverage1#",
+                "workflow_status": "active",
+                "planning": {
+                    "ednote": "test coverage",
+                    "slugline": "test slugline",
+                    "g2_content_type": "text"
+                },
+                "assigned_to": {
+                    "desk": "#desks._id#",
+                    "user": "507f191e810c19729de870eb",
+                    "assignment_id": "#assignment1#"
+                }
+            }]
+        }
+        """
+        Then we get OK response
+        When we get "assignments/#assignment1#"
+        Then we get existing resource
+        """
+        {
+            "assigned_to": {
+                "state": "assigned",
+                "desk": "#desks._id#",
+                "user": "507f191e810c19729de870eb"
+            }
+        }
+        """
+
+    @auth
+    @notification
+    @vocabulary
+    Scenario: Unassigning user preserves IN_PROGRESS state (config OFF)
+        Given empty "planning"
+        When we post to "/archive"
+        """
+        [{
+            "guid": "test_content_unassign_preserve",
+            "type": "text",
+            "headline": "test headline",
+            "slugline": "test slugline",
+            "task": {
+                "desk": "#desks._id#",
+                "user": "#CONTEXT_USER_ID#"
+            }
+        }]
+        """
+        Then we get OK response
+        When we post to "/planning"
+        """
+        [{
+            "guid": "test_unassign_preserve",
+            "headline": "Test unassignment preserves state",
+            "slugline": "test unassign preserve",
+            "planning_date": "2026-01-02"
+        }]
+        """
+        Then we get OK response
+        When we patch "/planning/#planning._id#"
+        """
+        {
+            "coverages": [{
+                "workflow_status": "active",
+                "planning": {
+                    "ednote": "test coverage",
+                    "slugline": "test slugline",
+                    "g2_content_type": "text"
+                },
+                "assigned_to": {
+                    "desk": "#desks._id#",
+                    "user": "#CONTEXT_USER_ID#"
+                }
+            }]
+        }
+        """
+        Then we get OK response
+        Then we store coverage id in "coverage1" from coverage 0
+        Then we store assignment id in "assignment1" from coverage 0
+        When we post to "assignments/link"
+        """
+        [{
+            "assignment_id": "#assignment1#",
+            "item_id": "#archive._id#",
+            "reassign": true
+        }]
+        """
+        Then we get OK response
+        When we get "assignments/#assignment1#"
+        Then we get existing resource
+        """
+        {
+            "assigned_to": {
+                "state": "in_progress",
+                "user": "#CONTEXT_USER_ID#"
+            }
+        }
+        """
+        When we patch "/planning/#planning._id#"
+        """
+        {
+            "coverages": [{
+                "coverage_id": "#coverage1#",
+                "workflow_status": "active",
+                "planning": {
+                    "ednote": "test coverage",
+                    "slugline": "test slugline",
+                    "g2_content_type": "text"
+                },
+                "assigned_to": {
+                    "desk": "#desks._id#",
+                    "assignment_id": "#assignment1#"
+                }
+            }]
+        }
+        """
+        Then we get OK response
+        When we get "assignments/#assignment1#"
+        Then we get existing resource
+        """
+        {
+            "assigned_to": {
+                "state": "in_progress",
+                "desk": "#desks._id#"
+            }
+        }
+        """
+
+    @auth
+    @notification
+    @vocabulary
+    Scenario: Unassigning user does NOT reset to ASSIGNED even with config enabled
+        Given empty "planning"
+        When we set config assignment reset state on reassignment to True
+        When we post to "/archive"
+        """
+        [{
+            "guid": "test_content_unassign_noreset",
+            "type": "text",
+            "headline": "test headline",
+            "slugline": "test slugline",
+            "task": {
+                "desk": "#desks._id#",
+                "user": "#CONTEXT_USER_ID#"
+            }
+        }]
+        """
+        Then we get OK response
+        When we post to "/planning"
+        """
+        [{
+            "guid": "test_unassign_noreset",
+            "headline": "Test unassignment with config enabled",
+            "slugline": "test unassign no reset",
+            "planning_date": "2026-01-02"
+        }]
+        """
+        Then we get OK response
+        When we patch "/planning/#planning._id#"
+        """
+        {
+            "coverages": [{
+                "workflow_status": "active",
+                "planning": {
+                    "ednote": "test coverage",
+                    "slugline": "test slugline",
+                    "g2_content_type": "text"
+                },
+                "assigned_to": {
+                    "desk": "#desks._id#",
+                    "user": "#CONTEXT_USER_ID#"
+                }
+            }]
+        }
+        """
+        Then we get OK response
+        Then we store coverage id in "coverage1" from coverage 0
+        Then we store assignment id in "assignment1" from coverage 0
+        When we post to "assignments/link"
+        """
+        [{
+            "assignment_id": "#assignment1#",
+            "item_id": "#archive._id#",
+            "reassign": true
+        }]
+        """
+        Then we get OK response
+        When we get "assignments/#assignment1#"
+        Then we get existing resource
+        """
+        {
+            "assigned_to": {
+                "state": "in_progress",
+                "user": "#CONTEXT_USER_ID#"
+            }
+        }
+        """
+        When we patch "/planning/#planning._id#"
+        """
+        {
+            "coverages": [{
+                "coverage_id": "#coverage1#",
+                "workflow_status": "active",
+                "planning": {
+                    "ednote": "test coverage",
+                    "slugline": "test slugline",
+                    "g2_content_type": "text"
+                },
+                "assigned_to": {
+                    "desk": "#desks._id#",
+                    "assignment_id": "#assignment1#"
+                }
+            }]
+        }
+        """
+        Then we get OK response
+        When we get "assignments/#assignment1#"
+        Then we get existing resource
+        """
+        {
+            "assigned_to": {
+                "state": "in_progress",
+                "desk": "#desks._id#"
+            }
+        }
+        """
+
+    @auth
+    @notification
+    @vocabulary
+    Scenario: Desk change without user change does NOT trigger state reset
+        Given empty "planning"
+        When we set config assignment reset state on reassignment to True
+        When we post to "desks"
+        """
+        {"name": "Politics Desk", "members": [{"user": "#CONTEXT_USER_ID#"}]}
+        """
+        Then we get OK response
+        When we post to "/archive"
+        """
+        [{
+            "guid": "test_content_desk_change",
+            "type": "text",
+            "headline": "test headline",
+            "slugline": "test slugline",
+            "task": {
+                "desk": "#desks._id#",
+                "user": "#CONTEXT_USER_ID#"
+            }
+        }]
+        """
+        Then we get OK response
+        When we post to "/planning"
+        """
+        [{
+            "guid": "test_desk_change",
+            "headline": "Test desk change",
+            "slugline": "test desk change",
+            "planning_date": "2026-01-02"
+        }]
+        """
+        Then we get OK response
+        When we patch "/planning/#planning._id#"
+        """
+        {
+            "coverages": [{
+                "workflow_status": "active",
+                "planning": {
+                    "ednote": "test coverage",
+                    "slugline": "test slugline",
+                    "g2_content_type": "text"
+                },
+                "assigned_to": {
+                    "desk": "#desks._id#",
+                    "user": "#CONTEXT_USER_ID#"
+                }
+            }]
+        }
+        """
+        Then we get OK response
+        Then we store coverage id in "coverage1" from coverage 0
+        Then we store assignment id in "assignment1" from coverage 0
+        When we post to "assignments/link"
+        """
+        [{
+            "assignment_id": "#assignment1#",
+            "item_id": "#archive._id#",
+            "reassign": true
+        }]
+        """
+        Then we get OK response
+        When we get "assignments/#assignment1#"
+        Then we get existing resource
+        """
+        {
+            "assigned_to": {
+                "state": "in_progress",
+                "desk": "#desks._id#",
+                "user": "#CONTEXT_USER_ID#"
+            }
+        }
+        """
+        When we patch "/planning/#planning._id#"
+        """
+        {
+            "coverages": [{
+                "coverage_id": "#coverage1#",
+                "workflow_status": "active",
+                "planning": {
+                    "ednote": "test coverage",
+                    "slugline": "test slugline",
+                    "g2_content_type": "text"
+                },
+                "assigned_to": {
+                    "desk": "#desks[1]._id#",
+                    "user": "#CONTEXT_USER_ID#",
+                    "assignment_id": "#assignment1#"
+                }
+            }]
+        }
+        """
+        Then we get OK response
+        When we get "assignments/#assignment1#"
+        Then we get existing resource
+        """
+        {
+            "assigned_to": {
+                "state": "in_progress",
+                "desk": "#desks[1]._id#",
+                "user": "#CONTEXT_USER_ID#"
+            }
+        }
+        """
+
+    @auth
+    @notification
+    @vocabulary
+    Scenario: ASSIGNED state is also reset on user reassignment when config enabled
+        Given empty "planning"
+        When we set config assignment reset state on reassignment to True
+        When we post to "/planning"
+        """
+        [{
+            "guid": "test_assigned_reset",
+            "headline": "Test ASSIGNED state reset",
+            "slugline": "test assigned reset",
+            "planning_date": "2026-01-02"
+        }]
+        """
+        Then we get OK response
+        When we patch "/planning/#planning._id#"
+        """
+        {
+            "coverages": [{
+                "workflow_status": "active",
+                "planning": {
+                    "ednote": "test coverage",
+                    "slugline": "test slugline",
+                    "g2_content_type": "text"
+                },
+                "assigned_to": {
+                    "desk": "#desks._id#",
+                    "user": "#CONTEXT_USER_ID#"
+                }
+            }]
+        }
+        """
+        Then we get OK response
+        Then we store coverage id in "coverage1" from coverage 0
+        Then we store assignment id in "assignment1" from coverage 0
+        When we get "assignments/#assignment1#"
+        Then we get existing resource
+        """
+        {
+            "assigned_to": {
+                "state": "assigned",
+                "user": "#CONTEXT_USER_ID#"
+            }
+        }
+        """
+        When we patch "/planning/#planning._id#"
+        """
+        {
+            "coverages": [{
+                "coverage_id": "#coverage1#",
+                "workflow_status": "active",
+                "planning": {
+                    "ednote": "test coverage",
+                    "slugline": "test slugline",
+                    "g2_content_type": "text"
+                },
+                "assigned_to": {
+                    "desk": "#desks._id#",
+                    "user": "507f191e810c19729de870eb",
+                    "assignment_id": "#assignment1#"
+                }
+            }]
+        }
+        """
+        Then we get OK response
+        When we get "assignments/#assignment1#"
+        Then we get existing resource
+        """
+        {
+            "assigned_to": {
+                "state": "assigned",
+                "desk": "#desks._id#",
+                "user": "507f191e810c19729de870eb"
+            }
+        }
+        """

--- a/server/features/planning_assignment_reassignment.feature
+++ b/server/features/planning_assignment_reassignment.feature
@@ -308,13 +308,13 @@ Feature: Planning Assignment Reassignment State Management
     @auth
     @notification
     @vocabulary
-    Scenario: Unassigning user does NOT reset to ASSIGNED even with config enabled
+    Scenario: Unassigning user resets to ASSIGNED when config enabled
         Given empty "planning"
         When we set config assignment reset state on reassignment to True
         When we post to "/archive"
         """
         [{
-            "guid": "test_content_unassign_noreset",
+            "guid": "test_content_unassign_reset",
             "type": "text",
             "headline": "test headline",
             "slugline": "test slugline",
@@ -328,9 +328,9 @@ Feature: Planning Assignment Reassignment State Management
         When we post to "/planning"
         """
         [{
-            "guid": "test_unassign_noreset",
+            "guid": "test_unassign_reset",
             "headline": "Test unassignment with config enabled",
-            "slugline": "test unassign no reset",
+            "slugline": "test unassign reset",
             "planning_date": "2026-01-02"
         }]
         """
@@ -387,6 +387,7 @@ Feature: Planning Assignment Reassignment State Management
                 },
                 "assigned_to": {
                     "desk": "#desks._id#",
+                    "user": null,
                     "assignment_id": "#assignment1#"
                 }
             }]
@@ -398,7 +399,7 @@ Feature: Planning Assignment Reassignment State Management
         """
         {
             "assigned_to": {
-                "state": "in_progress",
+                "state": "assigned",
                 "desk": "#desks._id#"
             }
         }

--- a/server/features/planning_assignment_reassignment.feature
+++ b/server/features/planning_assignment_reassignment.feature
@@ -111,7 +111,10 @@ Feature: Planning Assignment Reassignment State Management
     @vocabulary
     Scenario: User reassignment resets to ASSIGNED state when config enabled
         Given empty "planning"
-        When we set config assignment reset state on reassignment to True
+        Given config update
+        """
+        {"ASSIGNMENT_RESET_STATE_ON_REASSIGNMENT": true}
+        """
         When we post to "/archive"
         """
         [{
@@ -310,7 +313,10 @@ Feature: Planning Assignment Reassignment State Management
     @vocabulary
     Scenario: Unassigning user resets to ASSIGNED when config enabled
         Given empty "planning"
-        When we set config assignment reset state on reassignment to True
+        Given config update
+        """
+        {"ASSIGNMENT_RESET_STATE_ON_REASSIGNMENT": true}
+        """
         When we post to "/archive"
         """
         [{
@@ -410,7 +416,10 @@ Feature: Planning Assignment Reassignment State Management
     @vocabulary
     Scenario: Desk change without user change does NOT trigger state reset
         Given empty "planning"
-        When we set config assignment reset state on reassignment to True
+        Given config update
+        """
+        {"ASSIGNMENT_RESET_STATE_ON_REASSIGNMENT": true}
+        """
         When we post to "desks"
         """
         {"name": "Politics Desk", "members": [{"user": "#CONTEXT_USER_ID#"}]}
@@ -517,7 +526,10 @@ Feature: Planning Assignment Reassignment State Management
     @vocabulary
     Scenario: ASSIGNED state is also reset on user reassignment when config enabled
         Given empty "planning"
-        When we set config assignment reset state on reassignment to True
+        Given config update
+        """
+        {"ASSIGNMENT_RESET_STATE_ON_REASSIGNMENT": true}
+        """
         When we post to "/planning"
         """
         [{

--- a/server/features/steps/steps.py
+++ b/server/features/steps/steps.py
@@ -428,6 +428,11 @@ def then_set_assignment_manual_reassignment_only(context):
     context.app.config["ASSIGNMENT_MANUAL_REASSIGNMENT_ONLY"] = True
 
 
+@when("we set config assignment reset state on reassignment to True")
+def then_set_assignment_reset_state_on_reassignment(context):
+    context.app.config["ASSIGNMENT_RESET_STATE_ON_REASSIGNMENT"] = True
+
+
 @when("we set PLANNING_USE_XMP_FOR_PIC_ASSIGNMENTS")
 def then_set_use_xmp_for_pic_assignments(context):
     ABS_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), "../"))

--- a/server/planning/common.py
+++ b/server/planning/common.py
@@ -264,6 +264,10 @@ def get_config_assignment_manual_reassignment_only(current_app=None):
     return (current_app or get_current_app()).config.get("ASSIGNMENT_MANUAL_REASSIGNMENT_ONLY", False)
 
 
+def get_config_assignment_reset_state_on_reassignment(current_app=None) -> bool:
+    return get_config(bool, "ASSIGNMENT_RESET_STATE_ON_REASSIGNMENT", False)
+
+
 def get_coverage_status_from_cv(qcode: str):
     coverage_states = get_resource_service("vocabularies").find_one(req=None, _id="newscoveragestatus")
 

--- a/server/planning/common.py
+++ b/server/planning/common.py
@@ -256,15 +256,15 @@ def get_default_coverage_status_qcode_on_ingest():
     return get_app_config("PLANNING_DEFAULT_COVERAGE_STATUS_ON_INGEST", "ncostat:int")
 
 
-def get_config_planning_duplicate_retain_assignee_details(current_app=None):
-    return (current_app or get_current_app()).config.get("PLANNING_DUPLICATE_RETAIN_ASSIGNEE_DETAILS", False)
+def get_config_planning_duplicate_retain_assignee_details():
+    return get_config(bool, "PLANNING_DUPLICATE_RETAIN_ASSIGNEE_DETAILS", False)
 
 
-def get_config_assignment_manual_reassignment_only(current_app=None):
-    return (current_app or get_current_app()).config.get("ASSIGNMENT_MANUAL_REASSIGNMENT_ONLY", False)
+def get_config_assignment_manual_reassignment_only():
+    return get_config(bool, "ASSIGNMENT_MANUAL_REASSIGNMENT_ONLY", False)
 
 
-def get_config_assignment_reset_state_on_reassignment(current_app=None) -> bool:
+def get_config_assignment_reset_state_on_reassignment() -> bool:
     return get_config(bool, "ASSIGNMENT_RESET_STATE_ON_REASSIGNMENT", False)
 
 

--- a/server/planning/planning/planning.py
+++ b/server/planning/planning/planning.py
@@ -50,9 +50,9 @@ from planning.types import (
 from planning.planning.planning_history_async_service import PlanningHistoryAsyncService
 from planning.planning.planning_autosave_service import PlanningAutosaveAsyncService
 from planning.assignments.assignments_history_async import AssignmentsHistoryAsyncService
-from planning.assignments.assignments import get_next_assignment_status
 from planning.content_profiles.planning_types_async_service import PlanningTypesAsyncService
 from planning.common import (
+    get_next_assignment_status,
     get_coverage_status_from_cv,
     WORKFLOW_STATE,
     ASSIGNMENT_WORKFLOW_STATE,
@@ -1408,6 +1408,7 @@ class PlanningService(AsyncBaseService):
                 ).get(key):
                     return True
 
+            # check if priority exists in updates (not just truthy) to handle priority correctly
             if "priority" in updates["assigned_to"] and updates["assigned_to"]["priority"] != original.get("priority"):
                 return True
 

--- a/server/planning/planning/planning.py
+++ b/server/planning/planning/planning.py
@@ -1136,16 +1136,18 @@ class PlanningService(AsyncBaseService):
                 if self.is_coverage_assignment_modified(updates, original_assignment):
                     _update_assignment_assigned_to()
             elif current_state in [ASSIGNMENT_WORKFLOW_STATE.ASSIGNED, ASSIGNMENT_WORKFLOW_STATE.IN_PROGRESS]:
-                # Handle user reassignment (including unassigning)
-                if original.get("assigned_to", {}).get("user") != assigned_to.get("user"):
-                    should_reset_state = get_config_assignment_reset_state_on_reassignment()
+                if self.is_coverage_assignment_modified(updates, original_assignment):
+                    # By default, preserve the current state
+                    assigned_to["state"] = current_state
 
-                    if should_reset_state:
-                        assigned_to["state"] = get_next_assignment_status(
-                            original_assignment, ASSIGNMENT_WORKFLOW_STATE.ASSIGNED
-                        )
-                    else:
-                        assigned_to["state"] = current_state
+                    # Handle user reassignment (including unassigning) with state management
+                    if original.get("assigned_to", {}).get("user") != assigned_to.get("user"):
+                        should_reset_state = get_config_assignment_reset_state_on_reassignment()
+
+                        if should_reset_state:
+                            assigned_to["state"] = get_next_assignment_status(
+                                original_assignment, ASSIGNMENT_WORKFLOW_STATE.ASSIGNED
+                            )
 
                     _update_assignment_assigned_to()
 
@@ -1164,11 +1166,17 @@ class PlanningService(AsyncBaseService):
                 assignment["name"] = planning["name"] if not translated_value and translated_name else translated_name
 
             # If the coverage assignee has been changed and workflow status is active
-            if original.get("workflow_status") != WORKFLOW_STATE.DRAFT and self.is_coverage_assignment_modified(
-                updates, original_assignment
+            if (
+                original.get("workflow_status") != WORKFLOW_STATE.DRAFT
+                and self.is_coverage_assignment_modified(updates, original_assignment)
+                and current_state
+                not in [
+                    ASSIGNMENT_WORKFLOW_STATE.DRAFT,
+                    ASSIGNMENT_WORKFLOW_STATE.ASSIGNED,
+                    ASSIGNMENT_WORKFLOW_STATE.IN_PROGRESS,
+                ]
             ):
-                if current_state not in [ASSIGNMENT_WORKFLOW_STATE.ASSIGNED, ASSIGNMENT_WORKFLOW_STATE.IN_PROGRESS]:
-                    assigned_to["state"] = ASSIGNMENT_WORKFLOW_STATE.ASSIGNED
+                assigned_to["state"] = ASSIGNMENT_WORKFLOW_STATE.ASSIGNED
                 _update_assignment_assigned_to()
 
             # If there has been a change in the planning internal note then notify the assigned users/desk
@@ -1400,9 +1408,7 @@ class PlanningService(AsyncBaseService):
                 ).get(key):
                     return True
 
-            if updates["assigned_to"].get("priority") and updates["assigned_to"]["priority"] != original.get(
-                "priority"
-            ):
+            if "priority" in updates["assigned_to"] and updates["assigned_to"]["priority"] != original.get("priority"):
                 return True
 
         return False

--- a/server/planning/planning/planning.py
+++ b/server/planning/planning/planning.py
@@ -50,6 +50,7 @@ from planning.types import (
 from planning.planning.planning_history_async_service import PlanningHistoryAsyncService
 from planning.planning.planning_autosave_service import PlanningAutosaveAsyncService
 from planning.assignments.assignments_history_async import AssignmentsHistoryAsyncService
+from planning.assignments.assignments import get_next_assignment_status
 from planning.content_profiles.planning_types_async_service import PlanningTypesAsyncService
 from planning.common import (
     get_coverage_status_from_cv,
@@ -77,6 +78,7 @@ from planning.common import (
     UPDATE_FUTURE,
     UPDATE_ALL,
     POST_STATE,
+    get_config_assignment_reset_state_on_reassignment,
 )
 
 from planning.events.events_history_async_service import EventsHistoryAsyncService
@@ -1128,13 +1130,29 @@ class PlanningService(AsyncBaseService):
                     assigned_to["assigned_date_user"] = utcnow()
                     assigned_to["assignor_user"] = user.get(ID_FIELD)
 
-            if original_assignment.get("assigned_to").get("state") == ASSIGNMENT_WORKFLOW_STATE.DRAFT:
+            current_state = original_assignment.get("assigned_to", {}).get("state")
+
+            if current_state == ASSIGNMENT_WORKFLOW_STATE.DRAFT:
                 if self.is_coverage_assignment_modified(updates, original_assignment):
+                    _update_assignment_assigned_to()
+            elif current_state in [ASSIGNMENT_WORKFLOW_STATE.ASSIGNED, ASSIGNMENT_WORKFLOW_STATE.IN_PROGRESS]:
+                # Handle user reassignment (including unassigning)
+                if original.get("assigned_to", {}).get("user") != assigned_to.get("user"):
+                    should_reset_state = get_config_assignment_reset_state_on_reassignment()
+
+                    if should_reset_state:
+                        assigned_to["state"] = get_next_assignment_status(
+                            original_assignment, ASSIGNMENT_WORKFLOW_STATE.ASSIGNED
+                        )
+                    else:
+                        assigned_to["state"] = current_state
+
                     _update_assignment_assigned_to()
 
             # If we made a coverage 'active' - change assignment status to active
             if original.get("workflow_status") == WORKFLOW_STATE.DRAFT and not is_coverage_draft:
-                assigned_to["state"] = ASSIGNMENT_WORKFLOW_STATE.ASSIGNED
+                if current_state not in [ASSIGNMENT_WORKFLOW_STATE.ASSIGNED, ASSIGNMENT_WORKFLOW_STATE.IN_PROGRESS]:
+                    assigned_to["state"] = ASSIGNMENT_WORKFLOW_STATE.ASSIGNED
                 assignment["assigned_to"] = assigned_to
 
             # If the Planning description has been changed
@@ -1149,7 +1167,8 @@ class PlanningService(AsyncBaseService):
             if original.get("workflow_status") != WORKFLOW_STATE.DRAFT and self.is_coverage_assignment_modified(
                 updates, original_assignment
             ):
-                assigned_to["state"] = ASSIGNMENT_WORKFLOW_STATE.ASSIGNED
+                if current_state not in [ASSIGNMENT_WORKFLOW_STATE.ASSIGNED, ASSIGNMENT_WORKFLOW_STATE.IN_PROGRESS]:
+                    assigned_to["state"] = ASSIGNMENT_WORKFLOW_STATE.ASSIGNED
                 _update_assignment_assigned_to()
 
             # If there has been a change in the planning internal note then notify the assigned users/desk


### PR DESCRIPTION
### Purpose
This pull request introduces a new configuration option to control assignment state transitions when reassigning or unassigning users, and updates both the backend and frontend logic to support this behavior. The main changes include adding the `ASSIGNMENT_RESET_STATE_ON_REASSIGNMENT` config, updating assignment state logic in the backend, and ensuring the frontend correctly handles unassigned users.

### What has changed
**Assignment state transition improvements:**

* Added a new config option `ASSIGNMENT_RESET_STATE_ON_REASSIGNMENT` (default: `False`) that determines whether an assignment's state should be reset to `ASSIGNED` when reassigning or unassigning a user. This is documented in `README.md` and implemented in the backend config helpers. 
* Updated assignment update logic in `planning.py` to use the new config: if enabled, assignments in `ASSIGNED` or `IN_PROGRESS` state are reset to `ASSIGNED` on user change; otherwise, the current state is preserved. This includes calls to the new config getter and `get_next_assignment_status`. 

**Frontend assignment editor fix:**

* Modified the assignment editor to explicitly send `null` for unassigned users, ensuring the backend can distinguish between no change and unassignment.

Resolves: [STT-1560]



[STT-1560]: https://sofab.atlassian.net/browse/STT-1560?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ