### PR TITLE
Allow user unassignment from planning coverage UI

### DIFF
--- a/client/components/Assignments/AssignmentEditor.tsx
+++ b/client/components/Assignments/AssignmentEditor.tsx
@@ -88,7 +88,8 @@ export class AssignmentEditorComponent extends React.PureComponent<IProps> {
     }
 
     onUserChange = (value?: IUser) => {
-        this.props.onChange({[this.FIELDS.USER]: value?._id});
+        // use null explicitly to ensure unassigned user is sent to backend
+        this.props.onChange({[this.FIELDS.USER]: value?._id ?? null});
     }
 
     onContactChange = (contact: IContact) => {

--- a/server/planning/planning/planning.py
+++ b/server/planning/planning/planning.py
@@ -1124,7 +1124,7 @@ class PlanningService(AsyncBaseService):
                 if original_assignment.get("assigned_to", {}).get("desk") != assigned_to.get("desk"):
                     assigned_to["assigned_date_desk"] = utcnow()
                     assigned_to["assignor_desk"] = user.get(ID_FIELD)
-                if assigned_to.get("user") and original.get("assigned_to", {}).get("user") != assigned_to.get("user"):
+                if "user" in assigned_to and original.get("assigned_to", {}).get("user") != assigned_to.get("user"):
                     assigned_to["assigned_date_user"] = utcnow()
                     assigned_to["assignor_user"] = user.get(ID_FIELD)
 


### PR DESCRIPTION
### Purpose
 Enable user unassignment from coverage assignments in the coverage details modal. Previously, the backend would not process updates where user was explicitly set to null, preventing users from being unassigned through the UI

[STT-1560]



[STT-1560]: https://sofab.atlassian.net/browse/STT-1560?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ