### PR TITLE
[SDBELGA-1039] Filter assignments by user when no desk privilege

### DIFF
--- a/client/actions/assignments/tests/ui_test.ts
+++ b/client/actions/assignments/tests/ui_test.ts
@@ -558,7 +558,7 @@ describe('actions.assignments.ui', () => {
             restoreSinonStub(assignmentsUi.loadAssignments);
         });
 
-        it('sets the list groups and loads the assignments', () => {
+        it('filters by user when planning_assignments_desk privilege is absent', () => {
             const item = {
                 slugline: 'Olympics',
                 task: {desk: 'desk2'},
@@ -572,12 +572,12 @@ describe('actions.assignments.ui', () => {
 
             expect(assignmentsUi.loadAssignments.callCount).toBe(1);
             expect(assignmentsUi.loadAssignments.args[0]).toEqual([{
-                filterBy: 'Desk',
+                filterBy: 'User',
                 searchQuery: 'planning.slugline.phrase:("Olympics")',
                 orderByField: 'Scheduled',
                 filterByType: 'text',
                 filterByPriority: null,
-                selectedDeskId: ALL_DESKS,
+                selectedDeskId: null,
                 ignoreScheduledUpdates: true,
             }]);
         });
@@ -595,23 +595,24 @@ describe('actions.assignments.ui', () => {
 
             expect(assignmentsUi.loadAssignments.callCount).toBe(1);
             expect(assignmentsUi.loadAssignments.args[0]).toEqual([{
-                filterBy: 'Desk',
+                filterBy: 'User',
                 searchQuery: null,
                 orderByField: 'Scheduled',
                 filterByType: 'text',
                 filterByPriority: null,
-                selectedDeskId: ALL_DESKS,
+                selectedDeskId: null,
                 ignoreScheduledUpdates: true,
             }]);
         });
 
-        it('uses the currently selected desk to all desks', () => {
+        it('filters by desk and uses ALL_DESKS when planning_assignments_desk privilege is present', () => {
+            store.initialState.privileges.planning_assignments_desk = 1;
+
             const item = {
                 slugline: 'Olympics',
                 type: 'text',
             };
 
-            services.desks.active.desk = 'desk3';
             store.dispatch(assignmentsUi.loadFulfillModal(item, ['CURRENT', 'FUTURE']));
 
             expect(assignmentsUi.setListGroups.callCount).toBe(1);

--- a/client/actions/assignments/ui.ts
+++ b/client/actions/assignments/ui.ts
@@ -57,17 +57,18 @@ const loadFulfillModal = (item, groupKeys) => (
     (dispatch, getState, {desks}) => {
         dispatch(self.setListGroups(groupKeys));
 
+        const hasDeskPrivilege = !!selectors.general.privileges(getState())?.planning_assignments_desk;
         const searchQuery = get(item, 'slugline') ?
             `planning.slugline.phrase:("${item.slugline}")` :
             null;
 
         return dispatch(self.loadAssignments({
-            filterBy: 'Desk',
+            filterBy: hasDeskPrivilege ? 'Desk' : 'User',
             searchQuery: searchQuery,
             orderByField: 'Scheduled',
             filterByType: get(item, 'type'),
             filterByPriority: null,
-            selectedDeskId: ALL_DESKS,
+            selectedDeskId: hasDeskPrivilege ? ALL_DESKS : null,
             ignoreScheduledUpdates: true,
         }));
     }

--- a/client/apps/Assignments/AssignmentsSubNav.tsx
+++ b/client/apps/Assignments/AssignmentsSubNav.tsx
@@ -187,7 +187,7 @@ export class AssignmentsSubNavComponent extends React.Component<IProps> {
                     userDesks={showDeskSelection ? userDesks : []}
                     selectAssignmentsFrom={this.selectAssignmentsFrom}
                     showDeskSelection={showDeskSelection}
-                    showAllDeskOption={showAllDeskOption}
+                    showAllDeskOption={showAllDeskOption && showDeskAssignmentView}
                     changeSortField={this.changeSortField}
                     showDeskAssignmentView={showDeskAssignmentView}
                 />

--- a/client/services/tests/AssignmentsService_test.ts
+++ b/client/services/tests/AssignmentsService_test.ts
@@ -137,13 +137,13 @@ describe('assignments service', () => {
 
                 expect(actions.assignments.ui.changeListSettings.callCount).toBe(1);
                 expect(actions.assignments.ui.changeListSettings.args[0]).toEqual([{
-                    filterBy: 'Desk',
+                    filterBy: 'User',
                     searchQuery: 'planning.slugline.phrase:("test slugline")',
                     orderByField: 'Scheduled',
                     dayField: null,
                     filterByType: 'text',
                     filterByPriority: null,
-                    selectedDeskId: ALL_DESKS,
+                    selectedDeskId: null,
                     ignoreScheduledUpdates: true,
                 }]);
 
@@ -214,13 +214,13 @@ describe('assignments service', () => {
 
                     expect(actions.assignments.ui.changeListSettings.callCount).toBe(1);
                     expect(actions.assignments.ui.changeListSettings.args[0]).toEqual([{
-                        filterBy: 'Desk',
+                        filterBy: 'User',
                         searchQuery: 'planning.slugline.phrase:("test slugline")',
                         orderByField: 'Scheduled',
                         filterByType: 'text',
                         dayField: null,
                         filterByPriority: null,
-                        selectedDeskId: ALL_DESKS,
+                        selectedDeskId: null,
                         ignoreScheduledUpdates: true,
                     }]);
 


### PR DESCRIPTION
### Purpose
When opening the Fulfil Assignment modal, all desk assignments were visible regardless of the user's privileges, bypassing the restriction applied in the regular assignments view.

Users without the `planning_assignments_desk` privilege (e.g. freelancers) should only see their own assignments in the modal, consistent with their normal assignments view.

### What has changed
- loadFulfillModal: initialise with `filterBy='User'` and `selectedDeskId=null` when the user lacks `planning_assignments_desk` privilege
- AssignmentsSubNav: gate `showAllDeskOption` on `showDeskAssignmentView` to prevent the All Desks option from appearing for unprivileged users
- Update tests to reflect privilege-based behaviour

### Steps to test
- Create a **Role 1** without `planning_assignments_desk` permission
- Assign **User 1** to **Role 1**
- Create a planning item, add coverage and assign it to **User 1** and assign it to workflow 
- Create a planning item, add coverage and assign it to **User 2** (admin) and assign it to workflow 
- Login with **User 1**
- Create a new article item 
- Click 3 dots menu and then click Fulfil Assignment
- Remove the default search query in the modal Search Box and hit enter
- Observe that only **User 1's** assignments are visible
 - Login with **User 2** (admin) and do the same, observe the user can see all the assignments

Thanks for checking!

[SDBELGA-1039]


[SDBELGA-1039]: https://sofab.atlassian.net/browse/SDBELGA-1039?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ