### PR TITLE
[STT-1575][STT-1578] backend: Unify handling of Assignment editor updates

### DIFF
--- a/server/features/assignments.feature
+++ b/server/features/assignments.feature
@@ -2537,7 +2537,7 @@ Feature: Assignments
                 "assigned_to": {
                     "desk": "#desks._id#",
                     "user": "#CONTEXT_USER_ID#",
-                    "coverage_provider": "__no_value__"
+                    "coverage_provider": null
                 }
             },
             {

--- a/server/features/coverage_assignment_sync/assignment_update_coverage.feature
+++ b/server/features/coverage_assignment_sync/assignment_update_coverage.feature
@@ -1,0 +1,268 @@
+Feature: Coverages are updated when an Assignment is updated
+    Background: Initial setup
+        Given "users"
+        """
+        [{"_id": "507f191e810c19729de87034", "name":"testfoo", "email":"foo@122d.com", "username":"johnfoo"}]
+        """
+        When we post to "desks"
+        """
+        [
+            {"name": "Sports", "content_expiry": 60, "members": [{"user": "#CONTEXT_USER_ID#"}]},
+            {"name": "News", "content_expiry": 60, "members": [{"user": "#CONTEXT_USER_ID#"}]}
+        ]
+        """
+        Then we get OK response
+        And we store "SPORTS_DESK" with first item
+        And we store "NEWS_DESK" with 2 item
+
+    @auth
+    Scenario: Update Assignment assigned_to and priority updates Coverage
+        When we post to "/planning"
+        """
+        [{
+            "state": "draft",
+            "slugline": "test slugline",
+            "planning_date": "2035-06-30T14:00:00+0000",
+            "coverages": [{
+                "planning": {"g2_content_type": "text"},
+                "assigned_to": {
+                    "desk": "#SPORTS_DESK._id#",
+                    "priority": 3
+                },
+                "workflow_status": "active"
+            }]
+        }]
+        """
+        Then we get OK response
+        And we store coverage id in "COVERAGE_ID" from coverage 0
+        And we store assignment id in "ASSIGNMENT_ID" from coverage 0
+        When we patch "/assignments/#ASSIGNMENT_ID#"
+        """
+        {"assigned_to": {
+            "desk": "#NEWS_DESK._id#",
+            "user": "507f191e810c19729de87034"
+        }}
+        """
+        Then we get OK response
+        When we get "/planning/#planning._id#"
+        Then we get existing resource
+        """
+        {"coverages": [{
+            "coverage_id": "#COVERAGE_ID#",
+            "assigned_to": {
+                "desk": "#NEWS_DESK._id#",
+                "user": "507f191e810c19729de87034",
+                "priority": 3
+            }
+        }]}
+        """
+
+        When we patch "/assignments/#ASSIGNMENT_ID#"
+        """
+        {"priority": 1}
+        """
+        Then we get OK response
+        When we get "/planning/#planning._id#"
+        Then we get existing resource
+        """
+        {"coverages": [{
+            "coverage_id": "#COVERAGE_ID#",
+            "assigned_to": {
+                "desk": "#NEWS_DESK._id#",
+                "user": "507f191e810c19729de87034",
+                "priority": 1
+            }
+        }]}
+        """
+
+    @auth
+    Scenario: Update Coverage status when linking content to an Assignment
+        When we post to "/archive"
+        """
+        [{
+            "type": "text",
+            "headline": "test headline",
+            "slugline": "test slugline",
+            "task": {
+                "desk": "#SPORTS_DESK._id#",
+                "stage": "#SPORTS_DESK.incoming_stage#"
+            }
+        }]
+        """
+        Then we get OK response
+        When we post to "/planning"
+        """
+        [{
+            "state": "draft",
+            "slugline": "test slugline",
+            "planning_date": "2035-06-30T14:00:00+0000",
+            "coverages": [{
+                "planning": {"g2_content_type": "text"},
+                "assigned_to": {
+                    "desk": "#SPORTS_DESK._id#",
+                    "priority": 3
+                },
+                "workflow_status": "active"
+            }]
+        }]
+        """
+        Then we get OK response
+        And we store coverage id in "COVERAGE_ID" from coverage 0
+        And we store assignment id in "ASSIGNMENT_ID" from coverage 0
+        When we post to "assignments/link"
+        """
+        [{
+            "assignment_id": "#ASSIGNMENT_ID#",
+            "item_id": "#archive._id#",
+            "reassign": true
+        }]
+        """
+        Then we get OK response
+        When we get "/assignments/#ASSIGNMENT_ID#"
+        Then we get existing resource
+        """
+        {"assigned_to": {"state": "in_progress"}}
+        """
+        When we get "/planning/#planning._id#"
+        Then we get existing resource
+        """
+        {"coverages": [{
+            "coverage_id": "#COVERAGE_ID#",
+            "assigned_to": {"state": "in_progress"}
+        }]}
+        """
+        When we patch "/archive/#archive._id#"
+        """
+        {"slugline": "test"}
+        """
+        Then we get OK response
+        When we publish "#archive._id#" with "publish" type and "published" state
+        Then we get OK response
+        When we get "/assignments/#ASSIGNMENT_ID#"
+        Then we get existing resource
+        """
+        {"assigned_to": {"state": "completed"}}
+        """
+        When we get "/planning/#planning._id#"
+        Then we get existing resource
+        """
+        {"coverages": [{
+            "coverage_id": "#COVERAGE_ID#",
+            "assigned_to": {"state": "completed"}
+        }]}
+        """
+        When we post to "assignments/unlink" with success
+        """
+        [{
+            "assignment_id": "#ASSIGNMENT_ID#",
+            "item_id": "#archive._id#"
+        }]
+        """
+        When we get "/assignments/#ASSIGNMENT_ID#"
+        Then we get existing resource
+        """
+        {"assigned_to": {"state": "assigned"}}
+        """
+        When we get "/planning/#planning._id#"
+        Then we get existing resource
+        """
+        {"coverages": [{
+            "coverage_id": "#COVERAGE_ID#",
+            "assigned_to": {"state": "assigned"}
+        }]}
+        """
+
+    @auth
+    Scenario: Update Planning autosave when making changes to an Assignment
+        Given we have sessions "/sessions"
+        When we post to "/planning"
+        """
+        [{
+            "state": "draft",
+            "slugline": "test slugline",
+            "planning_date": "2035-06-30T14:00:00+0000",
+            "coverages": [{
+                "planning": {"g2_content_type": "text"},
+                "assigned_to": {
+                    "desk": "#SPORTS_DESK._id#",
+                    "priority": 3
+                },
+                "workflow_status": "active"
+            }]
+        }]
+        """
+        Then we get OK response
+        And we store coverage id in "COVERAGE_ID" from coverage 0
+        And we store assignment id in "ASSIGNMENT_ID" from coverage 0
+        When we post to "/planning/#planning._id#/lock"
+        """
+        {"lock_action": "edit"}
+        """
+        Then we get OK response
+        When we post to "/planning_autosave"
+        """
+        {
+            "_id": "#planning._id#",
+            "state": "draft",
+            "slugline": "test slugline",
+            "planning_date": "2035-06-30T14:00:00+0000",
+            "coverages": [{
+                "coverage_id": "#COVERAGE_ID#",
+                "planning": {
+                    "g2_content_type": "text",
+                    "ednote": "Dont forget stuff",
+                    "headline": "Test headline",
+                    "slugline": "Test slugline",
+                    "fields": [{
+                        "field": "location_details",
+                        "value": "somewhere in the foo"
+                    }, {
+                        "field": "my_custom",
+                        "value": "bar in the mud"
+                    }]
+                },
+                "assigned_to": {
+                    "desk": "#SPORTS_DESK._id#",
+                    "priority": 3
+                },
+                "workflow_status": "active"
+            }],
+            "lock_user": "#CONTEXT_USER_ID#",
+            "lock_session": "#SESSION_ID#",
+            "lock_action": "edit",
+            "lock_time": "#DATE#"
+        }
+        """
+        Then we get OK response
+        When we patch "/assignments/#ASSIGNMENT_ID#"
+        """
+        {"assigned_to": {
+            "desk": "#NEWS_DESK._id#",
+            "user": "507f191e810c19729de87034"
+        }}
+        """
+        Then we get OK response
+        When we get "/planning_autosave/#planning._id#"
+        Then we get existing resource
+        """
+        {"coverages": [{
+            "coverage_id": "#COVERAGE_ID#",
+            "assigned_to": {
+                "desk": "#NEWS_DESK._id#",
+                "user": "507f191e810c19729de87034"
+            },
+            "planning": {
+                "g2_content_type": "text",
+                "ednote": "Dont forget stuff",
+                "headline": "Test headline",
+                "slugline": "Test slugline",
+                "fields": [{
+                    "field": "location_details",
+                    "value": "somewhere in the foo"
+                }, {
+                    "field": "my_custom",
+                    "value": "bar in the mud"
+                }]
+            }
+        }]}
+        """

--- a/server/features/coverage_assignment_sync/coverage_create_assignment.feature
+++ b/server/features/coverage_assignment_sync/coverage_create_assignment.feature
@@ -1,0 +1,481 @@
+Feature: Assignments created when Coverages are created
+    Background: Initial setup
+        Given "users"
+        """
+        [{"_id": "507f191e810c19729de87034", "name":"testfoo", "email":"foo@122d.com", "username":"johnfoo"}]
+        """
+        When we post to "desks"
+        """
+        [{"name": "Sports", "content_expiry": 60, "members": [{"user": "#CONTEXT_USER_ID#"}]}]
+        """
+        Then we get OK response
+        And we store "SPORTS_DESK_ID" with value "#desks._id#" to context
+
+    @auth
+    Scenario: Create new planning with draft coverage and no assignee does not create an Assignment
+        When we post to "/planning"
+        """
+        [{
+            "state": "draft",
+            "slugline": "test slugline",
+            "planning_date": "2035-06-30T14:00:00+0000",
+            "coverages": [{
+                "planning": {"g2_content_type": "text"},
+                "workflow_status": "draft"
+            }]
+        }]
+        """
+        Then we get OK response
+        And we store coverage id in "COVERAGE_ID" from coverage 0
+        And the assignment not created for coverage 0
+        When we get "/planning/#planning._id#"
+        Then we get existing resource
+        """
+        {
+            "state": "draft",
+            "coverages": [{"coverage_id": "#COVERAGE_ID#", "assigned_to": "__no_value__"}]
+        }
+        """
+        When we get "/assignments"
+        Then we get list with 0 items
+
+    @auth
+    Scenario: Create new planning with draft coverage with desk assignee creates a draft Assignment
+        When we post to "/planning"
+        """
+        [{
+            "state": "draft",
+            "slugline": "test slugline",
+            "planning_date": "2035-06-30T14:00:00+0000",
+            "coverages": [{
+                "planning": {"g2_content_type": "text"},
+                "assigned_to": {"desk": "#SPORTS_DESK_ID#"},
+                "workflow_status": "draft"
+            }]
+        }]
+        """
+        Then we get OK response
+        And we store coverage id in "COVERAGE_ID" from coverage 0
+        And we store assignment id in "ASSIGNMENT_ID" from coverage 0
+        When we get "/planning/#planning._id#"
+        Then we get existing resource
+        """
+        {
+            "state": "draft",
+            "coverages": [{
+                "coverage_id": "#COVERAGE_ID#",
+                "assigned_to": {
+                    "assignment_id": "#ASSIGNMENT_ID#",
+                    "state": "draft",
+                    "desk": "#SPORTS_DESK_ID#"
+                }
+            }]
+        }
+        """
+        When we get "/assignments/#ASSIGNMENT_ID#"
+        Then we get existing resource
+        """
+        {
+            "planning_item": "#planning._id#",
+            "coverage_item": "#COVERAGE_ID#",
+            "assigned_to": {
+                "state": "draft",
+                "desk": "#SPORTS_DESK_ID#"
+            }
+        }
+        """
+
+    @auth
+    Scenario: Create new planning with active coverage and desk assignee creates an assigned Assignment
+        When we post to "/planning"
+        """
+        [{
+            "state": "draft",
+            "slugline": "test slugline",
+            "planning_date": "2035-06-30T14:00:00+0000",
+            "coverages": [{
+                "planning": {"g2_content_type": "text"},
+                "assigned_to": {"desk": "#SPORTS_DESK_ID#"},
+                "workflow_status": "active"
+            }]
+        }]
+        """
+        Then we get OK response
+        And we store coverage id in "COVERAGE_ID" from coverage 0
+        And we store assignment id in "ASSIGNMENT_ID" from coverage 0
+        When we get "/planning/#planning._id#"
+        Then we get existing resource
+        """
+        {
+            "state": "draft",
+            "coverages": [{
+                "coverage_id": "#COVERAGE_ID#",
+                "workflow_status": "active",
+                "assigned_to": {
+                    "assignment_id": "#ASSIGNMENT_ID#",
+                    "state": "assigned",
+                    "desk": "#SPORTS_DESK_ID#"
+                }
+            }]
+        }
+        """
+        When we get "/assignments/#ASSIGNMENT_ID#"
+        Then we get existing resource
+        """
+        {
+            "planning_item": "#planning._id#",
+            "coverage_item": "#COVERAGE_ID#",
+            "assigned_to": {
+                "state": "assigned",
+                "desk": "#SPORTS_DESK_ID#"
+            }
+        }
+        """
+
+    @auth
+    Scenario: Update planning with new draft coverage and no assignee does not create an Assignment
+        When we post to "/planning"
+        """
+        [{
+            "state": "draft",
+            "slugline": "test slugline",
+            "planning_date": "2035-06-30T14:00:00+0000"
+        }]
+        """
+        Then we get OK response
+        When we patch "/planning/#planning._id#"
+        """
+        {"coverages": [{
+            "planning": {"g2_content_type": "text"},
+            "workflow_status": "draft"
+        }]}
+        """
+        Then we get OK response
+        And we store coverage id in "COVERAGE_ID" from coverage 0
+        And the assignment not created for coverage 0
+        When we get "/planning/#planning._id#"
+        Then we get existing resource
+        """
+        {
+            "state": "draft",
+            "coverages": [{"coverage_id": "#COVERAGE_ID#", "assigned_to": "__no_value__"}]
+        }
+        """
+        When we get "/assignments"
+        Then we get list with 0 items
+
+    @auth
+    Scenario: Update planning with new draft coverage with desk assignee creates a draft Assignment
+        When we post to "/planning"
+        """
+        [{
+            "state": "draft",
+            "slugline": "test slugline",
+            "planning_date": "2035-06-30T14:00:00+0000"
+        }]
+        """
+        Then we get OK response
+        When we patch "/planning/#planning._id#"
+        """
+        {"coverages": [{
+            "planning": {"g2_content_type": "text"},
+            "assigned_to": {"desk": "#SPORTS_DESK_ID#"},
+            "workflow_status": "draft"
+        }]}
+        """
+        Then we get OK response
+        And we store coverage id in "COVERAGE_ID" from coverage 0
+        And we store assignment id in "ASSIGNMENT_ID" from coverage 0
+        When we get "/planning/#planning._id#"
+        Then we get existing resource
+        """
+        {
+            "state": "draft",
+            "coverages": [{
+                "coverage_id": "#COVERAGE_ID#",
+                "assigned_to": {
+                    "assignment_id": "#ASSIGNMENT_ID#",
+                    "state": "draft",
+                    "desk": "#SPORTS_DESK_ID#"
+                }
+            }]
+        }
+        """
+        When we get "/assignments/#ASSIGNMENT_ID#"
+        Then we get existing resource
+        """
+        {
+            "planning_item": "#planning._id#",
+            "coverage_item": "#COVERAGE_ID#",
+            "assigned_to": {
+                "state": "draft",
+                "desk": "#SPORTS_DESK_ID#"
+            }
+        }
+        """
+
+    @auth
+    Scenario: Update planning with active coverage and desk assignee creates an assigned Assignment
+        When we post to "/planning"
+        """
+        [{
+            "state": "draft",
+            "slugline": "test slugline",
+            "planning_date": "2035-06-30T14:00:00+0000"
+        }]
+        """
+        Then we get OK response
+        When we patch "/planning/#planning._id#"
+        """
+        {"coverages": [{
+            "planning": {"g2_content_type": "text"},
+            "assigned_to": {"desk": "#SPORTS_DESK_ID#"},
+            "workflow_status": "active"
+        }]}
+        """
+        Then we get OK response
+        And we store coverage id in "COVERAGE_ID" from coverage 0
+        And we store assignment id in "ASSIGNMENT_ID" from coverage 0
+        When we get "/planning/#planning._id#"
+        Then we get existing resource
+        """
+        {
+            "state": "draft",
+            "coverages": [{
+                "coverage_id": "#COVERAGE_ID#",
+                "workflow_status": "active",
+                "assigned_to": {
+                    "assignment_id": "#ASSIGNMENT_ID#",
+                    "state": "assigned",
+                    "desk": "#SPORTS_DESK_ID#"
+                }
+            }]
+        }
+        """
+        When we get "/assignments/#ASSIGNMENT_ID#"
+        Then we get existing resource
+        """
+        {
+            "planning_item": "#planning._id#",
+            "coverage_item": "#COVERAGE_ID#",
+            "assigned_to": {
+                "state": "assigned",
+                "desk": "#SPORTS_DESK_ID#"
+            }
+        }
+        """
+
+    @auth
+    Scenario: Update coverage and set to active creates an assigned Assignment
+        When we post to "/planning"
+        """
+        [{
+            "state": "draft",
+            "slugline": "test slugline",
+            "planning_date": "2035-06-30T14:00:00+0000",
+            "coverages": [{
+                "planning": {"g2_content_type": "text"},
+                "assigned_to": {"desk": "#SPORTS_DESK_ID#"},
+                "workflow_status": "draft"
+            }]
+        }]
+        """
+        Then we get OK response
+        And we store coverage id in "COVERAGE_ID" from coverage 0
+        And we store assignment id in "ASSIGNMENT_ID" from coverage 0
+        When we get "/planning/#planning._id#"
+        Then we get existing resource
+        """
+        {
+            "state": "draft",
+            "coverages": [{
+                "coverage_id": "#COVERAGE_ID#",
+                "workflow_status": "draft",
+                "assigned_to": {
+                    "assignment_id": "#ASSIGNMENT_ID#",
+                    "state": "draft",
+                    "desk": "#SPORTS_DESK_ID#"
+                }
+            }]
+        }
+        """
+        When we get "/assignments/#ASSIGNMENT_ID#"
+        Then we get existing resource
+        """
+        {
+            "planning_item": "#planning._id#",
+            "coverage_item": "#COVERAGE_ID#",
+            "assigned_to": {
+                "state": "draft",
+                "desk": "#SPORTS_DESK_ID#"
+            }
+        }
+        """
+        When we patch "/planning/#planning._id#"
+        """
+        {"coverages": [{
+            "coverage_id": "#COVERAGE_ID#",
+            "planning": {"g2_content_type": "text"},
+            "assigned_to": {
+                "assignment_id": "#ASSIGNMENT_ID#",
+                "desk": "#SPORTS_DESK_ID#"
+            },
+            "workflow_status": "active"
+        }]}
+        """
+        Then we get OK response
+        When we get "/planning/#planning._id#"
+        Then we get existing resource
+        """
+        {
+            "state": "draft",
+            "coverages": [{
+                "coverage_id": "#COVERAGE_ID#",
+                "workflow_status": "active",
+                "assigned_to": {
+                    "assignment_id": "#ASSIGNMENT_ID#",
+                    "state": "assigned",
+                    "desk": "#SPORTS_DESK_ID#"
+                }
+            }]
+        }
+        """
+        When we get "/assignments/#ASSIGNMENT_ID#"
+        Then we get existing resource
+        """
+        {
+            "planning_item": "#planning._id#",
+            "coverage_item": "#COVERAGE_ID#",
+            "assigned_to": {
+                "state": "assigned",
+                "desk": "#SPORTS_DESK_ID#"
+            }
+        }
+        """
+
+    @auth
+    Scenario: Copies all metadata from Coverage when creating an Assignment
+        When we post to "/contacts"
+        """
+        [{"first_name": "Foo", "last_name": "Bar", "public": true}]
+        """
+        Then we get OK response
+        When we post to "/planning"
+        """
+        [{
+            "state": "draft",
+            "slugline": "test slugline",
+            "planning_date": "2035-06-30T14:00:00+0000",
+            "coverages": [{
+                "planning": {
+                    "g2_content_type": "text",
+                    "multiple_content": true,
+                    "ednote": "Dont forget stuff",
+                    "headline": "Test headline",
+                    "slugline": "Test slugline",
+                    "contact_info": "#contacts._id#",
+                    "scheduled": "2035-06-30T18:00:00+0000",
+                    "genre": [{"qcode": "sidebar", "name": "Sidebar"}],
+                    "language": "fi",
+                    "priority": 3,
+                    "internal_note": "We should do stuff",
+                    "fields": [{
+                        "field": "location_details",
+                        "value": "somewhere in the foo"
+                    }, {
+                        "field": "my_custom",
+                        "value": "bar in the mud"
+                    }]
+                },
+                "assigned_to": {
+                    "desk": "#SPORTS_DESK_ID#",
+                    "user": "#CONTEXT_USER_ID#",
+                    "coverage_provider": {"name": "Stringer", "qcode": "stringer"},
+                    "priority": 1
+                },
+                "workflow_status": "draft"
+            }]
+        }]
+        """
+        Then we get OK response
+        And we store coverage id in "COVERAGE_ID" from coverage 0
+        And we store assignment id in "ASSIGNMENT_ID" from coverage 0
+        When we get "/planning/#planning._id#"
+        Then we get existing resource
+        """
+        {"coverages": [{
+            "coverage_id": "#COVERAGE_ID#",
+            "planning": {
+                "g2_content_type": "text",
+                "multiple_content": true,
+                "ednote": "Dont forget stuff",
+                "headline": "Test headline",
+                "slugline": "Test slugline",
+                "contact_info": "#contacts._id#",
+                "scheduled": "2035-06-30T18:00:00+0000",
+                "genre": [{"qcode": "sidebar", "name": "Sidebar"}],
+                "language": "fi",
+                "priority": 3,
+                "internal_note": "We should do stuff",
+                "fields": [{
+                    "field": "location_details",
+                    "value": "somewhere in the foo"
+                }, {
+                    "field": "my_custom",
+                    "value": "bar in the mud"
+                }]
+            },
+            "assigned_to": {
+                "state": "draft",
+                "assignment_id": "#ASSIGNMENT_ID#",
+                "desk": "#SPORTS_DESK_ID#",
+                "user": "#CONTEXT_USER_ID#",
+                "coverage_provider": {"name": "Stringer", "qcode": "stringer"},
+                "priority": 1,
+                "assigned_date_desk": "__now__",
+                "assigned_date_user": "__now__",
+                "assignor_desk": "#CONTEXT_USER_ID#",
+                "assignor_user": "#CONTEXT_USER_ID#"
+            },
+            "workflow_status": "draft"
+        }]}
+        """
+        When we get "/assignments/#ASSIGNMENT_ID#"
+        Then we get existing resource
+        """
+        {
+            "planning_item": "#planning._id#",
+            "coverage_item": "#COVERAGE_ID#",
+            "priority": 1,
+            "assigned_to": {
+                "state": "draft",
+                "desk": "#SPORTS_DESK_ID#",
+                "user": "#CONTEXT_USER_ID#",
+                "coverage_provider": {"name": "Stringer", "qcode": "stringer"},
+                "assigned_date_desk": "__now__",
+                "assigned_date_user": "__now__",
+                "assignor_desk": "#CONTEXT_USER_ID#",
+                "assignor_user": "#CONTEXT_USER_ID#"
+            },
+            "planning": {
+                "g2_content_type": "text",
+                "multiple_content": true,
+                "ednote": "Dont forget stuff",
+                "headline": "Test headline",
+                "slugline": "Test slugline",
+                "contact_info": "#contacts._id#",
+                "scheduled": "2035-06-30T18:00:00+0000",
+                "genre": [{"qcode": "sidebar", "name": "Sidebar"}],
+                "language": "fi",
+                "priority": 3,
+                "internal_note": "We should do stuff",
+                "fields": [{
+                    "field": "location_details",
+                    "value": "somewhere in the foo"
+                }, {
+                    "field": "my_custom",
+                    "value": "bar in the mud"
+                }]
+            }
+        }
+        """

--- a/server/features/coverage_assignment_sync/coverage_update_assignment.feature
+++ b/server/features/coverage_assignment_sync/coverage_update_assignment.feature
@@ -1,0 +1,414 @@
+Feature: Assignments updated when Coverages are updated
+    Background: Initial setup
+        Given "users"
+        """
+        [{"_id": "507f191e810c19729de87034", "name":"testfoo", "email":"foo@122d.com", "username":"johnfoo"}]
+        """
+        When we post to "desks"
+        """
+        [
+            {"name": "Sports", "content_expiry": 60, "members": [{"user": "#CONTEXT_USER_ID#"}]},
+            {"name": "News", "content_expiry": 60, "members": [{"user": "#CONTEXT_USER_ID#"}]}
+        ]
+        """
+        Then we get OK response
+        And we store "SPORTS_DESK" with first item
+        And we store "NEWS_DESK" with 2 item
+
+    @auth
+    Scenario: Update coverage updates Assignment without changes to state
+        When we post to "/planning"
+        """
+        [{
+            "state": "draft",
+            "slugline": "test slugline",
+            "planning_date": "2035-06-30T14:00:00+0000",
+            "coverages": [{
+                "planning": {"g2_content_type": "text"},
+                "assigned_to": {"desk": "#SPORTS_DESK._id#"},
+                "workflow_status": "draft"
+            }]
+        }]
+        """
+        Then we get OK response
+        And we store coverage id in "COVERAGE_ID" from coverage 0
+        And we store assignment id in "ASSIGNMENT_ID" from coverage 0
+        When we get "/planning/#planning._id#"
+        Then we get existing resource
+        """
+        {
+            "state": "draft",
+            "coverages": [{
+                "coverage_id": "#COVERAGE_ID#",
+                "workflow_status": "draft",
+                "assigned_to": {
+                    "assignment_id": "#ASSIGNMENT_ID#",
+                    "state": "draft",
+                    "desk": "#SPORTS_DESK._id#"
+                }
+            }]
+        }
+        """
+        When we get "/assignments/#ASSIGNMENT_ID#"
+        Then we get existing resource
+        """
+        {
+            "planning_item": "#planning._id#",
+            "coverage_item": "#COVERAGE_ID#",
+            "assigned_to": {
+                "state": "draft",
+                "desk": "#SPORTS_DESK._id#"
+            }
+        }
+        """
+        When we patch "/planning/#planning._id#"
+        """
+        {"coverages": [{
+            "coverage_id": "#COVERAGE_ID#",
+            "planning": {
+                "g2_content_type": "text",
+                "ednote": "Dont forget stuff"
+            },
+            "assigned_to": {
+                "assignment_id": "#ASSIGNMENT_ID#",
+                "desk": "#SPORTS_DESK._id#"
+            },
+            "workflow_status": "draft"
+        }]}
+        """
+        Then we get OK response
+        When we get "/planning/#planning._id#"
+        Then we get existing resource
+        """
+        {
+            "state": "draft",
+            "coverages": [{
+                "coverage_id": "#COVERAGE_ID#",
+                "workflow_status": "draft",
+                "planning": {
+                    "g2_content_type": "text",
+                    "ednote": "Dont forget stuff"
+                },
+                "assigned_to": {
+                    "assignment_id": "#ASSIGNMENT_ID#",
+                    "state": "draft",
+                    "desk": "#SPORTS_DESK._id#"
+                }
+            }]
+        }
+        """
+        When we get "/assignments/#ASSIGNMENT_ID#"
+        Then we get existing resource
+        """
+        {
+            "planning_item": "#planning._id#",
+            "coverage_item": "#COVERAGE_ID#",
+            "assigned_to": {
+                "state": "draft",
+                "desk": "#SPORTS_DESK._id#"
+            },
+            "planning": {
+                "g2_content_type": "text",
+                "ednote": "Dont forget stuff"
+            }
+        }
+        """
+
+    @auth
+    Scenario: Update Assignment that is in workflow
+        When we post to "/planning"
+        """
+        [{
+            "state": "draft",
+            "slugline": "test slugline",
+            "planning_date": "2035-06-30T14:00:00+0000",
+            "coverages": [{
+                "planning": {"g2_content_type": "text"},
+                "assigned_to": {"desk": "#SPORTS_DESK._id#"},
+                "workflow_status": "active"
+            }]
+        }]
+        """
+        Then we get OK response
+        And we store coverage id in "COVERAGE_ID" from coverage 0
+        And we store assignment id in "ASSIGNMENT_ID" from coverage 0
+        When we get "/assignments/#ASSIGNMENT_ID#"
+        Then we get existing resource
+        """
+        {
+            "planning_item": "#planning._id#",
+            "coverage_item": "#COVERAGE_ID#",
+            "assigned_to": {
+                "state": "assigned",
+                "desk": "#SPORTS_DESK._id#"
+            },
+            "planning": {"g2_content_type": "text"}
+        }
+        """
+        When we patch "/planning/#planning._id#"
+        """
+        {"coverages": [{
+            "coverage_id": "#COVERAGE_ID#",
+            "planning": {
+                "g2_content_type": "text",
+                "ednote": "Edit my stuff"
+            },
+            "assigned_to": {
+                "assignment_id": "#ASSIGNMENT_ID#",
+                "desk": "#SPORTS_DESK._id#"
+            }
+        }]}
+        """
+        Then we get OK response
+        When we get "/assignments/#ASSIGNMENT_ID#"
+        Then we get existing resource
+        """
+        {
+            "planning_item": "#planning._id#",
+            "coverage_item": "#COVERAGE_ID#",
+            "assigned_to": {
+                "state": "assigned",
+                "desk": "#SPORTS_DESK._id#"
+            },
+            "planning": {
+                "g2_content_type": "text",
+                "ednote": "Edit my stuff"
+            }
+        }
+        """
+
+    @auth
+    Scenario: Updates Assignment planning metadata when updating a Coverage
+        When we post to "/contacts"
+        """
+        [{"first_name": "Foo", "last_name": "Bar", "public": true}]
+        """
+        Then we get OK response
+        When we post to "/planning"
+        """
+        [{
+            "state": "draft",
+            "slugline": "test slugline",
+            "planning_date": "2035-06-30T14:00:00+0000",
+            "coverages": [{
+                "planning": {"g2_content_type": "text"},
+                "assigned_to": {"desk": "#SPORTS_DESK._id#"},
+                "workflow_status": "active"
+            }]
+        }]
+        """
+        Then we get OK response
+        And we store coverage id in "COVERAGE_ID" from coverage 0
+        And we store assignment id in "ASSIGNMENT_ID" from coverage 0
+        When we get "/assignments/#ASSIGNMENT_ID#"
+        Then we get existing resource
+        """
+        {
+            "planning_item": "#planning._id#",
+            "coverage_item": "#COVERAGE_ID#",
+            "assigned_to": {
+                "state": "assigned",
+                "desk": "#SPORTS_DESK._id#"
+            },
+            "planning": {"g2_content_type": "text"}
+        }
+        """
+        When we patch "/planning/#planning._id#"
+        """
+        {"coverages": [{
+            "coverage_id": "#COVERAGE_ID#",
+            "planning": {
+                "g2_content_type": "text",
+                "multiple_content": true,
+                "ednote": "Dont forget stuff",
+                "headline": "Test headline",
+                "slugline": "Test slugline",
+                "contact_info": "#contacts._id#",
+                "scheduled": "2035-06-30T18:00:00+0000",
+                "genre": [{"qcode": "sidebar", "name": "Sidebar"}],
+                "language": "fi",
+                "priority": 3,
+                "internal_note": "We should do stuff",
+                "fields": [{
+                    "field": "location_details",
+                    "value": "somewhere in the foo"
+                }, {
+                    "field": "my_custom",
+                    "value": "bar in the mud"
+                }]
+            },
+            "assigned_to": {
+                "assignment_id": "#ASSIGNMENT_ID#",
+                "desk": "#SPORTS_DESK._id#",
+                "user": "#CONTEXT_USER_ID#",
+                "coverage_provider": {"name": "Stringer", "qcode": "stringer"},
+                "priority": 1
+            },
+            "workflow_status": "active"
+        }]}
+        """
+        Then we get OK response
+        When we get "/assignments/#ASSIGNMENT_ID#"
+        Then we get existing resource
+        """
+        {
+            "planning_item": "#planning._id#",
+            "coverage_item": "#COVERAGE_ID#",
+            "priority": 1,
+            "assigned_to": {
+                "state": "assigned",
+                "desk": "#SPORTS_DESK._id#",
+                "user": "#CONTEXT_USER_ID#",
+                "coverage_provider": {"name": "Stringer", "qcode": "stringer"},
+                "assigned_date_desk": "__now__",
+                "assigned_date_user": "__now__",
+                "assignor_desk": "#CONTEXT_USER_ID#",
+                "assignor_user": "#CONTEXT_USER_ID#"
+            },
+            "planning": {
+                "g2_content_type": "text",
+                "multiple_content": true,
+                "ednote": "Dont forget stuff",
+                "headline": "Test headline",
+                "slugline": "Test slugline",
+                "contact_info": "#contacts._id#",
+                "scheduled": "2035-06-30T18:00:00+0000",
+                "genre": [{"qcode": "sidebar", "name": "Sidebar"}],
+                "language": "fi",
+                "priority": 3,
+                "internal_note": "We should do stuff",
+                "fields": [{
+                    "field": "location_details",
+                    "value": "somewhere in the foo"
+                }, {
+                    "field": "my_custom",
+                    "value": "bar in the mud"
+                }]
+            }
+        }
+        """
+
+    @auth
+    Scenario: Updates Assignment assigned_to when updating a Coverage
+        When we post to "/planning"
+        """
+        [{
+            "state": "draft",
+            "slugline": "test slugline",
+            "planning_date": "2035-06-30T14:00:00+0000",
+            "coverages": [{
+                "planning": {"g2_content_type": "text"},
+                "assigned_to": {"desk": "#SPORTS_DESK._id#"},
+                "workflow_status": "active"
+            }]
+        }]
+        """
+        Then we get OK response
+        And we store coverage id in "COVERAGE_ID" from coverage 0
+        And we store assignment id in "ASSIGNMENT_ID" from coverage 0
+        When we get "/assignments/#ASSIGNMENT_ID#"
+        Then we get existing resource
+        """
+        {
+            "planning_item": "#planning._id#",
+            "coverage_item": "#COVERAGE_ID#",
+            "assigned_to": {
+                "state": "assigned",
+                "desk": "#SPORTS_DESK._id#"
+            },
+            "planning": {"g2_content_type": "text"}
+        }
+        """
+        When we patch "/planning/#planning._id#"
+        """
+        {"coverages": [{
+            "coverage_id": "#COVERAGE_ID#",
+            "assigned_to": {
+                "assignment_id": "#ASSIGNMENT_ID#",
+                "desk": "#NEWS_DESK._id#",
+                "user": "507f191e810c19729de87034"
+            },
+            "planning": {"g2_content_type": "text"},
+            "workflow_status": "active"
+        }]}
+        """
+        Then we get OK response
+        When we get "/assignments/#ASSIGNMENT_ID#"
+        Then we get existing resource
+        """
+        {
+            "planning_item": "#planning._id#",
+            "coverage_item": "#COVERAGE_ID#",
+            "assigned_to": {
+                "state": "assigned",
+                "desk": "#NEWS_DESK._id#",
+                "user": "507f191e810c19729de87034",
+                "assigned_date_desk": "__now__",
+                "assigned_date_user": "__now__",
+                "assignor_desk": "#CONTEXT_USER_ID#",
+                "assignor_user": "#CONTEXT_USER_ID#"
+            }
+        }
+        """
+
+    @auth
+    @planning_cvs
+    Scenario: Updates Assignment when Coverage is cancelled
+        When we post to "/planning"
+        """
+        [{
+            "state": "draft",
+            "slugline": "test slugline",
+            "planning_date": "2035-06-30T14:00:00+0000",
+            "coverages": [{
+                "planning": {"g2_content_type": "text"},
+                "assigned_to": {"desk": "#SPORTS_DESK._id#"},
+                "workflow_status": "active"
+            }]
+        }]
+        """
+        Then we get OK response
+        And we store coverage id in "COVERAGE_ID" from coverage 0
+        And we store assignment id in "ASSIGNMENT_ID" from coverage 0
+        When we get "/assignments/#ASSIGNMENT_ID#"
+        Then we get existing resource
+        """
+        {
+            "planning_item": "#planning._id#",
+            "coverage_item": "#COVERAGE_ID#",
+            "assigned_to": {
+                "state": "assigned",
+                "desk": "#SPORTS_DESK._id#"
+            },
+            "planning": {"g2_content_type": "text"}
+        }
+        """
+        When we patch "/planning/#planning._id#"
+        """
+        {"coverages": [{
+            "coverage_id": "#COVERAGE_ID#",
+            "assigned_to": {
+                "assignment_id": "#ASSIGNMENT_ID#",
+                "desk": "#SPORTS_DESK._id#",
+                "state": "cancelled"
+            },
+            "planning": {
+                "g2_content_type": "text",
+                "workflow_status_reason": "Cancelling this one, because ..."
+            },
+            "workflow_status": "cancelled"
+        }]}
+        """
+        Then we get OK response
+        When we get "/assignments/#ASSIGNMENT_ID#"
+        Then we get existing resource
+        """
+        {
+            "planning_item": "#planning._id#",
+            "coverage_item": "#COVERAGE_ID#",
+            "assigned_to": {
+                "state": "cancelled",
+                "desk": "#SPORTS_DESK._id#"
+            }
+        }
+        """

--- a/server/features/events_cancel.feature
+++ b/server/features/events_cancel.feature
@@ -345,25 +345,6 @@ Feature: Events Cancel
         """
         [{"_id": "desk_123", "name": "Politic Desk"}]
         """
-        Given "assignments"
-        """
-        [{
-            "_id": "aaaaaaaaaaaaaaaaaaaaaaaa",
-            "planning_item": "plan1",
-            "planning": {
-                "ednote": "test coverage, I want 250 words",
-                "headline": "test headline",
-                "slugline": "test slugline",
-                "g2_content_type": "text",
-                "scheduled": "2029-11-21T14:00:00.000Z"
-            },
-            "assigned_to": {
-                "desk": "#desks._id#",
-                "user": "#CONTEXT_USER_ID#",
-                "state": "assigned"
-            }
-        }]
-        """
         Given "events"
         """
         [{
@@ -411,11 +392,11 @@ Feature: Events Cancel
                     "qcode": "ncostat:int",
                     "name": "Coverage intended"
                 },
-                  "assigned_to": {
-                        "desk": "#desks._id#",
-                        "user": "#CONTEXT_USER_ID#",
-                        "assignment_id": "aaaaaaaaaaaaaaaaaaaaaaaa"
-                  }
+                "assigned_to": {
+                    "desk": "#desks._id#",
+                    "user": "#CONTEXT_USER_ID#",
+                    "state": "assigned"
+                }
             }],
             "planning_date": "2029-11-21T14:00:00.000Z"
         }]

--- a/server/features/events_postpone.feature
+++ b/server/features/events_postpone.feature
@@ -312,25 +312,6 @@ Feature: Events Postpone
         """
         [{"_id": "desk_123", "name": "Politic Desk"}]
         """
-        Given "assignments"
-        """
-        [{
-            "_id": "aaaaaaaaaaaaaaaaaaaaaaaa",
-            "planning_item": "plan1",
-            "planning": {
-                "ednote": "test coverage, I want 250 words",
-                "headline": "test headline",
-                "slugline": "test slugline",
-                "g2_content_type": "text",
-                "scheduled": "2029-11-21T15:00:00.000Z"
-            },
-            "assigned_to": {
-                "desk": "#desks._id#",
-                "user": "#CONTEXT_USER_ID#",
-                "state": "assigned"
-            }
-        }]
-        """
         Given "events"
         """
         [{
@@ -378,7 +359,7 @@ Feature: Events Postpone
                 "assigned_to": {
                     "desk": "#desks._id#",
                     "user": "#CONTEXT_USER_ID#",
-                    "assignment_id": "aaaaaaaaaaaaaaaaaaaaaaaa"
+                    "state": "assigned"
                 }
             }],
             "planning_date": "2016-01-02"
@@ -507,25 +488,6 @@ Feature: Events Postpone
         """
         [{"_id": "desk_123", "name": "Politic Desk"}]
         """
-        Given "assignments"
-        """
-        [{
-            "_id": "aaaaaaaaaaaaaaaaaaaaaaaa",
-            "planning_item": "plan1",
-            "planning": {
-                "ednote": "test coverage, I want 250 words",
-                "headline": "test headline",
-                "slugline": "test slugline",
-                "g2_content_type": "text",
-                "scheduled": "2029-11-21T15:00:00.000Z"
-            },
-            "assigned_to": {
-                "desk": "#desks._id#",
-                "user": "#CONTEXT_USER_ID#",
-                "state": "assigned"
-            }
-        }]
-        """
         Given "events"
         """
         [{
@@ -574,7 +536,7 @@ Feature: Events Postpone
                 "assigned_to": {
                     "desk": "#desks._id#",
                     "user": "#CONTEXT_USER_ID#",
-                    "assignment_id": "aaaaaaaaaaaaaaaaaaaaaaaa"
+                    "state": "assigned"
                 }
             }],
             "planning_date": "2016-01-02"

--- a/server/features/events_reschedule.feature
+++ b/server/features/events_reschedule.feature
@@ -98,7 +98,7 @@ Feature: Events Reschedule
         """
 
     @auth
-    @notification @wip
+    @notification
     Scenario: Changes associated Planning items to `rescheduled`
         Given we have sessions "/sessions"
         Given "desks"

--- a/server/features/events_reschedule.feature
+++ b/server/features/events_reschedule.feature
@@ -98,7 +98,7 @@ Feature: Events Reschedule
         """
 
     @auth
-    @notification
+    @notification @wip
     Scenario: Changes associated Planning items to `rescheduled`
         Given we have sessions "/sessions"
         Given "desks"
@@ -123,25 +123,6 @@ Feature: Events Reschedule
           ]
         }]
         """
-        Given "assignments"
-        """
-        [{
-            "_id": "aaaaaaaaaaaaaaaaaaaaaaaa",
-            "planning_item": "plan1",
-            "planning": {
-                "ednote": "test coverage, I want 250 words",
-                "headline": "test headline",
-                "slugline": "test slugline",
-                "g2_content_type": "text",
-                "scheduled": "2029-11-21T12:00:00.000Z"
-            },
-            "assigned_to": {
-                "desk": "#desks._id#",
-                "user": "#CONTEXT_USER_ID#",
-                "state": "assigned"
-            }
-        }]
-        """
         Given "events"
         """
         [{
@@ -161,7 +142,7 @@ Feature: Events Reschedule
             "lock_time": "#DATE#"
         }]
         """
-        Given "planning"
+        When we post to "planning"
         """
         [{
             "_id": "plan1",
@@ -180,7 +161,7 @@ Feature: Events Reschedule
                 "assigned_to": {
                     "desk": "#desks._id#",
                     "user": "#CONTEXT_USER_ID#",
-                    "assignment_id": "aaaaaaaaaaaaaaaaaaaaaaaa"
+                    "state": "assigned"
                 },
                 "news_coverage_status" : {
                 "qcode" : "ncostat:int",
@@ -191,6 +172,8 @@ Feature: Events Reschedule
             "planning_date": "2016-01-02"
         }]
         """
+        Then we get OK response
+        And we store assignment id in "ASSIGNMENT_1_ID" from coverage 0
         When we reset notifications
         When we perform reschedule on events "event1"
         """
@@ -246,7 +229,7 @@ Feature: Events Reschedule
             }]
         }
         """
-        When we get "/assignments/aaaaaaaaaaaaaaaaaaaaaaaa"
+        When we get "/assignments/#ASSIGNMENT_1_ID#"
         Then we get existing resource
         """
         {

--- a/server/planning/assignments/assignments.py
+++ b/server/planning/assignments/assignments.py
@@ -52,7 +52,6 @@ from planning.common import (
     assignment_workflow_state,
     remove_lock_information,
     is_locked_in_this_session,
-    copy_assignment_details_to_coverage,
     get_coverage_type_name,
     get_version_item_for_post,
     get_related_items,
@@ -66,6 +65,7 @@ from planning.common import (
     get_notify_self_on_assignment,
     planning_auto_assign_to_workflow,
     get_config_assignment_manual_reassignment_only,
+    set_original_creator,
 )
 
 from planning.types import EventResourceModel
@@ -82,6 +82,7 @@ from planning.utils import (
     get_first_related_event_id_for_planning,
     get_first_event_item_for_planning_id,
 )
+from planning.coverage_assignments import update_planning_from_assignment_changes
 
 logger = logging.getLogger(__name__)
 planning_type = deepcopy(superdesk.Resource.rel("planning", type="string", required=True))
@@ -95,68 +96,12 @@ class AssignmentsService(AsyncBaseService):
         super().__init__(*args, **kwargs)
         self._skip_planning_sync: bool = False
 
-    async def _update_planning_coverages_from_assignment(
-        self, assignment: Dict[str, Any], skip_planning_sync: bool = False
-    ) -> None:
-        if skip_planning_sync or self._skip_planning_sync:
+    async def _update_planning_coverages_from_assignment(self, assignment: dict) -> None:
+        if self._skip_planning_sync:
             # Avoid clashing with planning updates that already manage coverages
             return
 
-        planning_id = assignment.get("planning_item")
-        coverage_id = assignment.get("coverage_item")
-        if not planning_id or not coverage_id:
-            return
-
-        planning_service = get_resource_service("planning")
-        is_scheduled_update = bool(assignment.get("scheduled_update_id"))
-
-        async def _apply_update(current_planning: Dict[str, Any]) -> bool:
-            coverages = current_planning.get("coverages") or []
-            updated = False
-            for coverage in coverages:
-                if str(coverage.get("coverage_id")) == str(coverage_id) and not is_scheduled_update:
-                    coverage.setdefault("assigned_to", {})
-                    copy_assignment_details_to_coverage(assignment, coverage)
-                    updated = True
-
-                if not is_scheduled_update:
-                    continue
-
-                for scheduled_update in coverage.get("scheduled_updates") or []:
-                    if str(scheduled_update.get("scheduled_update_id")) == str(assignment.get("scheduled_update_id")):
-                        scheduled_update.setdefault("assigned_to", {})
-                        copy_assignment_details_to_coverage(assignment, scheduled_update)
-                        updated = True
-
-            if not updated:
-                return False
-
-            result = await planning_service.backend.update_async(
-                planning_service.datasource,
-                current_planning[ID_FIELD],
-                {"coverages": coverages},
-                current_planning,
-            )
-            return bool(result)
-
-        planning_item = await planning_service.find_one_async(req=None, _id=planning_id)
-        if not planning_item:
-            return
-
-        try:
-            applied = await _apply_update(planning_item)
-        except Exception as exc:
-            logger.exception(
-                "Failed updating planning coverages from assignment",
-                extra={"planning_id": planning_id, "coverage_id": coverage_id, "assignment_id": assignment.get("_id")},
-            )
-            return
-
-        if not applied:
-            logger.warning(
-                "Planning coverages update was not applied",
-                extra={"planning_id": planning_id, "coverage_id": coverage_id, "assignment_id": assignment.get("_id")},
-            )
+        await update_planning_from_assignment_changes(assignment)
 
     async def on_fetched_resource_archive(self, docs):
         await self._enhance_archive_items(docs.get(ITEMS, []))
@@ -253,7 +198,12 @@ class AssignmentsService(AsyncBaseService):
 
     async def on_create_async(self, docs):
         for doc in docs:
-            self.set_assignment(doc)
+            set_original_creator(doc)
+            self.set_type(doc, {})
+            await self.validate_assignment(doc, {})
+
+            user = get_user()
+            doc["version_creator"] = str(user.get(ID_FIELD)) if user else None
 
     async def on_created_async(self, docs):
         for doc in docs:
@@ -271,27 +221,33 @@ class AssignmentsService(AsyncBaseService):
                 await get_resource_service("planning").set_xmp_file_info(doc)
                 await self.send_assignment_notification(doc, {})
 
-    def set_assignment(self, updates, original=None):
-        """Set the assignment information"""
-        if not original:
-            original = {}
-
+    async def on_update_async(self, updates, original):
         self.set_type(updates, original)
-
-        if not updates.get("assigned_to"):
-            if updates.get("priority"):
-                # Priority was edited - nothing to set here
-                return
+        await self.validate_assignment(updates, original)
+        if updates.get("assigned_to"):
+            if not updates["assigned_to"].get("user"):
+                # In case user was removed, make sure it's a null value
+                updates["assigned_to"]["user"] = None
             else:
-                updates["assigned_to"] = {}
+                # Moving from submitted to assigned after user assigned after desk submission
+                if original.get("assigned_to")["state"] == ASSIGNMENT_WORKFLOW_STATE.SUBMITTED:
+                    updates["assigned_to"]["state"] = get_next_assignment_status(
+                        updates, ASSIGNMENT_WORKFLOW_STATE.IN_PROGRESS
+                    )
+
+        user = get_user()
+        updates["version_creator"] = str(user.get(ID_FIELD)) if user else None
+        remove_lock_information(updates)
+
+    async def validate_assignment(self, updates: dict, original: dict) -> None:
+        if original:
+            await self.validate_assignment_action(original)
 
         assigned_to = updates.get("assigned_to") or {}
         if (assigned_to.get("user") or assigned_to.get("contact")) and planning_auto_assign_to_workflow():
             if not assigned_to.get("desk"):
                 raise SuperdeskApiError.badRequestError(message="Assignment should have a desk.")
 
-        # set the assignment information
-        user = get_user()
         if original.get("assigned_to", {}).get("desk") != assigned_to.get("desk"):
             if original.get("assigned_to", {}).get("state") in [
                 ASSIGNMENT_WORKFLOW_STATE.IN_PROGRESS,
@@ -301,42 +257,7 @@ class AssignmentsService(AsyncBaseService):
                     message="Assignment linked to content. Desk reassignment not allowed."
                 )
 
-            assigned_to["assigned_date_desk"] = utcnow()
-
-            if user and user.get(ID_FIELD):
-                assigned_to["assignor_desk"] = user.get(ID_FIELD)
-
-        if assigned_to.get("user") and original.get("assigned_to", {}).get("user") != assigned_to.get("user"):
-            assigned_to["assigned_date_user"] = utcnow()
-
-            if user and user.get(ID_FIELD):
-                assigned_to["assignor_user"] = user.get(ID_FIELD)
-
-        if not original.get(ID_FIELD):
-            updates["original_creator"] = str(user.get(ID_FIELD)) if user else None
-            updates["assigned_to"][ITEM_STATE] = get_next_assignment_status(
-                updates,
-                updates["assigned_to"].get(ITEM_STATE) or ASSIGNMENT_WORKFLOW_STATE.ASSIGNED,
-            )
-        else:
-            # In case user was removed
-            if not assigned_to.get("user"):
-                assigned_to["user"] = None
-            else:
-                # Moving from submitted to assigned after user assigned after desk submission
-                if original.get("assigned_to")["state"] == ASSIGNMENT_WORKFLOW_STATE.SUBMITTED:
-                    updates["assigned_to"]["state"] = get_next_assignment_status(
-                        updates, ASSIGNMENT_WORKFLOW_STATE.IN_PROGRESS
-                    )
-
-            updates["version_creator"] = str(user.get(ID_FIELD)) if user else None
-
-    async def on_update_async(self, updates, original):
-        await self.validate_assignment_action(original)
-        self.set_assignment(updates, original)
-        remove_lock_information(updates)
-
-    async def validate_assignment_action(self, assignment):
+    async def validate_assignment_action(self, assignment: dict) -> None:
         if assignment.get("_to_delete"):
             plan = await get_resource_service("planning").find_one_async(req=None, _id=assignment.get("planning_item"))
             state = "unposted" if (plan or {}).get("state") == WORKFLOW_STATE.KILLED else (plan or {}).get("state")
@@ -413,20 +334,20 @@ class AssignmentsService(AsyncBaseService):
         self._skip_planning_sync = skip_planning_sync
         try:
             rtn = await super().system_update_async(id, updates, original, **kwargs)
+            if self.is_assignment_being_activated(updates, original):
+                doc = deepcopy(original)
+                doc.update(updates)
+                await self._send_assignment_creation_notification(doc)
+                await AssignmentsHistoryAsyncService().on_item_add_to_workflow(updates, original)
+            elif (
+                original.get(LOCK_ACTION) != "content_edit"
+                and updates.get("assigned_to")
+                and updates.get("assigned_to").get("state") != ASSIGNMENT_WORKFLOW_STATE.CANCELLED
+            ):
+                app = get_current_app().as_any()
+                await app.on_updated_assignments.call_async(updates, original)
         finally:
             self._skip_planning_sync = False
-        if self.is_assignment_being_activated(updates, original):
-            doc = deepcopy(original)
-            doc.update(updates)
-            await self._send_assignment_creation_notification(doc)
-            await AssignmentsHistoryAsyncService().on_item_add_to_workflow(updates, original)
-        elif (
-            original.get(LOCK_ACTION) != "content_edit"
-            and updates.get("assigned_to")
-            and updates.get("assigned_to").get("state") != ASSIGNMENT_WORKFLOW_STATE.CANCELLED
-        ):
-            app = get_current_app().as_any()
-            await app.on_updated_assignments.call_async(updates, original)
         return rtn
 
     async def post_from_planning(self, docs):
@@ -1176,9 +1097,6 @@ class AssignmentsService(AsyncBaseService):
             # If no relevant Event fields have changed
             # then there is no need to send notifications
             return
-
-        # Add 'assigned_to' details to all the coverages
-        get_resource_service("planning").generate_related_assignments(plannings)
 
         for planning in plannings:
             for coverage in planning.get("coverages") or []:

--- a/server/planning/assignments/assignments_complete.py
+++ b/server/planning/assignments/assignments_complete.py
@@ -27,6 +27,7 @@ from planning.common import (
     get_coverage_for_assignment,
 )
 from planning.planning_notifications import PlanningNotifications
+from planning.coverage_assignments import update_planning_from_assignment_changes
 
 
 assignments_complete_schema = deepcopy(assignments_schema)
@@ -122,7 +123,7 @@ class AssignmentsCompleteService(AsyncBaseService):
 
         assignment = deepcopy(original)
         assignment.update(updates)
-        await assignments_service._update_planning_coverages_from_assignment(assignment)
+        await update_planning_from_assignment_changes(assignment)
 
         # publish the planning item
         await assignments_service.publish_planning(original["planning_item"])

--- a/server/planning/assignments/assignments_revert.py
+++ b/server/planning/assignments/assignments_revert.py
@@ -17,6 +17,7 @@ from superdesk.notification import push_notification
 from superdesk.errors import SuperdeskApiError
 from apps.archive.common import get_user, get_auth
 
+from planning.coverage_assignments import update_planning_from_assignment_changes
 from .assignments import AssignmentsResource, assignments_schema
 from .assignments_history_async import AssignmentsHistoryAsyncService
 from planning.common import (
@@ -75,6 +76,10 @@ class AssignmentsRevertService(AsyncBaseService):
 
         # Save history
         await AssignmentsHistoryAsyncService().on_item_revert_availability(updates, original)
+
+        assignment = deepcopy(original)
+        assignment.update(updates)
+        await update_planning_from_assignment_changes(assignment)
 
         push_notification(
             "assignments:reverted",

--- a/server/planning/commands/sync_assignment_coverages.py
+++ b/server/planning/commands/sync_assignment_coverages.py
@@ -156,7 +156,11 @@ class SyncAssignmentCoveragesCommand:
                 if assignment is None:
                     continue
                 elif copy_assigned_to_fields(
-                    scheduled_update, assignment, deepcopy(scheduled_update), destination="coverage", generate_assignor_fields=False
+                    scheduled_update,
+                    assignment,
+                    deepcopy(scheduled_update),
+                    destination="coverage",
+                    generate_assignor_fields=False,
                 ):
                     updated = True
 

--- a/server/planning/commands/sync_assignment_coverages.py
+++ b/server/planning/commands/sync_assignment_coverages.py
@@ -117,15 +117,6 @@ class SyncAssignmentCoveragesCommand:
     def sync_coverages(self, coverages: list[dict[str, Any]], assignments: dict[str, dict[str, Any]]) -> bool:
         updated = False
 
-        def _sync_assigned_to(target: dict[str, Any], assignment: dict[str, Any]) -> bool:
-            updates: dict = {}
-            if copy_assigned_to_fields(
-                updates, assignment, target, destination="coverage", generate_assignor_fields=False
-            ):
-                target.update(updates)
-                return True
-            return False
-
         for coverage in coverages:
             assigned_to = coverage.get("assigned_to") or {}
             assignment_id = assigned_to.get("assignment_id")
@@ -139,7 +130,12 @@ class SyncAssignmentCoveragesCommand:
                     assignment = self.find_assignment_by_id(assignment_id)
                     if assignment is not None:
                         assignments[str(assignment.get("_id"))] = assignment
-                if assignment and _sync_assigned_to(coverage, assignment):
+
+                if assignment is None:
+                    continue
+                elif copy_assigned_to_fields(
+                    coverage, assignment, deepcopy(coverage), destination="coverage", generate_assignor_fields=False
+                ):
                     updated = True
 
             for scheduled_update in coverage.get("scheduled_updates") or []:
@@ -156,7 +152,12 @@ class SyncAssignmentCoveragesCommand:
                     assignment = self.find_assignment_by_id(scheduled_assignment_id)
                     if assignment is not None:
                         assignments[str(assignment.get("_id"))] = assignment
-                if assignment and _sync_assigned_to(scheduled_update, assignment):
+
+                if assignment is None:
+                    continue
+                elif copy_assigned_to_fields(
+                    scheduled_update, assignment, deepcopy(scheduled_update), destination="coverage", generate_assignor_fields=False
+                ):
                     updated = True
 
         return updated

--- a/server/planning/commands/sync_assignment_coverages.py
+++ b/server/planning/commands/sync_assignment_coverages.py
@@ -118,10 +118,13 @@ class SyncAssignmentCoveragesCommand:
         updated = False
 
         def _sync_assigned_to(target: dict[str, Any], assignment: dict[str, Any]) -> bool:
-            before = deepcopy(target.get("assigned_to") or {})
-            target["assigned_to"] = {}
-            copy_assigned_to_fields(target, assignment, before, destination="coverage", generate_assignor_fields=False)
-            return before != target.get("assigned_to")
+            updates: dict = {}
+            if copy_assigned_to_fields(
+                updates, assignment, target, destination="coverage", generate_assignor_fields=False
+            ):
+                target.update(updates)
+                return True
+            return False
 
         for coverage in coverages:
             assigned_to = coverage.get("assigned_to") or {}

--- a/server/planning/commands/sync_assignment_coverages.py
+++ b/server/planning/commands/sync_assignment_coverages.py
@@ -18,7 +18,7 @@ from bson.errors import InvalidId
 from superdesk import get_resource_service
 from superdesk.commands import cli
 
-from planning.common import copy_assignment_details_to_coverage
+from planning.coverage_assignments import copy_assigned_to_fields
 
 
 @cli.command("planning:sync_assignment_coverages")
@@ -120,7 +120,7 @@ class SyncAssignmentCoveragesCommand:
         def _sync_assigned_to(target: dict[str, Any], assignment: dict[str, Any]) -> bool:
             before = deepcopy(target.get("assigned_to") or {})
             target["assigned_to"] = {}
-            copy_assignment_details_to_coverage(assignment, target)
+            copy_assigned_to_fields(target, assignment, before, destination="coverage", generate_assignor_fields=False)
             return before != target.get("assigned_to")
 
         for coverage in coverages:

--- a/server/planning/common.py
+++ b/server/planning/common.py
@@ -25,7 +25,7 @@ from superdesk.resource_fields import ID_FIELD, VERSION
 from superdesk.resource import not_analyzed, build_custom_hateoas
 from superdesk.publish_async.commands import publish_item
 from superdesk import get_resource_service, logger
-from superdesk.eve_async import AsyncEveCursor
+from superdesk.eve_async import AsyncEveCursor, AsyncListCursor
 from superdesk.metadata.item import ITEM_TYPE, CONTENT_STATE
 from superdesk.utc import utcnow
 from superdesk.errors import SuperdeskApiError
@@ -553,7 +553,7 @@ def set_actioned_date_to_event(updates, original):
 
 async def get_archive_items_for_assignment(assignment_id, descending_rewrite_seq=True) -> AsyncEveCursor:
     if not assignment_id:
-        return []
+        return AsyncListCursor()
 
     req = ParsedRequest()
     req.args = MultiDict()
@@ -808,59 +808,6 @@ def is_content_link_to_coverage_allowed(archive_item):
     allowed_coverage_link_types = get_planning_allowed_coverage_link_types()
 
     return True if not len(allowed_coverage_link_types) else archive_item["type"] in allowed_coverage_link_types
-
-
-def _sync_coverage_assigned_to(coverages, lookup_field, id_field):
-    if not coverages:
-        return
-
-    assignments = {
-        str(assignment[ID_FIELD]): assignment
-        for assignment in get_resource_service("assignments").get_from_mongo(
-            req=None,
-            lookup={lookup_field: {"$in": [coverage[id_field] for coverage in coverages]}},
-        )
-    }
-
-    for coverage in coverages:
-        if not coverage.get("assigned_to"):
-            coverage["assigned_to"] = {}
-            continue
-
-        assignment = assignments.get(str(coverage["assigned_to"].get("assignment_id")))
-
-        if not assignment:
-            continue
-
-        copy_assignment_details_to_coverage(assignment, coverage)
-
-
-def copy_assignment_details_to_coverage(assignment: dict, coverage: dict) -> None:
-    assignment.setdefault("assigned_to", {})
-    coverage["assigned_to"]["assignment_id"] = assignment[ID_FIELD]
-    coverage["assigned_to"]["desk"] = assignment["assigned_to"].get("desk")
-    coverage["assigned_to"]["user"] = assignment["assigned_to"].get("user")
-    coverage["assigned_to"]["contact"] = assignment["assigned_to"].get("contact")
-    coverage["assigned_to"]["state"] = assignment["assigned_to"].get("state")
-    coverage["assigned_to"]["assignor_user"] = assignment["assigned_to"].get("assignor_user")
-    coverage["assigned_to"]["assignor_desk"] = assignment["assigned_to"].get("assignor_desk")
-    coverage["assigned_to"]["assigned_date_desk"] = assignment["assigned_to"].get("assigned_date_desk")
-    coverage["assigned_to"]["assigned_date_user"] = assignment["assigned_to"].get("assigned_date_user")
-    coverage["assigned_to"]["coverage_provider"] = assignment["assigned_to"].get("coverage_provider")
-    coverage["assigned_to"]["priority"] = assignment.get("priority")
-
-
-def sync_assignment_details_to_coverages(doc):
-    doc.setdefault("coverages", [])
-    _sync_coverage_assigned_to(doc["coverages"], lookup_field="coverage_item", id_field="coverage_id")
-
-    for coverage in doc["coverages"]:
-        coverage.setdefault("scheduled_updates", [])
-        _sync_coverage_assigned_to(
-            coverage["scheduled_updates"],
-            lookup_field="scheduled_update_id",
-            id_field="scheduled_update_id",
-        )
 
 
 def get_assginment_name(assignment):

--- a/server/planning/common.py
+++ b/server/planning/common.py
@@ -553,7 +553,7 @@ def set_actioned_date_to_event(updates, original):
 
 async def get_archive_items_for_assignment(assignment_id, descending_rewrite_seq=True) -> AsyncEveCursor:
     if not assignment_id:
-        return AsyncListCursor()
+        return AsyncListCursor([])
 
     req = ParsedRequest()
     req.args = MultiDict()

--- a/server/planning/coverage_assignments.py
+++ b/server/planning/coverage_assignments.py
@@ -183,6 +183,9 @@ def get_metadata_updates_between_entities(
         if _copy_translated_values_to_assignment(updates, planning):
             destination_updated = True
 
+        if _set_assignment_state(updates, coverage):
+            destination_updated = True
+
     if not updates.get("assigned_to"):
         updates.pop("assigned_to", None)
     if not updates.get("planning"):
@@ -222,7 +225,14 @@ def copy_assigned_to_fields(
     updates.setdefault("assigned_to", {}).update(deepcopy(original["assigned_to"]))
 
     for field in ASSIGNED_TO_SYNC_FIELDS:
-        updates["assigned_to"][field] = source["assigned_to"].get(field)
+        if field in source["assigned_to"]:
+            new_value = source["assigned_to"][field]
+        elif field in original["assigned_to"]:
+            new_value = original["assigned_to"][field]
+        else:
+            new_value = None
+
+        updates["assigned_to"][field] = new_value
         if updates["assigned_to"][field] == original["assigned_to"].get(field):
             continue
 
@@ -306,6 +316,28 @@ def _get_coverage_planning_metadata(planning: dict, coverage: dict) -> dict:
     return planning_metadata
 
 
+def _set_assignment_state(updates: dict, coverage: dict) -> bool:
+    """
+    Determines and updates the assignment state based on the current coverage
+    workflow status and state.
+
+    :param updates: A dictionary to store the updated assignment state.
+    :param coverage: A dictionary containing coverage details.
+    :return: A boolean indicating whether the assignment state was updated.
+    """
+
+    assign_state = ASSIGNMENT_WORKFLOW_STATE.ASSIGNED
+    if coverage.get("workflow_status") == WORKFLOW_STATE.DRAFT:
+        assign_state = ASSIGNMENT_WORKFLOW_STATE.DRAFT
+    elif coverage["assigned_to"].get("state") and coverage["assigned_to"]["state"] != ASSIGNMENT_WORKFLOW_STATE.DRAFT:
+        assign_state = coverage["assigned_to"]["state"]
+
+    if updates["assigned_to"]["state"] != assign_state:
+        updates["assigned_to"]["state"] = assign_state
+        return True
+    return False
+
+
 def _copy_metadata_to_new_assignment(updates: dict, planning: dict, coverage: dict) -> None:
     """
     Updates the metadata of a new assignment by copying relevant details from planning
@@ -336,13 +368,6 @@ def _copy_metadata_to_new_assignment(updates: dict, planning: dict, coverage: di
 
     if TO_BE_CONFIRMED_FIELD in coverage:
         updates["planning"][TO_BE_CONFIRMED_FIELD] = coverage[TO_BE_CONFIRMED_FIELD]
-
-    assign_state = ASSIGNMENT_WORKFLOW_STATE.ASSIGNED
-    if coverage.get("workflow_status") == WORKFLOW_STATE.DRAFT:
-        assign_state = ASSIGNMENT_WORKFLOW_STATE.DRAFT
-    elif coverage["assigned_to"].get("state") and coverage["assigned_to"]["state"] != ASSIGNMENT_WORKFLOW_STATE.DRAFT:
-        assign_state = coverage["assigned_to"]["state"]
-    updates["assigned_to"]["state"] = assign_state
 
 
 def _copy_metadata_to_existing_assignment(updates: dict, assignment: dict, planning: dict, coverage: dict) -> bool:
@@ -380,6 +405,16 @@ def _copy_metadata_to_existing_assignment(updates: dict, assignment: dict, plann
         and (assignment.get("planning") or {}).get(TO_BE_CONFIRMED_FIELD) != coverage[TO_BE_CONFIRMED_FIELD]
     ):
         updates["planning"][TO_BE_CONFIRMED_FIELD] = coverage[TO_BE_CONFIRMED_FIELD]
+        assignment_updated = True
+
+    # If the Planning description has been changed
+    if planning.get("description_text") != assignment.get("description_text"):
+        updates["description_text"] = planning.get("description_text")
+        assignment_updated = True
+
+    # If the Planning name has been changed
+    if planning.get("name") != assignment.get("name"):
+        updates["name"] = planning.get("name")
         assignment_updated = True
 
     if (

--- a/server/planning/coverage_assignments.py
+++ b/server/planning/coverage_assignments.py
@@ -159,8 +159,7 @@ def get_metadata_updates_between_entities(
     if destination == "assignment":
         if not coverage.get("assigned_to"):
             return {}
-
-        if not coverage.get("assignment_id"):
+        elif not coverage["assigned_to"].get("assignment_id"):
             # We're attempting to create a new Assignment
 
             if not coverage["assigned_to"].get("user") and not coverage["assigned_to"].get("desk"):
@@ -246,7 +245,7 @@ def copy_assigned_to_fields(
     if destination == "coverage":
         if "assignment_id" not in updates["assigned_to"]:
             # Make sure the Coverage has the Assignment ID
-            updates["assigned_to"]["assignment_id"] = assignment.get("_id")
+            updates["assigned_to"]["assignment_id"] = str(assignment.get("_id"))
             destination_updated = True
 
         assignment_priority = assignment.get("priority")

--- a/server/planning/coverage_assignments.py
+++ b/server/planning/coverage_assignments.py
@@ -1,0 +1,442 @@
+from typing import Literal
+from copy import deepcopy
+import logging
+
+from superdesk import get_resource_service
+from superdesk.resource_fields import ID_FIELD
+from superdesk.utc import utcnow
+
+from apps.auth import get_user
+
+from planning.common import (
+    WORKFLOW_STATE,
+    ASSIGNMENT_WORKFLOW_STATE,
+    DEFAULT_ASSIGNMENT_PRIORITY,
+    TO_BE_CONFIRMED_FIELD,
+)
+from planning.types import PlanningAutosaveResourceModel
+
+__all__ = [
+    "update_planning_from_assignment_changes",
+    "get_metadata_updates_between_entities",
+    "copy_assigned_to_fields",
+]
+
+logger = logging.getLogger(__name__)
+ASSIGNED_TO_SYNC_FIELDS = ("desk", "user", "contact", "state", "coverage_provider")
+ASSIGNEE_FIELDS = ("desk", "user")
+
+
+async def update_planning_from_assignment_changes(
+    assignment: dict,
+    is_autosave: bool = False,
+) -> None:
+    """
+    Updates a planning item's coverage details from assignment changes.
+
+    This function processes the given assignment to locate the relevant planning item
+    and updates its coverages based on the new assignment data. It supports handling
+    both autosave and regular updates for planning items. If specific scheduled update
+    details are present in the assignment, it ensures those are also updated accordingly.
+
+    :param assignment: The Assignment used to update the associated Planning item for
+    :param is_autosave: Indicates whether the update pertains to an autosave resource. Defaults to False.
+    """
+
+    planning_id = assignment.get("planning_item")
+    coverage_id = assignment.get("coverage_item")
+    if not planning_id or not coverage_id:
+        return
+
+    planning_item: dict | None
+    if is_autosave:
+        planning_item = await PlanningAutosaveResourceModel.get_service().find_by_id_raw(item_id=planning_id)
+    else:
+        planning_item = await get_resource_service("planning").find_one_async(req=None, _id=planning_id)
+
+    if not planning_item:
+        if not is_autosave:
+            logger.warning(
+                "Failed to find planning item for assignment",
+                extra={"assignment_id": assignment.get("_id"), "planning_id": planning_id, "coverage_id": coverage_id},
+            )
+        return
+
+    coverages: list[dict] = planning_item.get("coverages") or []
+    coverage: dict | None = next(
+        (coverage for coverage in coverages if coverage.get("coverage_id") == coverage_id), None
+    )
+    if not coverage:
+        logger.warning(
+            "Failed to find coverage for assignment",
+            extra={"assignment_id": assignment.get("_id"), "planning_id": planning_id, "coverage_id": coverage_id},
+        )
+        return
+
+    is_scheduled_update = bool(assignment.get("scheduled_update_id"))
+    if is_scheduled_update:
+        scheduled_updates: list[dict] = coverage.get("scheduled_updates", [])
+        scheduled_update_coverage: dict | None = next(
+            (
+                scheduled_update
+                for scheduled_update in scheduled_updates
+                if scheduled_update.get("scheduled_update_id") == assignment.get("scheduled_update_id")
+            ),
+            None,
+        )
+        if not scheduled_update_coverage:
+            logger.warning(
+                "Failed to find scheduled update for assignment",
+                extra={
+                    "assignment_id": assignment.get("_id"),
+                    "planning_id": planning_id,
+                    "coverage_id": coverage_id,
+                    "scheduled_update_id": assignment.get("scheduled_update_id"),
+                },
+            )
+            return
+        coverage = scheduled_update_coverage
+
+    coverage_updates = get_metadata_updates_between_entities(
+        assignment, planning_item, coverage, destination="coverage"
+    )
+    if not coverage_updates:
+        # No updates needed to apply to the Planning item
+        logger.warning(
+            "Planning coverages update was not applied",
+            extra={"planning_id": planning_id, "coverage_id": coverage_id, "assignment_id": assignment.get("_id")},
+        )
+        return
+
+    coverage["assigned_to"].update(coverage_updates.pop("assigned_to", {}))
+    coverage["planning"].update(coverage_updates.pop("planning", {}))
+    coverage.update(coverage_updates)
+
+    if is_autosave:
+        await PlanningAutosaveResourceModel.get_service().system_update(
+            planning_item[ID_FIELD], updates={"coverages": coverages}
+        )
+    else:
+        planning_service = get_resource_service("planning")
+        await planning_service.backend.system_update_async(
+            planning_service.datasource,
+            planning_item[ID_FIELD],
+            {"coverages": coverages},
+            planning_item,
+        )
+
+
+def get_metadata_updates_between_entities(
+    assignment: dict,
+    planning: dict,
+    coverage: dict,
+    destination: Literal["coverage", "assignment"],
+) -> dict:
+    """
+    Determine metadata updates required between entities.
+
+    This function identifies and prepares changes in the metadata between an assignment,
+    planning item, and coverage, based on the specified destination. It ensures proper
+    metadata synchronization and determines if updates are necessary, returning the
+    adjusted metadata if changes are detected.
+
+    :param assignment: The assignment object containing metadata for a related assignment.
+    :param planning: The planning object providing additional metadata details.
+    :param coverage: The coverage object containing information about the coverage item.
+    :param destination: The target entity for the metadata updates; either 'coverage' or 'assignment'.
+    :return dict: A dictionary containing metadata updates if any changes are required; otherwise an empty dictionary.
+    """
+
+    updates: dict = {}
+
+    updates.setdefault("assigned_to", {})
+    updates.setdefault("planning", {})
+    destination_updated = False
+
+    if copy_assigned_to_fields(updates, assignment, coverage, destination):
+        destination_updated = True
+
+    if destination == "assignment":
+        if not coverage.get("assigned_to"):
+            return {}
+
+        if not coverage.get("assignment_id"):
+            # We're attempting to create a new Assignment
+
+            if not coverage["assigned_to"].get("user") and not coverage["assigned_to"].get("desk"):
+                # No assignee details, do not create an Assignment yet
+                return {}
+
+            _copy_metadata_to_new_assignment(updates, planning, coverage)
+            destination_updated = True
+        else:
+            # We're attempting to update an existing Assignment'
+            if assignment["assigned_to"]["state"] in [
+                ASSIGNMENT_WORKFLOW_STATE.COMPLETED,
+                ASSIGNMENT_WORKFLOW_STATE.CANCELLED,
+            ]:
+                # This Assignment is either marked as completed or is cancelled, do not update it
+                return {}
+
+            if _copy_metadata_to_existing_assignment(updates, assignment, planning, coverage):
+                destination_updated = True
+
+        if _copy_translated_values_to_assignment(updates, planning):
+            destination_updated = True
+
+    if not updates.get("assigned_to"):
+        updates.pop("assigned_to", None)
+    if not updates.get("planning"):
+        updates.pop("planning", None)
+
+    return updates if destination_updated else {}
+
+
+def copy_assigned_to_fields(
+    updates: dict,
+    assignment: dict,
+    coverage: dict,
+    destination: Literal["coverage", "assignment"],
+    generate_assignor_fields: bool = True,
+) -> bool:
+    """
+    Synchronizes the "assigned_to" fields between the source and destination, based on
+    the provided destination type, and updates metadata for assignee changes.
+
+    :param updates: A dictionary to store the updates made to the destination data.
+    :param assignment: The source assignment data.
+    :param coverage: The destination coverage data.
+    :param destination: The type of data to synchronize ("coverage" or "assignment").
+    :param generate_assignor_fields: Whether to generate assignor fields for the destination, or copy from source.
+    :return: A boolean indicating whether any changes were made to the destination data.
+    """
+
+    source = assignment if destination == "coverage" else coverage
+    original = coverage if destination == "coverage" else assignment
+
+    now = utcnow()
+    user = get_user()
+    user_id = user.get(ID_FIELD) if user else None
+    destination_updated = False
+    source.setdefault("assigned_to", {})
+    original.setdefault("assigned_to", {})
+    updates.setdefault("assigned_to", {}).update(deepcopy(original["assigned_to"]))
+
+    for field in ASSIGNED_TO_SYNC_FIELDS:
+        updates["assigned_to"][field] = source["assigned_to"].get(field)
+        if updates["assigned_to"][field] == original["assigned_to"].get(field):
+            continue
+
+        destination_updated = True
+        if field in ASSIGNEE_FIELDS:
+            assigned_date_field = f"assigned_date_{field}"
+            assignor_field = f"assignor_{field}"
+
+            # Set who and when the User and/or Desk assignees were updated
+            if generate_assignor_fields:
+                # Generate new assignor field values based on current request and date/time
+                updates["assigned_to"][assigned_date_field] = now
+                if user_id:
+                    updates["assigned_to"][assignor_field] = user_id
+            else:
+                # Just copy across the field values from the source
+                updates["assigned_to"][assigned_date_field] = source["assigned_to"].get(assigned_date_field)
+                updates["assigned_to"][assignor_field] = source["assigned_to"].get(assignor_field)
+
+    if destination == "coverage":
+        if "assignment_id" not in updates["assigned_to"]:
+            # Make sure the Coverage has the Assignment ID
+            updates["assigned_to"]["assignment_id"] = assignment.get("_id")
+            destination_updated = True
+
+        assignment_priority = assignment.get("priority")
+        updates["assigned_to"]["priority"] = assignment_priority or DEFAULT_ASSIGNMENT_PRIORITY
+        if coverage["assigned_to"].get("priority") != assignment_priority:
+            destination_updated = True
+    else:
+        coverage_priority = coverage["assigned_to"].get("priority")
+        updates["priority"] = coverage_priority or DEFAULT_ASSIGNMENT_PRIORITY
+        if updates["priority"] != coverage_priority:
+            destination_updated = True
+
+    return destination_updated
+
+
+def _get_coverage_by_id(planning: dict, coverage_id: str) -> dict | None:
+    """
+    Retrieve a specific coverage by its ID from the given planning dictionary.
+
+    This function searches through the list of coverages within the provided planning
+    dictionary and retrieves the first coverage that matches the specified coverage ID.
+
+    :param planning: A dictionary containing planning information with a list of coverages.
+    :param coverage_id: The unique identifier for the coverage to be retrieved.
+    :return: The first coverage dictionary that matches the given coverage ID, or None if no such coverage is found.
+    """
+
+    coverages = planning.get("coverages") or []
+    return next((c for c in coverages if c.get("coverage_id") == coverage_id), None)
+
+
+def _get_coverage_planning_metadata(planning: dict, coverage: dict) -> dict:
+    """
+    Retrieve or construct metadata for coverage planning based on the provided planning and
+    coverage details. If the coverage references a scheduled update, attempts to extract
+    metadata from its parent coverage and incorporates it into the resulting metadata.
+
+    :param planning: A dictionary containing planning information.
+    :param coverage: A dictionary containing coverage details.
+    :return: A dictionary containing metadata for coverage planning.
+    """
+
+    planning_metadata: dict = {}
+    if coverage.get("scheduled_update_id"):
+        if parent_coverage := _get_coverage_by_id(planning, coverage["coverage_id"]):
+            planning_metadata.update(deepcopy(parent_coverage.get("planning", {})))
+        else:
+            logger.warning(
+                "Failed to find parent coverage for scheduled update",
+                extra={
+                    "planning_id": planning[ID_FIELD],
+                    "coverage_id": coverage.get("coverage_id"),
+                    "scheduled_update_id": coverage["scheduled_update_id"],
+                },
+            )
+
+    planning_metadata.update(deepcopy(coverage.get("planning") or {}))
+    return planning_metadata
+
+
+def _copy_metadata_to_new_assignment(updates: dict, planning: dict, coverage: dict) -> None:
+    """
+    Updates the metadata of a new assignment by copying relevant details from planning
+    and coverage dictionaries into the updates dictionary.
+
+    This function primarily modifies the updates dictionary in-place, ensuring that
+    any metadata related to planning and coverage configurations is properly transferred. The
+    updates are made based on the current coverage's attributes, including scheduled updates,
+    workflow status, and assigned states. This ensures the resulting metadata in updates is
+    consistent and complete for assignment creation.
+
+    :param updates: The dictionary to update with metadata. This is modified in-place.
+    :param planning: The dictionary containing overall planning information.
+    :param coverage: The dictionary containing information about the specific coverage.
+    """
+
+    updates.update(
+        {
+            "planning_item": planning[ID_FIELD],
+            "coverage_item": coverage.get("coverage_id"),
+            "description_text": planning.get("description_text"),
+            "planning": _get_coverage_planning_metadata(planning, coverage),
+        }
+    )
+
+    if coverage.get("scheduled_update_id"):
+        updates["scheduled_update_id"] = coverage["scheduled_update_id"]
+
+    if TO_BE_CONFIRMED_FIELD in coverage:
+        updates["planning"][TO_BE_CONFIRMED_FIELD] = coverage[TO_BE_CONFIRMED_FIELD]
+
+    assign_state = ASSIGNMENT_WORKFLOW_STATE.ASSIGNED
+    if coverage.get("workflow_status") == WORKFLOW_STATE.DRAFT:
+        assign_state = ASSIGNMENT_WORKFLOW_STATE.DRAFT
+    elif coverage["assigned_to"].get("state") and coverage["assigned_to"]["state"] != ASSIGNMENT_WORKFLOW_STATE.DRAFT:
+        assign_state = coverage["assigned_to"]["state"]
+    updates["assigned_to"]["state"] = assign_state
+
+
+def _copy_metadata_to_existing_assignment(updates: dict, assignment: dict, planning: dict, coverage: dict) -> bool:
+    """
+    Updates metadata fields in an existing assignment object based on the given coverage data.
+
+    This function checks whether the planning or workflow state fields in the supplied
+    coverage dictionary differ from those in the corresponding assignment dictionary.
+    If differences are identified, specific fields in the `updates` dictionary are modified
+    to reflect the changes. The function also considers enabling assignments based on the
+    workflow state.
+
+    :param updates: The dictionary to update with metadata changes.
+    :param assignment: The existing assignment object.
+    :param planning: The dictionary containing overall planning information.
+    :param coverage: The dictionary containing information about the specific coverage.
+    :return: A boolean indicating whether the assignment was updated.
+    """
+
+    assignment_updated = False
+
+    update_planning_field = False
+    updated_planning_metadata = _get_coverage_planning_metadata(planning, coverage)
+    for field, updated_value in updated_planning_metadata.items():
+        if not field.startswith("_") and updated_value != (assignment.get("planning") or {}).get(field):
+            update_planning_field = True
+            break
+
+    if update_planning_field:
+        updates["planning"] = updated_planning_metadata
+        assignment_updated = True
+
+    if (
+        TO_BE_CONFIRMED_FIELD in coverage
+        and (assignment.get("planning") or {}).get(TO_BE_CONFIRMED_FIELD) != coverage[TO_BE_CONFIRMED_FIELD]
+    ):
+        updates["planning"][TO_BE_CONFIRMED_FIELD] = coverage[TO_BE_CONFIRMED_FIELD]
+        assignment_updated = True
+
+    if (
+        coverage.get("workflow_status") == WORKFLOW_STATE.ACTIVE
+        and assignment["assigned_to"]["state"] == ASSIGNMENT_WORKFLOW_STATE.DRAFT
+    ):
+        # The Coverage as been added to workflow, enable the Assignment now
+        updates["assigned_to"]["state"] = coverage["assigned_to"]["state"]
+        assignment_updated = True
+
+    return assignment_updated
+
+
+def _copy_translated_values_to_assignment(updates: dict, planning: dict) -> bool:
+    """
+    Copies translated values from the planning object to the updates dictionary based
+    on the specified language in the updates planning section. Returns a boolean
+    indicating if the assignment was updated.
+
+    :param updates: The dictionary to update with translated values.
+    :param planning: The dictionary containing overall planning information.
+    :return: A boolean indicating whether the assignment was updated.
+    """
+
+    if not planning.get("translations") or not updates["planning"].get("language"):
+        return False
+
+    translations: list[dict] = planning["translations"]
+    translated_values: dict = {
+        entry["field"]: entry["value"]
+        for entry in translations or []
+        if entry["language"] == updates["planning"]["language"]
+    }
+
+    if not translated_values:
+        return False
+
+    assignment_updated = False
+    translated_name: str | None = translated_values.get("name", translated_values.get("headline"))
+    planning_updates = {
+        key: val
+        for key, val in translated_values.items()
+        if key in ("ednote", "description_text", "headline", "slugline", "authors", "internal_note")
+        and updates["planning"].get(key) is None
+    }
+    if planning_updates:
+        updates["planning"].update(planning_updates)
+        assignment_updated = True
+
+    # Add translated names
+    if translated_name and "headline" not in updates["planning"]:
+        updates["planning"]["headline"] = translated_name
+        assignment_updated = True
+
+    if translated_name and updates.get("name") != translated_values.get("name"):
+        updates["name"] = translated_name
+        assignment_updated = True
+
+    return assignment_updated

--- a/server/planning/planning/__init__.py
+++ b/server/planning/planning/__init__.py
@@ -127,7 +127,6 @@ def init_app(app):
     app.on_updated_planning_cancel += planning_history_service.on_cancel
     app.on_updated_planning_reschedule += planning_history_service.on_reschedule
 
-    app.on_locked_planning += planning_service.on_locked_planning
     app.on_updated_assignments += PlanningAutosaveAsyncService().on_assignment_updated
 
     superdesk.privilege(

--- a/server/planning/planning/planning.py
+++ b/server/planning/planning/planning.py
@@ -991,8 +991,8 @@ class PlanningService(AsyncBaseService):
                 assignment={},
             )
             if assignment_updates:
-                assignment_id = str((await assignment_service.post_from_planning([assignment_updates]))[0])
-                updates["assigned_to"]["assignment_id"] = assignment_id
+                new_assignment_id = str((await assignment_service.post_from_planning([assignment_updates]))[0])
+                updates["assigned_to"]["assignment_id"] = new_assignment_id
                 # Copy across the ``priority`` as well (as it's placed in a different location)
                 if assignment_updates.get("priority"):
                     updates["assigned_to"]["priority"] = assignment_updates["priority"]
@@ -1008,8 +1008,8 @@ class PlanningService(AsyncBaseService):
 
             await self.set_xmp_file_info(updates, original)
 
-            assignment_id = ObjectId(assigned_to["assignment_id"])
-            original_assignment = await assignment_service.find_one_async(req=None, _id=assignment_id)
+            existing_assignment_id = ObjectId(assigned_to["assignment_id"])
+            original_assignment = await assignment_service.find_one_async(req=None, _id=existing_assignment_id)
             if not original_assignment:
                 # Assignment was already deleted - remove the stale assignment_id reference
                 # so the user can continue editing the coverage
@@ -1053,7 +1053,7 @@ class PlanningService(AsyncBaseService):
             if assignment_updates:
                 # Update only if anything got modified
                 await assignment_service.system_update_async(
-                    assignment_id,
+                    existing_assignment_id,
                     assignment_updates,
                     original_assignment,
                     skip_planning_sync=True,

--- a/server/planning/planning/planning.py
+++ b/server/planning/planning/planning.py
@@ -75,7 +75,6 @@ from planning.common import (
     get_planning_xmp_slugline_mapping,
     get_planning_use_xmp_for_pic_slugline,
     get_planning_use_xmp_for_pic_assignments,
-    sync_assignment_details_to_coverages,
     set_ingest_version_datetime,
     is_new_version,
     update_ingest_on_patch,
@@ -101,6 +100,7 @@ from planning.utils import (
     get_related_event_items_for_planning,
 )
 from .planning_utils import get_coverage_by_id
+from planning.coverage_assignments import get_metadata_updates_between_entities
 
 logger = logging.getLogger(__name__)
 
@@ -140,12 +140,6 @@ class PlanningService(AsyncBaseService):
         """Ignore cancelling on ingest, this will happen in ``update_post_item``"""
 
         pass
-
-    def generate_related_assignments(self, docs):
-        for doc in docs:
-            doc.pop("_planning_schedule", None)
-            doc.pop("_updates_schedule", None)
-            sync_assignment_details_to_coverages(doc)
 
     async def find_one_async(self, req, **lookup):
         item = await super().find_one_async(req, **lookup)
@@ -236,8 +230,6 @@ class PlanningService(AsyncBaseService):
                     updates["pubstatus"] = POST_STATE.USABLE
                     await update_post_item(updates, doc)
 
-        self.generate_related_assignments(docs)
-
     async def _update_event_history(self, doc: Planning):
         events_service = get_resource_service("events")
         events_history_service = EventsHistoryAsyncService()
@@ -270,9 +262,6 @@ class PlanningService(AsyncBaseService):
             removed_agendas=[],
             session=session_id,
         )
-
-    def on_locked_planning(self, item, user_id):
-        self.generate_related_assignments([item])
 
     def should_update(self, old_item, new_item, provider):
         return True
@@ -575,7 +564,6 @@ class PlanningService(AsyncBaseService):
             related_events_changed=related_events_changed,
         )
 
-        self.generate_related_assignments([doc])
         updates["coverages"] = doc.get("coverages") or []
 
         if original.get("lock_user") and "lock_user" in updates and updates.get("lock_user") is None:
@@ -764,7 +752,7 @@ class PlanningService(AsyncBaseService):
                 s["coverage_id"] = coverage["coverage_id"]
                 s["scheduled_update_id"] = generate_guid(type=GUID_NEWSML)
                 self.set_scheduled_update_active(s, updates, coverage)
-                await self._create_update_assignment(original, updates, s, None, coverage)
+                await self._create_update_assignment(original, updates, s, None)
 
     async def update_scheduled_updates(self, updates, original, coverage, original_coverage):
         for s in coverage.get("scheduled_updates") or []:
@@ -783,7 +771,7 @@ class PlanningService(AsyncBaseService):
                     and s.get("workflow_status") == WORKFLOW_STATE.ACTIVE
                 ):
                     self.set_scheduled_update_active(s, updates, coverage)
-                await self._create_update_assignment(original, updates, s, original_scheduled_update, coverage)
+                await self._create_update_assignment(original, updates, s, original_scheduled_update)
 
     async def update_coverages(self, updates, original):
         if "coverages" not in updates:
@@ -961,12 +949,11 @@ class PlanningService(AsyncBaseService):
 
     async def _create_update_assignment(
         self,
-        planning_original,
-        planning_updates,
-        updates,
-        original=None,
-        parent_coverage=None,
-    ):
+        planning_original: dict,
+        planning_updates: dict,
+        updates: dict,
+        original: dict | None = None,
+    ) -> None:
         """Create or update the assignment.
 
         :param dict planning_original: original parent planning document
@@ -980,177 +967,97 @@ class PlanningService(AsyncBaseService):
         planning = deepcopy(planning_original)
         planning.update(planning_updates)
         planning_id = planning.get(ID_FIELD)
-
-        doc = deepcopy(original)
-        doc.update(deepcopy(updates))
-        assignment_service = get_resource_service("assignments")
-        assigned_to = updates.get("assigned_to") or original.get("assigned_to")
-        new_assignment_id = None
-        if not assigned_to:
-            return
-
         if not planning_id:
             raise SuperdeskApiError.badRequestError("Planning item is required to create assignments.")
 
-        # Coverage is draft if original was draft and updates is still maintaining that state
-        coverage_status = updates.get("workflow_status", original.get("workflow_status"))
-        is_coverage_draft = coverage_status == WORKFLOW_STATE.DRAFT
+        assignment_service = get_resource_service("assignments")
+        updated_coverage = deepcopy(original)
+        updated_coverage.update(deepcopy(updates))
+        assigned_to: dict | None = updated_coverage.get("assigned_to")
 
-        translations = planning.get("translations")
-        translated_value = {}
-        translated_name = planning.get("name", planning.get("headline", ""))
-        doc.setdefault("planning", {})
+        if not assigned_to:
+            return
 
-        # SDBELGA-937
-        doc["planning"]["news_coverage_status"] = updates.get("news_coverage_status") or original.get(
-            "news_coverage_status"
-        )
+        assignment_updates: dict
+        if not assigned_to.get("assignment_id"):
+            if not assigned_to.get("user") and not assigned_to.get("desk"):
+                # If there is no Desk or User, we will not create a new Assignment yet
+                return
 
-        if translations is not None and doc["planning"].get("language") is not None:
-            translated_value.update(
-                {
-                    entry["field"]: entry["value"]
-                    for entry in translations or []
-                    if entry["language"] == doc["planning"]["language"]
-                }
+            assignment_updates = get_metadata_updates_between_entities(
+                planning=planning,
+                coverage=updated_coverage,
+                destination="assignment",
+                assignment={},
             )
-
-            translated_name = translated_value.get("name", translated_value.get("headline"))
-            doc["planning"].update(
-                {
-                    key: val
-                    for key, val in translated_value.items()
-                    if key in ("ednote", "description_text", "headline", "slugline", "authors", "internal_note")
-                    and doc["planning"].get(key) is None
-                }
-            )
-
-        if not assigned_to.get("assignment_id") and (assigned_to.get("user") or assigned_to.get("desk")):
-            # Creating a new assignment
-            assign_state = ASSIGNMENT_WORKFLOW_STATE.DRAFT if is_coverage_draft else ASSIGNMENT_WORKFLOW_STATE.ASSIGNED
-            if not is_coverage_draft:
-                # In case of article_rewrites, this will be 'in_progress' directly
-                if assigned_to.get("state") and assigned_to["state"] != ASSIGNMENT_WORKFLOW_STATE.DRAFT:
-                    assign_state = assigned_to.get("state")
-
-            if translated_value and translated_name and "headline" not in doc["planning"]:
-                doc["planning"]["headline"] = translated_name
-
-            assignment = {
-                "assigned_to": {
-                    "user": assigned_to.get("user"),
-                    "desk": assigned_to.get("desk"),
-                    "contact": assigned_to.get("contact"),
-                    "state": assign_state,
-                },
-                "planning_item": planning_id,
-                "coverage_item": doc.get("coverage_id"),
-                "planning": deepcopy(doc.get("planning")),
-                "priority": assigned_to.get("priority", DEFAULT_ASSIGNMENT_PRIORITY),
-                "description_text": planning.get("description_text"),
-            }
-            if translated_value and translated_name and assignment.get("name") != translated_value.get("name"):
-                assignment["name"] = translated_name
-
-            if doc.get("scheduled_update_id"):
-                assignment["scheduled_update_id"] = doc["scheduled_update_id"]
-                assignment["planning"] = deepcopy(parent_coverage.get("planning"))
-                assignment["planning"].update(doc.get("planning"))
-
-            if "coverage_provider" in assigned_to:
-                assignment["assigned_to"]["coverage_provider"] = assigned_to.get("coverage_provider")
-
-            if TO_BE_CONFIRMED_FIELD in doc:
-                assignment["planning"][TO_BE_CONFIRMED_FIELD] = doc[TO_BE_CONFIRMED_FIELD]
-
-            new_assignment_id = str((await assignment_service.post_from_planning([assignment]))[0])
-            updates["assigned_to"]["assignment_id"] = new_assignment_id
-            updates["assigned_to"]["state"] = assign_state
-            updates["assigned_to"]["priority"] = assignment.get("priority")
-        elif assigned_to.get("assignment_id"):
-            await self.set_xmp_file_info(updates, original)
-
+            if assignment_updates:
+                assignment_id = str((await assignment_service.post_from_planning([assignment_updates]))[0])
+                updates["assigned_to"]["assignment_id"] = assignment_id
+                # Copy across the ``priority`` as well (as it's placed in a different location)
+                if assignment_updates.get("priority"):
+                    updates["assigned_to"]["priority"] = assignment_updates["priority"]
+        else:
             if not updates.get("assigned_to"):
-                if planning_original.get("state") == WORKFLOW_STATE.CANCELLED or coverage_status not in [
-                    WORKFLOW_STATE.CANCELLED,
-                    WORKFLOW_STATE.DRAFT,
-                ]:
+                if planning_original.get("state") == WORKFLOW_STATE.CANCELLED or updated_coverage.get(
+                    "workflow_status"
+                ) not in [WORKFLOW_STATE.CANCELLED, WORKFLOW_STATE.DRAFT]:
                     raise SuperdeskApiError.badRequestError("Coverage not in correct state to remove assignment.")
 
                 # Return now, we will process the assignment after the DB is updated
                 return
 
-            # update the assignment using the coverage details
-            original_assignment = await assignment_service.find_one_async(
-                req=None, _id=assigned_to.get("assignment_id")
-            )
+            await self.set_xmp_file_info(updates, original)
 
+            assignment_id = ObjectId(assigned_to["assignment_id"])
+            original_assignment = await assignment_service.find_one_async(req=None, _id=assignment_id)
             if not original_assignment:
                 # Assignment was already deleted - remove the stale assignment_id reference
                 # so the user can continue editing the coverage
                 if not updates.get("assigned_to"):
                     updates["assigned_to"] = None
+                    await self.set_xmp_file_info(updates, original)
                 else:
                     del updates["assigned_to"]
                 return
 
-            # Check if coverage was cancelled
-            coverage_cancel_state = get_coverage_status_from_cv("ncostat:notint")
-            coverage_cancel_state.pop("is_active", None)
+            # Check if the coverage was cancelled
             if (
                 original.get("workflow_status") != updates.get("workflow_status")
                 and updates.get("workflow_status") == WORKFLOW_STATE.CANCELLED
             ):
+                coverage_cancel_state = get_coverage_status_from_cv("ncostat:notint")
+                coverage_cancel_state.pop("is_active", None)
                 await self.cancel_coverage(
                     updates,
                     coverage_cancel_state,
                     original.get("workflow_status"),
                     original_assignment,
-                    updates.get("planning").get("workflow_status_reason"),
+                    updates.get("planning", {}).get("workflow_status_reason"),
                 )
                 return
 
-            assignment = {}
-            if self.is_coverage_planning_modified(updates, original):
-                assignment["planning"] = deepcopy(doc.get("planning"))
-
-                if TO_BE_CONFIRMED_FIELD in doc:
-                    assignment["planning"][TO_BE_CONFIRMED_FIELD] = doc[TO_BE_CONFIRMED_FIELD]
-
-            def _update_assignment_assigned_to():
-                user = get_user()
-                assignment["priority"] = assigned_to.pop("priority", original_assignment.get("priority"))
-                assignment["assigned_to"] = assigned_to
-                if original_assignment.get("assigned_to", {}).get("desk") != assigned_to.get("desk"):
-                    assigned_to["assigned_date_desk"] = utcnow()
-                    assigned_to["assignor_desk"] = user.get(ID_FIELD)
-                if "user" in assigned_to and original.get("assigned_to", {}).get("user") != assigned_to.get("user"):
-                    assigned_to["assigned_date_user"] = utcnow()
-                    assigned_to["assignor_user"] = user.get(ID_FIELD)
-
-            if original_assignment.get("assigned_to").get("state") == ASSIGNMENT_WORKFLOW_STATE.DRAFT:
-                if self.is_coverage_assignment_modified(updates, original_assignment):
-                    _update_assignment_assigned_to()
-
-            # If we made a coverage 'active' - change assignment status to active
-            if original.get("workflow_status") == WORKFLOW_STATE.DRAFT and not is_coverage_draft:
-                assigned_to["state"] = ASSIGNMENT_WORKFLOW_STATE.ASSIGNED
-                assignment["assigned_to"] = assigned_to
-
-            # If the Planning description has been changed
-            if planning_original.get("description_text") != planning_updates.get("description_text"):
-                assignment["description_text"] = planning["description_text"]
-
-            # If the Planning name has been changed
-            if planning_original.get("name") != planning_updates.get("name"):
-                assignment["name"] = planning["name"] if not translated_value and translated_name else translated_name
-
-            # If the coverage assignee has been changed and workflow status is active
-            if original.get("workflow_status") != WORKFLOW_STATE.DRAFT and self.is_coverage_assignment_modified(
-                updates, original_assignment
+            if (
+                original.get("workflow_status") == WORKFLOW_STATE.DRAFT
+                and updated_coverage.get("workflow_status") == WORKFLOW_STATE.ACTIVE
             ):
+                # If we made a coverage 'active' - change assignment status to active
                 assigned_to["state"] = ASSIGNMENT_WORKFLOW_STATE.ASSIGNED
-                _update_assignment_assigned_to()
+
+            assignment_updates = get_metadata_updates_between_entities(
+                planning=planning,
+                coverage=updated_coverage,
+                destination="assignment",
+                assignment=original_assignment,
+            )
+
+            if assignment_updates:
+                # Update only if anything got modified
+                await assignment_service.system_update_async(
+                    assignment_id,
+                    assignment_updates,
+                    original_assignment,
+                    skip_planning_sync=True,
+                )
 
             # If there has been a change in the planning internal note then notify the assigned users/desk
             if planning_updates.get("internal_note") and planning_original.get("internal_note") != planning_updates.get(
@@ -1168,22 +1075,9 @@ class PlanningService(AsyncBaseService):
                     no_email=True,
                 )
 
-            # Update only if anything got modified
-            if (
-                "planning" in assignment
-                or "assigned_to" in assignment
-                or "description_text" in assignment
-                or "name" in assignment
-                or "priority" in assignment
-            ):
-                await assignment_service.system_update_async(
-                    ObjectId(assigned_to.get("assignment_id")),
-                    assignment,
-                    original_assignment,
-                    skip_planning_sync=True,
-                )
-
             if self.is_xmp_updated(updates, original):
+                updated_assignment = deepcopy(original_assignment)
+                updated_assignment.update(assignment_updates)
                 await PlanningNotifications().notify_assignment(
                     coverage_status=updates.get("workflow_status"),
                     target_desk=assigned_to.get("desk") if assigned_to.get("user") is None else None,
@@ -1193,8 +1087,15 @@ class PlanningService(AsyncBaseService):
                     meta_message="assignment_details_email",
                     coverage_type=get_coverage_type_name(updates.get("planning", {}).get("g2_content_type", "")),
                     slugline=planning.get("slugline", ""),
-                    assignment=assignment,
+                    assignment=updated_assignment,
                 )
+
+        # Copy Assignment updates back onto the Coverage so it gets stored in the DB
+        if assignment_updates.get("assigned_to"):
+            updates["assigned_to"].update(assignment_updates["assigned_to"])
+
+        if assignment_updates.get("priority"):
+            updates["assigned_to"]["priority"] = assignment_updates["priority"]
 
     async def cancel_coverage(
         self,
@@ -1264,7 +1165,6 @@ class PlanningService(AsyncBaseService):
         if not planning:
             raise SuperdeskApiError.badRequestError("Planning does not exist")
 
-        self.generate_related_assignments([planning])
         coverages = planning.get("coverages") or []
         try:
             coverage = next(c for c in coverages if c.get("coverage_id") == coverage_id)

--- a/server/planning/planning/planning_autosave_service.py
+++ b/server/planning/planning/planning_autosave_service.py
@@ -3,7 +3,8 @@ import logging
 from superdesk.core import get_current_app
 
 from planning.autosave_service import AutosaveAsyncService
-from planning.common import WORKFLOW_STATE, copy_assignment_details_to_coverage
+from planning.common import WORKFLOW_STATE
+from planning.coverage_assignments import update_planning_from_assignment_changes
 
 logger = logging.getLogger(__name__)
 
@@ -55,29 +56,6 @@ class PlanningAutosaveAsyncService(AutosaveAsyncService):
             # no need to respond to an Assignment update here
             return
 
-        planning_id = original.get("planning_item")
-        planning_autosave = await self.find_by_id_raw(item_id=planning_id)
-        if not planning_autosave:
-            # Item is not currently being edited (No current autosave item)
-            return
-
-        # There is a current autosave, we need to update it now
-        coverages = planning_autosave.get("coverages")
         assignment = original.copy()
         assignment.update(updates)
-
-        coverage_to_update = next(
-            (
-                coverage
-                for coverage in coverages
-                if str((coverage.get("assigned_to") or {}).get("assignment_id")) == str(assignment["_id"])
-            ),
-            None,
-        )
-
-        if not coverage_to_update:
-            logger.warning("Coverage not found for Assignment", extra={"assignment_id": assignment["_id"]})
-            return
-
-        copy_assignment_details_to_coverage(assignment, coverage_to_update)
-        await self.system_update(planning_autosave["_id"], updates={"coverages": coverages})
+        await update_planning_from_assignment_changes(assignment, is_autosave=True)

--- a/server/planning/planning/planning_service.py
+++ b/server/planning/planning/planning_service.py
@@ -40,7 +40,7 @@ from planning.common import (
     TEMP_ID_PREFIX,
     get_planning_allow_scheduled_updates,
     update_post_item,
-    sync_assignment_details_to_coverages,
+    # sync_assignment_details_to_coverages,
 )
 from planning.core.service import BasePlanningAsyncService
 from planning.assignments.assignments_history_async import AssignmentsHistoryAsyncService
@@ -257,7 +257,6 @@ class PlanningAsyncService(BasePlanningAsyncService[PlanningResourceModel]):
         for doc in docs:
             doc.pop("_planning_schedule", None)
             doc.pop("_updates_schedule", None)
-            sync_assignment_details_to_coverages(doc)
 
     async def validate_on_update(self, updates: dict[str, Any], original: PlanningResourceModel, user: dict[str, Any]):
         lock_user = original.lock_user

--- a/server/planning/tests/commands/sync_assignment_coverages_test.py
+++ b/server/planning/tests/commands/sync_assignment_coverages_test.py
@@ -76,7 +76,7 @@ class SyncAssignmentCoveragesCommandTestCase(TestCase):
         assert updated is not None
         coverage = updated.get("coverages")[0]
         assigned_to = coverage.get("assigned_to")
-        assert assigned_to.get("assignment_id") == assignment_id
+        assert assigned_to.get("assignment_id") == str(assignment_id)
         assert assigned_to.get("desk") == "desk-1"
         assert assigned_to.get("user") == "user-1"
         assert assigned_to.get("contact") == "contact-1"
@@ -89,7 +89,7 @@ class SyncAssignmentCoveragesCommandTestCase(TestCase):
         assert assigned_to.get("priority") == 2
 
         scheduled_assigned_to = coverage.get("scheduled_updates")[0].get("assigned_to")
-        assert scheduled_assigned_to.get("assignment_id") == update_assignment_id
+        assert scheduled_assigned_to.get("assignment_id") == str(update_assignment_id)
         assert scheduled_assigned_to.get("desk") == "desk-1"
         assert scheduled_assigned_to.get("user") == "user-1"
         assert scheduled_assigned_to.get("contact") == "contact-1"

--- a/server/planning/tests/commands/sync_assignment_coverages_test.py
+++ b/server/planning/tests/commands/sync_assignment_coverages_test.py
@@ -7,6 +7,7 @@ from planning.commands.sync_assignment_coverages import SyncAssignmentCoveragesC
 class SyncAssignmentCoveragesCommandTestCase(TestCase):
     async def test_command(self):
         assignment_id = ObjectId()
+        update_assignment_id = ObjectId()
         planning_id = ObjectId()
 
         planning_doc = {
@@ -22,7 +23,7 @@ class SyncAssignmentCoveragesCommandTestCase(TestCase):
                     "scheduled_updates": [
                         {
                             "scheduled_update_id": "su-1",
-                            "assigned_to": {"assignment_id": str(assignment_id)},
+                            "assigned_to": {"assignment_id": str(update_assignment_id)},
                         }
                     ],
                 }
@@ -46,10 +47,28 @@ class SyncAssignmentCoveragesCommandTestCase(TestCase):
             },
             "priority": 2,
         }
+        update_assignment_doc = {
+            "_id": update_assignment_id,
+            "planning_item": str(planning_id),
+            "coverage_item": "cov-1",
+            "scheduled_update_id": "su-1",
+            "assigned_to": {
+                "desk": "desk-1",
+                "user": "user-1",
+                "contact": "contact-1",
+                "state": "assigned",
+                "assignor_user": "user-1",
+                "assignor_desk": "desk-1",
+                "assigned_date_desk": "2026-01-20T00:00:00+0000",
+                "assigned_date_user": "2026-01-20T00:00:00+0000",
+                "coverage_provider": {"qcode": "cp-1", "name": "Provider"},
+            },
+            "priority": 2,
+        }
 
         async with self.app.app_context():
             self.app.data.insert("planning", [planning_doc])
-            self.app.data.insert("assignments", [assignment_doc])
+            self.app.data.insert("assignments", [assignment_doc, update_assignment_doc])
 
             await SyncAssignmentCoveragesCommand().run(dry_run=False)
 
@@ -70,7 +89,7 @@ class SyncAssignmentCoveragesCommandTestCase(TestCase):
         assert assigned_to.get("priority") == 2
 
         scheduled_assigned_to = coverage.get("scheduled_updates")[0].get("assigned_to")
-        assert scheduled_assigned_to.get("assignment_id") == assignment_id
+        assert scheduled_assigned_to.get("assignment_id") == update_assignment_id
         assert scheduled_assigned_to.get("desk") == "desk-1"
         assert scheduled_assigned_to.get("user") == "user-1"
         assert scheduled_assigned_to.get("contact") == "contact-1"

--- a/server/planning/tests/coverage_assignments_sync_test.py
+++ b/server/planning/tests/coverage_assignments_sync_test.py
@@ -1,0 +1,61 @@
+from bson import ObjectId
+from superdesk.utc import utcnow
+from superdesk.tests import utils as test_utils, fixtures
+
+from planning.tests import TestCase
+
+
+now = utcnow()
+
+
+class SyncAssignmentCoverageTest(TestCase):
+    async def test_planning_etag_not_changed_after_sync_assignment_coverage(self):
+        self.app.config["PLANNING_AUTO_ASSIGN_TO_WORKFLOW"] = True
+        await test_utils.post_items("users", [fixtures.users.admin().to_dict()])
+        await test_utils.post_items("desks", [fixtures.desks.sports_desk().to_dict()])
+        await test_utils.post_items("stages", [fixtures.stages.sports_working_stage()])
+
+        await test_utils.post_items(
+            "planning",
+            [
+                {
+                    "guid": "p1",
+                    "slugline": "test",
+                    "planning_date": now,
+                    "coverages": [
+                        {
+                            "coverage_id": "c1",
+                            "workflow_status": "draft",
+                            "news_coverage_status": {"qcode": "ncostat:int"},
+                            "planning": {"scheduled": now},
+                            "assigned_to": {
+                                "desk": fixtures.desks.SPORTS_DESK_ID,
+                                "state": "draft",
+                            },
+                        }
+                    ],
+                }
+            ],
+        )
+        planning = await test_utils.find_by_id("planning", "p1")
+        self.assertIsNotNone(planning)
+        original_planning_etag = planning["_etag"]
+        assigned_to = planning["coverages"][0]["assigned_to"]
+
+        assignment_id = assigned_to["assignment_id"]
+        assignment = await test_utils.find_by_id("assignments", assignment_id)
+        self.assertIsNotNone(assignment)
+        await test_utils.patch_item(
+            "assignments",
+            ObjectId(assignment_id),
+            {
+                "assigned_to": {
+                    **assigned_to,
+                    "desk": fixtures.desks.SPORTS_DESK_ID,
+                    "user": fixtures.users.ADMIN_USER_ID,
+                }
+            },
+        )
+
+        planning = await test_utils.find_by_id("planning", "p1")
+        self.assertEqual(original_planning_etag, planning["_etag"])


### PR DESCRIPTION
### Purpose
Throughout the history of Coverages & Assignments, more features and improvements were added. Recently the improvement was added to handle re-assigning Desk/User from the Planning form, which caused a whole mess of bugs.

### What has changed
**Backend**
* Create a single file where all Assignment & Coverage metadata syncing should be housed. There are other data handling that is not in here, but most of it should be there now.
* Clean up the Assignment service and use the new functionality
* Clean up the Planning service's coverage handling and use the new functionality
* Make sure data is sync'd when performing `Complete` or `Revert` on an Assignment

Resolves: [STT-1575](https://sofab.atlassian.net/browse/STT-1575)
Resolves: [STT-1578](https://sofab.atlassian.net/browse/STT-1578)



[STT-1575]: https://sofab.atlassian.net/browse/STT-1575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[STT-1578]: https://sofab.atlassian.net/browse/STT-1578?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ