### PR TITLE
Fix coverage language and user selection and on change logic

### DIFF
--- a/client/components/Coverages/CoverageAddAdvancedModal.tsx
+++ b/client/components/Coverages/CoverageAddAdvancedModal.tsx
@@ -170,7 +170,7 @@ class CoverageAddAdvancedModalComponent extends React.Component<IProps, IState> 
             desk: null,
             user: null,
             planning: {
-                language: this.getDefaultLanguage(),
+                language: coverage.planning?.language,
             } as ICoveragePlanningDetails,
             status: planningUtils.getDefaultCoverageStatus(this.props.newsCoverageStatus),
             filteredDesks: this.props.desks,
@@ -192,12 +192,20 @@ class CoverageAddAdvancedModalComponent extends React.Component<IProps, IState> 
         this.setState({coverages: coverages, isDirty: true});
     }
 
-    onDeskChange = (selected, desk) => {
+    onDeskChange = (selected: Partial<ICoverageLineItem>, desk: IDesk | null) => {
         const deskLanguage = desk?.desk_language;
+        let user = selected.user;
+
+        const deskUsers = getUsersForDesk(desk, this.props.users);
+
+        if (!user || !deskUsers.some((u) => u._id === user._id)) {
+            user = null;
+        }
+
         const updates: Partial<ICoverageLineItem> = {
             desk: desk,
-            filteredUsers: getUsersForDesk(desk, this.props.users),
-            user: null,
+            filteredUsers: deskUsers,
+            user: user,
         };
 
         // If desk has a language, check if it's available in the planning profile

--- a/client/components/Coverages/CoverageFieldsRow.tsx
+++ b/client/components/Coverages/CoverageFieldsRow.tsx
@@ -86,7 +86,7 @@ export const CoverageEditableFields = ({
                     );
                 }}
             >
-                <Option value={null} />
+                <Option value={null}>{gettext('Select a language')}</Option>
                 {languages.map((lang) => (
                     <Option key={lang.value.qcode} value={lang.value.qcode}>
                         {getVocabularyItemFieldTranslated(lang.value, 'name', language)}


### PR DESCRIPTION
### Purpose
If desk changes, and selected coverage user is in that desk, don't change the user. 
If we duplicate a coverage without a language, when the duplicated coverage is enabled don't set the language to the default one. 
Improve the language select - add a label of "Select a language" for the `null` option so it's consistent with the other dropdowns

Resolves: #[SDBELGA-1034]



[SDBELGA-1034]: https://sofab.atlassian.net/browse/SDBELGA-1034?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ