### PR TITLE
[STT-1574] data_update: Remove `anpa_category.scheme` from db

### DIFF
--- a/server/planning/data_updates/00037_20260216-140530_events_planning.py
+++ b/server/planning/data_updates/00037_20260216-140530_events_planning.py
@@ -1,0 +1,113 @@
+# -*- coding: utf-8; -*-
+# This file is part of Superdesk.
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+#
+# Author  : MarkLark86
+# Creation: 2026-02-16 14:30
+
+from typing import Iterator
+from motor.motor_asyncio import AsyncIOMotorCollection, AsyncIOMotorDatabase
+
+from superdesk import get_resource_service
+from superdesk.services import BaseService
+from superdesk.commands.data_updates import BaseDataUpdate
+
+
+class DataUpdate(BaseDataUpdate):
+    """Remove ``anpa_category.scheme`` from the database"""
+
+    resource = "events"
+    use_async_resources = True
+
+    async def forwards(self, _collection: AsyncIOMotorCollection, _database: AsyncIOMotorDatabase) -> None:
+        self._fix_events()
+        self._fix_planning()
+        self._fix_assignments()
+
+    def _fix_events(self) -> None:
+        service: BaseService = get_resource_service("events")
+        for item in self.iterate_items(service):
+            if self._remove_scheme(item):
+                service.system_update(item["_id"], {"anpa_category": item["anpa_category"]}, item)
+
+    def _fix_planning(self) -> None:
+        service = get_resource_service("planning")
+        for item in self.iterate_items(service):
+            updates: dict = {}
+            if self._remove_scheme(item):
+                updates["anpa_category"] = item["anpa_category"]
+
+            coverages_updated = False
+            coverages: list[dict] = item.get("coverages", [])
+            for coverage in coverages:
+                if self._remove_scheme(coverage.get("planning") or {}):
+                    coverages_updated = True
+
+            if coverages_updated:
+                updates["coverages"] = coverages
+
+            if updates:
+                service.system_update(item["_id"], updates, item)
+
+    def _fix_assignments(self) -> None:
+        service = get_resource_service("assignments")
+        for item in self.iterate_items(service):
+            if self._remove_scheme(item.get("planning") or {}):
+                service.system_update(item["_id"], {"planning": item["planning"]}, item)
+
+    def iterate_items(self, service: BaseService) -> Iterator[dict]:
+        def _get_query(field_prefix: str = "") -> dict:
+            return {"exists": {"field": f"{field_prefix}anpa_category.scheme"}}
+
+        query: dict
+        if service.datasource == "events":
+            query = {"query": {"bool": {"must": _get_query()}}}
+        elif service.datasource == "assignments":
+            query = {"query": {"bool": {"must": _get_query("planning.")}}}
+        elif service.datasource == "planning":
+            query = {
+                "query": {
+                    "bool": {
+                        "should": [
+                            _get_query(),
+                            {
+                                "nested": {
+                                    "path": "coverages",
+                                    "query": {"bool": {"must": [_get_query("coverages.planning.")]}},
+                                }
+                            },
+                        ],
+                        "minimum_should_match": 1,
+                    }
+                }
+            }
+        else:
+            print(f"Unknown datasource: {service.datasource}")
+            return
+
+        cursor = service.search(query)
+
+        if not cursor.count():
+            print(f"No {service.datasource} documents with `anpa_category.scheme` found")
+            return
+
+        for item in cursor:
+            yield item
+
+    def _remove_scheme(self, item: dict) -> bool:
+        categories: list[dict] = item.get("anpa_category", [])
+        if not categories:
+            return False
+
+        categories_updated = False
+        for category in categories:
+            if category.get("scheme"):
+                category["scheme"] = None
+                categories_updated = True
+
+        return categories_updated
+
+    async def backwards(self, _collection: AsyncIOMotorCollection, _database: AsyncIOMotorDatabase) -> None:
+        pass

--- a/server/planning/tests/data_updates/00037_events_planning_test.py
+++ b/server/planning/tests/data_updates/00037_events_planning_test.py
@@ -1,0 +1,131 @@
+import importlib
+from datetime import timedelta
+
+from superdesk import get_resource_service
+from superdesk.services import BaseService
+from superdesk.utc import utcnow
+from planning.tests import TestCase
+
+
+now = utcnow()
+DataUpdate = importlib.import_module("planning.data_updates.00037_20260216-140530_events_planning").DataUpdate
+
+
+class FixAnpaCategorySchemeTestCase(TestCase):
+    async def asyncSetUp(self):
+        await super().asyncSetUp()
+        self.data_update = DataUpdate()
+
+    def assertItemsToFix(self, service: BaseService, item_ids: set[str]):
+        self.assertEqual(set([item["_id"] for item in self.data_update.iterate_items(service)]), item_ids)
+
+    async def test_upgrade_events(self):
+        service: BaseService = get_resource_service("events")
+        dates = {"start": now, "end": now + timedelta(hours=1)}
+        service.post(
+            [
+                {"_id": "e1", "dates": dates},
+                {"_id": "e2", "dates": dates, "anpa_category": [{"qcode": "a", "name": "A", "scheme": "categories"}]},
+                {
+                    "_id": "e3",
+                    "dates": dates,
+                    "anpa_category": [
+                        {"qcode": "a", "name": "A", "scheme": "categories"},
+                        {"qcode": "b", "name": "B"},
+                        {"qcode": "c", "name": "C", "scheme": "test"},
+                    ],
+                },
+            ]
+        )
+
+        self.assertItemsToFix(service, {"e2", "e3"})
+        self.data_update._fix_events()
+        self.assertItemsToFix(service, set())
+        events = {event["_id"]: event for event in service.get(req=None, lookup={})}
+        self.assertDictContains(events["e2"], {"anpa_category": [{"qcode": "a", "name": "A", "scheme": None}]})
+        self.assertDictContains(
+            events["e3"],
+            {
+                "anpa_category": [
+                    {"qcode": "a", "name": "A", "scheme": None},
+                    {"qcode": "b", "name": "B"},
+                    {"qcode": "c", "name": "C", "scheme": None},
+                ]
+            },
+        )
+
+    async def test_upgrade_planning(self):
+        service: BaseService = get_resource_service("planning")
+        service.post(
+            [
+                {"_id": "p1", "planning_date": now},
+                {
+                    "_id": "p2",
+                    "planning_date": now,
+                    "anpa_category": [{"qcode": "a", "name": "A", "scheme": "categories"}],
+                },
+                {
+                    "_id": "p3",
+                    "planning_date": now,
+                    "anpa_category": [{"qcode": "a", "name": "A", "scheme": "categories"}],
+                    "coverages": [
+                        {
+                            "coverage_id": "c1",
+                            "planning": {
+                                "anpa_category": [{"qcode": "b", "name": "B", "scheme": "categories"}],
+                            },
+                        }
+                    ],
+                },
+                {
+                    "_id": "p4",
+                    "planning_date": now,
+                    "coverages": [
+                        {
+                            "coverage_id": "c2",
+                            "planning": {
+                                "anpa_category": [{"qcode": "c", "name": "C", "scheme": "categories"}],
+                            },
+                        }
+                    ],
+                },
+            ]
+        )
+
+        self.assertItemsToFix(service, {"p2", "p3", "p4"})
+        self.data_update._fix_planning()
+        self.assertItemsToFix(service, set())
+
+        planning = {planning["_id"]: planning for planning in service.get(req=None, lookup={})}
+        self.assertDictContains(planning["p2"], {"anpa_category": [{"qcode": "a", "name": "A", "scheme": None}]})
+        self.assertDictContains(planning["p3"], {"anpa_category": [{"qcode": "a", "name": "A", "scheme": None}]})
+        self.assertDictContains(
+            planning["p3"]["coverages"][0]["planning"], {"anpa_category": [{"qcode": "b", "name": "B", "scheme": None}]}
+        )
+        self.assertDictContains(
+            planning["p4"]["coverages"][0]["planning"], {"anpa_category": [{"qcode": "c", "name": "C", "scheme": None}]}
+        )
+
+    async def test_upgrade_assignments(self):
+        service: BaseService = get_resource_service("assignments")
+        service.post(
+            [
+                {"_id": "a1", "planning_date": now},
+                {
+                    "_id": "a2",
+                    "planning_date": now,
+                    "planning": {
+                        "scheduled": now,
+                        "anpa_category": [{"qcode": "a", "name": "A", "scheme": "categories"}],
+                    },
+                },
+            ]
+        )
+
+        self.assertItemsToFix(service, {"a2"})
+        self.data_update._fix_assignments()
+        self.assertItemsToFix(service, set())
+        assignments = {assignment["_id"]: assignment for assignment in service.get(req=None, lookup={})}
+        self.assertDictContains(
+            assignments["a2"]["planning"], {"anpa_category": [{"qcode": "a", "name": "A", "scheme": None}]}
+        )


### PR DESCRIPTION
### Purpose
When ANPA Category has `scheme` set it causes issues in the front-end. As we don't use this `scheme` attribute here (and might have only been populated by ingest).

### What has changed
Data migration script to remove:
* Event: `anpa_category.scheme`
* Planning: `anpa_category.scheme`
* Planning: `coverages.planning.anpa_category.scheme`
* Assignments: `planning.anpa_category.scheme`

Resolves: [STT-1574](https://sofab.atlassian.net/browse/STT-1574)



[STT-1574]: https://sofab.atlassian.net/browse/STT-1574?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ