### PR TITLE
[SDESK-7593] - Fixed workflow filter, added new feature file for changes

### DIFF
--- a/server/features/search_spike_state_filter.feature
+++ b/server/features/search_spike_state_filter.feature
@@ -1,0 +1,99 @@
+Feature: Planning Search with Spike State and Include Killed Filters
+    Background: Initial setup
+        Given "planning"
+        """
+        [
+            {
+                "guid": "planning_draft",
+                "headline": "Draft Planning Item",
+                "slugline": "draft_slug",
+                "name": "draft_item",
+                "planning_date": "2026-01-27T12:00:00+0000",
+                "state": "draft"
+            },
+            {
+                "guid": "planning_spiked",
+                "headline": "Spiked Planning Item",
+                "slugline": "spiked_slug",
+                "name": "spiked_item",
+                "planning_date": "2026-01-27T12:00:00+0000",
+                "state": "spiked"
+            },
+            {
+                "guid": "planning_killed",
+                "headline": "Killed Planning Item",
+                "slugline": "killed_slug",
+                "name": "killed_item",
+                "planning_date": "2026-01-27T12:00:00+0000",
+                "state": "killed"
+            }
+        ]
+        """
+
+    @auth
+    Scenario: Saved filter with spike_state=both and include_killed=true returns spiked and killed items
+        When we post to "events_planning_filters"
+        """
+        [{
+            "name": "Killed and Spiked Filter",
+            "item_type": "planning",
+            "params": {
+                "spike_state": "both",
+                "include_killed": true
+            }
+        }]
+        """
+        Then we get OK response
+        When we get "/events_planning_search?repo=planning&only_future=false&filter_id=#events_planning_filters._id#"
+        Then we get list with 3 items
+        """
+        {"_items": [
+            {"_id": "planning_draft"},
+            {"_id": "planning_spiked"},
+            {"_id": "planning_killed"}
+        ]}
+        """
+
+    @auth
+    Scenario: Saved filter with only include_killed=true excludes spiked items
+        When we post to "events_planning_filters"
+        """
+        [{
+            "name": "Killed Only Filter",
+            "item_type": "planning",
+            "params": {
+                "include_killed": true
+            }
+        }]
+        """
+        Then we get OK response
+        When we get "/events_planning_search?repo=planning&only_future=false&filter_id=#events_planning_filters._id#"
+        Then we get list with 2 items
+        """
+        {"_items": [
+            {"_id": "planning_draft"},
+            {"_id": "planning_killed"}
+        ]}
+        """
+
+    @auth
+    Scenario: Saved filter with only spike_state=both excludes killed items
+        When we post to "events_planning_filters"
+        """
+        [{
+            "name": "Spiked Only Filter",
+            "item_type": "planning",
+            "params": {
+                "spike_state": "both"
+            }
+        }]
+        """
+        Then we get OK response
+        When we get "/events_planning_search?repo=planning&only_future=false&filter_id=#events_planning_filters._id#"
+        Then we get list with 2 items
+        """
+        {"_items": [
+            {"_id": "planning_draft"},
+            {"_id": "planning_spiked"}
+        ]}
+        """

--- a/server/planning/search/queries/common.py
+++ b/server/planning/search/queries/common.py
@@ -384,7 +384,8 @@ def append_states_query_for_advanced_search(params: Dict[str, Any], query: elast
         query.must.append(elastic.terms(field="state", values=states))
     else:
         # Otherwise include/exclude Spiked/Killed based on the params provided
-        if spike_state == WORKFLOW_STATE.DRAFT:
+        # Default: exclude spiked unless spike_state=both
+        if spike_state == WORKFLOW_STATE.DRAFT or spike_state is None:
             query.must_not.append(elastic.term(field="state", value=WORKFLOW_STATE.SPIKED))
 
         if not strtobool(params.get("include_killed", False)):
@@ -480,6 +481,10 @@ def remove_filter_params_from_query(filter_params: Dict[str, Any], params: Dict[
         params["exclude_dates"] = True
 
     if filter_params.get("spike_state") == params.get("spike_state"):
+        params["exclude_states"] = True
+
+    # Skip request defaults when filter has spike_state or include_killed params
+    if filter_params.get("spike_state") or filter_params.get("include_killed"):
         params["exclude_states"] = True
 
 


### PR DESCRIPTION
### Purpose
Fix saved filters for workflow state (spiked/killed) not returning correct results. When a filter is created to include spiked or killed items, it should be respected when using that filter.

### What has changed
- Made changes to treat missing spike_state as "draft" and to also skip request defaults when a filter explicitly specifies spike_state or include_killed parameters
- Added feature file for testing changes

### Steps to test
1. Create a saved filter with `spike_state: "both"` and `include_killed: true`
2. Use that filter - should return draft, spiked, and killed items
3. Create a filter with only `include_killed: true` - should return killed items but exclude spiked
4. Create a filter with only `spike_state: "both"` - should return spiked items but exclude killed


Resolves: [SDESK-7593](https://sofab.atlassian.net/browse/SDESK-7593)



[SDESK-7593]: https://sofab.atlassian.net/browse/SDESK-7593?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ