### PR TITLE
[SDESK-7305] - Week start day setting not respected globally

### DIFF
--- a/client/config.ts
+++ b/client/config.ts
@@ -74,13 +74,11 @@ if (appConfig.start_of_week == null) {
 }
 
 // Align planning week start with core config
-if (appConfig.startingDay != null) {
-    appConfig.start_of_week = typeof appConfig.startingDay === 'string'
-        ? parseInt(appConfig.startingDay, 10)
-        : appConfig.startingDay;
-} else {
-    appConfig.startingDay = appConfig.start_of_week;
-}
+const startingDay = appConfig.startingDay;
+const normalizedStartingDay = typeof startingDay === 'string' ? parseInt(startingDay, 10) : startingDay;
+
+appConfig.start_of_week = normalizedStartingDay ?? appConfig.start_of_week;
+appConfig.startingDay = appConfig.start_of_week;
 
 if (appConfig.planning == null) {
     appConfig.planning = {};

--- a/client/config.ts
+++ b/client/config.ts
@@ -73,6 +73,15 @@ if (appConfig.start_of_week == null) {
     appConfig.start_of_week = parseInt(appConfig.start_of_week, 10);
 }
 
+// Align planning week start with core config
+if (appConfig.startingDay != null) {
+    appConfig.start_of_week = typeof appConfig.startingDay === 'string'
+        ? parseInt(appConfig.startingDay, 10)
+        : appConfig.startingDay;
+} else {
+    appConfig.startingDay = appConfig.start_of_week;
+}
+
 if (appConfig.planning == null) {
     appConfig.planning = {};
 }

--- a/client/config.ts
+++ b/client/config.ts
@@ -73,12 +73,8 @@ if (appConfig.start_of_week == null) {
     appConfig.start_of_week = parseInt(appConfig.start_of_week, 10);
 }
 
-// Align planning week start with core config
-const startingDay = appConfig.startingDay;
-const normalizedStartingDay = typeof startingDay === 'string' ? parseInt(startingDay, 10) : startingDay;
-
-appConfig.start_of_week = normalizedStartingDay ?? appConfig.start_of_week;
-appConfig.startingDay = appConfig.start_of_week;
+// Fallback when start_of_week is not provided.
+appConfig.start_of_week = appConfig.start_of_week ?? appConfig.startingDay ?? 0;
 
 if (appConfig.planning == null) {
     appConfig.planning = {};


### PR DESCRIPTION
### Purpose
Align Planning week-start behavior with client-core so it follows `startingDay` when present.

### What has changed
Updated Planning config normalization to mirror `startingDay` into `start_of_week`, and backfill `startingDay` when it’s missing.

### Steps to test
1. Set `startingDay: 1` in `superdesk.config.js` and set backend `START_OF_WEEK=0`.
2. Rebuild and start the client.
3. Open Planning date pickers (events/planning) and confirm week starts on Monday.

Note: This PR goes hand in hand with this change in [superdesk-client-core](https://github.com/superdesk/superdesk-client-core/pull/5073)

Resolves: [SDESK-7305](https://sofab.atlassian.net/browse/SDESK-7305)

[SDESK-7305]: https://sofab.atlassian.net/browse/SDESK-7305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ