### PR TITLE
fix failing e2e server install

### DIFF
--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -25,7 +25,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
-          cache-dependency-path: 'server/requirements.txt'
+          cache-dependency-path: |
+            server/requirements.txt
+            e2e/server/requirements.txt
+            e2e/server/core-requirements.txt
       - name: Setup Environment
         run: ./scripts/ci-install.sh
       - name: Install Planning Client

--- a/e2e/server/Dockerfile
+++ b/e2e/server/Dockerfile
@@ -24,9 +24,6 @@ ENV C_FORCE_ROOT=False
 ENV CELERYBEAT_SCHEDULE_FILENAME=/tmp/celerybeatschedule.db
 ENV TZ=Europe/London
 
-# update venv
-RUN python3 -m pip install -U pip wheel setuptools
-
 # install core requirements
 WORKDIR /tmp
 COPY e2e/server/core-requirements.txt .

--- a/scripts/ci-install.sh
+++ b/scripts/ci-install.sh
@@ -4,9 +4,6 @@
 sudo apt-get -y update
 sudo apt-get -y install libxml2-dev libxmlsec1-dev libxmlsec1-openssl
 
-# Update python core packages
-python -m pip install --upgrade pip wheel setuptools
-
 git config --global url."https://git@".insteadOf git://
 
 if [ "$INSTALL_NODE_MODULES" == "true" ]; then


### PR DESCRIPTION
### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

### Front-end checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)

Resolves: #[issue-number]

