### PR TITLE
[SDCP-1102] fix: CustomCV options now translating with item language

### DIFF
--- a/client/components/fields/editor/CustomCV.tsx
+++ b/client/components/fields/editor/CustomCV.tsx
@@ -36,6 +36,7 @@ export class EditorFieldCV extends React.PureComponent<ICustomCVFieldProps> {
                 testId={testId?.length ? testId : cv._id}
             >
                 <TreeSelect
+                    key={`${cv.display_name}-${language}`}
                     selectBranchWithChildren={cv.disable_entire_category_selection !== true}
                     sortable={true}
                     kind="synchronous"
@@ -53,6 +54,7 @@ export class EditorFieldCV extends React.PureComponent<ICustomCVFieldProps> {
                                 scheme: cv._id,
                                 parent: cvItem.parent,
                                 service: cvItem.service,
+                                translations: cvItem.translations,
                             })) as Array<ISubject>,
                             ({qcode}) => qcode.toString(),
                             ({parent}) => parent?.toString(),


### PR DESCRIPTION
### Purpose
Custom vocabulary input fields were not using translations to display the values & options.

### What has changed
* Include `translations` attribute when getting list of options
* Add `key` to `TreeSelect` rendering so it re-renders when language changes (couldn't find a way to do this with changes to the `TreeSelect` component, so fell back to this solution)

### Steps to test
1. Create a Planning item
2. Select a value in the `EVENT TYPES` field
3. Change the language of the item to `fr-CA`

The values and options should update to use the new language you selected.

Resolves: SDCP-1102

