### PR TITLE
[SDBELGA-1030] fix: Copy translated fields from Event to Coverage in embedded form

### DIFF
--- a/client/components/fields/editor/EventRelatedPlannings/AddNewCoverages.tsx
+++ b/client/components/fields/editor/EventRelatedPlannings/AddNewCoverages.tsx
@@ -16,6 +16,7 @@ import {IDesk, IUser} from 'superdesk-api';
 
 import * as selectors from '../../../../selectors';
 import {planningUtils, generateTempId} from '../../../../utils';
+import {getTranslatedValue} from '../../index';
 
 import {ButtonGroup, Button, IconLabel} from 'superdesk-ui-framework/react';
 import {ICoverageDetails, CoverageRowForm} from './CoverageRowForm';
@@ -171,6 +172,7 @@ class AddNewCoveragesComponent extends React.Component<IProps, IState> {
             return;
         }
 
+        const multilingualFields = ['slugline', 'headline', 'internal_note', 'ednote'];
         const coverages: Array<DeepPartial<IPlanningCoverageItem>> = this.state.coverages
             .filter((coverage) => coverage.enabled)
             .map((coverage) => {
@@ -192,6 +194,15 @@ class AddNewCoveragesComponent extends React.Component<IProps, IState> {
                     }
 
                     newCoverage.planning.language = coverage.language;
+
+                    // Copy translated field values based on the language of the Coverage
+                    for (const field of multilingualFields) {
+                        const value = getTranslatedValue(newCoverage.planning.language, this.props.event, field);
+
+                        if (value != null) {
+                            newCoverage.planning[field] = value;
+                        }
+                    }
                 }
 
                 if (coverage.status) {


### PR DESCRIPTION
### Purpose
When adding a new coverage in the Event form (using the Coverage embedded form), the multilingual fields aren't being copied across based on the language of the coverage. This causes some issues when creating content from the associated Assignment.

### What has changed
* After clicking on the `ADD COVERAGE(S)` button, make sure to copy the correct data based on the chosen language of the coverage.

### Front-end checklist
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)

Resolves: [SDBELGA-1030](https://sofab.atlassian.net/browse/SDBELGA-1030)



[SDBELGA-1030]: https://sofab.atlassian.net/browse/SDBELGA-1030?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ