### PR TITLE
fix permissions when working with assignments

### DIFF
--- a/server/features/assignments_lock.feature
+++ b/server/features/assignments_lock.feature
@@ -74,6 +74,80 @@ Feature: Assignments Locking
         """
 
     @auth
+    Scenario: Can lock assignment for reassign with archive privilege only
+        Given "assignments"
+        """
+        [{
+            "_id": "a124",
+            "planning": {
+                "ednote": "test coverage, I want 250 words",
+                "headline": "test headline",
+                "slugline": "test slugline",
+                "scheduled": "2016-01-02T14:00:00+0000"
+            },
+            "assigned_to": {
+                "desk": "Politic Desk",
+                "user": "507f191e810c19729de870eb",
+                "state": "assigned"
+            }
+        }]
+        """
+        When we switch user
+        When we patch "/users/#USERS_ID#"
+        """
+        {"user_type": "user", "privileges": {"archive": 1, "planning_planning_management": 0}}
+        """
+        Then we get OK response
+        When we post to "/assignments/a124/lock"
+        """
+        {"lock_action": "reassign"}
+        """
+        Then we get existing resource
+        """
+        {
+            "_id": "a124",
+            "lock_user": "#CONTEXT_USER_ID#"
+        }
+        """
+
+    @auth
+    Scenario: Can lock assignment for complete with archive privilege only
+        Given "assignments"
+        """
+        [{
+            "_id": "a125",
+            "planning": {
+                "ednote": "test coverage, I want 250 words",
+                "headline": "test headline",
+                "slugline": "test slugline",
+                "scheduled": "2016-01-02T14:00:00+0000"
+            },
+            "assigned_to": {
+                "desk": "Politic Desk",
+                "user": "507f191e810c19729de870eb",
+                "state": "assigned"
+            }
+        }]
+        """
+        When we switch user
+        When we patch "/users/#USERS_ID#"
+        """
+        {"user_type": "user", "privileges": {"archive": 1, "planning_planning_management": 0}}
+        """
+        Then we get OK response
+        When we post to "/assignments/a125/lock"
+        """
+        {"lock_action": "complete"}
+        """
+        Then we get existing resource
+        """
+        {
+            "_id": "a125",
+            "lock_user": "#CONTEXT_USER_ID#"
+        }
+        """
+
+    @auth
     Scenario: Lock fails if associated content item is locked by another user
         Given "desks"
         """

--- a/server/planning/item_lock.py
+++ b/server/planning/item_lock.py
@@ -184,7 +184,7 @@ class LockService(BaseComponent):
         service = superdesk.get_resource_service(resource)
         check_method = service.can_edit
 
-        if resource == "assignments" and action in ["start_working", "content_edit"]:
+        if resource == "assignments" and action in ["start_working", "content_edit", "reassign", "complete"]:
             check_method = service.can_work_on_content
 
         can_user_edit, error_message = check_method(item, user_id)


### PR DESCRIPTION
stop requiring `planning_planning_management` permission when working with assignments.

SDBELGA-1036 SDBELGA-1040

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

### Front-end checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)

Resolves: #[issue-number]

