### PR TITLE
[SDBELGA-1056] fix(prodapi): Use `get_all_batch_elastic` when getting Planning for Event search

### DIFF
--- a/server/planning/prod_api/events/service.py
+++ b/server/planning/prod_api/events/service.py
@@ -91,6 +91,7 @@ class EventsService(ProdApiService):
         if not isinstance(query, dict):
             raise SuperdeskApiError.badRequestError("planning_source must be an object")
 
+        query.setdefault("sort", [{"_created": "asc"}, {"_updated": "asc"}, {"guid": "asc"}])
         query.setdefault("_source", ["_id", "_resource", "event_item"])
 
         return query

--- a/server/planning/prod_api/events/service.py
+++ b/server/planning/prod_api/events/service.py
@@ -91,7 +91,6 @@ class EventsService(ProdApiService):
         if not isinstance(query, dict):
             raise SuperdeskApiError.badRequestError("planning_source must be an object")
 
-        query.setdefault("size", 10_000)
         query.setdefault("_source", ["_id", "_resource", "event_item"])
 
         return query
@@ -102,14 +101,13 @@ class EventsService(ProdApiService):
 
         # Search for planning documents matching the query
         try:
-            results = planning_service.search(planning_query)
+            results = planning_service.get_all_batch_elastic(planning_query)
+            event_ids = {event_id for event_id in self._extract_event_items(results) if event_id}
+            return list(event_ids)
         except RequestError as e:
             raise SuperdeskApiError.badRequestError(
                 f"Invalid planning_source query: {str(e.info.get('error', {}).get('reason', str(e)))}"
             )
-
-        event_ids = {event_id for event_id in self._extract_event_items(results) if event_id}
-        return list(event_ids)
 
     def _extract_event_items(self, results: Iterable[Dict]) -> Iterable[str]:
         for item in results:

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -21,4 +21,4 @@ behave==1.2.6
 
 -e .
 # Install in editable state so we get feature fixtures
--e git+https://github.com/superdesk/superdesk-core.git@release/2.10#egg=superdesk-core
+-e git+https://github.com/superdesk/superdesk-core.git@release/2.11#egg=superdesk-core


### PR DESCRIPTION
### Purpose
When searching for Events in the ProductionAPI, we have the ability to search for Events based on associated Planning items. At the moment the limit of Planning items we can match is 10,000.

### What has changed
* Increase the limit of matched Planning item to 5,000,000 by using the new `get_all_batch_elastic` method which should reduce system resources required from Elastic to perform this search with a large result set.

Resolves: [SDBELGA-1056](https://sofab.atlassian.net/browse/SDBELGA-1056)
Depends on: https://sofab.atlassian.net/browse/SDBELGA-1056



[SDBELGA-1056]: https://sofab.atlassian.net/browse/SDBELGA-1056?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ