### PR TITLE
add coverages info to events in prod api

### DIFF
--- a/server/planning/prod_api/events/service.py
+++ b/server/planning/prod_api/events/service.py
@@ -14,6 +14,7 @@ from typing import Dict, Iterable, List
 from elasticsearch.exceptions import RequestError
 from eve.utils import config
 from superdesk.errors import SuperdeskApiError
+from flask import has_request_context, request
 from werkzeug.datastructures import MultiDict
 
 from superdesk import get_resource_service
@@ -24,11 +25,21 @@ from planning.prod_api.assignments.utils import (
     get_assignment_ids_from_planning,
     construct_assignment_links,
 )
-from planning.prod_api.planning.utils import construct_planning_link
+from planning.prod_api.planning.utils import (
+    construct_planning_link,
+    extract_coverage_summaries,
+    str_to_bool,
+)
 
 
 class EventsService(ProdApiService):
     excluded_fields = ProdApiService.excluded_fields | excluded_lock_fields
+
+    def _include_assignment_links(self) -> bool:
+        if not has_request_context():
+            return True
+
+        return not str_to_bool(request.args.get("exclude_assignments"), default=False)
 
     def get(self, req, lookup):
         planning_query = self._extract_planning_source(req)
@@ -114,9 +125,15 @@ class EventsService(ProdApiService):
                 assignment_ids.extend(get_assignment_ids_from_planning(plan))
 
             if doc.get(config.LINKS):
-                doc[config.LINKS]["plannings"] = [construct_planning_link(item[config.ID_FIELD]) for item in plannings]
+                doc[config.LINKS]["plannings"] = [
+                    construct_planning_link(
+                        item[config.ID_FIELD],
+                        coverages=extract_coverage_summaries(item.get("coverages") or []),
+                    )
+                    for item in plannings
+                ]
 
-                if len(assignment_ids):
+                if len(assignment_ids) and self._include_assignment_links():
                     doc[config.LINKS]["assignments"] = construct_assignment_links(assignment_ids)
 
 

--- a/server/planning/prod_api/planning/utils.py
+++ b/server/planning/prod_api/planning/utils.py
@@ -8,11 +8,41 @@
 # AUTHORS and LICENSE files distributed with this source code, or
 # at https://www.sourcefabric.org/superdesk/license
 
+from typing import Dict, Iterable, List, Optional
+
 from .resource import PlanningResource
 
 
-def construct_planning_link(plan_id: str):
-    return {
+def str_to_bool(value: Optional[object], default: bool = False) -> bool:
+    if value is None:
+        return default
+
+    if isinstance(value, bool):
+        return value
+
+    return str(value).strip().lower() in {"1", "true", "t", "yes", "y", "on"}
+
+
+def construct_planning_link(plan_id: str, coverages: Optional[List[Dict]] = None):
+    link = {
         "title": PlanningResource.resource_title,
         "href": f"{PlanningResource.url}/{plan_id}",
+        "coverages": coverages or [],
     }
+
+    return link
+
+
+def extract_coverage_summaries(coverages: Iterable[Dict]) -> List[Dict]:
+    summaries = []
+    for coverage in coverages:
+        summaries.append(
+            {
+                "coverage_id": coverage.get("coverage_id"),
+                "workflow_status": coverage.get("workflow_status"),
+                "news_coverage_status": coverage.get("news_coverage_status"),
+                "g2_content_type": (coverage.get("planning") or {}).get("g2_content_type"),
+            }
+        )
+
+    return summaries

--- a/server/tests/prod_api/tests/test_events.py
+++ b/server/tests/prod_api/tests/test_events.py
@@ -247,3 +247,70 @@ def test_planning_source_malformed_elasticsearch_query(prodapi_app_with_data, pr
         assert resp.status_code == 400
         assert "_message" in resp_data
         assert "Invalid planning_source query" in resp_data["_message"]
+
+
+def test_event_planning_links_include_coverage_summaries(prodapi_app_with_data, prodapi_app_with_data_client):
+    """Ensure event planning links include limited coverage summaries."""
+
+    event_id = "urn:newsml:localhost:5000:2019-09-10T15:43:13.722490:5dcea683-fb9b-42ca-a77f-ce1216aef8b1"
+
+    with prodapi_app_with_data.test_request_context():
+        resp = prodapi_app_with_data_client.get(
+            url_for("events|item_lookup", _id=event_id),
+        )
+        resp_data = json.loads(resp.data.decode("utf-8"))
+
+        assert resp.status_code == 200
+        assert resp_data["guid"] == event_id
+
+        plannings = (resp_data.get("_links") or {}).get("plannings") or []
+        assert len(plannings) == 1
+
+        coverage_summaries = plannings[0].get("coverages") or []
+        assert len(coverage_summaries) == 2
+
+        expected_status = {
+            "qcode": "ncostat:int",
+            "name": "coverage intended",
+            "label": "Planned",
+        }
+        expected_coverage_ids = {
+            "urn:newsml:localhost:5000:2019-09-10T15:47:04.656641:5cfa0851-6985-47c3-8091-3c06dae91c66",
+            "urn:newsml:localhost:5000:2019-09-10T16:15:02.472468:39bf806f-a802-4cb4-bc81-9f28477c7a64",
+        }
+
+        assert {coverage.get("coverage_id") for coverage in coverage_summaries} == expected_coverage_ids
+
+        for coverage in coverage_summaries:
+            assert set(coverage.keys()) == {
+                "coverage_id",
+                "workflow_status",
+                "news_coverage_status",
+                "g2_content_type",
+            }
+            assert coverage["workflow_status"] == "active"
+            assert coverage["news_coverage_status"] == expected_status
+            assert coverage["g2_content_type"] == "text"
+
+
+def test_event_assignments_links_optional(prodapi_app_with_data, prodapi_app_with_data_client):
+    """Ensure assignment links can be excluded via query param."""
+
+    event_id = "urn:newsml:localhost:5000:2019-09-10T15:43:13.722490:5dcea683-fb9b-42ca-a77f-ce1216aef8b1"
+
+    with prodapi_app_with_data.test_request_context():
+        resp = prodapi_app_with_data_client.get(
+            url_for("events|item_lookup", _id=event_id),
+        )
+        resp_data = json.loads(resp.data.decode("utf-8"))
+
+        assert resp.status_code == 200
+        assert "assignments" in (resp_data.get("_links") or {})
+
+        resp = prodapi_app_with_data_client.get(
+            url_for("events|item_lookup", _id=event_id, exclude_assignments=1),
+        )
+        resp_data = json.loads(resp.data.decode("utf-8"))
+
+        assert resp.status_code == 200
+        assert "assignments" not in (resp_data.get("_links") or {})


### PR DESCRIPTION
and make assignments info optional

SDBELGA-1035

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

### Front-end checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)

Resolves: #[issue-number]

