### PR TITLE
fix posting of related planning items with embedded editor config

### DIFF
--- a/server/features/planning_validate.feature
+++ b/server/features/planning_validate.feature
@@ -33,6 +33,9 @@ Feature: Planning Validate
             "editor":{
                 "place": {
                     "enabled":true
+                },
+                "description_text": {
+                    "enabled":true
                 }
             },
             "schema": {
@@ -47,7 +50,8 @@ Feature: Planning Validate
                 },
                 "description_text": {
                     "type": "string",
-                    "required": false
+                    "required": false,
+                    "show_in_embedded_editor": true
                 },
                 "internal_note": {
                     "type": "string",
@@ -310,4 +314,83 @@ Feature: Planning Validate
                 "code": 400
             }
         }
+        """
+
+    @auth
+    Scenario: Publishing related planning alongside event succeeds when show_in_embedded_editor is enabled
+        Given the "planning_types"
+        """
+        [{
+            "_id": "event", "name": "event",
+            "editor": {"related_plannings": {"enabled": true}},
+            "schema": {
+                "slugline": {
+                    "type": "string",
+                    "required": true,
+                    "validate_on_post": true
+                },
+                "related_plannings": {
+                    "planning_auto_publish": true
+                }
+            }
+        }, {
+            "_id": "planning", "name": "planning",
+            "editor": {
+                "place": {"enabled": true},
+                "description_text": {"enabled": true}
+            },
+            "schema": {
+                "place": {
+                    "type": "list",
+                    "required": true,
+                    "validate_on_post": true
+                },
+                "description_text": {
+                    "type": "string",
+                    "required": false,
+                    "show_in_embedded_editor": true
+                }
+            }
+        }]
+        """
+        When we post to "events"
+        """
+        [{
+            "name": "Test Event",
+            "slugline": "test-event",
+            "dates": {
+                "start": "2029-11-21T01:00:00.000Z",
+                "end": "2029-11-21T04:00:00.000Z",
+                "tz": "Australia/Sydney"
+            }
+        }]
+        """
+        Then we get OK response
+        When we post to "/planning"
+        """
+        [{
+            "planning_date": "2029-11-21",
+            "place": [{"qcode": "NSW"}],
+            "related_events": [{"_id": "#events._id#", "link_type": "primary"}],
+            "slugline": "test"
+        }]
+        """
+        Then we get OK response
+        When we post to "/events/post"
+        """
+        {
+            "event": "#events._id#",
+            "etag": "#events._etag#",
+            "pubstatus": "usable"
+        }
+        """
+        Then we get OK response
+        Then we get updated response
+        """
+        {"failed_planning_ids": "__empty__"}
+        """
+        When we get "/planning/#planning._id#"
+        Then we get existing resource
+        """
+        {"state": "scheduled", "pubstatus": "usable"}
         """

--- a/server/planning/events/events_post.py
+++ b/server/planning/events/events_post.py
@@ -260,7 +260,7 @@ class EventsPostService(AsyncBaseService):
                 docs = [
                     {
                         "planning": planning[ID_FIELD],
-                        "etag": planning.get("etag"),
+                        "etag": planning.get("etag") or planning.get("_etag"),
                         "pubstatus": POST_STATE.USABLE,
                     }
                     for planning in plannings

--- a/server/planning/events/events_post.py
+++ b/server/planning/events/events_post.py
@@ -260,7 +260,7 @@ class EventsPostService(AsyncBaseService):
                 docs = [
                     {
                         "planning": planning[ID_FIELD],
-                        "etag": planning.get("etag") or planning.get("_etag"),
+                        "etag": planning.get("_etag"),
                         "pubstatus": POST_STATE.USABLE,
                     }
                     for planning in plannings

--- a/server/planning/validate/planning_validate.py
+++ b/server/planning/validate/planning_validate.py
@@ -90,6 +90,14 @@ class SchemaValidator(Validator):
         """
         pass
 
+    def _validate_show_in_embedded_editor(self, show_in_embedded_editor, field, value):
+        """
+        {'type': 'boolean', 'nullable': True}
+        """
+
+        # Ignore this profile as it's for the front-end embedded editor
+        pass
+
 
 def get_validator_schema(schema) -> dict:
     """Get schema for given data that will work with validator.
@@ -111,13 +119,16 @@ def get_filtered_validator_schema(validator, validate_on_post: bool) -> dict:
     """
     Get schema for a given validator, excluding fields with None values,
     and only include fields that are in enabled_fields.
+    When no editor configuration is present, all schema fields are considered enabled.
     """
 
-    enabled_fields = get_enabled_fields(validator)
+    enabled_fields = get_enabled_fields(validator) if validator.get("editor") else None
     return {
         field: get_validator_schema(field_schema)
         for field, field_schema in validator["schema"].items()
-        if field in enabled_fields and field_schema and field_schema.get("validate_on_post", False) == validate_on_post
+        if (enabled_fields is None or field in enabled_fields)
+        and field_schema
+        and field_schema.get("validate_on_post", False) == validate_on_post
     }
 
 


### PR DESCRIPTION
SDCP-1071

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

### Front-end checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)

Resolves: #[issue-number]

