### PR TITLE
[SDCP-1102] fix: Subjects options not translating with item language

### DIFF
--- a/client/components/UI/Form/SelectMetaTermsInput/index.tsx
+++ b/client/components/UI/Form/SelectMetaTermsInput/index.tsx
@@ -29,6 +29,7 @@ export interface IProps {
     maxLength?: number;
     language?: string;
     invalid?: boolean;
+    getLabel?(option: any): string;
 }
 
 interface IState {
@@ -47,7 +48,7 @@ export class SelectMetaTermsInput extends React.Component<IProps, IState> {
     constructor(props: IProps) {
         super(props);
         this.state = {
-            multiLevel: false,
+            multiLevel: this.props.options.filter((o) => (o.parent)).length > 0,
             openSelectPopup: false,
         };
 
@@ -55,11 +56,6 @@ export class SelectMetaTermsInput extends React.Component<IProps, IState> {
         this.toggleOpenSelectPopup = this.toggleOpenSelectPopup.bind(this);
         this.onChange = this.onChange.bind(this);
         this.addBtn = React.createRef();
-    }
-
-    componentWillMount() {
-        // There is at least one parent or multi-level option
-        this.setState({multiLevel: this.props.options.filter((o) => (o.parent)).length > 0});
     }
 
     toggleOpenSelectPopup() {
@@ -89,12 +85,23 @@ export class SelectMetaTermsInput extends React.Component<IProps, IState> {
         }
     }
 
-    removeValuesFromOptions() {
+    getListOfOptions() {
+        let options: Array<any>;
+
         if (!this.state.multiLevel) {
-            return differenceBy(this.props.options, this.props.value, this.props.valueKey);
+            options = differenceBy(this.props.options, this.props.value, this.props.valueKey);
         } else {
-            return this.props.options;
+            options = this.props.options;
         }
+
+        if (this.props.getLabel == null) {
+            return options;
+        }
+
+        return options.map((option) => ({
+            ...option,
+            [this.props.labelKey]: this.props.getLabel(option),
+        }));
     }
 
     onChange(opt) {
@@ -135,7 +142,7 @@ export class SelectMetaTermsInput extends React.Component<IProps, IState> {
             ...props
         } = this.props;
 
-        const options = this.removeValuesFromOptions();
+        const options = this.getListOfOptions();
         const disabled = (() => {
             // No options available to be selected
             if (options.length === 0) {

--- a/client/components/fields/editor/base/vocabulary.tsx
+++ b/client/components/fields/editor/base/vocabulary.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import {get, set} from 'lodash';
 
+import {getVocabularyItemFieldTranslated} from '../../../../utils/vocabularies';
 import {IEditorFieldProps} from '../../../../interfaces';
 import {SelectMetaTermsInput, Row} from '../../../UI/Form';
 
@@ -13,6 +14,7 @@ export interface IEditorFieldVocabularyProps extends IEditorFieldProps {
     noMargin?: boolean; // defaults to true
     valueAsString?: boolean;
     singleSelect?: boolean;
+    language?: string;
 }
 
 export class EditorFieldVocabulary extends React.PureComponent<IEditorFieldVocabularyProps> {
@@ -24,19 +26,17 @@ export class EditorFieldVocabulary extends React.PureComponent<IEditorFieldVocab
         valueAsString: false,
     }
 
-    constructor(props: IEditorFieldVocabularyProps) {
-        super(props);
-
-        this.onChange = this.onChange.bind(this);
-    }
-
-    onChange(field: string, value: Array<any>) {
+    onChange = (field: string, value: Array<any>) => {
         this.props.onChange(
             field,
             !this.props.valueAsString ?
                 value :
                 value.map((val) => get(val, this.props.valueKey))
         );
+    }
+
+    getTranslatedOptionLabel = (option: any): string => {
+        return getVocabularyItemFieldTranslated(option, this.props.labelKey, this.props.language);
     }
 
     render() {
@@ -75,6 +75,7 @@ export class EditorFieldVocabulary extends React.PureComponent<IEditorFieldVocab
                     required={this.props.required ?? this.props.schema?.required}
                     onChange={this.onChange}
                     singleSelect={this.props.singleSelect}
+                    getLabel={this.props.language == null ? undefined : this.getTranslatedOptionLabel}
                 />
             </Row>
         );

--- a/client/services/PlanningStoreService.ts
+++ b/client/services/PlanningStoreService.ts
@@ -3,7 +3,7 @@ import {createStore} from '../utils';
 import {COVERAGES, ITEM_TYPE, ASSIGNMENTS} from '../constants';
 import * as selectors from '../selectors';
 import * as actions from '../actions';
-import {planningApi} from '../superdeskApi';
+import {planningApi, superdeskApi} from '../superdeskApi';
 import {isCustomVocabulary} from '../helpers';
 import {PLANNING_EXPORT_TEMPLATES_RESOURCE} from '../constants/exportTemplates';
 
@@ -232,7 +232,7 @@ export class PlanningStoreService {
                             })),
                     },
                     privileges: privileges,
-                    subjects: this.metadata.values.subjectcodes,
+                    subjects: superdeskApi.entities.vocabulary.getVocabulary('subject_custom')?.items || [],
                     genres: genres,
                     users: users,
                     desks: this.desks.desks._items,


### PR DESCRIPTION
### Purpose
Subject input fields were not using translations to display the values & options.

### What has changed
* Add `getLabel` optional prop to `SelectMetaTermsInput`, and make translation occur on render
* Replace getting `subjects` CV from AngularJS service to the SuperdeskAPI - AngularJS service was not providing the `translations` dictionary required

### Steps to test
1. Create a Planning item
2. Select a value in the `SUBJECT` field
3. Change the language of the item to fr-CA

The values and options should update to use the new language you selected.

Resolves: [SDCP-1102](https://sofab.atlassian.net/browse/SDCP-1102)



[SDCP-1102]: https://sofab.atlassian.net/browse/SDCP-1102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ