### PR TITLE
[STT-1550] Refactor `ExportAsArticleModal` and allow selecting/unselecting items

### DIFF
--- a/client/actions/multiSelect.ts
+++ b/client/actions/multiSelect.ts
@@ -1,14 +1,17 @@
+import moment from 'moment';
+
 import {appConfig} from 'appConfig';
+import {planningApi, superdeskApi} from '../superdeskApi';
+import {IEventOrPlanningItem} from '../interfaces';
 
 import * as selectors from '../selectors';
-import {get} from 'lodash';
-import moment from 'moment';
+import {MULTISELECT, ITEM_TYPE, MODALS, PERSONAL_WORKSPACE} from '../constants';
+
+import {getItemType, getItemInArrayById, getErrorMessage} from '../utils';
+
 import {showModal} from './index';
-import {MULTISELECT, ITEM_TYPE, MODALS} from '../constants';
 import eventsUi from './events/ui';
 import planningUi from './planning/ui';
-import {getItemType, gettext, getItemInArrayById, getErrorMessage, lockUtils} from '../utils';
-import {planningApi} from '../superdeskApi';
 
 /**
  * Action Dispatcher to select an/all Event(s)
@@ -114,6 +117,7 @@ const deSelectPlannings = (planningId, all = false) => (
 // Bulk actions on items
 const itemBulkSpikeModal = (items) => (
     (dispatch) => {
+        const {gettext} = superdeskApi.localization;
         const itemType = getItemType(items[0]);
         const itemSpikeDispatch = itemType === ITEM_TYPE.EVENT ?
             eventsUi.spike : planningUi.spike;
@@ -133,6 +137,7 @@ const itemBulkSpikeModal = (items) => (
 
 const itemBulkUnSpikeModal = (items) => (
     (dispatch) => {
+        const {gettext} = superdeskApi.localization;
         const itemType = getItemType(items[0]);
         const itemUnSpikeDispatch = itemType === ITEM_TYPE.EVENT ?
             eventsUi.unspike : planningUi.unspike;
@@ -190,51 +195,20 @@ const bulkAddPlanningCoveragesToWorkflow = (items) => (
         }))
 );
 
-const exportAsArticle = (items = [], download) => (
-    (dispatch, getState, {api, notify, gettext, superdesk, $location, $interpolate, desks}) => {
-        if (get(items, 'length', 0) <= 0) {
+const exportAsArticle = (items: Array<IEventOrPlanningItem>, download: boolean = false) => (
+    (dispatch, getState, {api, desks}) => {
+        const {gettext} = superdeskApi.localization;
+        const {notify} = superdeskApi.ui;
+
+        const selectedItems = items.filter(
+            (item) => item.type === 'event' || item.flags.marked_for_not_publication !== true
+        );
+
+        if (selectedItems.length === 0) {
+            notify.warning(gettext('No items selected.'));
             return Promise.resolve;
         }
 
-        const itemType = getItemType(items[0]);
-        const isPlanning = itemType === ITEM_TYPE.PLANNING;
-        const state = getState();
-        const sortableItems = [];
-        const label = (item) => item.headline || item.slugline || item.description_text || item.name;
-        const locks = selectors.locks.getLockedItems(state);
-
-        items.forEach((item) => {
-            const isLocked = lockUtils.isItemLocked(item, locks);
-            const isNotForPublication = get(item, 'flags.marked_for_not_publication');
-
-            if (isLocked || isNotForPublication) {
-                return;
-            }
-
-            sortableItems.push({
-                ...item,
-                label: label(item),
-            });
-        });
-
-        if (sortableItems.length < items.length) {
-            const count = items.length - sortableItems.length;
-
-            if (count === 1) {
-                notify.warning(gettext('1 item was not included in the export.'));
-            } else {
-                const message = gettext('{{ count }} items were not included in the export.');
-
-                notify.warning($interpolate(message)({count}));
-            }
-        }
-
-        if (!sortableItems.length) { // nothing to sort, stop
-            return;
-        }
-
-        const templates = isPlanning ? selectors.general.getPlanningExportTemplates(getState()) :
-            selectors.general.getEventExportTemplates(getState());
         const exportArticlesDispatch = (items, desk, template, type, download, articleTemplate) => {
             const itemIds = items.map((item) => item._id);
 
@@ -243,7 +217,7 @@ const exportAsArticle = (items = [], download) => (
                 let queryString = `${appConfig.server.url}/planning_download/events?tz=${timeZoneOffsetSecs}`;
 
                 if (template) {
-                    queryString = `${queryString}&template=${template}`;
+                    queryString += `&template=${template}`;
                 }
 
                 downloadEvents(queryString, itemIds);
@@ -252,7 +226,7 @@ const exportAsArticle = (items = [], download) => (
                 return Promise.resolve();
             } else {
                 return api.save('planning_article_export', {
-                    desk: desk === 'personal-workspace' ? null : desk,
+                    desk: desk === PERSONAL_WORKSPACE._id ? null : desk,
                     items: itemIds,
                     template: template,
                     type: type,
@@ -263,8 +237,7 @@ const exportAsArticle = (items = [], download) => (
                             button: {
                                 label: gettext('Open'),
                                 onClick: () => {
-                                    $location.url('/workspace/monitoring');
-                                    superdesk.intent('edit', 'item', item);
+                                    superdeskApi.ui.article.edit(item._id);
                                 },
                             },
                         });
@@ -285,30 +258,16 @@ const exportAsArticle = (items = [], download) => (
                     });
             }
         };
-        const personalWorkspace = {_id: 'personal-workspace', name: 'Personal Workspace'};
-        const articleTemplates = getState().templates;
-        const defaultDesk = getItemInArrayById(selectors.general.userDesks(getState()), desks.getCurrentDeskId())
-            || personalWorkspace;
+        const defaultDeskId = desks.getCurrentDeskId() ?? PERSONAL_WORKSPACE._id;
 
         return dispatch(showModal({
             modalType: MODALS.EXPORT_AS_ARTICLE,
             modalProps: {
-                items: sortableItems,
+                items: selectedItems,
                 action: exportArticlesDispatch,
-                desks: [...selectors.general.userDesks(getState()), personalWorkspace],
-
-                // If download is `true`, template is meant only for download, otherwise
-                // it can be used for both
-                templates: templates.filter((t) => download ? t.download : !t.download),
-                defaultTemplate: templates.find((t) =>
-                    (isPlanning && t.name === 'default_planning') || (!isPlanning && t.name === 'default_event')),
-                defaultDesk: defaultDesk,
-                type: itemType,
+                defaultDeskId: defaultDeskId,
+                type: selectedItems[0].type,
                 download: download,
-                articleTemplates: articleTemplates,
-                defaultArticleTemplate: articleTemplates.find((t) =>
-                    t._id === get(defaultDesk, 'default_content_template')) || articleTemplates[0],
-                agendas: selectors.general.agendas(state),
             },
         }));
     }

--- a/client/components/Events/EventMetadata/RelatedEventListItem.tsx
+++ b/client/components/Events/EventMetadata/RelatedEventListItem.tsx
@@ -26,6 +26,7 @@ interface IBaseProps {
     shadow?: number;
     dateOnly?: boolean;
     eventActions?: React.ReactNode;
+    noColumnPadding?: boolean;
     onClick?(): void;
 
     // Redux Store
@@ -110,7 +111,7 @@ class RelatedEventListItemComponent extends React.PureComponent<IProps> {
                 <List.Column
                     grow={true}
                     border={false}
-                    style={{paddingBlock: 'var(--space--1)'}}
+                    style={this.props.noColumnPadding ? undefined : {paddingBlock: 'var(--space--1)'}}
                 >
                     <LineItems
                         firstLine={eventFirstLineConfig.filter(({fieldId}) => fieldId !== 'related_plannings')}

--- a/client/components/Events/EventMetadata/RelatedEventListItem.tsx
+++ b/client/components/Events/EventMetadata/RelatedEventListItem.tsx
@@ -3,6 +3,7 @@ import {connect} from 'react-redux';
 
 import {IEventItem, ILockedItems} from '../../../interfaces';
 import {ICON_COLORS} from '../../../constants';
+import {superdeskApi} from '../../../superdeskApi';
 
 import {lockUtils} from '../../../utils';
 import * as selectors from '../../../selectors';
@@ -14,8 +15,9 @@ import {eventFirstLineConfig, eventSecondLineConfig} from '../../../config';
 import {renderFields} from '../../../components/fields';
 import {getUserInterfaceLanguageFromCV} from '../../../utils/users';
 import {ILineConfig} from 'globals';
+import {Checkbox} from 'superdesk-ui-framework/react';
 
-interface IProps {
+interface IBaseProps {
     item: DeepPartial<IEventItem>;
     active?: boolean;
     noBg?: boolean;
@@ -30,12 +32,27 @@ interface IProps {
     lockedItems: ILockedItems;
 }
 
+interface IWithoutCheckboxProps extends IBaseProps {
+    showCheckbox?: never;
+    checked?: never;
+    onCheckToggle?: never;
+}
+
+interface IWithCheckboxProps extends IBaseProps {
+    showCheckbox: true;
+    checked: boolean;
+    onCheckToggle(value: boolean): void;
+}
+
+type IProps = IWithoutCheckboxProps | IWithCheckboxProps;
+
 const mapStateToProps = (state) => ({
     lockedItems: selectors.locks.getLockedItems(state),
 });
 
 class RelatedEventListItemComponent extends React.PureComponent<IProps> {
     render() {
+        const {gettext} = superdeskApi.localization;
         const {item} = this.props;
         const isItemLocked = lockUtils.isItemLocked(
             item,
@@ -67,6 +84,19 @@ class RelatedEventListItemComponent extends React.PureComponent<IProps> {
                 )}
 
                 <div className="sd-list-item__border" />
+
+                {!this.props.showCheckbox ? null : (
+                    <List.Column>
+                        <Checkbox
+                            label={{
+                                text: gettext('Selected'),
+                                hidden: true,
+                            }}
+                            checked={this.props.checked}
+                            onChange={this.props.onCheckToggle}
+                        />
+                    </List.Column>
+                )}
 
                 {!this.props.showIcon ? null : (
                     <List.Column>

--- a/client/components/ExportAsArticleModal.tsx
+++ b/client/components/ExportAsArticleModal.tsx
@@ -1,41 +1,102 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import {get} from 'lodash';
+import {connect} from 'react-redux';
 
-import {gettext, getItemType} from '../utils';
-import {ITEM_TYPE} from '../constants';
+import {IDesk, ITemplate} from 'superdesk-api';
+import {superdeskApi} from '../superdeskApi';
+import {IEventOrPlanningItem, ILockedItems, IPlanningExportTemplate} from '../interfaces';
 
-import {Button} from './UI';
-import {SelectInput, Row} from './UI/Form';
+import {KEYCODES, PERSONAL_WORKSPACE} from '../constants';
+import {lockUtils} from '../utils';
+import * as selectors from '../selectors';
+
 import {Modal} from './index';
 import SortItems from './SortItems/index';
-import {KEYCODES} from '../constants';
 import {RelatedEventListItem} from './Events/EventMetadata/RelatedEventListItem';
 import {RelatedPlanningListItem} from './RelatedPlannings/PlanningMetaData/RelatedPlanningListItem';
+import {
+    Alert,
+    Button,
+    ButtonGroup,
+    FormLayout,
+    FormGroupV2,
+    FormGroupItem,
+    Select,
+    Option,
+    Spacer,
+} from 'superdesk-ui-framework/react';
 
-export class ExportAsArticleModal extends React.Component {
-    constructor(props) {
+interface IOwnProps {
+    handleHide(): void;
+    modalProps: {
+        items: Array<IEventOrPlanningItem>;
+        download: boolean;
+        type: IEventOrPlanningItem['type'];
+        defaultDeskId: IDesk['_id'];
+        action(
+            items: Array<IEventOrPlanningItem>,
+            desk: IDesk['_id'],
+            planningTemplate: IPlanningExportTemplate['name'],
+            type: IEventOrPlanningItem['type'],
+            download: boolean,
+            articleTemplate: ITemplate['_id'],
+        ): void;
+    };
+}
+
+interface IReduxStateProps {
+    articleTemplates: Array<ITemplate>;
+    userDesks: Array<IDesk>;
+    lockedItems: ILockedItems;
+    planningTemplates: Array<IPlanningExportTemplate>;
+}
+
+type IProps = IOwnProps & IReduxStateProps;
+
+interface IState {
+    planningTemplateName?: IPlanningExportTemplate['name'];
+    deskId?: IDesk['_id'];
+    items: Array<IEventOrPlanningItem>;
+    selectedItems: Array<IEventOrPlanningItem['_id']>;
+    articleTemplateId?: ITemplate['_id'];
+    articleTemplates: Array<ITemplate>;
+}
+
+const mapStateToProps = (state: any, ownProps: IOwnProps) => ({
+    articleTemplates: selectors.general.templates(state),
+    userDesks: selectors.general.userDesks(state),
+    lockedItems: selectors.locks.getLockedItems(state),
+    planningTemplates: (ownProps.modalProps.type === 'planning' ?
+        selectors.general.getPlanningExportTemplates(state) :
+        selectors.general.getEventExportTemplates(state)
+    ).filter((planningTemplate) => (
+        ownProps.modalProps.download ? planningTemplate.download === true : planningTemplate.download !== true
+    )),
+});
+
+class ExportAsArticleModalComponent extends React.Component<IProps, IState> {
+    constructor(props: IProps) {
         super(props);
 
-        this.state = {
-            template: this.props.modalProps.defaultTemplate,
-            desk: this.props.modalProps.defaultDesk,
-            items: this.props.modalProps.items,
-            articleTemplate: this.props.modalProps.defaultArticleTemplate,
-            articleTemplates: this.props.modalProps.articleTemplates,
-        };
+        const {defaultDeskId, type} = this.props.modalProps;
+        const [articleTemplateId, articleTemplates] = this.getFilteredArticleTemplates(defaultDeskId);
+        const defaultTemplateName = this.props.planningTemplates.find((planningTemplate) => (
+            (type === 'planning' && planningTemplate.name === 'default_planning')
+            || (type !== 'planning' && planningTemplate.name === 'default_event')
+        ))?.name;
 
-        this.onChange = this.onChange.bind(this);
-        this.onSortChange = this.onSortChange.bind(this);
-        this.onSubmit = this.onSubmit.bind(this);
-        this.filterArticleTemplates = this.filterArticleTemplates.bind(this);
-        this.getListElement = this.getListElement.bind(this);
-        this.handleKeydown = this.handleKeydown.bind(this);
-        this.onCloseItem = this.onCloseItem.bind(this);
+        this.state = {
+            planningTemplateName: defaultTemplateName,
+            deskId: this.props.modalProps.defaultDeskId,
+            items: this.props.modalProps.items,
+            selectedItems: this.props.modalProps.items
+                .filter((item) => !lockUtils.isItemLocked(item, this.props.lockedItems))
+                .map((item) => item._id),
+            articleTemplateId: articleTemplateId,
+            articleTemplates: articleTemplates,
+        };
     }
 
     componentDidMount() {
-        this.filterArticleTemplates(this.state.desk);
         document.addEventListener('keydown', this.handleKeydown);
     }
 
@@ -43,71 +104,144 @@ export class ExportAsArticleModal extends React.Component {
         document.removeEventListener('keydown', this.handleKeydown);
     }
 
-    handleKeydown(event) {
+    handleKeydown = (event) => {
         if (event.keyCode === KEYCODES.ESCAPE) {
             event.preventDefault();
             this.props.handleHide();
         }
     }
 
-    onChange(field, value) {
-        if (field === 'desk') { // on desk change filter article-templates based on desk selected
-            this.filterArticleTemplates(value);
-        }
-        this.setState({[field]: value});
+    onChangeDesk = (deskId: IDesk['_id']) => {
+        // on desk change filter article-templates based on desk selected
+        const [articleTemplateId, articleTemplates] = this.getFilteredArticleTemplates(deskId);
+
+        this.setState({
+            deskId: deskId,
+            articleTemplateId: articleTemplateId,
+            articleTemplates: articleTemplates,
+        });
     }
 
-    onSubmit() {
-        const {
-            desk,
-            template,
-            items,
-            articleTemplate,
-        } = this.state;
+    onChangeTemplate = (templateId: ITemplate['_id']) => {
+        this.setState({articleTemplateId: templateId});
+    }
 
-        this.props.modalProps.action(items, get(desk, '_id'), get(template, 'name'),
-            get(this.props, 'modalProps.type'), get(this.props, 'modalProps.download'), get(articleTemplate, '_id'));
+    onChangePlanningTemplate = (planningTemplateName: IPlanningExportTemplate['name']) => {
+        this.setState({planningTemplateName: planningTemplateName});
+    }
+
+    onSubmit = () => {
+        const {deskId, planningTemplateName, items, articleTemplateId} = this.state;
+        const {type, download} = this.props.modalProps;
+
+        const selectedItems = items.filter(
+            (item) => this.state.selectedItems.includes(item._id)
+        );
+
+        this.props.modalProps.action(selectedItems, deskId, planningTemplateName, type, download, articleTemplateId);
         this.props.handleHide();
     }
 
-    onSortChange(items) {
+    onSortChange = (items: Array<IEventOrPlanningItem>) => {
         this.setState({items: items});
     }
 
-    onCloseItem(itemId) {
-        this.setState({items: this.state.items.filter((i) => i._id !== itemId)});
+    getFilteredArticleTemplates(deskId: IDesk['_id']): [ITemplate['_id'], Array<ITemplate>] {
+        if (deskId === PERSONAL_WORKSPACE._id) {
+            return [null, []];
+        }
+
+        const desk = this.props.userDesks.find((desk) => desk._id === deskId);
+
+        if (desk == null) {
+            console.warn('Desk not found, cannot filter article templates');
+            return [null, []];
+        }
+
+        const articleTemplates = this.props.articleTemplates.filter(
+            (articleTemplate) => (articleTemplate.template_desks?.includes(deskId))
+        );
+
+        return [
+            (articleTemplates.find(
+                (articleTemplate) => (articleTemplate._id === desk.default_content_template)
+            ) || articleTemplates[0])?._id,
+            articleTemplates,
+        ];
     }
 
-    filterArticleTemplates(desk) {
-        const newObj = {};
-
-        newObj.articleTemplates = this.props.modalProps.articleTemplates.filter((t) =>
-            Object.keys(t).length > 0 && t.template_desks && t.template_desks.includes(desk._id));
-        newObj.articleTemplate = newObj.articleTemplates.find((t) =>
-            Object.keys(t).length > 0 && t._id === get(desk, 'default_content_template'))
-            || newObj.articleTemplates[0];
-
-        this.setState((prevState) => ({...prevState, ...newObj}));
+    toggleItemSelection = (item: IEventOrPlanningItem) => {
+        this.setState((prevState) => {
+            if (prevState.selectedItems.includes(item._id)) {
+                return {
+                    selectedItems: prevState.selectedItems.filter((itemId) => itemId !== item._id),
+                    // Re-assign items to a new value so `SortItems` re-renders
+                    items: [...prevState.items],
+                };
+            } else {
+                return {
+                    selectedItems: [...prevState.selectedItems, item._id],
+                    // Re-assign items to a new value so `SortItems` re-renders
+                    items: [...prevState.items],
+                };
+            }
+        });
     }
 
-    getListElement(item) {
-        const itemType = getItemType(item);
+    includeAllLockedItems = () => {
+        this.setState((prevState) => {
+            const unselectedLockedItemIds = this.getLockedItemIds().filter(
+                (itemId) => !prevState.selectedItems.includes(itemId)
+            );
 
-        if (itemType === ITEM_TYPE.EVENT) {
+            return {
+                selectedItems: [...prevState.selectedItems, ...unselectedLockedItemIds],
+                // Re-assign items to a new value so `SortItems` re-renders
+                items: [...prevState.items],
+            };
+        });
+    }
+
+    excludeAllLockedItems = () => {
+        this.setState((prevState) => {
+            const lockedItemIds = this.getLockedItemIds();
+
+            return {
+                selectedItems: prevState.selectedItems.filter((itemId) => !lockedItemIds.includes(itemId)),
+                // Re-assign items to a new value so `SortItems` re-renders
+                items: [...prevState.items],
+            };
+        });
+    }
+
+    getListElement = (item: IEventOrPlanningItem) => {
+        const selected = this.state.selectedItems.includes(item._id);
+
+        if (item.type === 'event') {
             return (
                 <RelatedEventListItem
                     item={item}
                     showIcon={true}
                     shadow={1}
+                    showBorder={true}
+                    active={selected}
+                    showCheckbox={true}
+                    checked={selected}
+                    onCheckToggle={this.toggleItemSelection.bind(this, item)}
                 />
             );
-        } else if (itemType === ITEM_TYPE.PLANNING) {
+        } else if (item.type === 'planning') {
             return (
                 <RelatedPlanningListItem
                     item={item}
                     showIcon={true}
                     shadow={1}
+                    showBorder={true}
                     isAgendaEnabled={false}
+                    active={selected}
+                    showCheckbox={true}
+                    checked={selected}
+                    onCheckToggle={this.toggleItemSelection.bind(this, item)}
                 />
             );
         } else {
@@ -115,86 +249,132 @@ export class ExportAsArticleModal extends React.Component {
         }
     }
 
-    render() {
-        const {
-            desks,
-            templates,
-            download,
-        } = this.props.modalProps;
+    getLockedItemIds(): Array<IEventOrPlanningItem['_id']> {
+        return this.state.items
+            .filter((item) => lockUtils.isItemLocked(item, this.props.lockedItems))
+            .map((item) => item._id);
+    }
 
-        const {
-            desk,
-            template,
-            articleTemplate,
-            articleTemplates,
-        } = this.state;
+    render() {
+        const {gettext, gettextPlural} = superdeskApi.localization;
+        const lockedItemIds = this.getLockedItemIds();
+        const unselectedLockedItemIds = lockedItemIds.filter((itemId) => !this.state.selectedItems.includes(itemId));
 
         return (
-            <Modal show={true}>
+            <Modal show={true} large={true}>
                 <Modal.Header>
                     <h3 className="modal__heading">{gettext('Export as article')}</h3>
                 </Modal.Header>
                 <Modal.Body>
-                    <Row>
-                        <SortItems
-                            items={this.state.items}
-                            onSortChange={this.onSortChange}
-                            getListElement={this.getListElement}
-                        />
-                    </Row>
-                    {!download && [<Row key={0}>
-                        <SelectInput
-                            field="desk"
-                            label={gettext('Desk')}
-                            value={desk}
-                            onChange={this.onChange}
-                            options={desks}
-                            labelField="name"
-                            keyField="_id"
-                        />
-                    </Row>,
-                    <Row key={1}>
-                        <SelectInput
-                            field="articleTemplate"
-                            label={gettext('Select Article Template')}
-                            value={articleTemplate}
-                            onChange={this.onChange}
-                            options={articleTemplates}
-                            labelField="template_name"
-                            keyField="_id"
-                            clearable
-                        />
-                    </Row>]}
-                    <Row>
-                        <SelectInput
-                            field="template"
-                            label={gettext('Custom Layout')}
-                            value={template}
-                            onChange={this.onChange}
-                            options={templates}
-                            labelField="label"
-                            keyField="name"
-                            clearable
-                        />
-                    </Row>
+                    <FormLayout marginBottom="spaces">
+                        {this.props.modalProps.download === true ? null : (
+                            <React.Fragment>
+                                <FormGroupV2>
+                                    <FormGroupItem>
+                                        <Select
+                                            label={gettext('Desk')}
+                                            value={this.state.deskId}
+                                            onChange={this.onChangeDesk}
+                                            required={true}
+                                        >
+                                            <Option value={PERSONAL_WORKSPACE._id}>
+                                                {PERSONAL_WORKSPACE.name}
+                                            </Option>
+                                            {this.props.userDesks.map((desk) => (
+                                                <Option key={desk._id} value={desk._id}>{desk.name}</Option>
+                                            ))}
+                                        </Select>
+                                    </FormGroupItem>
+                                </FormGroupV2>
+                                <FormGroupV2>
+                                    <FormGroupItem>
+                                        <Select
+                                            label={gettext('Article Template')}
+                                            value={this.state.articleTemplateId}
+                                            onChange={this.onChangeTemplate}
+                                        >
+                                            <Option />
+                                            {this.state.articleTemplates.map((articleTemplate) => (
+                                                <Option key={articleTemplate._id} value={articleTemplate._id}>
+                                                    {articleTemplate.template_name}
+                                                </Option>
+                                            ))}
+                                        </Select>
+                                    </FormGroupItem>
+                                </FormGroupV2>
+                            </React.Fragment>
+                        )}
+
+                        <FormGroupV2>
+                            <FormGroupItem>
+                                <Select
+                                    label={gettext('Custom Layout')}
+                                    value={this.state.planningTemplateName}
+                                    onChange={this.onChangePlanningTemplate}
+                                >
+                                    <Option />
+                                    {this.props.planningTemplates.map((planningTemplate) => (
+                                        <Option key={planningTemplate.name} value={planningTemplate.name}>
+                                            {planningTemplate.label}
+                                        </Option>
+                                    ))}
+                                </Select>
+                            </FormGroupItem>
+                        </FormGroupV2>
+                    </FormLayout>
+                    {lockedItemIds.length === 0 ? null : (
+                        <React.Fragment>
+                            <Alert
+                                style="hollow"
+                                size="normal"
+                                icon="warning-sign"
+                                type="warning"
+                                restoreIcon="info"
+                            >
+                                <Spacer v={true} gap="4">
+                                    {gettextPlural(
+                                        lockedItemIds.length,
+                                        'One of the items that was selected is locked. ' +
+                                        'By default locked items are not included in the export.',
+                                        '{{ count }} items that were selected are locked. ' +
+                                        'By default locked items are not included in the export.',
+                                        {count: lockedItemIds.length}
+                                    )}
+                                    <ButtonGroup align="end">
+                                        <Button
+                                            type="tertiary"
+                                            onClick={unselectedLockedItemIds.length > 0 ?
+                                                this.includeAllLockedItems :
+                                                this.excludeAllLockedItems
+                                            }
+                                            text={unselectedLockedItemIds.length > 0 ?
+                                                gettext('Include all locked items') :
+                                                gettext('Exclude all locked items')
+                                            }
+                                        />
+                                    </ButtonGroup>
+                                </Spacer>
+                            </Alert>
+                        </React.Fragment>
+                    )}
+                    <SortItems
+                        items={this.state.items}
+                        onSortChange={this.onSortChange}
+                        getListElement={this.getListElement}
+                    />
                 </Modal.Body>
                 <Modal.Footer>
                     <div className="button-group button-group--end button-group--comfort">
-                        <Button type="button" onClick={this.props.handleHide}>
-                            {gettext('Cancel')}
-                        </Button>
-                        {!download && (
+                        <Button type="default" onClick={this.props.handleHide} text={gettext('Cancel')} />
+                        {this.props.modalProps.download !== true ? (
                             <Button
-                                type="submit"
-                                className="btn--primary"
-                                disabled={!desk}
+                                type="primary"
+                                disabled={this.state.deskId == null}
                                 onClick={this.onSubmit}
-                            >{gettext('Export')}</Button>
-                        )}
-                        {download && (
-                            <Button type="submit" className="btn--primary"onClick={this.onSubmit}>
-                                {gettext('Download')}
-                            </Button>
+                                text={gettext('Export')}
+                            />
+                        ) : (
+                            <Button type="primary" onClick={this.onSubmit} text={gettext('Download')} />
                         )}
                     </div>
                 </Modal.Footer>
@@ -203,19 +383,6 @@ export class ExportAsArticleModal extends React.Component {
     }
 }
 
-ExportAsArticleModal.propTypes = {
-    handleHide: PropTypes.func,
-    modalProps: PropTypes.shape({
-        items: PropTypes.array,
-        desks: PropTypes.array,
-        templates: PropTypes.array,
-        defaultDesk: PropTypes.object,
-        defaultTemplate: PropTypes.object,
-        onSortChange: PropTypes.func,
-        action: PropTypes.func,
-        download: PropTypes.bool,
-        articleTemplates: PropTypes.array,
-        defaultArticleTemplate: PropTypes.object,
-        agendas: PropTypes.array,
-    }),
-};
+export const ExportAsArticleModal = connect<IReduxStateProps, {}, IOwnProps>(
+    mapStateToProps
+)(ExportAsArticleModalComponent);

--- a/client/components/ExportAsArticleModal.tsx
+++ b/client/components/ExportAsArticleModal.tsx
@@ -5,11 +5,10 @@ import {IDesk, ITemplate} from 'superdesk-api';
 import {superdeskApi} from '../superdeskApi';
 import {IEventOrPlanningItem, ILockedItems, IPlanningExportTemplate} from '../interfaces';
 
-import {KEYCODES, PERSONAL_WORKSPACE} from '../constants';
+import {PERSONAL_WORKSPACE} from '../constants';
 import {lockUtils} from '../utils';
 import * as selectors from '../selectors';
 
-import {Modal} from './index';
 import SortItems from './SortItems/index';
 import {RelatedEventListItem} from './Events/EventMetadata/RelatedEventListItem';
 import {RelatedPlanningListItem} from './RelatedPlannings/PlanningMetaData/RelatedPlanningListItem';
@@ -23,6 +22,7 @@ import {
     Select,
     Option,
     Spacer,
+    Modal,
 } from 'superdesk-ui-framework/react';
 
 interface IOwnProps {
@@ -94,21 +94,6 @@ class ExportAsArticleModalComponent extends React.Component<IProps, IState> {
             articleTemplateId: articleTemplateId,
             articleTemplates: articleTemplates,
         };
-    }
-
-    componentDidMount() {
-        document.addEventListener('keydown', this.handleKeydown);
-    }
-
-    componentWillUnmount() {
-        document.removeEventListener('keydown', this.handleKeydown);
-    }
-
-    handleKeydown = (event) => {
-        if (event.keyCode === KEYCODES.ESCAPE) {
-            event.preventDefault();
-            this.props.handleHide();
-        }
     }
 
     onChangeDesk = (deskId: IDesk['_id']) => {
@@ -228,6 +213,7 @@ class ExportAsArticleModalComponent extends React.Component<IProps, IState> {
                     showCheckbox={true}
                     checked={selected}
                     onCheckToggle={this.toggleItemSelection.bind(this, item)}
+                    noColumnPadding={true}
                 />
             );
         } else if (item.type === 'planning') {
@@ -242,6 +228,7 @@ class ExportAsArticleModalComponent extends React.Component<IProps, IState> {
                     showCheckbox={true}
                     checked={selected}
                     onCheckToggle={this.toggleItemSelection.bind(this, item)}
+                    noColumnPadding={true}
                 />
             );
         } else {
@@ -261,110 +248,15 @@ class ExportAsArticleModalComponent extends React.Component<IProps, IState> {
         const unselectedLockedItemIds = lockedItemIds.filter((itemId) => !this.state.selectedItems.includes(itemId));
 
         return (
-            <Modal show={true} large={true}>
-                <Modal.Header>
-                    <h3 className="modal__heading">{gettext('Export as article')}</h3>
-                </Modal.Header>
-                <Modal.Body>
-                    <FormLayout marginBottom="spaces">
-                        {this.props.modalProps.download === true ? null : (
-                            <React.Fragment>
-                                <FormGroupV2>
-                                    <FormGroupItem>
-                                        <Select
-                                            label={gettext('Desk')}
-                                            value={this.state.deskId}
-                                            onChange={this.onChangeDesk}
-                                            required={true}
-                                        >
-                                            <Option value={PERSONAL_WORKSPACE._id}>
-                                                {PERSONAL_WORKSPACE.name}
-                                            </Option>
-                                            {this.props.userDesks.map((desk) => (
-                                                <Option key={desk._id} value={desk._id}>{desk.name}</Option>
-                                            ))}
-                                        </Select>
-                                    </FormGroupItem>
-                                </FormGroupV2>
-                                <FormGroupV2>
-                                    <FormGroupItem>
-                                        <Select
-                                            label={gettext('Article Template')}
-                                            value={this.state.articleTemplateId}
-                                            onChange={this.onChangeTemplate}
-                                        >
-                                            <Option />
-                                            {this.state.articleTemplates.map((articleTemplate) => (
-                                                <Option key={articleTemplate._id} value={articleTemplate._id}>
-                                                    {articleTemplate.template_name}
-                                                </Option>
-                                            ))}
-                                        </Select>
-                                    </FormGroupItem>
-                                </FormGroupV2>
-                            </React.Fragment>
-                        )}
-
-                        <FormGroupV2>
-                            <FormGroupItem>
-                                <Select
-                                    label={gettext('Custom Layout')}
-                                    value={this.state.planningTemplateName}
-                                    onChange={this.onChangePlanningTemplate}
-                                >
-                                    <Option />
-                                    {this.props.planningTemplates.map((planningTemplate) => (
-                                        <Option key={planningTemplate.name} value={planningTemplate.name}>
-                                            {planningTemplate.label}
-                                        </Option>
-                                    ))}
-                                </Select>
-                            </FormGroupItem>
-                        </FormGroupV2>
-                    </FormLayout>
-                    {lockedItemIds.length === 0 ? null : (
-                        <React.Fragment>
-                            <Alert
-                                style="hollow"
-                                size="normal"
-                                icon="warning-sign"
-                                type="warning"
-                                restoreIcon="info"
-                            >
-                                <Spacer v={true} gap="4">
-                                    {gettextPlural(
-                                        lockedItemIds.length,
-                                        'One of the items that was selected is locked. ' +
-                                        'By default locked items are not included in the export.',
-                                        '{{ count }} items that were selected are locked. ' +
-                                        'By default locked items are not included in the export.',
-                                        {count: lockedItemIds.length}
-                                    )}
-                                    <ButtonGroup align="end">
-                                        <Button
-                                            type="tertiary"
-                                            onClick={unselectedLockedItemIds.length > 0 ?
-                                                this.includeAllLockedItems :
-                                                this.excludeAllLockedItems
-                                            }
-                                            text={unselectedLockedItemIds.length > 0 ?
-                                                gettext('Include all locked items') :
-                                                gettext('Exclude all locked items')
-                                            }
-                                        />
-                                    </ButtonGroup>
-                                </Spacer>
-                            </Alert>
-                        </React.Fragment>
-                    )}
-                    <SortItems
-                        items={this.state.items}
-                        onSortChange={this.onSortChange}
-                        getListElement={this.getListElement}
-                    />
-                </Modal.Body>
-                <Modal.Footer>
-                    <div className="button-group button-group--end button-group--comfort">
+            <Modal
+                visible={true}
+                size="large"
+                position="top"
+                headerTemplate={gettext('Export as article')}
+                onHide={this.props.handleHide}
+                closeOnEscape={true}
+                footerTemplate={(
+                    <ButtonGroup align="end">
                         <Button type="default" onClick={this.props.handleHide} text={gettext('Cancel')} />
                         {this.props.modalProps.download !== true ? (
                             <Button
@@ -376,8 +268,107 @@ class ExportAsArticleModalComponent extends React.Component<IProps, IState> {
                         ) : (
                             <Button type="primary" onClick={this.onSubmit} text={gettext('Download')} />
                         )}
-                    </div>
-                </Modal.Footer>
+                    </ButtonGroup>
+                )}
+            >
+                <FormLayout spaces="compact" className="mb-4">
+                    {this.props.modalProps.download === true ? null : (
+                        <React.Fragment>
+                            <FormGroupV2>
+                                <FormGroupItem>
+                                    <Select
+                                        label={gettext('Desk')}
+                                        value={this.state.deskId}
+                                        onChange={this.onChangeDesk}
+                                        required={true}
+                                    >
+                                        <Option value={PERSONAL_WORKSPACE._id}>
+                                            {PERSONAL_WORKSPACE.name}
+                                        </Option>
+                                        {this.props.userDesks.map((desk) => (
+                                            <Option key={desk._id} value={desk._id}>{desk.name}</Option>
+                                        ))}
+                                    </Select>
+                                </FormGroupItem>
+                            </FormGroupV2>
+                            <FormGroupV2>
+                                <FormGroupItem>
+                                    <Select
+                                        label={gettext('Article Template')}
+                                        value={this.state.articleTemplateId}
+                                        onChange={this.onChangeTemplate}
+                                    >
+                                        <Option />
+                                        {this.state.articleTemplates.map((articleTemplate) => (
+                                            <Option key={articleTemplate._id} value={articleTemplate._id}>
+                                                {articleTemplate.template_name}
+                                            </Option>
+                                        ))}
+                                    </Select>
+                                </FormGroupItem>
+                            </FormGroupV2>
+                        </React.Fragment>
+                    )}
+
+                    <FormGroupV2>
+                        <FormGroupItem>
+                            <Select
+                                label={gettext('Custom Layout')}
+                                value={this.state.planningTemplateName}
+                                onChange={this.onChangePlanningTemplate}
+                            >
+                                <Option />
+                                {this.props.planningTemplates.map((planningTemplate) => (
+                                    <Option key={planningTemplate.name} value={planningTemplate.name}>
+                                        {planningTemplate.label}
+                                    </Option>
+                                ))}
+                            </Select>
+                        </FormGroupItem>
+                    </FormGroupV2>
+                </FormLayout>
+                {lockedItemIds.length === 0 ? null : (
+                    <React.Fragment>
+                        <Alert
+                            style="hollow"
+                            size="normal"
+                            margin="small"
+                            icon="warning-sign"
+                            type="warning"
+                            restoreIcon="info"
+                        >
+                            <Spacer v={true} gap="4">
+                                {gettextPlural(
+                                    lockedItemIds.length,
+                                    'One of the items that was selected is locked. ' +
+                                    'By default locked items are not included in the export.',
+                                    '{{ count }} items that were selected are locked. ' +
+                                    'By default locked items are not included in the export.',
+                                    {count: lockedItemIds.length}
+                                )}
+                                <ButtonGroup align="end">
+                                    <Button
+                                        type="tertiary"
+                                        size="small"
+                                        onClick={unselectedLockedItemIds.length > 0 ?
+                                            this.includeAllLockedItems :
+                                            this.excludeAllLockedItems
+                                        }
+                                        text={unselectedLockedItemIds.length > 0 ?
+                                            gettext('Include all locked items') :
+                                            gettext('Exclude all locked items')
+                                        }
+                                    />
+                                </ButtonGroup>
+                            </Spacer>
+                        </Alert>
+                    </React.Fragment>
+                )}
+                <SortItems
+                    items={this.state.items}
+                    onSortChange={this.onSortChange}
+                    getListElement={this.getListElement}
+                />
             </Modal>
         );
     }

--- a/client/components/RelatedPlannings/PlanningMetaData/RelatedPlanningListItem.tsx
+++ b/client/components/RelatedPlannings/PlanningMetaData/RelatedPlanningListItem.tsx
@@ -27,6 +27,7 @@ interface IBaseProps {
     shadow?: number;
     editPlanningComponent?: React.ReactNode;
     isAgendaEnabled: boolean;
+    noColumnPadding?: boolean;
     onClick?(): void;
 }
 
@@ -118,7 +119,7 @@ class RelatedPlanningListItemComponent extends React.PureComponent<IProps> {
                 <List.Column
                     grow={true}
                     border={false}
-                    style={{paddingBlock: 'var(--space--1)'}}
+                    style={this.props.noColumnPadding ? undefined : {paddingBlock: 'var(--space--1)'}}
                 >
                     <LineItems
                         firstLine={planningFirstLineConfig.filter(({fieldId}) => fieldId !== 'related_events')}

--- a/client/components/RelatedPlannings/PlanningMetaData/RelatedPlanningListItem.tsx
+++ b/client/components/RelatedPlannings/PlanningMetaData/RelatedPlanningListItem.tsx
@@ -3,6 +3,7 @@ import {connect} from 'react-redux';
 
 import {IPlanningItem, IG2ContentType, ILockedItems, IAgenda} from '../../../interfaces';
 import {IDesk, IUser} from 'superdesk-api';
+import {superdeskApi} from '../../../superdeskApi';
 
 import {lockUtils} from '../../../utils';
 import * as selectors from '../../../selectors';
@@ -15,8 +16,9 @@ import {getPlanningSecondLineConfig, planningFirstLineConfig} from '../../../con
 import {getUserInterfaceLanguageFromCV} from '../../../utils/users';
 import {renderFields} from '../../../components/fields';
 import {ILineConfig} from 'globals';
+import {Checkbox} from 'superdesk-ui-framework/react';
 
-interface IOwnProps {
+interface IBaseProps {
     item: DeepPartial<IPlanningItem>;
     active?: boolean;
     noBg?: boolean;
@@ -27,6 +29,20 @@ interface IOwnProps {
     isAgendaEnabled: boolean;
     onClick?(): void;
 }
+
+interface IWithoutCheckboxProps extends IBaseProps {
+    showCheckbox?: never;
+    checked?: never;
+    onCheckToggle?: never;
+}
+
+interface IWithCheckboxProps extends IBaseProps {
+    showCheckbox: true;
+    checked: boolean;
+    onCheckToggle(value: boolean): void;
+}
+
+type IOwnProps = IWithoutCheckboxProps | IWithCheckboxProps;
 
 interface IStateProps {
     users: Array<IUser>;
@@ -48,6 +64,7 @@ const mapStateToProps = (state) => ({
 
 class RelatedPlanningListItemComponent extends React.PureComponent<IProps> {
     render() {
+        const {gettext} = superdeskApi.localization;
         const isItemLocked = lockUtils.isItemLocked(
             this.props.item,
             this.props.lockedItems
@@ -74,6 +91,19 @@ class RelatedPlanningListItemComponent extends React.PureComponent<IProps> {
             >
                 {!(this.props.showBorder && isItemLocked) ? null : (
                     <List.Border state="locked" />
+                )}
+
+                {!this.props.showCheckbox ? null : (
+                    <List.Column>
+                        <Checkbox
+                            label={{
+                                text: gettext('Selected'),
+                                hidden: true,
+                            }}
+                            checked={this.props.checked}
+                            onChange={this.props.onCheckToggle}
+                        />
+                    </List.Column>
                 )}
 
                 {!this.props.showIcon ? null : (

--- a/client/components/SortItems/style.scss
+++ b/client/components/SortItems/style.scss
@@ -1,12 +1,17 @@
 .sortable-list__item {
     list-style-type: none;
     cursor: move;
-    z-index: 1100;
+    z-index: 2000;  // Make sure the items are visible in Modals too
     background-color: #fff;
 
     &--no-padding {
         padding: 0 0 0 10px !important;
     }
+}
+
+// Make sure text within the list items are not selectable
+.sortable-list__item * {
+    user-select: none;
 }
 
 .sortable-list__item button {

--- a/client/components/fields/editor/DeskId.tsx
+++ b/client/components/fields/editor/DeskId.tsx
@@ -4,6 +4,7 @@ import {connect} from 'react-redux';
 import {superdeskApi} from '../../../superdeskApi';
 import {IDesk} from 'superdesk-api';
 import {IEditorFieldProps} from '../../../interfaces';
+import {PERSONAL_WORKSPACE} from '../../../constants';
 
 import {desks as getDesks, userDesks as getUserDesks} from '../../../selectors/general';
 import {EditorFieldSelect} from './base/select';
@@ -28,10 +29,7 @@ export class EditorFieldDeskIdComponent extends React.PureComponent<IProps> {
             Array.from(this.props.userDesks);
 
         if (this.props.includePersonal) {
-            desks.push({
-                _id: 'personal-workspace',
-                name: gettext('Personal Workspace'),
-            });
+            desks.push(PERSONAL_WORKSPACE);
         }
 
         return (

--- a/client/constants/index.ts
+++ b/client/constants/index.ts
@@ -154,6 +154,7 @@ export const TIME_COMPARISON_GRANULARITY = {
 };
 
 export const ALL_DESKS = '_all';
+export const PERSONAL_WORKSPACE = {_id: 'personal-workspace', name: 'Personal Workspace'};
 
 export const SORT_DIRECTION = {
     ASCENDING: 'Asc',
@@ -166,6 +167,7 @@ export function assignConstantLabelTranslations() {
 
     DATE_FORMATS.DISPLAY_TBC_FORMAT = `D. MMMM YYYY @ ${TO_BE_CONFIRMED_SHORT_TEXT}`;
     DATE_FORMATS.DISPLAY_CDATE_TBC_FORMAT = `D. MMMM @ ${TO_BE_CONFIRMED_SHORT_TEXT}`;
+    PERSONAL_WORKSPACE.name = gettext('Personal Workspace');
 
     assignEventConstantTranslations();
     assignPlanningConstantTranslations();


### PR DESCRIPTION
### Purpose
When selecting items and opening the `ExportAsArticleModal`, any item that was locked was excluded from the selection and a toast notification to the user was provided. The user did now have a choice as to what to do with the locked items.

### What has changed
Refactor `ExportAsArticleModal` to:
* Use typesecript interfaces instead of proptypes
* Use UI-Framework elements instead of locally defined ones
* Connect the component to Redux, to reduce how many props are *required* to pass in
* Add checkbox to list items, allowing to not only re-order the items but include/exclude items manually
* Improve UX when it comes to locked items, an alert box is now used to indicate items are locked, and a button to include/exclude the locked items.

### Steps to test
1. Navigate to the Planning page
2. Select either `Events only` or `Planning only` filters
3. Select multiple items (making sure at least 1 of them is currently locked)
4. Click on the `Export` or `Download` bulk action

### Screenshots
<img width="931" height="710" alt="image" src="https://github.com/user-attachments/assets/bd3e9a83-2a12-4cfe-ba0b-e94cb0443dce" />



### Front-end checklist
- [x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [x] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [x] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [x] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [x] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [x] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [x] This pull request is not adding redux based modals
- [x] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [x] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)

Resolves: [STT-1550](https://sofab.atlassian.net/browse/STT-1550)



[STT-1550]: https://sofab.atlassian.net/browse/STT-1550?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ