### PR TITLE
[SDESK-7865] fix: Hourly scheduled filter has invalid hours value

### DIFF
--- a/server/planning/data_updates/00038_20260324-131530_events_planning_filters.py
+++ b/server/planning/data_updates/00038_20260324-131530_events_planning_filters.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8; -*-
+# This file is part of Superdesk.
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+#
+# Author  : MarkLark86
+# Creation: 2026-03-24 13:15
+
+from motor.motor_asyncio import AsyncIOMotorCollection, AsyncIOMotorDatabase
+
+from superdesk.commands.data_updates import BaseDataUpdate
+from planning.search import EventsPlanningFiltersAsyncService
+
+
+class DataUpdate(BaseDataUpdate):
+    """Update ``events_planning_filters`` to fix invalid schedule attributes"""
+
+    resource = "events_planning_filters"
+    use_async_resources = True
+
+    async def forwards(self, collection: AsyncIOMotorCollection, database: AsyncIOMotorDatabase) -> None:
+        service = EventsPlanningFiltersAsyncService()
+        async for search_filter in collection.find({}):
+            if not search_filter.get("schedules"):
+                continue
+
+            service.set_schedule(search_filter)
+            await collection.find_one_and_update(
+                {"_id": search_filter["_id"]}, {"$set": {"schedules": search_filter["schedules"]}}
+            )
+
+    async def backwards(self, collection: AsyncIOMotorCollection, database: AsyncIOMotorDatabase) -> None:
+        pass

--- a/server/planning/search/eventsplanning_filters_service.py
+++ b/server/planning/search/eventsplanning_filters_service.py
@@ -59,7 +59,15 @@ class EventsPlanningFiltersAsyncService(BasePlanningAsyncService[EventPlanningFi
             frequency = schedule.get("frequency") or "hourly"
 
             if frequency == "hourly":
-                schedule.update({"frequency": "hourly", "hour": -1, "day": -1, "week_days": []})
+                schedule.update(
+                    {
+                        "frequency": "hourly",
+                        "hours": [],
+                        "hour": -1,
+                        "day": -1,
+                        "week_days": [],
+                    }
+                )
             elif frequency == "daily":
                 schedule.update(
                     {

--- a/server/planning/tests/data_updates/00038_events_planning_filters_test.py
+++ b/server/planning/tests/data_updates/00038_events_planning_filters_test.py
@@ -1,0 +1,70 @@
+import importlib
+
+from bson import ObjectId
+
+from superdesk.utc import utcnow
+from planning.types import SearchItemType
+from planning.tests import TestCase
+
+DataUpdate = importlib.import_module("planning.data_updates.00038_20260324-131530_events_planning_filters").DataUpdate
+
+
+class FixFilterScheduleParamsDataUpdateTestCase(TestCase):
+    async def test_upgrade(self):
+        mongo_db = self.async_app.mongo.get_db_async(DataUpdate.resource)
+        mongo_collection = self.async_app.mongo.get_collection_async(DataUpdate.resource)
+
+        filter_1_id = ObjectId()
+        desk_id = ObjectId()
+
+        search_filters = [
+            {
+                "_id": filter_1_id,
+                "name": "Invalid Hourly Schema",
+                "item_type": SearchItemType.EVENT,
+                "_created": utcnow(),
+                "_updated": utcnow(),
+                "_type": "events_planning_filters",
+                "_etag": "a28d1efb44ea8aec575e35ccc239026c96351aaa",
+                "original_creator": ObjectId(),
+                "version_creator": ObjectId(),
+                "params": {"calendars": [{"name": "finance", "qcode": "finance"}]},
+                "schedules": [
+                    {
+                        "frequency": "hourly",
+                        "hours": ["00:00"],
+                        "hour": 14,
+                        "day": 10,
+                        "week_days": ["Monday"],
+                        "desk": desk_id,
+                    },
+                ],
+            },
+        ]
+        await mongo_collection.insert_many(search_filters)
+
+        item = await mongo_collection.find_one({"_id": filter_1_id})
+        self.assertEqual(
+            item["schedules"][0],
+            {
+                "frequency": "hourly",
+                "hours": ["00:00"],
+                "hour": 14,
+                "day": 10,
+                "week_days": ["Monday"],
+                "desk": desk_id,
+            },
+        )
+        await DataUpdate().forwards(mongo_collection, mongo_db)
+        item = await mongo_collection.find_one({"_id": filter_1_id})
+        self.assertEqual(
+            item["schedules"][0],
+            {
+                "frequency": "hourly",
+                "hours": [],
+                "hour": -1,
+                "day": -1,
+                "week_days": [],
+                "desk": desk_id,
+            },
+        )


### PR DESCRIPTION
### Purpose
It was possible for a Event/Planning Filter to have an hourly schedule with `hours` value set, which leads to the item running once a day and not hourly.

### What has changed
* Make sure if an hourly schedule is created/updated, set the `hours` value to empty
* Create a migration script to fix existing filters

Resolves: [SDESK-7865](https://sofab.atlassian.net/browse/SDESK-7865)



[SDESK-7865]: https://sofab.atlassian.net/browse/SDESK-7865?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ