### PR TITLE
[STT-1575][STT-1578] frontend: Unify handling of Assignment editor updates

### DIFF
--- a/client/actions/assignments/notifications.ts
+++ b/client/actions/assignments/notifications.ts
@@ -1,13 +1,11 @@
 import {get, cloneDeep} from 'lodash';
 
-import {
-    IWebsocketMessageData, EDITOR_TYPE, IEventOrPlanningItem, IPlanningItem, IPlanningAppState} from '../../interfaces';
+import {IWebsocketMessageData, IPlanningAppState} from '../../interfaces';
 
 import {planningApi, superdeskApi} from '../../superdeskApi';
-import {ASSIGNMENTS, WORKSPACE, MODALS, ITEM_TYPE} from '../../constants';
-import {lockUtils, assignmentUtils, gettext, isExistingItem, getAutosaveItem} from '../../utils';
+import {ASSIGNMENTS, WORKSPACE, MODALS} from '../../constants';
+import {lockUtils, assignmentUtils, gettext, isExistingItem} from '../../utils';
 
-import {editors as editorsActions} from '../../actions';
 import * as selectors from '../../selectors';
 import assignments from './index';
 import main from '../main';
@@ -75,8 +73,12 @@ const onAssignmentCreated = (_e, data) => (
  * @param {object} _e - Event object
  * @param {object} data - Assignment, User, Desk IDs
  */
-const onAssignmentUpdated = (_e, data) => (
+const onAssignmentUpdated = (_e: any, data: IWebsocketMessageData['ASSIGNMENT_UPDATED']) => (
     (dispatch, getState, {desks}) => {
+        window.dispatchEvent(
+            new CustomEvent<IWebsocketMessageData['ASSIGNMENT_UPDATED']>('assignments:updated', {detail: data}),
+        );
+
         // If this planning item was updated by this user in AddToPlanning Modal
         // Then ignore this notification
         if (selectors.general.sessionId(getState()) === data.session && (
@@ -147,7 +149,7 @@ const onAssignmentUpdated = (_e, data) => (
             }
         }
 
-        if (!get(data, 'lock_user')) {
+        if (data.lock_user == null) {
             // Assignment was completed on editor but context was a different desk
             return dispatch(assignments.api.fetchAssignmentById(data.item, false))
                 .then((assignmentInStore) => {
@@ -180,44 +182,6 @@ const onAssignmentUpdated = (_e, data) => (
 );
 
 /**
- * Synchronizes editor state with updated planning coverages after assignment changes
- * When assignments are modified (desk changed, state changed to in-progress, etc.), the planning
- * editor's coverage data becomes stale. This action refreshes the editor form and autosave with
- * the latest coverage information from the server.
- * @param {string} planningId - The planning item ID
- * @param {IPlanningItem[]} loadedPlannings - Planning items freshly loaded from server
- * @returns {Function} Thunk action that syncs the editor if the planning item is currently being edited
- */
-const syncEditorWithUpdatedPlanning = (planningId: string, loadedPlannings: IPlanningItem[]) => (
-    (dispatch, getState: GetStateFunc) => {
-        const currentState = getState();
-        const editorSelectors = selectors.editors.editorSelectors[EDITOR_TYPE.INLINE];
-        const editorDiff = cloneDeep(editorSelectors.getEditorDiff(currentState));
-
-        // only update if this planning item is currently being edited
-        if (editorDiff?._id === planningId && loadedPlannings.length > 0) {
-            const updatedDiff = {
-                ...editorDiff,
-                coverages: loadedPlannings[0]?.coverages || []
-            };
-
-            dispatch(editorsActions.setFormDiff(EDITOR_TYPE.INLINE, updatedDiff));
-
-            const autosaves = selectors.forms.autosaves(currentState);
-            const autosaveItem = getAutosaveItem(
-                autosaves,
-                ITEM_TYPE.PLANNING,
-                planningId
-            );
-
-            return planningApi.autosave.save(autosaveItem, updatedDiff as IEventOrPlanningItem);
-        }
-
-        return Promise.resolve();
-    }
-);
-
-/**
  * Updates planning item when its related assignment changes
  * Reloads the planning item's coverages from the server and synchronizes them with the editor
  * if the planning item is currently being edited. Also updates the item history.
@@ -240,9 +204,7 @@ const updatePlanningRelatedToAssignment = (data) => (
 
         if (!coverage) return;
 
-        const loadedPlannings = await dispatch(planningApis.loadPlanningByIds([data.planning]));
-
-        await dispatch(syncEditorWithUpdatedPlanning(data.planning, loadedPlannings));
+        await dispatch(planningApis.loadPlanningByIds([data.planning]));
         await dispatch(main.fetchItemHistory(planningItem));
     }
 );
@@ -338,37 +300,41 @@ function onAssignmentUnlocked(_e, data: IWebsocketMessageData['ITEM_UNLOCKED']) 
  * @param {object} _e - Event object
  * @param {object} data - IDs for the Assignment, Planning and Coverage items
  */
-const onAssignmentRemoved = (_e, data) => (
-    (dispatch, getState, {notify}) => {
-        if (get(data, 'assignments')) {
-            dispatch({
-                type: ASSIGNMENTS.ACTIONS.REMOVE_ASSIGNMENT,
-                payload: data,
-            });
-
-            data.assignments.forEach((a) => {
-                dispatch(_notifyAssignmentEdited(a));
-                // Though assignment is removed, this is to remove the orphan lock in the store
-                dispatch({
-                    type: ASSIGNMENTS.ACTIONS.UNLOCK_ASSIGNMENT,
-                    payload: {assignment: {_id: a}},
-                });
-            });
-
-            // Updates my assignment count
-            dispatch(
-                assignments.ui.queryAndGetMyAssignments(
-                    [
-                        ASSIGNMENTS.WORKFLOW_STATE.ASSIGNED,
-                        ASSIGNMENTS.WORKFLOW_STATE.SUBMITTED,
-                    ]
-                )
-            );
-
-            return dispatch(updatePlanningRelatedToAssignment(data));
+const onAssignmentRemoved = (_e: any, data: IWebsocketMessageData['ASSIGNMENT_REMOVED']) => (
+    (dispatch) => {
+        if (data.assignments == null) {
+            return Promise.resolve();
         }
 
-        return Promise.resolve();
+        window.dispatchEvent(
+            new CustomEvent<IWebsocketMessageData['ASSIGNMENT_REMOVED']>('assignments:removed', {detail: data}),
+        );
+
+        dispatch({
+            type: ASSIGNMENTS.ACTIONS.REMOVE_ASSIGNMENT,
+            payload: data,
+        });
+
+        data.assignments.forEach((a) => {
+            dispatch(_notifyAssignmentEdited(a));
+            // Though assignment is removed, this is to remove the orphan lock in the store
+            dispatch({
+                type: ASSIGNMENTS.ACTIONS.UNLOCK_ASSIGNMENT,
+                payload: {assignment: {_id: a}},
+            });
+        });
+
+        // Updates my assignment count
+        dispatch(
+            assignments.ui.queryAndGetMyAssignments(
+                [
+                    ASSIGNMENTS.WORKFLOW_STATE.ASSIGNED,
+                    ASSIGNMENTS.WORKFLOW_STATE.SUBMITTED,
+                ]
+            )
+        );
+
+        return dispatch(updatePlanningRelatedToAssignment(data));
     }
 );
 

--- a/client/components/Planning/PlanningEditor/index.tsx
+++ b/client/components/Planning/PlanningEditor/index.tsx
@@ -148,61 +148,13 @@ class PlanningEditorComponent extends React.Component<IProps, IState> {
             this.props.fetchEventFiles(this.props.event);
         }
 
-        // No need for partial save features if the editor is in read-only mode
-        if (this.props.readOnly) {
-            return;
-        } else if (
+        if (
+            !this.props.readOnly &&
             this.props.addNewsItemToPlanning &&
             !this.props.itemExists &&
             this.props.diff?.coverages?.length === 0
         ) {
             this.handleAddToPlanningLoading();
-            return;
-        } else if (currentItemId !== prevItemId || this.props.submitting) {
-            return;
-        }
-
-        // If the assignment associated with the planning item are modified
-        const originalCoverages = prevProps.original?.coverages || [];
-        const updatedCoverages = this.props.original?.coverages || [];
-
-        if (!originalCoverages.length) {
-            return;
-        }
-
-        let updates: {[key: string]: any} = {};
-
-        originalCoverages.forEach((original) => {
-            // Push notification updates from 'assignment' workflow changes
-            const index = updatedCoverages.findIndex(
-                (c) => c.coverage_id === original.coverage_id
-            );
-            const covUpdates = index >= 0 ?
-                updatedCoverages[index] :
-                null;
-
-            if (covUpdates == null) {
-                return;
-            }
-
-            if (isEqual(covUpdates.assigned_to, original.assigned_to)) {
-                // If assignment has not changed
-                return;
-            }
-
-            updates[`coverages[${index}]`] = covUpdates;
-        });
-
-        if (prevProps.original?._etag != null &&
-            this.props.original?._etag != null &&
-            prevProps.original._etag !== this.props.original._etag
-        ) {
-            // Update the `_etag` if it has changed
-            updates._etag = this.props.original._etag;
-        }
-
-        if (Object.keys(updates).length) {
-            this.props.itemManager.finalisePartialSave(updates, false);
         }
     }
 

--- a/client/components/fields/editor/Coverages.tsx
+++ b/client/components/fields/editor/Coverages.tsx
@@ -1,24 +1,121 @@
 import * as React from 'react';
 import {get} from 'lodash';
 
-import {superdeskApi} from '../../../superdeskApi';
+import {superdeskApi, planningApi} from '../../../superdeskApi';
+import {IWebsocketMessageData, IPlanningItem, IPlanningAssignedTo, IAssignmentItem} from '../../../interfaces';
 
 import {CoverageArrayInput} from '../../Coverages';
 import {getFileDownloadURL} from '../../../utils';
 import {IPropsEditorFieldCoverages} from './coverages.interface';
 
+/**
+ * Copy assignment details from an assignment to a coverage assignment.
+ *
+ * TODO-PR: Update the location where this function should be synced with
+ * Note: This was copied from the `planning.common.copy_assignment_details_to_coverage` backend function.
+ * The functionality between these two should be kept in sync.
+ */
+function copyAssignmentDetailsToCoverage(
+    assignment: IAssignmentItem,
+    coverageAssignedTo: DeepPartial<IPlanningAssignedTo>,
+): void {
+    coverageAssignedTo.desk = assignment.assigned_to.desk;
+    coverageAssignedTo.user = assignment.assigned_to.user;
+    coverageAssignedTo.contact = assignment.assigned_to.contact;
+    coverageAssignedTo.state = assignment.assigned_to.state;
+    coverageAssignedTo.assignor_user = assignment.assigned_to.assignor_user;
+    coverageAssignedTo.assignor_desk = assignment.assigned_to.assignor_desk;
+    coverageAssignedTo.assigned_date_desk = assignment.assigned_to.assigned_date_desk;
+    coverageAssignedTo.assigned_date_user = assignment.assigned_to.assigned_date_user;
+    coverageAssignedTo.coverage_provider = assignment.assigned_to.coverage_provider;
+    coverageAssignedTo.priority = assignment.priority;
+}
+
 export class EditorFieldCoverages extends React.PureComponent<IPropsEditorFieldCoverages> {
+    componentDidMount() {
+        window.addEventListener('assignments:updated', this.onAssignmentUpdated);
+        window.addEventListener('assignments:removed', this.onAssignmentRemoved);
+    }
+
+    componentWillUnmount() {
+        window.removeEventListener('assignments:updated', this.onAssignmentUpdated);
+        window.removeEventListener('assignments:removed', this.onAssignmentRemoved);
+    }
+
+    onAssignmentUpdated = (event: CustomEvent<IWebsocketMessageData['ASSIGNMENT_UPDATED']>) => {
+        if (event.detail.planning !== this.props.item._id) {
+            // This notification was not for the current Planning item
+            return;
+        }
+
+        planningApi.assignments.getById(event.detail.item).then((assignment) => {
+            const coverages = this.getCoverages();
+            let coverageAssignedTo: DeepPartial<IPlanningAssignedTo> | null = null;
+            let coverageIndex: number;
+            let coverage: DeepPartial<IPlanningItem['coverages'][number]>;
+
+            for (coverageIndex = 0; coverageIndex < coverages.length; coverageIndex++) {
+                coverage = coverages[coverageIndex];
+
+                if (assignment.coverage_item === coverage.coverage_id) {
+                    coverageAssignedTo = assignment.scheduled_update_id == null ?
+                        coverage.assigned_to :
+                        coverage.scheduled_updates.find(
+                            (c) => c.scheduled_update_id === assignment.scheduled_update_id,
+                        )?.assigned_to;
+
+                    break;
+                }
+            }
+
+            if (coverageAssignedTo == null) {
+                console.warn(`Coverage for Assignment ${assignment._id} not found`);
+                return;
+            }
+
+            copyAssignmentDetailsToCoverage(assignment, coverageAssignedTo);
+            debugger;
+            this.props.onChange(`coverages[${coverageIndex}].assigned_to`, coverageAssignedTo);
+        });
+    }
+
+    onAssignmentRemoved = (event: CustomEvent<IWebsocketMessageData['ASSIGNMENT_REMOVED']>) => {
+        if (event.detail.planning !== this.props.item._id) {
+            return;
+        }
+
+        const coverages = this.getCoverages();
+        const coverageIndex = coverages.findIndex((coverage) => coverage.coverage_id === event.detail.coverage);
+
+        if (coverageIndex === -1) {
+            console.warn(`Coverage ${event.detail.coverage} not found`);
+        }
+
+        coverages[coverageIndex].assigned_to = {};
+        coverages[coverageIndex].workflow_status = 'draft';
+        for (let scheduledUpdate of coverages[coverageIndex].scheduled_updates ?? []) {
+            scheduledUpdate.assigned_to = {};
+            scheduledUpdate.workflow_status = 'draft';
+        }
+
+        this.props.onChange(`coverages[${coverageIndex}]`, coverages[coverageIndex]);
+    }
+
+    getCoverages(): IPlanningItem['coverages'] {
+        const field = this.props.field ?? 'coverages';
+
+        return get(this.props.item, field, this.props.defaultValue) as IPlanningItem['coverages'];
+    }
+
     render() {
         const {gettext} = superdeskApi.localization;
-        const field = this.props.field ?? 'coverages';
-        const value = get(this.props.item, field, this.props.defaultValue);
 
         return (
             <CoverageArrayInput
                 {...this.props}
                 testId="field-coverages"
                 field={this.props.field ?? 'coverages'}
-                value={value}
+                value={this.getCoverages()}
                 disabled={this.props.disabled}
                 addButtonText={this.props.addButtonText ?? gettext('Add a coverage')}
                 createUploadLink={getFileDownloadURL}

--- a/client/components/fields/editor/Coverages.tsx
+++ b/client/components/fields/editor/Coverages.tsx
@@ -2,7 +2,14 @@ import * as React from 'react';
 import {get} from 'lodash';
 
 import {superdeskApi, planningApi} from '../../../superdeskApi';
-import {IWebsocketMessageData, IPlanningItem, IPlanningAssignedTo, IAssignmentItem} from '../../../interfaces';
+import {
+    IWebsocketMessageData,
+    IPlanningItem,
+    IPlanningAssignedTo,
+    IAssignmentItem,
+    IPlanningCoverageItem,
+    ICoverageScheduledUpdate,
+} from '../../../interfaces';
 
 import {CoverageArrayInput} from '../../Coverages';
 import {getFileDownloadURL} from '../../../utils';
@@ -49,31 +56,44 @@ export class EditorFieldCoverages extends React.PureComponent<IPropsEditorFieldC
 
         planningApi.assignments.getById(event.detail.item).then((assignment) => {
             const coverages = this.getCoverages();
-            let coverageAssignedTo: DeepPartial<IPlanningAssignedTo> | null = null;
+            let coverageToUpdate: DeepPartial<IPlanningCoverageItem | ICoverageScheduledUpdate> | null = null;
             let coverageIndex: number;
+            let scheduledUpdateIndex: number = -1;
             let coverage: DeepPartial<IPlanningItem['coverages'][number]>;
 
             for (coverageIndex = 0; coverageIndex < coverages.length; coverageIndex++) {
                 coverage = coverages[coverageIndex];
 
-                if (assignment.coverage_item === coverage.coverage_id) {
-                    coverageAssignedTo = assignment.scheduled_update_id == null ?
-                        coverage.assigned_to :
-                        coverage.scheduled_updates.find(
-                            (c) => c.scheduled_update_id === assignment.scheduled_update_id,
-                        )?.assigned_to;
+                if (assignment.coverage_item !== coverage.coverage_id) {
+                    continue;
+                } else if (assignment.scheduled_update_id == null) {
+                    coverageToUpdate = coverage;
+                } else {
+                    scheduledUpdateIndex = coverage.scheduled_updates.findIndex(
+                        (c) => c.scheduled_update_id === assignment.scheduled_update_id,
+                    );
 
-                    break;
+                    if (scheduledUpdateIndex === -1) {
+                        console.warn(`Scheduled update ${assignment.scheduled_update_id} not found`);
+                        return;
+                    }
+                    coverageToUpdate = coverage.scheduled_updates[scheduledUpdateIndex];
                 }
+
+                break;
             }
 
-            if (coverageAssignedTo == null) {
+            if (coverageToUpdate == null || coverageToUpdate?.assigned_to == null) {
                 console.warn(`Coverage for Assignment ${assignment._id} not found`);
                 return;
             }
 
-            copyAssignmentDetailsToCoverage(assignment, coverageAssignedTo);
-            this.props.onChange(`coverages[${coverageIndex}].assigned_to`, coverageAssignedTo);
+            copyAssignmentDetailsToCoverage(assignment, coverageToUpdate.assigned_to);
+            const fieldName = scheduledUpdateIndex === -1 ?
+                `coverages[${coverageIndex}].assigned_to` :
+                `coverages[${coverageIndex}].scheduled_updates[${scheduledUpdateIndex}].assigned_to`;
+
+            this.props.onChange(fieldName, coverageToUpdate.assigned_to);
         });
     }
 
@@ -87,6 +107,7 @@ export class EditorFieldCoverages extends React.PureComponent<IPropsEditorFieldC
 
         if (coverageIndex === -1) {
             console.warn(`Coverage ${event.detail.coverage} not found`);
+            return;
         }
 
         coverages[coverageIndex].assigned_to = {};

--- a/client/components/fields/editor/Coverages.tsx
+++ b/client/components/fields/editor/Coverages.tsx
@@ -11,9 +11,8 @@ import {IPropsEditorFieldCoverages} from './coverages.interface';
 /**
  * Copy assignment details from an assignment to a coverage assignment.
  *
- * TODO-PR: Update the location where this function should be synced with
- * Note: This was copied from the `planning.common.copy_assignment_details_to_coverage` backend function.
- * The functionality between these two should be kept in sync.
+ * This copies the data that is editable from the Assignment, all other data is read-only from the
+ * Assignment point of view.
  */
 function copyAssignmentDetailsToCoverage(
     assignment: IAssignmentItem,
@@ -74,7 +73,6 @@ export class EditorFieldCoverages extends React.PureComponent<IPropsEditorFieldC
             }
 
             copyAssignmentDetailsToCoverage(assignment, coverageAssignedTo);
-            debugger;
             this.props.onChange(`coverages[${coverageIndex}].assigned_to`, coverageAssignedTo);
         });
     }

--- a/client/interfaces.ts
+++ b/client/interfaces.ts
@@ -672,6 +672,7 @@ export interface ICoverageScheduledUpdate {
 export interface IPlanningCoverageItem {
     coverage_id: string;
     original_coverage_id: string;
+    scheduled_update_id: never;
     guid: string;
     original_creator: string;
     version_creator: string;

--- a/client/interfaces.ts
+++ b/client/interfaces.ts
@@ -163,6 +163,10 @@ export type IPlanningAssignedTo = {
         name: string;
         contact_type: string;
     };
+    assignor_desk: IDesk['_id'];
+    assignor_user: IUser['_id'];
+    assigned_date_desk: string | Date;
+    assigned_date_user: string | Date;
 };
 
 export type IEventUpdateMethod = 'single' | 'future' | 'all';
@@ -888,21 +892,8 @@ export interface IAssignmentItem extends IBaseRestApiResponse {
     planning_item: IPlanningItem['_id'];
     scheduled_update_id: string;
 
-    assigned_to: {
-        desk: string;
-        user: string;
-        assignor_desk: string;
-        assignor_user: string;
-        assigned_date_desk: string | Date;
-        assigned_date_user: string | Date;
-        contact: string;
-        state: ASSIGNMENT_STATE;
-        revert_state: ASSIGNMENT_STATE;
-        coverage_provider: {
-            qcode: string;
-            name: string;
-            contact_type: string;
-        };
+    assigned_to: Omit<IPlanningAssignedTo, 'assignment_id' | 'priority'> & {
+        revert_state: IPlanningWorkflowStatus;
     };
 
     original_creator: string;
@@ -2278,7 +2269,33 @@ export interface IWebsocketMessageData {
         planning: IPlanningItem['_id'];
         links: Array<IPlanningItem['_id']>;
         _created: string; // ISO 8601 datetime
-    }
+    };
+    ASSIGNMENT_UPDATED: {
+        item: IAssignmentItem['_id'];
+        etag: IAssignmentItem['_etag'];
+        coverage: IAssignmentItem['coverage_item'];
+        planning: IAssignmentItem['planning_item'];
+        assigned_user: IAssignmentItem['assigned_to']['user'];
+        assigned_date_user: IAssignmentItem['assigned_to']['assigned_date_user'];
+        assigned_desk: IAssignmentItem['assigned_to']['desk'];
+        assigned_date_desk: IAssignmentItem['assigned_to']['assigned_date_desk'];
+        assigned_contact: IAssignmentItem['assigned_to']['contact'];
+        user: IUser['_id'];
+        original_assigned_desk: IAssignmentItem['assigned_to']['desk'];
+        original_assigned_user: IAssignmentItem['assigned_to']['user'];
+        assignment_state: IAssignmentItem['assigned_to']['state'];
+        lock_user: IAssignmentItem['lock_user'];
+        session: ISession['sessionId'];
+    };
+    ASSIGNMENT_REMOVED: {
+        item: IAssignmentItem['_id'];
+        session: ISession['sessionId'];
+        assignments: Array<IAssignmentItem['_id']>;
+        planning: IAssignmentItem['planning_item'];
+        coverage: IAssignmentItem['coverage_item'];
+        planning_etag: IPlanningItem['_etag'];
+        event_ids: Array<IEventItem['_id']>;
+    };
 }
 
 export interface IEditorAPI {


### PR DESCRIPTION
### Purpose
Throughout the history of Coverages & Assignments, more features and improvements were added. Recently the improvement was added to handle re-assigning Desk/User from the Planning form, which caused a whole mess of bugs.

### What has changed
**Frontend**
- Move some handling of Assignment updated websocket notifications into the editor field for Coverages. This way the editor is in charge of what changes it must apply locally
- Removed duplicate handling of Assignment/Coverage updates that are now handled by the Coverages field
- Improve assigned_to types

### Front-end checklist
- [x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [x] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [x] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [x] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [x] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [x] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [x] This pull request is not adding redux based modals
- [x] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [x] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)

Resolves: [STT-1575](https://sofab.atlassian.net/browse/STT-1575)
Resolves: [STT-1578](https://sofab.atlassian.net/browse/STT-1578)



[STT-1575]: https://sofab.atlassian.net/browse/STT-1575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ