### PR TITLE
[SDBELGA-1038] fix: Embed form not using PLANNING_MANUAL_NEWS_COVERAGE_STATUS

### DIFF
--- a/client/components/Planning/PlanningEditor/index.tsx
+++ b/client/components/Planning/PlanningEditor/index.tsx
@@ -275,21 +275,7 @@ class PlanningEditorComponent extends React.Component<IProps, IState> {
         let valueToUpdate = value;
 
         if (field.match(/^coverages\[/)) {
-            const {newsCoverageStatus} = this.props;
-            const coverage = value as IPlanningCoverageItem;
-
-            // If there is an assignment and coverage status not planned,
-            // change it to 'planned'
-            if (planningConfig.planning.manual_news_coverage_status !== true &&
-                newsCoverageStatus.length > 0 &&
-                coverage?.news_coverage_status?.qcode !== newsCoverageStatus[0].qcode &&
-                coverage?.assigned_to?.desk != null
-            ) {
-                valueToUpdate = {
-                    ...coverage,
-                    news_coverage_status: this.props.newsCoverageStatus[0],
-                };
-            }
+            planningUtils.setNewsCoverageStatusOnChange(value as IPlanningCoverageItem);
 
             if (field.match(/g2_content_type$/) &&
                 value === 'text' &&

--- a/client/components/fields/editor/EventRelatedPlannings/EmbeddedCoverageForm.tsx
+++ b/client/components/fields/editor/EventRelatedPlannings/EmbeddedCoverageForm.tsx
@@ -12,6 +12,7 @@ import {
 import {ICoverageDetails} from './CoverageRowForm';
 import {superdeskApi, planningApi} from '../../../../superdeskApi';
 import {getDesksForUser, getUsersForDesk} from '../../../../utils';
+import {getNewsCoverageStatusPlanned} from '../../../../utils/vocabularies';
 import {Select, Option} from 'superdesk-ui-framework/react';
 import * as List from '../../../UI/List';
 import {Row} from '../../../UI/Form';
@@ -112,6 +113,16 @@ export class EmbeddedCoverageFormComponent extends React.PureComponent<IProps, I
             filteredUsers: getUsersForDesk(newDesk, this.props.users),
             user: null,
         };
+
+        if (appConfig.planning.manual_news_coverage_status !== true) {
+            // If there is an assignment and coverage status not planned,
+            // change it to 'planned'
+            const plannedStatus = getNewsCoverageStatusPlanned();
+
+            if (this.props.coverage.status?.qcode !== plannedStatus.qcode && newDesk != null) {
+                updates.status = plannedStatus;
+            }
+        }
 
         const hasDeskLanguage = deskLanguage != null;
         const noCoverageLanguageSet = coverageLanguage == null;

--- a/client/components/fields/editor/EventRelatedPlannings/RelatedCoverageItems.tsx
+++ b/client/components/fields/editor/EventRelatedPlannings/RelatedCoverageItems.tsx
@@ -32,7 +32,7 @@ interface IProps {
     keywords: Array<string>;
     editorType: EDITOR_TYPE;
 
-    updateCoverage(field: string, value: any): void;
+    updateCoverage(index: number, field: string, value: any): void;
     removeCoverage(coverage: DeepPartial<IPlanningCoverageItem>): void;
     duplicateCoverage(coverage: DeepPartial<IPlanningCoverageItem>, duplicateAs?: IG2ContentType['qcode']): void;
     setCoverageDefaultDesk(coverage: DeepPartial<IPlanningCoverageItem>): void;
@@ -82,7 +82,9 @@ class RelatedCoverageItemsComponent extends React.PureComponent<IProps> {
                         field={`coverages[${index}]`}
                         includeScheduledUpdates={false}
 
-                        onChange={this.props.updateCoverage}
+                        onChange={(field, value) => {
+                            this.props.updateCoverage(index, field, value);
+                        }}
                         remove={() => this.props.removeCoverage(coverage)}
                         onDuplicateCoverage={this.props.duplicateCoverage}
                         setCoverageDefaultDesk={() => this.props.setCoverageDefaultDesk(coverage)}

--- a/client/components/fields/editor/EventRelatedPlannings/RelatedPlanningItem.tsx
+++ b/client/components/fields/editor/EventRelatedPlannings/RelatedPlanningItem.tsx
@@ -67,10 +67,14 @@ export class RelatedPlanningItem extends React.PureComponent<IProps> {
         this.props.updatePlanningItem(this.props.item, updates, scrollOnChange);
     }
 
-    updateCoverage(field: string, value: any) {
+    updateCoverage(index: number, field: string, value: IPlanningCoverageItem) {
         const updates = {coverages: [...this.props.item.coverages]};
 
+        // Make sure this specific Coverage gets a new value reference
+        // So any shallow comparison causes a re-render
+        updates.coverages[index] = {...updates.coverages[index]};
         set(updates, field, value);
+        planningUtils.setNewsCoverageStatusOnChange(value);
         this.update(updates, false);
     }
 

--- a/client/utils/planning.ts
+++ b/client/utils/planning.ts
@@ -65,6 +65,7 @@ import {
 import * as selectors from '../selectors';
 import {IMenuItem} from 'superdesk-ui-framework/react/components/Menu';
 import {planningConfig} from '../config';
+import {getNewsCoverageStatusPlanned} from './vocabularies';
 
 const isCoverageAssigned = (coverage) => !!get(coverage, 'assigned_to.desk');
 
@@ -1715,6 +1716,20 @@ function duplicateCoverage(
     return diffCoverages;
 }
 
+function setNewsCoverageStatusOnChange(coverage: IPlanningCoverageItem): void {
+    // If there is an assignment and coverage status not planned,
+    // change it to 'planned'
+    if (planningConfig.planning.manual_news_coverage_status === true) {
+        return;
+    }
+
+    const plannedStatus = getNewsCoverageStatusPlanned();
+
+    if (coverage.news_coverage_status?.qcode !== plannedStatus.qcode && coverage.assigned_to?.desk != null) {
+        coverage.news_coverage_status = plannedStatus;
+    }
+}
+
 // eslint-disable-next-line consistent-this
 const self = {
     canSpikePlanning,
@@ -1770,6 +1785,7 @@ const self = {
     showXMPFileUIControl,
     duplicateCoverage,
     toUIFrameworkInterface,
+    setNewsCoverageStatusOnChange,
 };
 
 export default self;

--- a/client/utils/planning.ts
+++ b/client/utils/planning.ts
@@ -1716,9 +1716,13 @@ function duplicateCoverage(
     return diffCoverages;
 }
 
+/**
+ * Updates the news coverage status of a given coverage item when changes occur,
+ * setting it to "planned" if a Desk has been assigned
+ *
+ * @param {IPlanningCoverageItem} coverage - The coverage item whose news coverage status is being evaluated and potentially updated.
+ */
 function setNewsCoverageStatusOnChange(coverage: IPlanningCoverageItem): void {
-    // If there is an assignment and coverage status not planned,
-    // change it to 'planned'
     if (planningConfig.planning.manual_news_coverage_status === true) {
         return;
     }

--- a/client/utils/vocabularies.ts
+++ b/client/utils/vocabularies.ts
@@ -1,3 +1,6 @@
+import {IPlanningNewsCoverageStatus} from '../interfaces';
+import {superdeskApi} from '../superdeskApi';
+
 export function getVocabularyItemFieldTranslated(
     item: {
         translations?: {[key: string]: any},
@@ -95,4 +98,16 @@ export function getVocabularyItemNameFromString<T>(
             nameField as string,
             language
         );
+}
+
+export function getNewsCoverageStatusPlanned(): IPlanningNewsCoverageStatus {
+    const items = (
+        superdeskApi.entities.vocabulary.getVocabulary('newscoveragestatus')?.items ?? []
+    ) as Array<IPlanningNewsCoverageStatus>;
+
+    return items.find((item) => item.qcode === 'ncostat:int') ?? {
+        qcode: 'ncostat:int',
+        name: 'coverage intended',
+        label: 'Planned',
+    };
 }


### PR DESCRIPTION
### Purpose
The embedded Planning form within the Event form was not using the `PLANNING_MANUAL_NEWS_COVERAGE_STATUS` config.

Additionally another bug was found during testing, where the `Coverage Status` was not being updated/re-rendered when the value changed (again, in the embedded planning form)

Resolves: [SDBELGA-1038](https://sofab.atlassian.net/browse/SDBELGA-1038)



[SDBELGA-1038]: https://sofab.atlassian.net/browse/SDBELGA-1038?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ