### PR TITLE
[SDBELGA-1028] Add content privilege checks for assignment locks

### DIFF
--- a/client/constants/privileges.ts
+++ b/client/constants/privileges.ts
@@ -2,6 +2,7 @@ export const PRIVILEGES = {
     ARCHIVE: 'archive',
     AGENDA_MANAGEMENT: 'planning_agenda_management',
     DELETE_AGENDA: 'planning_agenda_delete',
+    PLANNING: 'planning',
     PLANNING_MANAGEMENT: 'planning_planning_management',
     SPIKE_PLANNING: 'planning_planning_spike',
     UNSPIKE_PLANNING: 'planning_planning_unspike',

--- a/client/utils/assignments.ts
+++ b/client/utils/assignments.ts
@@ -146,6 +146,10 @@ function canRevertAssignment(
         get(assignment, 'assigned_to.state') === ASSIGNMENTS.WORKFLOW_STATE.COMPLETED;
 }
 
+function canEditPlanning(privileges: IPrivileges) {
+    return !!privileges[PRIVILEGES.PLANNING] && !!privileges[PRIVILEGES.PLANNING_MANAGEMENT];
+}
+
 const assignmentHasContent = (assignment) => (
     get(assignment, 'item_ids.length', 0) > 0
 );
@@ -289,6 +293,8 @@ function getAssignmentItemActions(
             self.canEditPriorityOrReassignAssignment(assignment, session, privileges, PRIVILEGES.ARCHIVE, lockedItems),
         [ASSIGNMENTS.ITEM_ACTIONS.START_WORKING.actionName]: () =>
             self.canStartWorking(assignment, session, privileges, contentTypes),
+        [ASSIGNMENTS.ITEM_ACTIONS.EDIT_PLANNING.actionName]: () =>
+            self.canEditPlanning(privileges),
         [ASSIGNMENTS.ITEM_ACTIONS.REMOVE.actionName]: () =>
             self.canRemoveAssignment(assignment, session, privileges, PRIVILEGES.PLANNING_MANAGEMENT, lockedItems),
         [ASSIGNMENTS.ITEM_ACTIONS.PREVIEW_ARCHIVE.actionName]: () =>
@@ -467,6 +473,7 @@ const self = {
     getAssignmentActions,
     canStartWorking,
     canFulfilAssignment,
+    canEditPlanning,
     getAssignmentGroupsByStates,
     canEditDesk,
     assignmentHasContent,

--- a/server/planning/assignments/assignments.py
+++ b/server/planning/assignments/assignments.py
@@ -1196,20 +1196,20 @@ class AssignmentsService(superdesk.Service):
             lock_service = get_component(LockService)
             lock_service.unlock(assignment, user_id, get_auth()["_id"], "assignments")
 
-    def can_work_on_content(self, item, user_id):
+    def can_work_on_content(self, _item, _user_id):
         """Check if user can work on assignment content (lock/unlock for content operations).
 
         This requires only the archive privilege, as working on content means creating/editing archive items.
         Used for: start_working action, content_edit action, and unlocking assignments.
         """
         if not current_user_has_privilege("archive"):
-            return False, "User does not have sufficient permissions."
+            return False, lazy_gettext("User does not have sufficient permissions.")
         return True, ""
 
     def can_edit(self, item, user_id):
         # Check privileges
         if not current_user_has_privilege("planning_planning_management"):
-            return False, "User does not have sufficient permissions."
+            return False, lazy_gettext("User does not have sufficient permissions.")
         return True, ""
 
     def is_associated_planning_or_event_locked(self, planning_item):

--- a/server/planning/assignments/assignments.py
+++ b/server/planning/assignments/assignments.py
@@ -1196,6 +1196,16 @@ class AssignmentsService(superdesk.Service):
             lock_service = get_component(LockService)
             lock_service.unlock(assignment, user_id, get_auth()["_id"], "assignments")
 
+    def can_work_on_content(self, item, user_id):
+        """Check if user can work on assignment content (lock/unlock for content operations).
+
+        This requires only the archive privilege, as working on content means creating/editing archive items.
+        Used for: start_working action, content_edit action, and unlocking assignments.
+        """
+        if not current_user_has_privilege("archive"):
+            return False, "User does not have sufficient permissions."
+        return True, ""
+
     def can_edit(self, item, user_id):
         # Check privileges
         if not current_user_has_privilege("planning_planning_management"):

--- a/server/planning/item_lock.py
+++ b/server/planning/item_lock.py
@@ -67,7 +67,7 @@ class LockService(BaseComponent):
             raise SuperdeskApiError.forbiddenError(message="Item is locked by another user.")
 
         try:
-            can_user_lock, error_message = self.can_lock(item, user_id, session_id, resource)
+            can_user_lock, error_message = self.can_lock(item, user_id, session_id, resource, action)
 
             if can_user_lock:
                 # following line executes handlers attached to function:
@@ -177,19 +177,25 @@ class LockService(BaseComponent):
         for item in item_service.search({"query": {"bool": {"filter": {"term": term_filter}}}}):
             self.unlock(item, user_id, session_id, resource)
 
-    def can_lock(self, item, user_id, session_id, resource):
+    def can_lock(self, item, user_id, session_id, resource, action=None):
         """
         Function checks whether user can lock the item or not. If not then raises exception.
         """
-        can_user_edit, error_message = superdesk.get_resource_service(resource).can_edit(item, user_id)
+        service = superdesk.get_resource_service(resource)
+        check_method = service.can_edit
+
+        if resource == "assignments" and action in ["start_working", "content_edit"]:
+            check_method = service.can_work_on_content
+
+        can_user_edit, error_message = check_method(item, user_id)
 
         if can_user_edit:
-            if item.get(LOCK_USER):
-                if str(item.get(LOCK_USER, "")) == str(user_id) and str(item.get(LOCK_SESSION)) != str(session_id):
-                    return False, "Item is locked by you in another session."
+            if lock_user := item.get(LOCK_USER):
+                if str(lock_user) == str(user_id):
+                    if str(item.get(LOCK_SESSION)) != str(session_id):
+                        return False, "Item is locked by you in another session."
                 else:
-                    if str(item.get(LOCK_USER, "")) != str(user_id):
-                        return False, "Item is locked by another user."
+                    return False, "Item is locked by another user."
         else:
             return False, error_message
 
@@ -199,8 +205,14 @@ class LockService(BaseComponent):
         """
         Function checks whether user can unlock the item or not.
         """
-        can_user_edit, error_message = superdesk.get_resource_service(resource).can_edit(item, user_id)
 
+        service = superdesk.get_resource_service(resource)
+        check_method = service.can_edit
+
+        if resource == "assignments":
+            check_method = service.can_work_on_content
+
+        can_user_edit, error_message = check_method(item, user_id)
         if can_user_edit:
             resource_privileges = get_resource_privileges(resource).get("PATCH")
 


### PR DESCRIPTION
### Purpose
Users with "Assignments" and "Create Content" privileges but without "Planning - Planning item management" privilege were unable to use the "Start Working" action on assignments. When clicking the action, they received an "User does not have sufficient permissions." error, even though the action was correctly visible in the UI.

### What has changed
- Introduces `can_work_on_content` to `AssignmentsService` to check archive privilege for content operations.
- Updates `LockService` to use this method for assignment lock/unlock actions related to content, ensuring correct permission checks for `start_working` and `content_edit` actions.

> [!IMPORTANT]  
> The tests broken in this PR were already broken in branch `release/2.11`. I think those have been addressed on other branches so not fixing them here. 

Resolves: [SDBELGA-1028]


[SDBELGA-1028]: https://sofab.atlassian.net/browse/SDBELGA-1028?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ