### PR TITLE
[SDCP-1073] fix all-day end date timezone

### DIFF
--- a/client/components/UI/Form/DateTimeInput/index.tsx
+++ b/client/components/UI/Form/DateTimeInput/index.tsx
@@ -77,6 +77,14 @@ export const DateTimeInput = ({
     ...props
 }: IProps) => {
     let timeValue = timeField ? get(diff, timeField, null) : value;
+    let dateValue = value;
+
+    if (props.allDay && value != null) {
+        const tz = remoteTimeZone || moment.tz.guess();
+        const momentValue = moment.isMoment(value) ? value : moment(value);
+
+        dateValue = moment.tz(momentValue.format('YYYY-MM-DD'), tz);
+    }
 
     if (props.allDay) {
         timeValue = null;
@@ -98,7 +106,7 @@ export const DateTimeInput = ({
                 row={false}
                 component={DateInput}
                 field={`${field}.date`}
-                value={value}
+                value={dateValue as moment.Moment}
                 item={item}
                 diff={diff}
                 readOnly={readOnly}

--- a/client/components/UI/Form/DateTimeInput/index.tsx
+++ b/client/components/UI/Form/DateTimeInput/index.tsx
@@ -81,7 +81,7 @@ export const DateTimeInput = ({
     let dateValue = value;
 
     if (props.allDay && value != null) {
-        dateValue = timeUtils.normalizeAllDayDate(value);
+        dateValue = timeUtils.allDayDateToLocalDate(value);
     }
 
     if (props.allDay) {

--- a/client/components/UI/Form/DateTimeInput/index.tsx
+++ b/client/components/UI/Form/DateTimeInput/index.tsx
@@ -6,6 +6,7 @@ import './style.scss';
 import Button from '../../Button';
 import {gettext} from '../../utils';
 import {get} from 'lodash';
+import timeUtils from '../../../../utils/time';
 
 interface IProps {
     field: string;
@@ -80,10 +81,7 @@ export const DateTimeInput = ({
     let dateValue = value;
 
     if (props.allDay && value != null) {
-        const tz = remoteTimeZone || moment.tz.guess();
-        const momentValue = moment.isMoment(value) ? value : moment(value);
-
-        dateValue = moment.tz(momentValue.format('YYYY-MM-DD'), tz);
+        dateValue = timeUtils.normalizeAllDayDate(value);
     }
 
     if (props.allDay) {

--- a/client/components/fields/editor/EventSchedule.tsx
+++ b/client/components/fields/editor/EventSchedule.tsx
@@ -233,7 +233,8 @@ export class EditorFieldEventSchedule extends React.PureComponent<IEventSchedule
                     toBeConfirmed={this.props.item[TO_BE_CONFIRMED_FIELD] === true}
                     isLocalTimeZoneDifferent={isLocalTimeZoneDifferent}
                     remoteTimeZone={this.props.item.dates?.tz}
-                    allDay={this.props.item.dates?.no_end_time ?? this.props.item.dates?.all_day}
+                    allDay={this.props.item.dates?.all_day === true ||
+                        this.props.item.dates?.no_end_time === true}
                 />
                 <Row
                     flex={true}

--- a/client/utils/tests/time_test.ts
+++ b/client/utils/tests/time_test.ts
@@ -1,4 +1,4 @@
-import moment from 'moment';
+import moment from 'moment-timezone';
 import sinon from 'sinon';
 import {timeUtils} from '../';
 import {restoreSinonStub} from '../testUtils';
@@ -182,6 +182,30 @@ describe('utils.time', () => {
             sinon.stub(timeUtils, 'localTimeZone').callsFake(() => 'Europe/Amsterdam');
             expect(timeUtils.isEventInDifferentTimeZone(event)).toBeFalsy();
             restoreSinonStub(timeUtils.localTimeZone);
+        });
+    });
+
+    describe('allDayDateToLocalDate', () => {
+        afterEach(() => {
+            moment.tz.setDefault();
+        });
+
+        it('keeps the same calendar day in a negative timezone', () => {
+            moment.tz.setDefault('America/Toronto');
+
+            const value = '2026-02-14T00:00:00.000Z';
+            const result = timeUtils.allDayDateToLocalDate(value);
+
+            expect(result.format('YYYY-MM-DD')).toBe('2026-02-14');
+        });
+
+        it('keeps the same calendar day in a positive timezone', () => {
+            moment.tz.setDefault('Australia/Sydney');
+
+            const value = '2026-02-14T00:00:00.000Z';
+            const result = timeUtils.allDayDateToLocalDate(value);
+
+            expect(result.format('YYYY-MM-DD')).toBe('2026-02-14');
         });
     });
 });

--- a/client/utils/time.ts
+++ b/client/utils/time.ts
@@ -174,7 +174,7 @@ function getDateAsString(value: string | Date | moment.Moment): string {
     }
 }
 
-function normalizeAllDayDate(value: moment.MomentInput): moment.Moment {
+function allDayDateToLocalDate(value: moment.MomentInput): moment.Moment {
     return moment(moment.utc(value).format('YYYY-MM-DD'));
 }
 
@@ -191,7 +191,7 @@ const self = {
     getTimeZoneAbbreviation,
     getDateForVersionInList,
     getDateAsString,
-    normalizeAllDayDate,
+    allDayDateToLocalDate,
 };
 
 export default self;

--- a/client/utils/time.ts
+++ b/client/utils/time.ts
@@ -174,6 +174,16 @@ function getDateAsString(value: string | Date | moment.Moment): string {
     }
 }
 
+/**
+ * Converts a UTC all-day date to a local date-only moment instance.
+ *
+ * This normalizes the value to a `YYYY-MM-DD` string in UTC and then
+ * creates a local moment from that date-only representation to avoid
+ * timezone offsets shifting the displayed day.
+ *
+ * @param {moment.MomentInput} value - The UTC date value for an all-day event.
+ * @return {moment.Moment} A local moment representing the same calendar day.
+ */
 function allDayDateToLocalDate(value: moment.MomentInput): moment.Moment {
     return moment(moment.utc(value).format('YYYY-MM-DD'));
 }

--- a/client/utils/time.ts
+++ b/client/utils/time.ts
@@ -174,6 +174,10 @@ function getDateAsString(value: string | Date | moment.Moment): string {
     }
 }
 
+function normalizeAllDayDate(value: moment.MomentInput): moment.Moment {
+    return moment(moment.utc(value).format('YYYY-MM-DD'));
+}
+
 // eslint-disable-next-line consistent-this
 const self = {
     getStartOfNextWeek,
@@ -187,6 +191,7 @@ const self = {
     getTimeZoneAbbreviation,
     getDateForVersionInList,
     getDateAsString,
+    normalizeAllDayDate,
 };
 
 export default self;


### PR DESCRIPTION
### Purpose
This PR fixes the off‑by‑one day issue when selecting end dates for all‑day multi‑day events in negative timezones like Toronto

### What has changed
- Ensure the end date field is treated as all‑day when either `dates.all_day` or `dates.no_end_time` is true.
- Normalize all‑day date values to the event timezone before passing them into the date picker, so the calendar day remains stable across timezones.

### Steps to test
1. Set your local timezone to a negative offset like Toronto 
2. Create a multi‑day all‑day event
3. Select a start date and an end date several days apart
4. Verify the picker shows the same day you click
5. Repeat in positive timezones e.g Kenya or even Sydney to ensure nothing breaks


Resolves : [SDCP-1073](https://sofab.atlassian.net/browse/SDCP-1073)


[SDCP-1073]: https://sofab.atlassian.net/browse/SDCP-1073?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ