### PR TITLE
[SDESK-7873] improve(onclusive): Don't update contact if nothing changed

### DIFF
--- a/server/planning/feed_parsers/onclusive.py
+++ b/server/planning/feed_parsers/onclusive.py
@@ -351,10 +351,13 @@ class OnclusiveFeedParser(FeedParser):
                     updates["organisation"] = value
 
             elif field == "pressContactName":
-                try:
-                    first, last = value.rsplit(" ", 1)
-                except ValueError:
-                    first, last = "", value
+                if not value:
+                    first, last = "", ""
+                else:
+                    try:
+                        first, last = value.rsplit(" ", 1)
+                    except ValueError:
+                        first, last = "", value
 
                 if first != existing_contact.get("first_name"):
                     updates["first_name"] = first

--- a/server/planning/feed_parsers/onclusive.py
+++ b/server/planning/feed_parsers/onclusive.py
@@ -277,15 +277,11 @@ class OnclusiveFeedParser(FeedParser):
 
             try:
                 if existing_contact_id is None:
-                    updates.setdefault(
-                        {
-                            "contact_email": [],
-                            "contact_phone": [],
-                            "organisation": "",
-                            "first_name": "",
-                            "last_name": "",
-                        }
-                    )
+                    updates.setdefault("contact_email", [])
+                    updates.setdefault("contact_phone", [])
+                    updates.setdefault("organisation", "")
+                    updates.setdefault("first_name", "")
+                    updates.setdefault("last_name", "")
                     await contacts_service.post_async([updates])
                     item["event_contact_info"].append(bson.ObjectId(updates["_id"]))
                 elif updates:
@@ -327,24 +323,28 @@ class OnclusiveFeedParser(FeedParser):
 
         for field in {"pressContactEmail", "pressContactTelephone", "pressContactOffice", "pressContactName"}:
             value = contact_info.get(field)
-            if not value:
-                continue
-
-            elif field == "pressContactEmail":
+            if field == "pressContactEmail":
                 existing_emails = existing_contact.get("contact_email") or []
-                if value not in existing_emails:
+                if not value:
+                    if existing_emails:
+                        updates["contact_email"] = []
+                elif value not in existing_emails:
                     updates["contact_email"] = [value]
 
             elif field == "pressContactTelephone":
                 existing_phones = existing_contact.get("contact_phone") or []
-                phone_exists = False
-                for phone in existing_phones:
-                    if phone.get("number") == value:
-                        phone_exists = True
-                        break
+                if not value:
+                    if existing_phones:
+                        updates["contact_phone"] = []
+                else:
+                    phone_exists = False
+                    for phone in existing_phones:
+                        if phone.get("number") == value:
+                            phone_exists = True
+                            break
 
-                if not phone_exists:
-                    updates["contact_phone"] = [{"number": value, "public": True}]
+                    if not phone_exists:
+                        updates["contact_phone"] = [{"number": value, "public": True}]
 
             elif field == "pressContactOffice":
                 if value != existing_contact.get("organisation"):

--- a/server/planning/feed_parsers/onclusive.py
+++ b/server/planning/feed_parsers/onclusive.py
@@ -260,12 +260,11 @@ class OnclusiveFeedParser(FeedParser):
         return parsed.replace(tzinfo=pytz.utc)
 
     async def parse_contact_info(self, event, item):
+        item.setdefault("event_contact_info", [])
         if not event.get("pressContacts"):
             return
 
         contacts_service = get_resource_service("contacts")
-        item.setdefault("event_contact_info", [])
-
         for contact_info in event["pressContacts"]:
             if not contact_info.get("pressContactID"):
                 logger.warning(

--- a/server/planning/feed_parsers/onclusive.py
+++ b/server/planning/feed_parsers/onclusive.py
@@ -283,10 +283,11 @@ class OnclusiveFeedParser(FeedParser):
                     updates.setdefault("first_name", "")
                     updates.setdefault("last_name", "")
                     await contacts_service.post_async([updates])
-                    item["event_contact_info"].append(bson.ObjectId(updates["_id"]))
+                    existing_contact_id = bson.ObjectId(updates["_id"])
                 elif updates:
                     await contacts_service.patch_async(existing_contact_id, updates)
-                    item["event_contact_info"].append(existing_contact_id)
+
+                item["event_contact_info"].append(existing_contact_id)
             except Exception:
                 # Make sure that if we fail to create/update the contact, we still ingest the Event
                 logger.exception("Error when parsing Onclusive contact info", extra={"contact": contact_info})

--- a/server/planning/feed_parsers/onclusive.py
+++ b/server/planning/feed_parsers/onclusive.py
@@ -260,51 +260,108 @@ class OnclusiveFeedParser(FeedParser):
         return parsed.replace(tzinfo=pytz.utc)
 
     async def parse_contact_info(self, event, item):
-        for contact_info in event.get("pressContacts"):
-            item.setdefault("event_contact_info", [])
-            contact_uri = "onclusive:{}".format(contact_info["pressContactID"])
-            data = {
-                "uri": contact_uri,
-                "contact_email": [],
-                "contact_phone": [],
-                "organisation": "",
-                "first_name": "",
-                "last_name": "",
-            }
+        if not event.get("pressContacts"):
+            return
 
-            if contact_info.get("pressContactEmail"):
-                data["contact_email"].append(contact_info["pressContactEmail"])
+        contacts_service = get_resource_service("contacts")
+        item.setdefault("event_contact_info", [])
 
-            if contact_info.get("pressContactTelephone"):
-                data["contact_phone"].append({"number": contact_info["pressContactTelephone"], "public": True})
-
-            if contact_info.get("pressContactOffice"):
-                data["organisation"] = contact_info["pressContactOffice"]
-
-            if contact_info.get("pressContactName"):
-                try:
-                    first, last = contact_info["pressContactName"].rsplit(" ", 1)
-                except ValueError:
-                    first = ""
-                    last = contact_info["pressContactName"]
-                data["first_name"] = first
-                data["last_name"] = last
-
-            existing_contact = await get_resource_service("contacts").find_one_async(req=None, uri=contact_uri)
-            if existing_contact is None:
-                data.update(
-                    {
-                        "is_active": True,
-                        "public": True,
-                    }
+        for contact_info in event["pressContacts"]:
+            if not contact_info.get("pressContactID"):
+                logger.warning(
+                    "Onclusive contact info missing pressContactID, skipping", extra={"contact": contact_info}
                 )
-                await get_resource_service("contacts").post_async([data])
-                item["event_contact_info"].append(bson.ObjectId(data["_id"]))
-            else:
-                print(existing_contact)
-                existing_contact_id = bson.ObjectId(existing_contact["_id"])
-                await get_resource_service("contacts").patch_async(existing_contact_id, data)
-                item["event_contact_info"].append(existing_contact_id)
+                continue
+
+            updates, existing_contact_id = await self._get_contact_updates(contact_info)
+
+            try:
+                if existing_contact_id is None:
+                    updates.setdefault(
+                        {
+                            "contact_email": [],
+                            "contact_phone": [],
+                            "organisation": "",
+                            "first_name": "",
+                            "last_name": "",
+                        }
+                    )
+                    await contacts_service.post_async([updates])
+                    item["event_contact_info"].append(bson.ObjectId(updates["_id"]))
+                elif updates:
+                    await contacts_service.patch_async(existing_contact_id, updates)
+                    item["event_contact_info"].append(existing_contact_id)
+            except Exception:
+                # Make sure that if we fail to create/update the contact, we still ingest the Event
+                logger.exception("Error when parsing Onclusive contact info", extra={"contact": contact_info})
+                continue
+
+    async def _get_contact_updates(self, contact_info: dict) -> tuple[dict, bson.ObjectId | None]:
+        """
+        Retrieves and prepares contact updates based on the provided contact information.
+
+        This method analyzes the provided `contact_info` dictionary containing details about a
+        press contact and determines what updates should be made in comparison to the data
+        of an existing contact retrieved from a resource service. Updates may include changes
+        to email, phone numbers, organization, and name details.
+
+        :param contact_info: A dictionary containing information about the press contact.
+        :return tuple[dict, bson.ObjectId | None]: A tuple where:
+            - The first element is a dictionary containing the updates to be applied.
+            - The second element is the ObjectId of the existing contact, or `None` if no existing contact is found.
+        """
+
+        contact_uri = f"onclusive:{contact_info['pressContactID']}"
+        existing_contact: dict = (
+            await get_resource_service("contacts").find_one_async(req=None, uri=contact_uri)
+        ) or {}
+        updates: dict = {}
+        if not existing_contact:
+            updates.update(
+                {
+                    "uri": contact_uri,
+                    "is_active": True,
+                    "public": True,
+                }
+            )
+
+        for field in {"pressContactEmail", "pressContactTelephone", "pressContactOffice", "pressContactName"}:
+            value = contact_info.get(field)
+            if not value:
+                continue
+
+            elif field == "pressContactEmail":
+                existing_emails = existing_contact.get("contact_email") or []
+                if value not in existing_emails:
+                    updates["contact_email"] = [value]
+
+            elif field == "pressContactTelephone":
+                existing_phones = existing_contact.get("contact_phone") or []
+                phone_exists = False
+                for phone in existing_phones:
+                    if phone.get("number") == value:
+                        phone_exists = True
+                        break
+
+                if not phone_exists:
+                    updates["contact_phone"] = [{"number": value, "public": True}]
+
+            elif field == "pressContactOffice":
+                if value != existing_contact.get("organisation"):
+                    updates["organisation"] = value
+
+            elif field == "pressContactName":
+                try:
+                    first, last = value.rsplit(" ", 1)
+                except ValueError:
+                    first, last = "", value
+
+                if first != existing_contact.get("first_name"):
+                    updates["first_name"] = first
+                if last != existing_contact.get("last_name"):
+                    updates["last_name"] = last
+
+        return updates, bson.ObjectId(existing_contact["_id"]) if existing_contact.get("_id") else None
 
     def set_expiry(self, event, provider) -> None:
         expiry_minutes = (

--- a/server/planning/feed_parsers/onclusive_tests.py
+++ b/server/planning/feed_parsers/onclusive_tests.py
@@ -203,3 +203,38 @@ class OnclusiveFeedParserTestCase(TestCase):
         with self.assertLogs("planning", level=logging.ERROR) as logger:
             await OnclusiveFeedParser().parse([data])
             assert "Error when parsing Onclusive event" in logger.output[0]
+
+    async def test_get_contact_updates(self):
+        contacts_service = superdesk.get_resource_service("contacts")
+        parser = OnclusiveFeedParser()
+        contact_info = self.data["pressContacts"][0].copy()
+
+        # 1. Get data for a contact not currently in the db
+        updates, contact_id = await parser._get_contact_updates(contact_info)
+        self.assertIsNone(contact_id)
+        self.assertEqual(
+            updates,
+            {
+                "uri": "onclusive:28871",
+                "is_active": True,
+                "public": True,
+                "contact_email": ["customerservice@americanconference.com"],
+                "contact_phone": [{"number": "1 212 352 3220", "public": True}],
+                "organisation": "American Conference Institute",
+                "first_name": "Benjamin Andrew",
+                "last_name": "Stokes",
+            },
+        )
+
+        # 2. Get empty updates for contact in db with no changes from ingest
+        await contacts_service.post_async([updates])
+        existing_contact_id = bson.ObjectId(updates["_id"])
+        updates, contact_id = await parser._get_contact_updates(contact_info)
+        self.assertEqual(contact_id, existing_contact_id)
+        self.assertEqual(updates, {})
+
+        # 3. Get name updates for contact in db with changes from ingest
+        contact_info["pressContactName"] = "Foo Bar"
+        updates, contact_id = await parser._get_contact_updates(contact_info)
+        self.assertEqual(contact_id, existing_contact_id)
+        self.assertEqual(updates, {"first_name": "Foo", "last_name": "Bar"})

--- a/server/planning/feed_parsers/onclusive_tests.py
+++ b/server/planning/feed_parsers/onclusive_tests.py
@@ -238,3 +238,37 @@ class OnclusiveFeedParserTestCase(TestCase):
         updates, contact_id = await parser._get_contact_updates(contact_info)
         self.assertEqual(contact_id, existing_contact_id)
         self.assertEqual(updates, {"first_name": "Foo", "last_name": "Bar"})
+
+    async def test_parse_event_maintains_existing_contact_linkage(self):
+        """
+        Ensure that when an event is parsed multiple times with the same, unchanged
+        contact data, the existing contact is reused and the event remains linked
+        to that contact via event_contact_info.
+        """
+
+        parser = OnclusiveFeedParser()
+        data = deepcopy(self.data)
+
+        # 1st version: create the contact and link it to the event via event_contact_info
+        event_v1 = (await parser.parse([data]))[0]
+        self.assertEqual(len(event_v1["event_contact_info"]), 1)
+        contact_id_v1 = event_v1["event_contact_info"][0]
+        self.assertTrue(bson.ObjectId.is_valid(contact_id_v1))
+
+        # 2nd version: unchanged contact data - should reuse the same contact
+        item_v2 = (await parser.parse([data]))[0]
+        self.assertEqual(len(item_v2["event_contact_info"]), 1)
+        # Verify that the contact linkage is maintained and no new contact is created
+        self.assertEqual(contact_id_v1, item_v2["event_contact_info"][0])
+
+        # 3rd version: changed contact data - should reuse the same contact
+        data["pressContacts"][0]["pressContactEmail"] = "foo@bar.org"
+        item_v3 = (await parser.parse([data]))[0]
+        self.assertEqual(len(item_v3["event_contact_info"]), 1)
+        # Verify that the contact linkage is maintained and no new contact is created
+        self.assertEqual(contact_id_v1, item_v3["event_contact_info"][0])
+
+        # 4th version: no contacts - should remove contacts from Event
+        data["pressContacts"] = []
+        item_v4 = (await parser.parse([data]))[0]
+        self.assertEqual(len(item_v4["event_contact_info"]), 0)


### PR DESCRIPTION
### Purpose
When ingesting an Event from Onclusive, the Contacts DB **ALWAYS** update even if nothing has changed.

### What has changed
* Move Contact data extraction to a separate method
* Only update the Contact document if something has changed
* Log a warning if Contact `pressContactID` not found in ingest
* Wrap the Contact DB actions in a `try...except`, so any errors are logged but the Event still gets ingested

Resolves: [SDESK-7873](https://sofab.atlassian.net/browse/SDESK-7873)



[SDESK-7873]: https://sofab.atlassian.net/browse/SDESK-7873?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ