### PR TITLE
set 1k page size when exporting from planning

### DIFF
--- a/server/planning/planning_article_export.py
+++ b/server/planning/planning_article_export.py
@@ -32,6 +32,7 @@ from planning.archive import create_item_from_template
 
 PLACEHOLDER_TEXT = r"{{content}}"
 PLACEHOLDER_HTML = "<p>%s</p>" % PLACEHOLDER_TEXT
+EXPORT_FETCH_PAGE_SIZE = 1000
 
 
 class PlanningArticleExportResource(Resource):
@@ -60,7 +61,9 @@ class PlanningArticleExportResource(Resource):
 def get_items(ids, resource_type):
     ids_string = [str(item_id) for item_id in ids]
     items = get_resource_service("events_planning_search").search_repos(
-        resource_type, {"item_ids": ",".join(ids_string), "only_future": False}
+        resource_type,
+        {"item_ids": ",".join(ids_string), "only_future": False},
+        page_size=EXPORT_FETCH_PAGE_SIZE,
     )
     items = sorted(items, key=lambda i: ids_string.index(str(i.get("_id"))))
 

--- a/server/planning/tests/planning_article_export_test.py
+++ b/server/planning/tests/planning_article_export_test.py
@@ -1,5 +1,7 @@
+from unittest import mock
+
 from planning.tests import TestCase
-from planning.planning_article_export import get_items
+from planning.planning_article_export import get_items, EXPORT_FETCH_PAGE_SIZE
 
 
 class PlanningArticleExportTest(TestCase):
@@ -82,3 +84,25 @@ class PlanningArticleExportTest(TestCase):
             assert items[0]["_id"] == "event2"
             assert items[1]["_id"] == "event1"
             assert items[2]["_id"] == "event3"
+
+    def test_get_items_uses_export_page_size(self):
+        search_service = mock.Mock()
+        search_service.search_repos.return_value = [{"_id": "plan1", "type": "planning"}]
+        events_service = mock.Mock()
+
+        def get_service(name):
+            if name == "events_planning_search":
+                return search_service
+            if name == "events":
+                return events_service
+            raise AssertionError("Unexpected service requested: {}".format(name))
+
+        with mock.patch("planning.planning_article_export.get_resource_service", side_effect=get_service):
+            items = get_items(["plan1"], "planning")
+
+        assert items == [{"_id": "plan1", "type": "planning"}]
+        search_service.search_repos.assert_called_once_with(
+            "planning",
+            {"item_ids": "plan1", "only_future": False},
+            page_size=EXPORT_FETCH_PAGE_SIZE,
+        )


### PR DESCRIPTION
instead of using default limit 100

SDBELGA-1055

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

### Front-end checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)

Resolves: #[issue-number]

