### PR TITLE
add planning_source param to prod_api events

### DIFF
--- a/server/planning/prod_api/events/service.py
+++ b/server/planning/prod_api/events/service.py
@@ -8,7 +8,12 @@
 # AUTHORS and LICENSE files distributed with this source code, or
 # at https://www.sourcefabric.org/superdesk/license
 
+import json
+from typing import Dict, Iterable, List
+
 from eve.utils import config
+from superdesk.errors import SuperdeskApiError
+from werkzeug.datastructures import MultiDict
 
 from superdesk import get_resource_service
 from prod_api.service import ProdApiService
@@ -23,6 +28,73 @@ from planning.prod_api.planning.utils import construct_planning_link
 
 class EventsService(ProdApiService):
     excluded_fields = ProdApiService.excluded_fields | excluded_lock_fields
+
+    def get(self, req, lookup):
+        planning_query = self._extract_planning_source(req)
+
+        if planning_query is not None:
+            event_ids = self._get_event_ids_from_planning(planning_query)
+            req.args = req.args.copy() if hasattr(req.args, "copy") else MultiDict(req.args)
+
+            # Build an elasticsearch query that filters by event_ids
+            if event_ids:
+                # Create an elasticsearch source query for event filtering
+                event_query = {"query": {"terms": {"_id": event_ids}}}
+                # Merge with any existing source query in req
+                if "source" in req.args:
+                    existing_source = json.loads(req.args["source"])
+                    # Combine queries with AND (must clause)
+                    combined_query = {
+                        "query": {
+                            "bool": {"must": [existing_source.get("query", existing_source), event_query["query"]]}
+                        }
+                    }
+                    req.args["source"] = json.dumps(combined_query)
+                else:
+                    req.args["source"] = json.dumps(event_query)
+            else:
+                # No matching events, create a query that returns nothing
+                no_results_query = {"query": {"match_none": {}}}
+                req.args["source"] = json.dumps(no_results_query)
+
+        return super().get(req, lookup)
+
+    def _extract_planning_source(self, req) -> Dict | None:
+        if not getattr(req, "args", None):
+            return None
+
+        raw_planning_source = req.args.get("planning_source")
+        if not raw_planning_source:
+            return None
+
+        planning_query = self._parse_planning_source(raw_planning_source)
+        return planning_query
+
+    def _parse_planning_source(self, raw_planning_source) -> Dict:
+        try:
+            query = json.loads(raw_planning_source) if isinstance(raw_planning_source, str) else raw_planning_source
+        except (TypeError, ValueError):
+            raise SuperdeskApiError.badRequestError("Invalid planning_source parameter")
+
+        if not isinstance(query, dict):
+            raise SuperdeskApiError.badRequestError("planning_source must be an object")
+
+        return query
+
+    def _get_event_ids_from_planning(self, planning_query: Dict) -> List[str]:
+        # Query planning documents using the planning service
+        planning_service = get_resource_service("planning")
+
+        # Search for planning documents matching the query
+        results = planning_service.search(planning_query)
+
+        event_ids = {event_id for event_id in self._extract_event_items(results) if event_id}
+        return list(event_ids)
+
+    def _extract_event_items(self, results: Iterable[Dict]) -> Iterable[str]:
+        for item in results:
+            if item.get("event_item"):
+                yield item["event_item"]
 
     def _process_fetched_object(self, doc):
         super()._process_fetched_object(doc)

--- a/server/tests/prod_api/conftest.py
+++ b/server/tests/prod_api/conftest.py
@@ -1,1 +1,45 @@
-from prod_api.conftest import *  # noqa
+import os
+import pytest
+from pathlib import Path
+from flask import json
+from eve.methods.common import parse
+
+from prod_api.conftest import get_test_prodapi_app, teardown_app
+
+
+@pytest.fixture(scope="function")
+def prodapi_app_with_data(request):
+    """
+    Override the base fixture to use planning fixtures instead of the superdesk-core ones.
+    """
+    extra_config = getattr(request, "param", {})
+    extra_config["PRODAPI_AUTH_ENABLED"] = False
+    app = get_test_prodapi_app(extra_config)
+
+    # fill with data from our fixtures
+    with app.app_context():
+        p = Path(os.path.join(os.path.dirname(__file__), "tests/fixtures"))
+        for fixture_file in sorted(p.iterdir()):
+            if fixture_file.is_file():
+                with fixture_file.open() as f:
+                    resource = fixture_file.stem
+                    values = json.load(f)
+                    docs = [parse(value, resource) for value in values]
+                    app.data.insert(resource=resource, docs=docs)
+
+    def test_app_teardown():
+        teardown_app(app)
+
+    request.addfinalizer(test_app_teardown)
+
+    return app
+
+
+@pytest.fixture(scope="function")
+def prodapi_app_with_data_client(prodapi_app_with_data):
+    """Test client for prod api with filled data"""
+
+    client = prodapi_app_with_data.test_client()
+
+    with prodapi_app_with_data.app_context():
+        yield client

--- a/server/tests/prod_api/tests/fixtures/planning.json
+++ b/server/tests/prod_api/tests/fixtures/planning.json
@@ -2,6 +2,7 @@
     {
         "_id": "urn:newsml:localhost:5000:2019-09-10T15:47:04.367097:714ceeb4-c366-48af-b360-e7aefdf9941a",
         "type": "planning",
+        "event_item": "urn:newsml:localhost:5000:2019-09-10T15:43:13.722490:5dcea683-fb9b-42ca-a77f-ce1216aef8b1",
         "planning_date": "2019-09-10T13:46:38.000Z",
         "agendas": [],
         "state": "draft",
@@ -117,6 +118,7 @@
     {
         "_id": "urn:newsml:localhost:5000:2019-09-10T16:22:02.020996:dd01be40-e401-407f-a2f4-f6532c3f907c",
         "type": "planning",
+        "event_item": "urn:newsml:localhost:5000:2019-09-10T16:22:34.066960:6b2d9c79-08b9-456f-b890-9b2154ee997a",
         "planning_date": "2019-09-10T14:21:45.000Z",
         "agendas": [],
         "state": "draft",
@@ -183,6 +185,7 @@
     {
         "_id": "urn:newsml:localhost:5000:2019-10-21T11:48:10.807263:c61d74ec-fb22-4665-98e1-f773f618826d",
         "type": "planning",
+        "event_item": "urn:newsml:localhost:5000:2019-08-22T15:50:04.270524:86da81f0-c3fa-4b93-9e28-ed21ad2f1ed9",
         "planning_date": "2019-10-21T09:47:59.000Z",
         "agendas": [],
         "state": "draft",

--- a/server/tests/prod_api/tests/test_events.py
+++ b/server/tests/prod_api/tests/test_events.py
@@ -72,3 +72,31 @@ def test_excluded_fields(prodapi_app_with_data, prodapi_app_with_data_client):
         resp_data = json.loads(resp.data.decode("utf-8"))
 
         assert len(set(resp_data.keys()) & excluded_fields) == 0
+
+
+def test_filter_events_by_source_and_planning_source(prodapi_app_with_data, prodapi_app_with_data_client):
+    """Test combining event search via source param with planning filtering via planning_source param
+
+    :param prodapi_app_with_data: prod api app with filled data
+    :param prodapi_app_with_data_client: client for prod api app with filled data
+    """
+
+    target_event_id = "urn:newsml:localhost:5000:2019-09-10T16:22:34.066960:6b2d9c79-08b9-456f-b890-9b2154ee997a"
+
+    with prodapi_app_with_data.test_request_context():
+        # Search for events matching "EVENT" in slugline AND filter to planning items with "PLAN B"
+        event_source = {"query": {"query_string": {"query": "EVENT", "default_field": "slugline"}}}
+        planning_source = {"query": {"match": {"slugline": "PLAN B"}}}
+
+        resp = prodapi_app_with_data_client.get(
+            url_for(
+                "events|resource",
+                source=json.dumps(event_source),
+                planning_source=json.dumps(planning_source),
+            ),
+        )
+        resp_data = json.loads(resp.data.decode("utf-8"))
+
+        assert resp.status_code == 200
+        assert len(resp_data["_items"]) == 1
+        assert resp_data["_items"][0]["guid"] == target_event_id

--- a/server/tests/prod_api/tests/test_events.py
+++ b/server/tests/prod_api/tests/test_events.py
@@ -74,6 +74,27 @@ def test_excluded_fields(prodapi_app_with_data, prodapi_app_with_data_client):
         assert len(set(resp_data.keys()) & excluded_fields) == 0
 
 
+def test_filter_by_planning_search(prodapi_app_with_data, prodapi_app_with_data_client):
+    """Test filtering events by planning items using planning_source parameter with Elasticsearch query.
+
+    Note: The query must use analyzed field queries (match, query_string) not term queries
+    because planning fields like 'slugline' are analyzed during indexing.
+    """
+    target_event_id = "urn:newsml:localhost:5000:2019-09-10T16:22:34.066960:6b2d9c79-08b9-456f-b890-9b2154ee997a"
+
+    with prodapi_app_with_data.test_request_context():
+        # Use match query for analyzed fields like slugline
+        elastic_query = {"query": {"match": {"slugline": "PLAN B"}}}
+        resp = prodapi_app_with_data_client.get(
+            url_for("events|resource", planning_source=json.dumps(elastic_query)),
+        )
+        resp_data = json.loads(resp.data.decode("utf-8"))
+
+        assert resp.status_code == 200
+        assert len(resp_data["_items"]) == 1
+        assert resp_data["_items"][0]["guid"] == target_event_id
+
+
 def test_filter_events_by_source_and_planning_source(prodapi_app_with_data, prodapi_app_with_data_client):
     """Test combining event search via source param with planning filtering via planning_source param
 
@@ -94,6 +115,107 @@ def test_filter_events_by_source_and_planning_source(prodapi_app_with_data, prod
                 source=json.dumps(event_source),
                 planning_source=json.dumps(planning_source),
             ),
+        )
+        resp_data = json.loads(resp.data.decode("utf-8"))
+
+        assert resp.status_code == 200
+        assert len(resp_data["_items"]) == 1
+        assert resp_data["_items"][0]["guid"] == target_event_id
+
+
+def test_planning_source_invalid_json(prodapi_app_with_data, prodapi_app_with_data_client):
+    """Test that invalid JSON in planning_source parameter returns 400 error
+
+    :param prodapi_app_with_data: prod api app with filled data
+    :param prodapi_app_with_data_client: client for prod api app with filled data
+    """
+
+    with prodapi_app_with_data.test_request_context():
+        # Pass invalid JSON as planning_source
+        resp = prodapi_app_with_data_client.get(
+            url_for("events|resource", planning_source="not valid json"),
+        )
+
+        assert resp.status_code == 400
+
+
+def test_planning_source_no_matches(prodapi_app_with_data, prodapi_app_with_data_client):
+    """Test that planning_source matching no items returns empty results
+
+    :param prodapi_app_with_data: prod api app with filled data
+    :param prodapi_app_with_data_client: client for prod api app with filled data
+    """
+
+    with prodapi_app_with_data.test_request_context():
+        # Query for planning items that don't exist
+        elastic_query = {"query": {"match": {"slugline": "NONEXISTENT_PLANNING"}}}
+        resp = prodapi_app_with_data_client.get(
+            url_for("events|resource", planning_source=json.dumps(elastic_query)),
+        )
+        resp_data = json.loads(resp.data.decode("utf-8"))
+
+        assert resp.status_code == 200
+        assert len(resp_data["_items"]) == 0
+
+
+def test_planning_items_without_event_item(prodapi_app_with_data, prodapi_app_with_data_client):
+    """Test that planning items without event_item field are skipped
+
+    When planning items match the query but have no event_item field,
+    they should be ignored (not cause errors).
+
+    :param prodapi_app_with_data: prod api app with filled data
+    :param prodapi_app_with_data_client: client for prod api app with filled data
+    """
+
+    with prodapi_app_with_data.test_request_context():
+        # Query for "test planning item" which exists but may not have event_item
+        elastic_query = {"query": {"match": {"slugline": "test"}}}
+        resp = prodapi_app_with_data_client.get(
+            url_for("events|resource", planning_source=json.dumps(elastic_query)),
+        )
+        resp_data = json.loads(resp.data.decode("utf-8"))
+
+        # Should not error, just return whatever matches
+        assert resp.status_code == 200
+
+
+def test_event_source_without_planning_source(prodapi_app_with_data, prodapi_app_with_data_client):
+    """Test that event source filtering works independently without planning_source
+
+    :param prodapi_app_with_data: prod api app with filled data
+    :param prodapi_app_with_data_client: client for prod api app with filled data
+    """
+
+    with prodapi_app_with_data.test_request_context():
+        # Use only source parameter, no planning_source
+        event_source = {"query": {"query_string": {"query": "EVENT A", "default_field": "slugline"}}}
+        resp = prodapi_app_with_data_client.get(
+            url_for("events|resource", source=json.dumps(event_source)),
+        )
+        resp_data = json.loads(resp.data.decode("utf-8"))
+
+        assert resp.status_code == 200
+        # Should return event matching the source query
+        assert len(resp_data["_items"]) >= 1
+        for item in resp_data["_items"]:
+            assert "EVENT A" in item.get("slugline", "")
+
+
+def test_planning_source_alone_filters_correctly(prodapi_app_with_data, prodapi_app_with_data_client):
+    """Test that planning_source alone (without source parameter) filters events correctly
+
+    :param prodapi_app_with_data: prod api app with filled data
+    :param prodapi_app_with_data_client: client for prod api app with filled data
+    """
+
+    target_event_id = "urn:newsml:localhost:5000:2019-09-10T16:22:34.066960:6b2d9c79-08b9-456f-b890-9b2154ee997a"
+
+    with prodapi_app_with_data.test_request_context():
+        # Use only planning_source, no event source parameter
+        planning_source = {"query": {"match": {"slugline": "PLAN B"}}}
+        resp = prodapi_app_with_data_client.get(
+            url_for("events|resource", planning_source=json.dumps(planning_source)),
         )
         resp_data = json.loads(resp.data.decode("utf-8"))
 


### PR DESCRIPTION
SDBELGA-1027

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

### Front-end checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)

Resolves: #[issue-number]

