### PR TITLE
[STT-1582] Allow Assignment re-assign if multiple_content enabled

### DIFF
--- a/client/utils/assignments.ts
+++ b/client/utils/assignments.ts
@@ -46,9 +46,15 @@ function canEditPriorityOrReassignAssignment(
     privilege: string,
     lockedItems: ILockedItems,
 ) {
-    return !!privileges[privilege] &&
-        self.isNotLockRestricted(assignment, session, lockedItems) &&
-        self.isAssignmentInEditableState(assignment);
+    return !!privileges[privilege]
+        && self.isNotLockRestricted(assignment, session, lockedItems)
+        && (
+            self.isAssignmentInEditableState(assignment)
+            || (
+                assignment.planning?.multiple_content === true
+                && assignment.assigned_to?.state !== ASSIGNMENTS.WORKFLOW_STATE.CANCELLED
+            )
+        );
 }
 
 function canRemoveAssignment(

--- a/client/utils/tests/assignments_test.ts
+++ b/client/utils/tests/assignments_test.ts
@@ -96,6 +96,9 @@ describe('can edit assignment', () => {
             expect(canEditPriority()).toBe(true);
             expect(canConfirmAvailability()).toBe(false);
             expect(canRevertAvailability()).toBe(false);
+
+            assignment.planning.multiple_content = true;
+            expect(canStartWorking()).toBe(true);
         });
 
         it('assignment workflow state is `completed`', () => {
@@ -107,6 +110,10 @@ describe('can edit assignment', () => {
             expect(canEditPriority()).toBe(false);
             expect(canConfirmAvailability()).toBe(false);
             expect(canRevertAvailability()).toBe(true);
+
+            assignment.planning.multiple_content = true;
+            expect(canReassign()).toBe(true);
+            expect(canEditPriority()).toBe(true);
         });
 
         it('assignment workflow state is `submitted`', () => {
@@ -118,6 +125,9 @@ describe('can edit assignment', () => {
             expect(canEditPriority()).toBe(true);
             expect(canConfirmAvailability()).toBe(false);
             expect(canRevertAvailability()).toBe(false);
+
+            assignment.planning.multiple_content = true;
+            expect(canStartWorking()).toBe(true);
         });
 
         it('assignment workflow state is `cancelled`', () => {
@@ -129,6 +139,10 @@ describe('can edit assignment', () => {
             expect(canEditPriority()).toBe(false);
             expect(canConfirmAvailability()).toBe(false);
             expect(canRevertAvailability()).toBe(false);
+
+            assignment.planning.multiple_content = true;
+            expect(canReassign()).toBe(false);
+            expect(canEditPriority()).toBe(false);
         });
     });
 


### PR DESCRIPTION
### Purpose
Previously Assignments details followed the linked content. This is because it was a 1-to-1 relationship.
Now that we have `multiple_content` capabilities, the user should be able to modify the assignee details even if at least 1 content item has been completed (aka published).

### What has changed
* Allow `Reassign` or `Edit Priority` of an Assignment that has `multiple_content` enabled and is not cancelled.

Resolves: [STT-1582](https://sofab.atlassian.net/browse/STT-1582)



[STT-1582]: https://sofab.atlassian.net/browse/STT-1582?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ