### PR TITLE
[SDBELGA-1057] fix: Show templates in export to personal

### DIFF
--- a/client/components/ExportAsArticleModal.tsx
+++ b/client/components/ExportAsArticleModal.tsx
@@ -83,11 +83,11 @@ export class ExportAsArticleModal extends React.Component {
     filterArticleTemplates(desk) {
         const newObj = {};
 
-        newObj.articleTemplates = desk._id === 'personal-workspace' ?
-            this.props.modalProps.articleTemplates :
-            this.props.modalProps.articleTemplates.filter(
-                (t) => Object.keys(t).length > 0 && t.template_desks && t.template_desks.includes(desk._id)
-            );
+        const { articleTemplates } = this.props.modalProps;
+        
+        newObj.articleTemplates = desk._id === 'personal-workspace'
+            ? articleTemplates
+            : articleTemplates.filter(t => t?.template_desks?.includes(desk._id));
         newObj.articleTemplate = newObj.articleTemplates.find((t) =>
             Object.keys(t).length > 0 && t._id === get(desk, 'default_content_template'))
             || newObj.articleTemplates[0];

--- a/client/components/ExportAsArticleModal.tsx
+++ b/client/components/ExportAsArticleModal.tsx
@@ -83,8 +83,11 @@ export class ExportAsArticleModal extends React.Component {
     filterArticleTemplates(desk) {
         const newObj = {};
 
-        newObj.articleTemplates = this.props.modalProps.articleTemplates.filter((t) =>
-            Object.keys(t).length > 0 && t.template_desks && t.template_desks.includes(desk._id));
+        newObj.articleTemplates = desk._id === 'personal-workspace' ?
+            this.props.modalProps.articleTemplates :
+            this.props.modalProps.articleTemplates.filter(
+                (t) => Object.keys(t).length > 0 && t.template_desks && t.template_desks.includes(desk._id)
+            );
         newObj.articleTemplate = newObj.articleTemplates.find((t) =>
             Object.keys(t).length > 0 && t._id === get(desk, 'default_content_template'))
             || newObj.articleTemplates[0];

--- a/client/components/ExportAsArticleModal.tsx
+++ b/client/components/ExportAsArticleModal.tsx
@@ -83,11 +83,11 @@ export class ExportAsArticleModal extends React.Component {
     filterArticleTemplates(desk) {
         const newObj = {};
 
-        const { articleTemplates } = this.props.modalProps;
-        
+        const {articleTemplates} = this.props.modalProps;
+
         newObj.articleTemplates = desk._id === 'personal-workspace'
             ? articleTemplates
-            : articleTemplates.filter(t => t?.template_desks?.includes(desk._id));
+            : articleTemplates.filter((t) => t?.template_desks?.includes(desk._id));
         newObj.articleTemplate = newObj.articleTemplates.find((t) =>
             Object.keys(t).length > 0 && t._id === get(desk, 'default_content_template'))
             || newObj.articleTemplates[0];


### PR DESCRIPTION
### Purpose
When exporting an item we filter the available templates based on the selected desk (if that Template is available on said desk). However if the user selects `Personal Workspace`, then no template matches.

### What has changed
* If the user selects `Personal Workspace`, then show all available templtes

Resolves: [SDBELGA-1057](https://sofab.atlassian.net/browse/SDBELGA-1057)



[SDBELGA-1057]: https://sofab.atlassian.net/browse/SDBELGA-1057?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ