### PR TITLE
allow updates of canceled events by onclusive

### DIFF
--- a/server/planning/events/events.py
+++ b/server/planning/events/events.py
@@ -882,11 +882,15 @@ class EventsService(AsyncBaseService):
                 await files_service.delete_action_async(lookup={"_id": file})
 
     def should_update(self, old_item, new_item, provider):
-        return old_item is None or not any(
-            [
-                old_item.get("pubstatus") == "cancelled",
-                old_item.get("state") == "killed",
-            ]
+        return (
+            old_item is None
+            or old_item.get("version_creator") is None
+            or not any(
+                [
+                    old_item.get("pubstatus") == "cancelled",
+                    old_item.get("state") == "killed",
+                ]
+            )
         )
 
 

--- a/server/planning/events/events.py
+++ b/server/planning/events/events.py
@@ -881,7 +881,25 @@ class EventsService(AsyncBaseService):
             if await events_using_file.count() == 0:
                 await files_service.delete_action_async(lookup={"_id": file})
 
-    def should_update(self, old_item, new_item, provider):
+    def should_update(self, old_item, new_item, provider) -> bool:
+        """Determine if an ingest feed event should update the local event.
+
+        Allows updates when:
+        - Event doesn't exist locally
+        - Event never manually edited (version_creator is None), even if cancelled/killed
+        - Event manually edited but not cancelled/killed
+
+        Key behavior: Ingest feeds can update cancelled/killed events only if never manually
+        touched. Once user-edited, cancelled/killed events won't be updated from feeds.
+
+        Args:
+            old_item: Existing event (None if doesn't exist)
+            new_item: Incoming event from feed
+            provider: Ingest provider config
+
+        Returns:
+            True if should update, False otherwise
+        """
         return (
             old_item is None
             or old_item.get("version_creator") is None

--- a/server/planning/events/events_service.py
+++ b/server/planning/events/events_service.py
@@ -375,7 +375,7 @@ class EventsAsyncService(BasePlanningAsyncService[EventResourceModel]):
         if not start_date or not end_date:
             raise SuperdeskApiError(message="Event START DATE and END DATE are mandatory.")
 
-        if end_date < start_date and not event.dates.no_end_date:
+        if end_date < start_date and not event.dates.no_end_time:
             raise SuperdeskApiError(message="END TIME should be after START TIME")
 
         if event.dates.recurring_rule and not event.dates.recurring_rule.until and not event.dates.recurring_rule.count:

--- a/server/planning/events/events_service.py
+++ b/server/planning/events/events_service.py
@@ -375,7 +375,7 @@ class EventsAsyncService(BasePlanningAsyncService[EventResourceModel]):
         if not start_date or not end_date:
             raise SuperdeskApiError(message="Event START DATE and END DATE are mandatory.")
 
-        if end_date < start_date:
+        if end_date < start_date and not event.dates.no_end_date:
             raise SuperdeskApiError(message="END TIME should be after START TIME")
 
         if event.dates.recurring_rule and not event.dates.recurring_rule.until and not event.dates.recurring_rule.count:

--- a/server/planning/feed_parsers/onclusive.py
+++ b/server/planning/feed_parsers/onclusive.py
@@ -222,13 +222,14 @@ class OnclusiveFeedParser(FeedParser):
             # item["subjects"] = categories
         if event.get("eventTypes"):
             for category in event["eventTypes"]:
-                categories.append(
-                    {
-                        "name": category["tagName"],
-                        "qcode": str(category["tagId"]),
-                        "scheme": "onclusive_event_types",
-                    }
-                )
+                if category["tagId"] and category["tagName"]:
+                    categories.append(
+                        {
+                            "name": category["tagName"],
+                            "qcode": str(category["tagId"]),
+                            "scheme": "onclusive_event_types",
+                        }
+                    )
         item["subject"] = categories
 
     def datetime(self, date, time=None, timezone=None, tzinfo=None):

--- a/server/planning/tests/events_service_test.py
+++ b/server/planning/tests/events_service_test.py
@@ -62,10 +62,26 @@ def test_should_update():
     old_event = {"versioncreated": datetime.now(), "version_creator": None}
     assert service.should_update(old_event, new_event, provider={})
 
+    # Test: should_update returns True when version_creator exists but not cancelled/killed
+    old_event = {
+        "versioncreated": datetime.now(),
+        "version_creator": "user_id",
+        "state": "draft",
+    }
+    assert service.should_update(old_event, new_event, provider={})
+
     # Test: should_update returns False when pubstatus is "cancelled"
     old_event = {
         "versioncreated": datetime.now(),
         "version_creator": "user_id",
         "pubstatus": "cancelled",
+    }
+    assert not service.should_update(old_event, new_event, provider={})
+
+    # Test: should_update returns False when state is "killed"
+    old_event = {
+        "versioncreated": datetime.now(),
+        "version_creator": "user_id",
+        "state": "killed",
     }
     assert not service.should_update(old_event, new_event, provider={})

--- a/server/planning/tests/events_service_test.py
+++ b/server/planning/tests/events_service_test.py
@@ -54,3 +54,18 @@ def test_should_update():
     old_event: Event = new_event.copy()
 
     assert service.should_update(old_event, new_event, provider={})
+
+    # Test: should_update returns True when old_item is None
+    assert service.should_update(None, new_event, provider={})
+
+    # Test: should_update returns True when version_creator is None
+    old_event = {"versioncreated": datetime.now(), "version_creator": None}
+    assert service.should_update(old_event, new_event, provider={})
+
+    # Test: should_update returns False when pubstatus is "cancelled"
+    old_event = {
+        "versioncreated": datetime.now(),
+        "version_creator": "user_id",
+        "pubstatus": "cancelled",
+    }
+    assert not service.should_update(old_event, new_event, provider={})


### PR DESCRIPTION
if those were not canceled manually

SDCP-1083

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

### Front-end checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)

Resolves: #[issue-number]

