### PR TITLE
[SDESK-7856] fix: Missing async functionality in feeding services

### DIFF
--- a/server/planning/feed_parsers/ics_2_0.py
+++ b/server/planning/feed_parsers/ics_2_0.py
@@ -51,21 +51,21 @@ class IcsTwoFeedParser(FileFeedParser):
     def can_parse(self, cal):
         return isinstance(cal, Calendar)
 
-    def parse_email(self, content, content_type, provider):
+    async def parse_email(self, content, content_type, provider):
         if content_type != "text/calendar":
             raise ParserError.parseMessageError("Not supported content type.")
 
         content.seek(0)
         cal = Calendar.from_ical(content.read())
-        return self.parse(cal, provider)
+        return await self.parse(cal, provider)
 
-    def parse_file(self, fstream, provider):
+    async def parse_file(self, fstream, provider):
         cal = Calendar.from_ical(fstream.read())
-        return self.parse(cal, provider)
+        return await self.parse(cal, provider)
 
-    def parse_http(self, content, provider):
+    async def parse_http(self, content, provider):
         cal = Calendar.from_ical(content)
-        return self.parse(cal, provider)
+        return await self.parse(cal, provider)
 
     async def parse(self, cal, provider=None):
         try:

--- a/server/planning/feeding_services/event_email_service.py
+++ b/server/planning/feeding_services/event_email_service.py
@@ -95,7 +95,7 @@ class EventEmailFeedingService(FeedingService):
     """
     service = "events"
 
-    def _update(self, provider, update):
+    async def _update(self, provider, update):
         config = provider.get("config", {})
         server = config.get("server", "")
         port = int(config.get("port", 993))
@@ -117,7 +117,7 @@ class EventEmailFeedingService(FeedingService):
                         if rv == "OK":
                             try:
                                 logger.info("Ingesting events from email")
-                                parser = self.get_feed_parser(provider, data)
+                                parser = await self.get_feed_parser(provider, data)
                                 for response_part in data:
                                     if isinstance(response_part, tuple):
                                         if isinstance(response_part[1], bytes):
@@ -141,7 +141,7 @@ class EventEmailFeedingService(FeedingService):
                                                 if getattr(parser, "parse_email"):
                                                     try:
                                                         new_items.append(
-                                                            parser.parse_email(
+                                                            await parser.parse_email(
                                                                 content,
                                                                 content_type,
                                                                 provider,
@@ -150,7 +150,7 @@ class EventEmailFeedingService(FeedingService):
                                                     except ParserError.parseMessageError:
                                                         continue
                                                 else:
-                                                    new_items.append(parser.parse(data, provider))
+                                                    new_items.append(await parser.parse(data, provider))
                                 rv, data = imap.store(num, "+FLAGS", "\\Seen")
                             except IngestEmailError:
                                 continue

--- a/server/planning/feeding_services/event_file_service.py
+++ b/server/planning/feeding_services/event_file_service.py
@@ -57,17 +57,17 @@ class EventFileFeedingService(FileFeedingService):
         }
     ]
 
-    def _update(self, provider, update):
+    async def _update(self, provider, update):
         self.provider = provider
         self.path = provider.get("config", {}).get("path", None)
 
         if not self.path:
-            logger.warn(
+            logger.warning(
                 "File Feeding Service {} is configured without path. Please check the configuration".format(
                     provider["name"]
                 )
             )
-            return []
+            return
 
         for filename in get_sorted_files(self.path, sort_by=FileSortAttributes.created):
             try:
@@ -78,26 +78,26 @@ class EventFileFeedingService(FileFeedingService):
                     last_updated = datetime.fromtimestamp(stat.st_mtime, tz=utc)
 
                     if self.is_latest_content(last_updated, provider.get("last_updated")):
-                        parser = self.get_feed_parser(provider, file_path)
+                        parser = await self.get_feed_parser(provider, file_path)
                         logger.info("Ingesting events with {} parser".format(parser.__class__.__name__))
                         if hasattr(parser, "parse_file"):
                             with open(file_path, "rb") as f:
-                                item = parser.parse_file(f, provider)
+                                item = await parser.parse_file(f, provider)
                         else:
-                            item = parser.parse(file_path, provider)
+                            item = await parser.parse(file_path, provider)
 
                         self.after_extracting(item, provider)
-                        self.move_file(self.path, filename, provider=provider, success=True)
+                        await self.move_file(self.path, filename, provider=provider, success=True)
 
                         if isinstance(item, list):
                             yield item
                         else:
                             yield [item]
                     else:
-                        self.move_file(self.path, filename, provider=provider, success=True)
+                        await self.move_file(self.path, filename, provider=provider, success=True)
             except Exception as ex:
                 if last_updated and self.is_old_content(last_updated):
-                    self.move_file(self.path, filename, provider=provider, success=False)
+                    await self.move_file(self.path, filename, provider=provider, success=False)
                 raise ParserError.parseFileError("{}-{}".format(provider["name"], self.NAME), filename, ex, provider)
 
         push_notification("ingest:update")

--- a/server/planning/feeding_services/event_file_service_tests.py
+++ b/server/planning/feeding_services/event_file_service_tests.py
@@ -8,17 +8,13 @@ get_sorted_files = object()
 
 
 class EventFileFeedingServiceTestCase(TestCase):
-    def setUp(self):
-        super().setUp()
-
     @patch("planning.feeding_services.event_file_service.os")
     @patch("planning.feeding_services.event_file_service.get_sorted_files")
     async def test_update(self, mock_os, mock_get_sorted_files):
-        async with self.app.app_context():
-            service = EventFileFeedingService()
-            provider = {"feed_parser": "ics20", "config": {"path": "/test_file_drop"}}
-            mock_get_sorted_files.return_value = ["file1.txt", "file2.txt", "file3.txt"]
-            mock_os.path.isfile.return_value = True
+        service = EventFileFeedingService()
+        provider = {"feed_parser": "ics20", "config": {"path": "/test_file_drop"}}
+        mock_get_sorted_files.return_value = ["file1.txt", "file2.txt", "file3.txt"]
+        mock_os.path.isfile.return_value = True
 
-            events = list(service._update(provider, None))
-            self.assertEqual(len(events), 0)
+        events = [event async for event in service._update(provider, None)]
+        self.assertEqual(len(events), 0)

--- a/server/planning/feeding_services/event_http_service.py
+++ b/server/planning/feeding_services/event_http_service.py
@@ -62,9 +62,9 @@ class EventHTTPFeedingService(HTTPFeedingServiceBase):
         logger.info("Ingesting content: {} ...".format(str(response.content)[:4000]))
 
         if hasattr(parser, "parse_http"):
-            items = parser.parse_http(response.content, provider)
+            items = await parser.parse_http(response.content, provider)
         else:
-            items = parser.parse(response.content)
+            items = await parser.parse(response.content)
 
         if isinstance(items, list):
             yield items

--- a/server/planning/feeding_services/event_http_service_tests.py
+++ b/server/planning/feeding_services/event_http_service_tests.py
@@ -3,21 +3,17 @@ from planning.tests import TestCase
 
 
 class EventHTTPFeedingServiceTestCase(TestCase):
-    def setUp(self):
-        super().setUp()
-
     async def test_update(self):
-        async with self.app.app_context():
-            service = EventHTTPFeedingService()
-            provider = {
-                "_id": "ics_20",
-                "name": "ics20",
-                "feed_parser": "ics20",
-                "config": {
-                    "url": "https://gist.github.com/vied12/9efa0655704c05b6e442c581c9eb1f89/"
-                    + "raw/539d2911052f5d03713811ebe19ca594391d6b80/event.ics",
-                },
-            }
+        service = EventHTTPFeedingService()
+        provider = {
+            "_id": "ics_20",
+            "name": "ics20",
+            "feed_parser": "ics20",
+            "config": {
+                "url": "https://gist.github.com/vied12/9efa0655704c05b6e442c581c9eb1f89/"
+                + "raw/539d2911052f5d03713811ebe19ca594391d6b80/event.ics",
+            },
+        }
 
-            events = [event async for event in await service.update(provider, {})]
-            self.assertEqual(len(events), 1)
+        events = [event async for event in await service.update(provider, {})]
+        self.assertEqual(len(events), 1)

--- a/server/planning/feeding_services/onclusive_api_service.py
+++ b/server/planning/feeding_services/onclusive_api_service.py
@@ -71,7 +71,7 @@ class OnclusiveApiService(HTTPFeedingServiceBase):
     HTTP_AUTH = False
     timeout = (5, 60)
 
-    def _update(self, provider, update):
+    async def _update(self, provider, update):
         """
         Fetch events from external API.
 
@@ -85,7 +85,7 @@ class OnclusiveApiService(HTTPFeedingServiceBase):
         LIMIT = 2000
         self.session = requests.Session()
         self.language = "en-CA"  # make sure there is some default
-        parser = self.get_feed_parser(provider)
+        parser = await self.get_feed_parser(provider)
         update["tokens"] = provider.get("tokens") or {}
         with timer("onclusive:update"):
             self.authenticate(provider, update["tokens"])
@@ -150,7 +150,7 @@ class OnclusiveApiService(HTTPFeedingServiceBase):
                     params[iterations_param] = i
                     logger.info("Onclusive PARAMS %s", params)
                     content = self._fetch(url, params, provider, update["tokens"])
-                    items = parser.parse(content, provider)
+                    items = await parser.parse(content, provider)
                     logger.info("Onclusive returned %d items", len(items))
                     for item in items:
                         item.setdefault("language", self.language)

--- a/server/planning/feeding_services/onclusive_api_service_tests.py
+++ b/server/planning/feeding_services/onclusive_api_service_tests.py
@@ -1,24 +1,22 @@
-import unittest
 import responses
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch, AsyncMock
 from datetime import datetime, timedelta
 
-from superdesk.flask import Flask
 from planning.feed_parsers.onclusive import OnclusiveFeedParser
+from planning.tests import TestCase
 
 from .onclusive_api_service import OnclusiveApiService
 
 
-parser = MagicMock(OnclusiveFeedParser)
+parser = AsyncMock(OnclusiveFeedParser)
 
 
-class OnclusiveApiServiceTestCase(unittest.TestCase):
-    def setUp(self) -> None:
+class OnclusiveApiServiceTestCase(TestCase):
+    async def asyncSetUp(self) -> None:
         super().setUp()
-        self.app = Flask(__name__)
         self.service = OnclusiveApiService()
-        self.service.get_feed_parser = MagicMock(return_value=parser)
+        self.service.get_feed_parser = AsyncMock(return_value=parser)
         event = {"versioncreated": datetime(2023, 3, 1, 8, 0, 0)}
 
         parser.parse.return_value = [
@@ -54,56 +52,54 @@ class OnclusiveApiServiceTestCase(unittest.TestCase):
         )  # first returns an item
         responses.get("https://api.abc.com/api/v2/events/date", json=[])  # ones won't
 
-        async with self.app.app_context():
-            updates = {}
-            items = list(self.service._update(self.provider, updates))
-            self.assertIn("tokens", updates)
-            self.assertEqual("refresh", updates["tokens"]["refreshToken"])
-            self.assertIn("import_finished", updates["tokens"])
-            self.assertEqual(updates["last_updated"], updates["tokens"]["next_start"])
-            self.assertEqual("fr-CA", items[0][0]["language"])
+        updates = {}
+        items = [item async for item in self.service._update(self.provider, updates)]
+        self.assertIn("tokens", updates)
+        self.assertEqual("refresh", updates["tokens"]["refreshToken"])
+        self.assertIn("import_finished", updates["tokens"])
+        self.assertEqual(updates["last_updated"], updates["tokens"]["next_start"])
+        self.assertEqual("fr-CA", items[0][0]["language"])
 
-            self.provider.update(updates)
-            updates = {}
-            responses.post(
-                "https://api.abc.com/api/v2/auth/renew",
-                json={
-                    "token": "tok2",
-                    "refreshToken": "refresh2",
-                },
-            )
-            responses.get("https://api.abc.com/api/v2/events/latest", json=[])
-            list(self.service._update(self.provider, updates))
-            self.assertEqual("refresh2", updates["tokens"]["refreshToken"])
+        self.provider.update(updates)
+        updates = {}
+        responses.post(
+            "https://api.abc.com/api/v2/auth/renew",
+            json={
+                "token": "tok2",
+                "refreshToken": "refresh2",
+            },
+        )
+        responses.get("https://api.abc.com/api/v2/events/latest", json=[])
+        await self.service._update(self.provider, updates).asend(None)
+        self.assertEqual("refresh2", updates["tokens"]["refreshToken"])
 
     @patch("planning.feeding_services.onclusive_api_service.touch")
     async def test_reingest(self, lock_touch):
-        async with self.app.app_context():
-            start = datetime.now() - timedelta(days=30)
-            self.provider["config"]["days_to_reingest"] = "30"
-            self.provider["config"]["days_to_ingest"] = "10"
-            updates = {}
-            with responses.RequestsMock() as rsps:  # checks if all requests were fired
+        start = datetime.now() - timedelta(days=30)
+        self.provider["config"]["days_to_reingest"] = "30"
+        self.provider["config"]["days_to_ingest"] = "10"
+        updates = {}
+        with responses.RequestsMock() as rsps:  # checks if all requests were fired
+            rsps.add(
+                responses.POST,
+                url="https://api.abc.com/api/v2/auth",
+                json={
+                    "token": "tok",
+                    "refreshToken": "refresh",
+                    "productId": 10,
+                },
+            )
+
+            for i in range(0, 10):
                 rsps.add(
-                    responses.POST,
-                    url="https://api.abc.com/api/v2/auth",
-                    json={
-                        "token": "tok",
-                        "refreshToken": "refresh",
-                        "productId": 10,
-                    },
+                    responses.GET,
+                    "https://api.abc.com/api/v2/events/date?limit=2000&date={}".format(
+                        (start + timedelta(days=i)).strftime("%Y%m%d")
+                    ),
+                    json=[self.event],
                 )
 
-                for i in range(0, 10):
-                    rsps.add(
-                        responses.GET,
-                        "https://api.abc.com/api/v2/events/date?limit=2000&date={}".format(
-                            (start + timedelta(days=i)).strftime("%Y%m%d")
-                        ),
-                        json=[self.event],
-                    )
-
-                items = list(self.service._update(self.provider, updates))
-                assert 10 == len(items)
-                assert 1 == len(items[0])
-                assert updates["tokens"]["import_finished"]
+            items = [item async for item in self.service._update(self.provider, updates)]
+            assert 10 == len(items)
+            assert 1 == len(items[0])
+            assert updates["tokens"]["import_finished"]


### PR DESCRIPTION
### Purpose
Planning based feeding services were not updated to use async functionality.

### What has changed
* Convert all feeding service's `_update` methods to async
* Prefix all `get_feed_parser` and `parse` calls with `await`
* Fix tests

Resolves: [SDESK-7856](https://sofab.atlassian.net/browse/SDESK-7856)



[SDESK-7856]: https://sofab.atlassian.net/browse/SDESK-7856?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ