### PR TITLE
fix event validators for onclusive events

### DIFF
--- a/client/validators/events.ts
+++ b/client/validators/events.ts
@@ -25,13 +25,11 @@ const validateRequiredDates = ({value, errors, messages, diff}) => {
         messages.push(gettext('TIMEZONE is a required field'));
     }
 
-    if (value.all_day === true && value.no_end_time === false) {
-        set(errors, '_startTime', gettext('This field is required'));
-        messages.push(gettext('START TIME is required when END TIME is set'));
-    }
-
     if (!get(diff, TO_BE_CONFIRMED_FIELD)) {
-        if (!value._startTime && value.all_day !== true) {
+        if (value.start != null && value._endTime != null && value._startTime == null) {
+            set(errors, '_startTime', gettext('This field is required'));
+            messages.push(gettext('START TIME is required when END TIME is set'));
+        } else if (!value._startTime && value.all_day !== true) {
             set(errors, '_startTime', gettext('This field is required'));
             messages.push(gettext('START TIME is a required field'));
         }

--- a/client/validators/tests/events_test.ts
+++ b/client/validators/tests/events_test.ts
@@ -103,6 +103,24 @@ describe('eventValidators', () => {
             event.dates.all_day = true;
             testValidate(eventValidators.validateDates, 'dates', {});
         });
+
+        it('fails if end time is set but start time is not', () => {
+            const value = {
+                ...event.dates,
+                _startTime: null,
+                _endTime: event.dates.end,
+            };
+
+            eventValidators.validateRequiredDates({
+                value: value,
+                errors: errors,
+                messages: errorMessages,
+            });
+            expect(errors).toEqual({_startTime: 'This field is required'});
+            expect(errorMessages).toEqual([
+                'START TIME is required when END TIME is set',
+            ]);
+        });
     });
 
     describe('validateDateRange', () => {


### PR DESCRIPTION
use UI values for validation, the flags from server are not consistent for ingested content (it's fixed in more recent version, but the older ingested events wouldn't pass).

SDCP-1128

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

### Front-end checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)

Resolves: #[issue-number]

