### PR TITLE
fix assignments reloading state

### DIFF
--- a/client/reducers/assignment.ts
+++ b/client/reducers/assignment.ts
@@ -113,10 +113,8 @@ const setListSortOrder = (state, payload) => {
 };
 
 const setGroupLoading = (state, payload) => {
-    state.lists[payload.list] = {
-        ...state.lists[payload.list],
-        isLoading: payload.isLoading,
-    };
+    state.lists[payload.list].isLoading = payload.isLoading;
+
     return state;
 };
 
@@ -189,7 +187,9 @@ const assignmentReducer = createReducer(initialState, {
     ),
 
     [ASSIGNMENTS.ACTIONS.SET_LOADING]: (state, payload) => (
-        setGroupLoading(state, payload)
+        produce(state, (draft) => {
+            setGroupLoading(draft, payload);
+        })
     ),
 
     [ASSIGNMENTS.ACTIONS.SET_SORT_FIELD]: (state, payload) => ({

--- a/client/reducers/tests/assignment_test.ts
+++ b/client/reducers/tests/assignment_test.ts
@@ -598,6 +598,44 @@ describe('assignment', () => {
         }));
     });
 
+    it('SET_LOADING', () => {
+        let result = assignment(initialState, {
+            type: ASSIGNMENTS.ACTIONS.SET_LOADING,
+            payload: {
+                list: 'TODO',
+                isLoading: true,
+            },
+        });
+
+        expect(result.lists).toEqual(jasmine.objectContaining({
+            TODO: {
+                assignmentIds: [],
+                total: 0,
+                lastPage: null,
+                sortOrder: 'Asc',
+                isLoading: true,
+            },
+        }));
+
+        result = assignment(result, {
+            type: ASSIGNMENTS.ACTIONS.SET_LOADING,
+            payload: {
+                list: 'TODO',
+                isLoading: false,
+            },
+        });
+
+        expect(result.lists).toEqual(jasmine.objectContaining({
+            TODO: {
+                assignmentIds: [],
+                total: 0,
+                lastPage: null,
+                sortOrder: 'Asc',
+                isLoading: false,
+            },
+        }));
+    });
+
     it('SET_SORT_FIELD', () => {
         const result = assignment(initialState, {
             type: ASSIGNMENTS.ACTIONS.SET_SORT_FIELD,


### PR DESCRIPTION
it was stuck in loading state after some actions

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

### Front-end checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)

Resolves: #[issue-number]

