### PR TITLE
fix json event formatter subject name translations

### DIFF
--- a/server/planning/output_formatters/json_base_formatter.py
+++ b/server/planning/output_formatters/json_base_formatter.py
@@ -34,7 +34,7 @@ class BaseJsonFormatter(Formatter):
 
     async def format(self, item, subscriber, codes=None):
         output_item = await self._format_item(deepcopy(item))
-        await self._enhance_item(item)
+        await self._enhance_item(output_item)
 
         return [
             (

--- a/server/planning/tests/output_formatters/json_event_test.py
+++ b/server/planning/tests/output_formatters/json_event_test.py
@@ -164,6 +164,25 @@ class JsonEventTestCase(TestCase):
             self.assertEqual(output_item.get("anpa_category")[0]["name"], "News")
             self.assertEqual(output_item.get("language"), "en")
 
+    async def test_subject_translation_uses_item_language(self):
+        async with self.app.app_context():
+            formatter = JsonEventFormatter()
+            item = self.item.copy()
+            item["language"] = "cs"
+            item["subject"] = [
+                {
+                    "name": "tourism",
+                    "qcode": "10006000",
+                    "parent": "10000000",
+                    "translations": {"name": {"cs": "Cestovní ruch", "en": "Tourism"}},
+                }
+            ]
+
+            output = (await formatter.format(item, self.subscriber))[0]
+            output_item = json.loads(output[1])
+
+            self.assertEqual(output_item["subject"][0]["name"], "Cestovní ruch")
+
     async def test_files_publishing(self):
         async with self.app.app_context():
             init_app(self.app)


### PR DESCRIPTION
SDCP-1106

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

### Front-end checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)

Resolves: #[issue-number]

