### PR TITLE
[STT-1562] fix: Dont copy Planning metadata to Coverage if field not enabled

### DIFF
--- a/.travis-docker-compose.yml
+++ b/.travis-docker-compose.yml
@@ -6,17 +6,18 @@ services:
             - "6379:6379"
 
     mongo:
-        image: mongo:3.6
+        image: mongo:6
         ports:
             - "27017:27017"
         tmpfs:
             - /data/db
 
     elastic:
-        image: elasticsearch:7.6.2
+        image: elasticsearch:7.17.29
         ports:
             - "9200:9200"
         environment:
             - discovery.type=single-node
+            - xpack.security.enabled=false
         tmpfs:
             - /usr/share/elasticsearch/data

--- a/.travis-docker-compose.yml
+++ b/.travis-docker-compose.yml
@@ -13,7 +13,7 @@ services:
             - /data/db
 
     elastic:
-        image: elasticsearch:7.17.29
+        image: elasticsearch:7.17.28
         ports:
             - "9200:9200"
         environment:

--- a/server/features/planning.feature
+++ b/server/features/planning.feature
@@ -4365,3 +4365,100 @@ Feature: Planning
         }
         """
         Then we get error 400
+
+    @auth
+    Scenario: Coverage inherits metadata from Planning
+        Given "vocabularies"
+        """
+        [{
+            "_id": "my_options",
+            "selection_type": "single selection",
+            "display_name": "My Custom Options",
+            "service": {"all": 1},
+            "items": [
+                {"qcode": "a", "name": "Option A", "is_active": true},
+                {"qcode": "b", "name": "Option B", "is_active": true},
+                {"qcode": "c", "name": "Option C", "is_active": true},
+                {"qcode": "d", "name": "Option D", "is_active": true}
+            ]
+        }]
+        """
+        Given "planning_types"
+        """
+        [{
+            "_id": "planning",
+            "name": "planning",
+            "editor": {
+                "slugline": {"enabled": true, "index": 1},
+                "anpa_category": {"enabled": true, "index": 3},
+                "subject": {"enabled": true, "index": 4},
+                "my_options": {"enabled": true, "index": 5}
+            },
+            "schema": {
+                "slugline": {"required": true},
+                "anpa_category": {"required": true},
+                "subject": {"required": true},
+                "my_options": {"type": "custom_vocabulary", "required": false}
+            }
+        }]
+        """
+        Given "coverage_profiles"
+        """
+        [{
+            "name": "Custom Text Coverage",
+            "content_type": "text",
+            "editor": {
+                "g2_content_type": {"enabled": true, "index": 1},
+                "slugline": {"enabled": true, "index": 2},
+                "scheduled": {"enabled": true, "index": 3},
+                "my_options": {"enabled": true, "index": 4},
+                "anpa_category": {"enabled": false}
+            },
+            "schema": {
+                "g2_content_type": {"required": true},
+                "slugline": {"required": true},
+                "scheduled": {"required": true},
+                "my_options": {"type": "custom_vocabulary", "required": false}
+            }
+        }]
+        """
+        When we post to "/planning" with success
+        """
+        [{
+            "slugline": "test slugline",
+            "planning_date": "2036-01-02",
+            "anpa_category": [{"name": "Sports", "qcode": "s"}],
+            "subject": [
+                {"qcode": "test", "name": "Testing"},
+                {"qcode": "b", "name": "Option B", "scheme": "my_options"}
+            ]
+        }]
+        """
+        When we patch "/planning/#planning._id#"
+        """
+        {"coverages": [{
+            "profile": "#coverage_profiles._id#",
+            "workflow_status": "draft",
+            "news_coverage_status": {"qcode": "ncostat:int"},
+            "planning": {
+                "ednote": "testing stuff",
+                "g2_content_type": "text",
+                "scheduled": "2036-01-03"
+            }
+        }]}
+        """
+        When we get "/planning/#planning._id#"
+        Then we get existing resource
+        """
+        {
+            "coverages": [{
+                "planning": {
+                    "slugline": "test slugline",
+                    "anpa_category": "__no_value__",
+                    "subject": [
+                        {"qcode": "b", "name": "Option B", "scheme": "my_options"}
+                    ]
+                }
+            }]
+        }
+        """

--- a/server/planning/assignments/assignments_content.py
+++ b/server/planning/assignments/assignments_content.py
@@ -95,8 +95,8 @@ async def get_item_from_assignment(assignment, template=None):
                 await merge_subject(item, planning)
                 merge_list("place", item, planning)
 
-                if anpa_category := planning_data.get("anpa_category"):
-                    item["anpa_category"] = deepcopy(anpa_category)
+                if planning_data.get("anpa_category"):
+                    merge_list("anpa_category", item, planning_data)
                 else:
                     merge_list("anpa_category", item, planning)
 

--- a/server/planning/content_profiles/service.py
+++ b/server/planning/content_profiles/service.py
@@ -122,6 +122,20 @@ class PlanningTypesService(AsyncBaseService):
 
 
 class ContentProfilesService(AsyncBaseService):
+    async def find_one_async(self, req, **lookup):
+        try:
+            coverage_profile = await super().find_one_async(req, **lookup)
+
+            default_coverage_profile = deepcopy(DEFAULT_COVERAGE_PROFILE)
+            if not coverage_profile:
+                return default_coverage_profile
+
+            self.merge_content_profile(coverage_profile, default_coverage_profile)
+            return coverage_profile
+
+        except IndexError:
+            return None
+
     async def get_async(self, req: ParsedRequest, lookup: dict[str, Any] | None) -> AsyncListCursor:
         """Get all content profiles with default fields merged in.
 

--- a/server/planning/content_profiles/utils.py
+++ b/server/planning/content_profiles/utils.py
@@ -8,41 +8,53 @@
 # AUTHORS and LICENSE files distributed with this source code, or
 # at https://www.sourcefabric.org/superdesk/license
 
-from typing import Set
+from bson import ObjectId
+
 from superdesk import get_resource_service
-from planning.types import ContentProfile
+from planning.types import BaseProfile, ContentProfile, CoverageProfile
 
 
 async def get_planning_schema(resource: str) -> ContentProfile:
     return await get_resource_service("planning_types").find_one_async(req=None, name=resource)
 
 
-def is_field_enabled(field: str, profile: ContentProfile) -> bool:
+async def get_coverage_schema(schema_id: ObjectId | str) -> CoverageProfile | None:
+    return await get_resource_service("coverage_profiles").find_one_async(req=None, _id=ObjectId(schema_id))
+
+
+def is_field_enabled(field: str, profile: BaseProfile) -> bool:
     try:
         return profile["editor"][field]["enabled"]
     except (KeyError, TypeError):
         return False
 
 
-def get_enabled_fields(profile: ContentProfile) -> Set[str]:
+def get_enabled_fields(profile: BaseProfile) -> set[str]:
     return set(field for field in profile["editor"].keys() if is_field_enabled(field, profile))
 
 
-def is_field_editor_3(field: str, profile: ContentProfile) -> bool:
+def is_field_editor_3(field: str, profile: BaseProfile) -> bool:
     try:
         return is_field_enabled(field, profile) and profile["schema"][field]["field_type"] == "editor_3"
     except (KeyError, TypeError):
         return False
 
 
-def is_multilingual_enabled(field: str, profile: ContentProfile) -> bool:
+def is_field_custom_vocabulary(field: str, profile: BaseProfile) -> bool:
+    try:
+        return is_field_enabled(field, profile) and profile["schema"][field]["type"] == "custom_vocabulary"
+    except (KeyError, TypeError):
+        return False
+
+
+def is_multilingual_enabled(field: str, profile: BaseProfile) -> bool:
     try:
         return profile["schema"][field]["multilingual"]
     except (KeyError, TypeError):
         return False
 
 
-def get_multilingual_fields_from_profile(profile: ContentProfile) -> Set[str]:
+def get_multilingual_fields_from_profile(profile: BaseProfile) -> set[str]:
     return (
         set()
         if not is_multilingual_enabled("language", profile)
@@ -58,20 +70,24 @@ def get_multilingual_fields_from_profile(profile: ContentProfile) -> Set[str]:
     )
 
 
-async def get_multilingual_fields(resource: str) -> Set[str]:
+def get_custom_vocabulary_fields_from_profile(profile: BaseProfile) -> set[str]:
+    return set(field_name for field_name in profile["schema"].keys() if is_field_custom_vocabulary(field_name, profile))
+
+
+async def get_multilingual_fields(resource: str) -> set[str]:
     return get_multilingual_fields_from_profile(await get_planning_schema(resource))
 
 
-async def get_editor3_fields(resource: str) -> Set[str]:
+async def get_editor3_fields(resource: str) -> set[str]:
     profile = await get_planning_schema(resource)
     return set(field_name for field_name in profile["schema"].keys() if is_field_editor_3(field_name, profile))
 
 
 class ContentProfileData:
-    profile: ContentProfile
+    profile: BaseProfile
     is_multilingual: bool
-    multilingual_fields: Set[str]
-    enabled_fields: Set[str]
+    multilingual_fields: set[str]
+    enabled_fields: set[str]
 
     @classmethod
     async def get(cls, resource: str):

--- a/server/planning/planning/planning.py
+++ b/server/planning/planning/planning.py
@@ -46,11 +46,17 @@ from planning.types import (
     PlanningRelatedEventLink,
     ContentProfile,
     PLANNING_RELATED_EVENT_LINK_TYPE,
+    CoverageProfile,
 )
 from planning.planning.planning_history_async_service import PlanningHistoryAsyncService
 from planning.planning.planning_autosave_service import PlanningAutosaveAsyncService
 from planning.assignments.assignments_history_async import AssignmentsHistoryAsyncService
 from planning.content_profiles.planning_types_async_service import PlanningTypesAsyncService
+from planning.content_profiles.utils import (
+    get_coverage_schema,
+    get_enabled_fields,
+    get_custom_vocabulary_fields_from_profile,
+)
 from planning.common import (
     get_next_assignment_status,
     get_coverage_status_from_cv,
@@ -718,7 +724,7 @@ class PlanningService(AsyncBaseService):
                 coverage.setdefault("planning", {})
                 coverage["planning"].setdefault("scheduled", planning_date)
 
-                self.inherit_planning_metadata(coverage, updates)
+                await self.inherit_planning_metadata(coverage, updates, original)
 
                 set_original_creator(coverage)
                 self.set_coverage_active(coverage, updates)
@@ -806,7 +812,7 @@ class PlanningService(AsyncBaseService):
             coverage.setdefault("planning", {})
             coverage["planning"].setdefault("scheduled", (original_coverage.get("planning") or {}).get("scheduled"))
 
-            self.inherit_planning_metadata(coverage, updates)
+            await self.inherit_planning_metadata(coverage, updates, original)
 
             self.set_coverage_active(coverage, updates)
             await self.set_slugline_from_xmp(coverage, original_coverage)
@@ -1858,15 +1864,54 @@ class PlanningService(AsyncBaseService):
                 continue
             yield plan
 
-    def inherit_planning_metadata(self, coverage, updates):
+    async def inherit_planning_metadata(self, coverage: dict, updates: dict, original: dict) -> None:
         """
         Inherit planning metadata fields to coverage if not explicitly set in coverage profile.
         The fields inherited are those overlapping metadata fields from the planning schema and coverage schema
         """
-        fields_to_inherit = ["anpa_category", "subject", "genre", "priority", "location"]
-        for field in fields_to_inherit:
-            if updates.get(field):
-                coverage["planning"].setdefault(field, updates[field])
+
+        schema: CoverageProfile | None = None
+
+        if coverage.get("profile"):
+            schema = await get_coverage_schema(coverage["profile"])
+            if not schema:
+                logger.warning(
+                    "Issue copying Planning metadata to Coverage, CoverageProfile not found",
+                    extra={
+                        "coverage_id": coverage.get("coverage_id"),
+                        "profile": coverage["profile"],
+                    },
+                )
+
+        supported_fields = {"anpa_category", "subject", "genre", "priority", "location", "headline", "slugline"}
+
+        if schema:
+            custom_vocabulary_fields = get_custom_vocabulary_fields_from_profile(schema)
+            enabled_fields = {
+                field
+                for field in get_enabled_fields(schema)
+                if field in supported_fields and field not in custom_vocabulary_fields
+            }
+        else:
+            enabled_fields = supported_fields
+            custom_vocabulary_fields = set()
+
+        for field in enabled_fields:
+            value = updates.get(field, original.get(field))
+            if field != "subject" and value:
+                coverage["planning"].setdefault(field, value)
+
+        subjects: list[dict] | None = updates.get("subject", original.get("subject"))
+        if subjects and "subject" not in coverage["planning"]:
+            # Copy ``Subject`` and ``Custom Vocabulary`` fields that are enabled in both Planning and Coverage profiles
+            coverage["planning"]["subject"] = [
+                subject
+                for subject in subjects
+                if (
+                    (not subject.get("scheme") and "subject" in enabled_fields)
+                    or (subject.get("scheme") in custom_vocabulary_fields)
+                )
+            ]
 
     @staticmethod
     def _should_update_version_creator(updates, original):

--- a/server/planning/types/__init__.py
+++ b/server/planning/types/__init__.py
@@ -11,7 +11,7 @@
 from typing import TypedDict, Dict, Any, Literal
 from datetime import datetime
 
-from .content_profiles import ContentFieldSchema, ContentFieldEditor, ContentProfile  # noqa
+from .content_profiles import ContentFieldSchema, ContentFieldEditor, BaseProfile, ContentProfile, CoverageProfile
 
 from .base import BasePlanningModel
 from .common import (
@@ -87,7 +87,11 @@ __all__ = [
     "SearchScheduleFrequency",
     "SearchWeekDay",
     "SearchDateRange",
+    "ContentFieldSchema",
+    "ContentFieldEditor",
+    "BaseProfile",
     "ContentProfile",
+    "CoverageProfile",
     "PlanningRelatedEventLink",
     "AgendasResourceModel",
     "AgendaItem",

--- a/server/planning/types/content_profiles.py
+++ b/server/planning/types/content_profiles.py
@@ -10,8 +10,11 @@
 
 from typing import TypedDict, Dict, List
 
+from bson import ObjectId
+
 
 class ContentFieldSchema(TypedDict, total=False):
+    type: str
     multilingual: bool
     field_type: str
     planning_auto_publish: bool  # Only available in ``related_plannings`` field
@@ -23,8 +26,17 @@ class ContentFieldEditor(TypedDict):
     enabled: bool
 
 
-class ContentProfile(TypedDict):
-    _id: str
-    name: str
+class BaseProfile(TypedDict):
     schema: Dict[str, ContentFieldSchema]
     editor: Dict[str, ContentFieldEditor]
+
+
+class ContentProfile(BaseProfile):
+    _id: str
+    name: str
+
+
+class CoverageProfile(BaseProfile):
+    _id: ObjectId
+    content_type: str
+    name: str | None

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -22,4 +22,4 @@ aioresponses==0.7.8
 
 -e .
 # Install in editable state so we get feature fixtures
--e git+https://github.com/superdesk/superdesk-core.git@release/3.1#egg=superdesk-core
+-e git+https://github.com/superdesk/superdesk-core.git@release/3.3#egg=superdesk-core

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -11,8 +11,8 @@ coveralls==4.0.2
 mock==5.2.0
 httmock==1.4.0
 responses==0.25.8
-pytest==8.4.2
-pytest-asyncio==1.0.0
+pytest==9.0.2
+pytest-asyncio==1.3.0
 pytest-env==1.2.0
 black~=25.11
 behave==1.2.6


### PR DESCRIPTION
### Purpose
When a Coverage is added to a Planning item, the back-end copied certain metadata from the Planning item to the Coverage (if not already defined by the Coverage).

Previously the metadata was copied even if that particular field was not enabled on the Coverage. This caused issues when creating an Assignment and then Content from it, if the Planning's Category field was changed, the Coverage's Content field was still used (but never shown to the end user).

### What has changed
* Add `get_coverage_schema`, `is_field_custom_vocabulary` and `get_custom_vocabulary_fields_from_profile` to ContentProfile utilities
* Use CoveargeProfile to determine what fields to copy from the Planning item to the Coverage (including custom vocabularies)
* Set `superdesk-core` version in dev requirements to `release/3.3`

Resolves: [STT-1562](https://sofab.atlassian.net/browse/STT-1562)



[STT-1562]: https://sofab.atlassian.net/browse/STT-1562?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ