### PR TITLE
[STT-1557] - Applying date filters hides Planning items without coverage from lists

### DIFF
--- a/client/utils/index.ts
+++ b/client/utils/index.ts
@@ -678,7 +678,7 @@ export const isDateInRange = (inputDate, startDate, endDate, allDay = false) => 
 
     if (allDay) {
         if (startDate && inputDate.isBefore(startDate, 'day') ||
-            endDate && inputDate.isSameOrAfter(endDate, 'day')
+            endDate && inputDate.isAfter(endDate, 'day') // when allDay is true, endDate should be inclusive
         ) {
             return false;
         }


### PR DESCRIPTION
### Purpose
This PR cherry-picks the fix from commit [cd517c84](https://github.com/superdesk/superdesk-planning/commit/cd517c84) which also solves STT-1557

### What has changed
Cherry-picked commit `Fix planning item filtering (#2689)` from the develop branch.

### Steps to test
1. Create a planning item without coverage and one with coverage and set it for a specific date
2. Go to Planning module and apply a date filter for that exact date
3. Both items should be visible in the list

Resolves: #[STT-1557](https://sofab.atlassian.net/browse/STT-1557)



[STT-1557]: https://sofab.atlassian.net/browse/STT-1557?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ