### PR TITLE
[SDESK-7879] Event end date by default is set to a day before when rescheduling or updating repetitions

### DIFF
--- a/client/utils/events.tsx
+++ b/client/utils/events.tsx
@@ -1189,10 +1189,9 @@ function modifyForClient(event: Partial<IEventItem>): Partial<IEventItem> {
 
     convertEventDatesForTimezone(event);
 
-    if (event.dates?.end != null) {
+    if (event.dates?.end != null && !event.dates.all_day && !event.dates.no_end_time) {
         event.dates.end = timeUtils.getDateInRemoteTimeZone(event.dates.end, timeUtils.localTimeZone());
-        event._endTime = event.dates.all_day || event.dates.no_end_time ? null
-            : timeUtils.getDateInRemoteTimeZone(event.dates.end, timeUtils.localTimeZone());
+        event._endTime = timeUtils.getDateInRemoteTimeZone(event.dates.end, timeUtils.localTimeZone());
     }
 
     if (get(event, 'dates.recurring_rule.until')) {


### PR DESCRIPTION
### Purpose
Fix the incorrect display of all-day event end dates in negative UTC timezones. When users in timezones like America/Toronto (UTC-5) opened the "reschedule" or "convert to recurring" modals, the end date was showing as one day earlier than the actual event date. This was caused by a double timezone conversion in the modifyForClient function.

###What has changed
- Modified client/utils/events.tsx in the `modifyForClient` function by adding condition to skip the second timezone conversion for all-day and no-end-time events
- The `convertEventDatesForTimezone` function already correctly handles all-day dates using moment.utc(), but modifyForClient was re-processing the end date with getDateInRemoteTimeZone() which shifted it to local timezone and caused the day shift in negative UTC timezones

### Steps to test
1. Create an all-day event  with timezone set to America/Toronto for example
2. In your browser's timezone set to Toronto (UTC-5):
   - Open the event list view - verify the date shows March 10th (not March 9th)
   - Click "Reschedule" action - verify the end date shows March 10th
   - Click "Convert to recurring" action - verify "First event ends" shows March 10th
3. Change your browser timezone to a positive UTC timezone (e.g., Africa/Nairobi UTC+3):
   - Verify the event list and all modals still show March 10th
4. Test with regular (non-all-day) events to ensure no regression in timezone handling


Resolves: [#SDESK-7879](https://sofab.atlassian.net/browse/SDESK-7879)

