### PR TITLE
handle elastic request error when filtering by planning items

### DIFF
--- a/server/planning/prod_api/events/service.py
+++ b/server/planning/prod_api/events/service.py
@@ -11,6 +11,7 @@
 import json
 from typing import Dict, Iterable, List
 
+from elasticsearch.exceptions import RequestError
 from eve.utils import config
 from superdesk.errors import SuperdeskApiError
 from werkzeug.datastructures import MultiDict
@@ -86,7 +87,12 @@ class EventsService(ProdApiService):
         planning_service = get_resource_service("planning")
 
         # Search for planning documents matching the query
-        results = planning_service.search(planning_query)
+        try:
+            results = planning_service.search(planning_query)
+        except RequestError as e:
+            raise SuperdeskApiError.badRequestError(
+                f"Invalid planning_source query: {str(e.info.get('error', {}).get('reason', str(e)))}"
+            )
 
         event_ids = {event_id for event_id in self._extract_event_items(results) if event_id}
         return list(event_ids)

--- a/server/tests/prod_api/tests/test_events.py
+++ b/server/tests/prod_api/tests/test_events.py
@@ -222,3 +222,28 @@ def test_planning_source_alone_filters_correctly(prodapi_app_with_data, prodapi_
         assert resp.status_code == 200
         assert len(resp_data["_items"]) == 1
         assert resp_data["_items"][0]["guid"] == target_event_id
+
+
+def test_planning_source_malformed_elasticsearch_query(prodapi_app_with_data, prodapi_app_with_data_client):
+    """Test that malformed Elasticsearch query in planning_source returns 400 error
+
+    When the planning_source contains a malformed Elasticsearch query that causes
+    an Elasticsearch RequestError, it should be caught and returned as a 400 Bad Request
+    instead of a 500 Internal Server Error.
+
+    :param prodapi_app_with_data: prod api app with filled data
+    :param prodapi_app_with_data_client: client for prod api app with filled data
+    """
+
+    with prodapi_app_with_data.test_request_context():
+        # Pass a malformed Elasticsearch query (exists query without proper structure)
+        # This simulates: [exists] query malformed, no start_object after query name
+        malformed_query = {"query": {"exists": "field_name"}}  # Should be {"exists": {"field": "field_name"}}
+        resp = prodapi_app_with_data_client.get(
+            url_for("events|resource", planning_source=json.dumps(malformed_query)),
+        )
+        resp_data = json.loads(resp.data.decode("utf-8"))
+
+        assert resp.status_code == 400
+        assert "_message" in resp_data
+        assert "Invalid planning_source query" in resp_data["_message"]


### PR DESCRIPTION
SDBELGA-1027

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

### Front-end checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)

Resolves: #[issue-number]

