### PR TITLE
[SDBELGA-1076] Add configurable auto-expand for related planning items in combined view

### DIFF
--- a/client/actions/eventsPlanning/tests/ui_test.ts
+++ b/client/actions/eventsPlanning/tests/ui_test.ts
@@ -1,9 +1,12 @@
 import eventsPlanningApi from '../api';
 import eventsPlanningUi from '../ui';
 import eventsApi from '../../events/api';
+import planningApi from '../../planning/api';
 import sinon from 'sinon';
 import {getTestActionStore, restoreSinonStub} from '../../../utils/testUtils';
 import {PLANNING, EVENTS, EVENTS_PLANNING, MAIN} from '../../../constants';
+import {planningApis} from '../../../api';
+import {appConfig} from 'appConfig';
 
 describe('actions.eventsplanning.ui', () => {
     let store;
@@ -405,6 +408,150 @@ describe('actions.eventsplanning.ui', () => {
                     expect(services.notify.success.args[0][0]).toEqual(
                         'The Events and Planning view filter is deleted.'
                     );
+                    done();
+                })
+                .catch(done.fail);
+        });
+    });
+
+    describe('loadAllRelatedPlannings', () => {
+        const relatedPlannings = [
+            {_id: 'p10', type: 'planning', event_item: 'e1', slugline: 'RelatedPlan1'},
+            {_id: 'p11', type: 'planning', event_item: 'e1', slugline: 'RelatedPlan2'},
+        ];
+
+        beforeEach(() => {
+            sinon.stub(planningApis.planning, 'searchGetAll').callsFake(
+                () => Promise.resolve(relatedPlannings)
+            );
+            sinon.stub(planningApi, 'receivePlannings').callsFake(
+                () => ({type: PLANNING.ACTIONS.RECEIVE_PLANNINGS, payload: relatedPlannings})
+            );
+        });
+
+        afterEach(() => {
+            restoreSinonStub(planningApis.planning.searchGetAll);
+            restoreSinonStub(planningApi.receivePlannings);
+        });
+
+        it('fetches related plannings for events with planning_ids', (done) => {
+            const items = [
+                {_id: 'e1', type: 'event', planning_ids: ['p10', 'p11']},
+                {_id: 'e2', type: 'event', planning_ids: []},
+                {_id: 'p1', type: 'planning', slugline: 'Plan1'},
+            ];
+
+            store.test(done, eventsPlanningUi.loadAllRelatedPlannings(items))
+                .then(() => {
+                    expect(planningApis.planning.searchGetAll.callCount).toBe(1);
+                    expect(planningApis.planning.searchGetAll.args[0][0]).toEqual({
+                        event_item: ['e1'],
+                        only_future: false,
+                        include_killed: true,
+                    });
+
+                    expect(planningApi.receivePlannings.callCount).toBe(1);
+                    expect(planningApi.receivePlannings.args[0][0]).toEqual(relatedPlannings);
+
+                    done();
+                })
+                .catch(done.fail);
+        });
+
+        it('dispatches _showRelatedPlannings for each event with plannings', (done) => {
+            const items = [
+                {_id: 'e1', type: 'event', planning_ids: ['p10']},
+                {_id: 'e2', type: 'event', planning_ids: ['p11']},
+            ];
+
+            store.test(done, eventsPlanningUi.loadAllRelatedPlannings(items))
+                .then(() => {
+                    const showRelatedDispatches = store.dispatch.args.filter(
+                        (args) => args[0]?.type === EVENTS_PLANNING.ACTIONS.SHOW_RELATED_PLANNINGS
+                    );
+
+                    expect(showRelatedDispatches.length).toBe(2);
+                    expect(showRelatedDispatches[0][0].payload._id).toBe('e1');
+                    expect(showRelatedDispatches[1][0].payload._id).toBe('e2');
+
+                    done();
+                })
+                .catch(done.fail);
+        });
+
+        it('resolves immediately when no events have planning_ids', (done) => {
+            const items = [
+                {_id: 'e1', type: 'event', planning_ids: []},
+                {_id: 'p1', type: 'planning', slugline: 'Plan1'},
+            ];
+
+            store.test(done, eventsPlanningUi.loadAllRelatedPlannings(items))
+                .then(() => {
+                    expect(planningApis.planning.searchGetAll.callCount).toBe(0);
+                    done();
+                })
+                .catch(done.fail);
+        });
+
+        it('skips planning items in the input', (done) => {
+            const items = [
+                {_id: 'p1', type: 'planning', slugline: 'Plan1'},
+                {_id: 'p2', type: 'planning', slugline: 'Plan2'},
+            ];
+
+            store.test(done, eventsPlanningUi.loadAllRelatedPlannings(items))
+                .then(() => {
+                    expect(planningApis.planning.searchGetAll.callCount).toBe(0);
+                    done();
+                })
+                .catch(done.fail);
+        });
+    });
+
+    describe('receiveEventsPlanning with planning_expand_related_plannings', () => {
+        let originalExpandSetting;
+
+        beforeEach(() => {
+            originalExpandSetting = appConfig.planning_expand_related_plannings;
+            sinon.stub(planningApis.planning, 'searchGetAll').callsFake(
+                () => Promise.resolve([])
+            );
+            sinon.stub(planningApi, 'receivePlannings').callsFake(
+                (items) => ({type: PLANNING.ACTIONS.RECEIVE_PLANNINGS, payload: items})
+            );
+        });
+
+        afterEach(() => {
+            appConfig.planning_expand_related_plannings = originalExpandSetting;
+            restoreSinonStub(planningApis.planning.searchGetAll);
+            restoreSinonStub(planningApi.receivePlannings);
+        });
+
+        it('calls loadAllRelatedPlannings when config is true', (done) => {
+            appConfig.planning_expand_related_plannings = true;
+
+            const items = [
+                {_id: 'e1', type: 'event', planning_ids: ['p10']},
+            ];
+
+            store.test(done, eventsPlanningUi.receiveEventsPlanning(items))
+                .then(() => {
+                    expect(planningApis.planning.searchGetAll.callCount).toBe(1);
+                    done();
+                })
+                .catch(done.fail);
+        });
+
+        it('does not call loadAllRelatedPlannings when config is false', (done) => {
+            appConfig.planning_expand_related_plannings = false;
+
+            const items = [
+                {_id: 'e1', type: 'event', planning_ids: ['p10']},
+            ];
+
+            store.test(done, eventsPlanningUi.receiveEventsPlanning(items))
+                .then(() => {
+                    expect(planningApis.planning.searchGetAll.callCount).toBe(0);
                     done();
                 })
                 .catch(done.fail);

--- a/client/actions/eventsPlanning/ui.ts
+++ b/client/actions/eventsPlanning/ui.ts
@@ -8,6 +8,8 @@ import {getItemType, dispatchUtils, getErrorMessage} from '../../utils';
 import main from '../main';
 import {gettext} from '../../utils';
 import {showModal} from '../index';
+import {appConfig} from 'appConfig';
+import {planningApis} from '../../api';
 
 /**
  * Action to fetch events and planning based on the params
@@ -133,6 +135,11 @@ const receiveEventsPlanning = (items = []) => (
 
         dispatch(eventsApi.receiveEvents(events));
         dispatch(planningApi.receivePlannings(plannings));
+
+        if (appConfig.planning_expand_related_plannings) {
+            dispatch(self.loadAllRelatedPlannings(items));
+        }
+
         return Promise.resolve();
     }
 );
@@ -173,6 +180,32 @@ const _showRelatedPlannings = (event) => ({
     type: EVENTS_PLANNING.ACTIONS.SHOW_RELATED_PLANNINGS,
     payload: event,
 });
+
+const loadAllRelatedPlannings = (items) => (
+    (dispatch) => {
+        const eventsWithPlannings = items.filter(
+            (item) => getItemType(item) === ITEM_TYPE.EVENT && (item.planning_ids?.length ?? 0) > 0
+        );
+
+        if (eventsWithPlannings.length === 0) {
+            return Promise.resolve();
+        }
+
+        const eventIds = eventsWithPlannings.map((event) => event._id);
+
+        return planningApis.planning.searchGetAll({
+            event_item: eventIds,
+            only_future: false,
+            include_killed: true,
+        }).then((plannings) => {
+            dispatch(planningApi.receivePlannings(plannings));
+            eventsWithPlannings.forEach((event) => {
+                dispatch(self._showRelatedPlannings(event));
+            });
+            return plannings;
+        });
+    }
+);
 
 /**
  * Saves the combined view filter
@@ -325,6 +358,7 @@ const self = {
     clearList,
     showRelatedPlannings,
     _showRelatedPlannings,
+    loadAllRelatedPlannings,
     loadMore,
     requestEventsPlanning,
     refetch,

--- a/client/actions/planning/notifications.ts
+++ b/client/actions/planning/notifications.ts
@@ -15,6 +15,7 @@ import main from '../main';
 import {showModal, hideModal} from '../index';
 import eventsPlanning from '../eventsPlanning';
 import planningApis from '../planning/api';
+import {appConfig} from 'appConfig';
 
 /**
  * WS Action when a new Planning item is created
@@ -39,6 +40,19 @@ const onPlanningCreated = (_e, data) => (
                     data.item
                 ));
                 dispatch(main.fetchItemHistory({_id: data.event_item, type: ITEM_TYPE.EVENT}));
+
+                if (appConfig.planning_expand_related_plannings) {
+                    const relatedPlannings = selectors.eventsPlanning.getRelatedPlanningsList(getState());
+                    const isAlreadyTracked = relatedPlannings[data.event_item] != null;
+
+                    if (!isAlreadyTracked) {
+                        const event = selectors.events.storedEvents(getState())[data.event_item];
+
+                        if (event) {
+                            dispatch(eventsPlanning.ui.showRelatedPlannings(event));
+                        }
+                    }
+                }
             }
 
             dispatch(main.setUnsetLoadingIndicator(true));

--- a/client/actions/planning/notifications.ts
+++ b/client/actions/planning/notifications.ts
@@ -393,20 +393,22 @@ const onPlanningFilesUpdated = (_e, data) => (
 const expandRelatedPlanningsIfNeeded = (eventId) => (
     (dispatch, getState) => {
         if (!appConfig.planning_expand_related_plannings) {
-            return;
+            return Promise.resolve();
         }
 
         const relatedPlannings = selectors.eventsPlanning.getRelatedPlanningsList(getState());
 
         if (relatedPlannings[eventId] != null) {
-            return;
+            return Promise.resolve();
         }
 
         const event = selectors.events.storedEvents(getState())[eventId];
 
         if (event) {
-            dispatch(eventsPlanning.ui.showRelatedPlannings(event));
+            return dispatch(eventsPlanning.ui.showRelatedPlannings(event));
         }
+
+        return Promise.resolve();
     }
 );
 

--- a/client/actions/planning/notifications.ts
+++ b/client/actions/planning/notifications.ts
@@ -41,18 +41,7 @@ const onPlanningCreated = (_e, data) => (
                 ));
                 dispatch(main.fetchItemHistory({_id: data.event_item, type: ITEM_TYPE.EVENT}));
 
-                if (appConfig.planning_expand_related_plannings) {
-                    const relatedPlannings = selectors.eventsPlanning.getRelatedPlanningsList(getState());
-                    const isAlreadyTracked = relatedPlannings[data.event_item] != null;
-
-                    if (!isAlreadyTracked) {
-                        const event = selectors.events.storedEvents(getState())[data.event_item];
-
-                        if (event) {
-                            dispatch(eventsPlanning.ui.showRelatedPlannings(event));
-                        }
-                    }
-                }
+                dispatch(self.expandRelatedPlanningsIfNeeded(data.event_item));
             }
 
             dispatch(main.setUnsetLoadingIndicator(true));
@@ -401,6 +390,26 @@ const onPlanningFilesUpdated = (_e, data) => (
     (dispatch) => (dispatch(planning.api.getFiles([data.item])))
 );
 
+const expandRelatedPlanningsIfNeeded = (eventId) => (
+    (dispatch, getState) => {
+        if (!appConfig.planning_expand_related_plannings) {
+            return;
+        }
+
+        const relatedPlannings = selectors.eventsPlanning.getRelatedPlanningsList(getState());
+
+        if (relatedPlannings[eventId] != null) {
+            return;
+        }
+
+        const event = selectors.events.storedEvents(getState())[eventId];
+
+        if (event) {
+            dispatch(eventsPlanning.ui.showRelatedPlannings(event));
+        }
+    }
+);
+
 // eslint-disable-next-line consistent-this
 const self: any = {
     onPlanningCreated,
@@ -418,6 +427,7 @@ const self: any = {
     onPlanningFeaturedLocked,
     onPlanningFeaturedUnLocked,
     onPlanningFilesUpdated,
+    expandRelatedPlanningsIfNeeded,
 };
 
 // Map of notification name and Action Event to execute

--- a/client/actions/planning/tests/notifications_test.ts
+++ b/client/actions/planning/tests/notifications_test.ts
@@ -10,6 +10,7 @@ import {registerNotifications} from '../../../utils';
 import planningNotifications from '../notifications';
 import {getTestActionStore, restoreSinonStub} from '../../../utils/testUtils';
 import {MAIN, PLANNING} from '../../../constants';
+import {appConfig} from 'appConfig';
 
 describe('actions.planning.notifications', () => {
     let store;
@@ -188,6 +189,85 @@ describe('actions.planning.notifications', () => {
 
                     expect(planningUi.scheduleRefetch.callCount).toBe(1);
                     expect(eventsPlanningUi.scheduleRefetch.callCount).toBe(1);
+                    done();
+                })
+                .catch(done.fail);
+        });
+    });
+
+    describe('`planning:created` with planning_expand_related_plannings', () => {
+        let originalExpandSetting;
+
+        beforeEach(() => {
+            originalExpandSetting = appConfig.planning_expand_related_plannings;
+            sinon.stub(eventsApi, 'markEventHasPlannings').callsFake(() => (Promise.resolve()));
+            sinon.stub(eventsPlanningUi, 'scheduleRefetch').callsFake(() => (Promise.resolve()));
+            sinon.stub(eventsPlanningUi, 'showRelatedPlannings').callsFake(() => (Promise.resolve()));
+            sinon.stub(planningUi, 'scheduleRefetch').callsFake(() => (Promise.resolve()));
+            sinon.stub(main, 'setUnsetLoadingIndicator').callsFake(() => (Promise.resolve()));
+        });
+
+        afterEach(() => {
+            appConfig.planning_expand_related_plannings = originalExpandSetting;
+            restoreSinonStub(eventsApi.markEventHasPlannings);
+            restoreSinonStub(planningUi.scheduleRefetch);
+            restoreSinonStub(eventsPlanningUi.scheduleRefetch);
+            restoreSinonStub(eventsPlanningUi.showRelatedPlannings);
+            restoreSinonStub(main.setUnsetLoadingIndicator);
+        });
+
+        it('calls showRelatedPlannings for untracked event when config is true', (done) => {
+            appConfig.planning_expand_related_plannings = true;
+            store.initialState.main.filter = MAIN.FILTERS.PLANNING;
+            store.initialState.eventsPlanning = {
+                ...store.initialState.eventsPlanning,
+                relatedPlannings: {},
+            };
+            store.initialState.events.events = {
+                e1: {_id: 'e1', type: 'event', planning_ids: ['p2']},
+            };
+
+            return store.test(done, planningNotifications.onPlanningCreated({}, {
+                item: 'p2',
+                event_item: 'e1',
+            }))
+                .then(() => {
+                    expect(eventsPlanningUi.showRelatedPlannings.callCount).toBe(1);
+                    expect(eventsPlanningUi.showRelatedPlannings.args[0][0]._id).toBe('e1');
+                    done();
+                })
+                .catch(done.fail);
+        });
+
+        it('does not call showRelatedPlannings when event is already tracked', (done) => {
+            appConfig.planning_expand_related_plannings = true;
+            store.initialState.main.filter = MAIN.FILTERS.PLANNING;
+            store.initialState.eventsPlanning = {
+                ...store.initialState.eventsPlanning,
+                relatedPlannings: {e1: ['p2']},
+            };
+
+            return store.test(done, planningNotifications.onPlanningCreated({}, {
+                item: 'p2',
+                event_item: 'e1',
+            }))
+                .then(() => {
+                    expect(eventsPlanningUi.showRelatedPlannings.callCount).toBe(0);
+                    done();
+                })
+                .catch(done.fail);
+        });
+
+        it('does not call showRelatedPlannings when config is false', (done) => {
+            appConfig.planning_expand_related_plannings = false;
+            store.initialState.main.filter = MAIN.FILTERS.PLANNING;
+
+            return store.test(done, planningNotifications.onPlanningCreated({}, {
+                item: 'p2',
+                event_item: 'e1',
+            }))
+                .then(() => {
+                    expect(eventsPlanningUi.showRelatedPlannings.callCount).toBe(0);
                     done();
                 })
                 .catch(done.fail);

--- a/client/components/Events/EventItemWithPlanning.tsx
+++ b/client/components/Events/EventItemWithPlanning.tsx
@@ -42,7 +42,7 @@ export class EventItemWithPlanning extends React.Component<IProps, IState> {
     constructor(props) {
         super(props);
         this.state = {
-            openPlanningItems: appConfig.planning_expand_related_plannings ?? false,
+            openPlanningItems: appConfig.planning_expand_related_plannings,
             activeIndex: -1, // Index of active nested element (-1=None, 0=event, 1....=respective planning item)
         };
         this.toggleRelatedPlanning = this.toggleRelatedPlanning.bind(this);

--- a/client/components/Events/EventItemWithPlanning.tsx
+++ b/client/components/Events/EventItemWithPlanning.tsx
@@ -10,6 +10,7 @@ import {
     IPlanningItem,
 } from '../../interfaces';
 import {superdeskApi} from '../../superdeskApi';
+import {appConfig} from 'appConfig';
 
 import {onEventCapture} from '../../utils';
 import {KEYCODES} from '../../constants';
@@ -41,7 +42,7 @@ export class EventItemWithPlanning extends React.Component<IProps, IState> {
     constructor(props) {
         super(props);
         this.state = {
-            openPlanningItems: false,
+            openPlanningItems: appConfig.planning_expand_related_plannings ?? false,
             activeIndex: -1, // Index of active nested element (-1=None, 0=event, 1....=respective planning item)
         };
         this.toggleRelatedPlanning = this.toggleRelatedPlanning.bind(this);

--- a/client/config.ts
+++ b/client/config.ts
@@ -67,6 +67,10 @@ if (appConfig?.planning_auto_close_popup_editor == null) {
     appConfig.planning_auto_close_popup_editor = true;
 }
 
+if (appConfig.planning_expand_related_plannings == null) {
+    appConfig.planning_expand_related_plannings = false;
+}
+
 // Configured start of the week (0=Sunday, 1=Monday, ..., 6=Saturday)
 if (appConfig.start_of_week == null) {
     appConfig.start_of_week = 0;

--- a/client/interfaces.ts
+++ b/client/interfaces.ts
@@ -283,6 +283,7 @@ export interface IPlanningConfig extends ISuperdeskGlobalConfig {
     planning_allow_freetext_location: boolean;
     planning_allow_scheduled_updates?: boolean;
     planning_auto_assign_to_workflow?: boolean;
+    planning_expand_related_plannings?: boolean;
     planning_check_for_assignment_on_publish?: boolean;
     planning_check_for_assignment_on_send?: boolean;
     planning_fulfil_on_publish_for_desks: Array<string>;

--- a/server/planning/__init__.py
+++ b/server/planning/__init__.py
@@ -30,6 +30,7 @@ from .common import (
     planning_auto_assign_to_workflow,
     get_long_event_duration_threshold,
     get_planning_allow_scheduled_updates,
+    get_planning_expand_related_plannings,
     event_templates_enabled,
     planning_link_updates_to_coverage,
     get_planning_use_xmp_for_pic_assignments,
@@ -231,6 +232,7 @@ def init_app(app):
     app.client_config["long_event_duration_threshold"] = get_long_event_duration_threshold(app)
     app.client_config["event_templates_enabled"] = event_templates_enabled(app)
     app.client_config["planning_allow_scheduled_updates"] = get_planning_allow_scheduled_updates(app)
+    app.client_config["planning_expand_related_plannings"] = get_planning_expand_related_plannings(app)
     app.client_config["planning_link_updates_to_coverage"] = planning_link_updates_to_coverage(app)
     app.client_config["planning_use_xmp_for_pic_assignments"] = get_planning_use_xmp_for_pic_assignments(app)
     app.client_config["planning_use_xmp_for_pic_slugline"] = get_planning_use_xmp_for_pic_slugline(app)

--- a/server/planning/common.py
+++ b/server/planning/common.py
@@ -198,6 +198,12 @@ def get_planning_allow_scheduled_updates(current_app=None):
     return app.config.get("PLANNING_ALLOW_SCHEDULED_UPDATES", True)
 
 
+def get_planning_expand_related_plannings(current_app=None):
+    if current_app is not None:
+        return current_app.config.get("PLANNING_EXPAND_RELATED_PLANNINGS", False)
+    return app.config.get("PLANNING_EXPAND_RELATED_PLANNINGS", False)
+
+
 def get_planning_use_xmp_for_pic_assignments(current_app=None):
     if current_app is not None:
         return current_app.config.get("PLANNING_USE_XMP_FOR_PIC_ASSIGNMENTS", False)


### PR DESCRIPTION
### Purpose
Allow customers with high event volumes to have related planning items automatically expanded in the combined
Events & Planning view, controlled by a server-side configuration setting.

### What has changed
- Added `PLANNING_EXPAND_RELATED_PLANNINGS` server config (defaults to `False`) exposed via client_config
- Added `loadAllRelatedPlannings` action that batch-fetches all related plannings using searchGetAll with `only_future: false` and `include_killed: true` (like pre-existing mechanism when unfolding the items manually)
- Hooked the bulk preload into `receiveEventsPlanning` so it applies to `fetch`, `loadMore`, and `refetch` without
duplication
- Added a targeted fetch in the `onPlanningCreated` websocket notification for the first-planning-on-event case
- `EventItemWithPlanning` now initializes its open/closed state from the config value
- Added unit tests covering the new actions and config-guarded behavior

### Steps to test
- Set `PLANNING_EXPAND_RELATED_PLANNINGS = True` in server config
- Open the combined Events & Planning view
- Verify events with planning items have their plannings automatically expanded
- Verify the toggle still works to collapse/expand individual events
- Create a new planning item on an event and verify it appears immediately under the event
- Set the config to `False` (or leave it unset) and verify the previous default behavior (collapsed) is preserved

Resolves: [SDBELGA-1076]



[SDBELGA-1076]: https://sofab.atlassian.net/browse/SDBELGA-1076?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ