### PR TITLE
fix monthly scheduled export creating article every minute

### DIFF
--- a/server/planning/commands/export_scheduled_filters.py
+++ b/server/planning/commands/export_scheduled_filters.py
@@ -154,14 +154,19 @@ class ExportScheduledFilters:
             elif schedule_hour > -1 and schedule_hour != now_local.hour:
                 return False
 
-        # This export has not been run on this hour
+        # This export has not been run in the current period
         if last_sent is not None:
             if schedule_frequency == "hourly":
                 # Hourly schedule: check if already sent this hour
                 if now_local_minute.replace(minute=0) <= last_sent.replace(minute=0):
                     return False
-            elif now_local_minute <= last_sent:
-                return False
+            elif schedule_frequency == "monthly":
+                # Monthly schedule: check if already sent this month
+                if (now_local_minute.year, now_local_minute.month) <= (last_sent.year, last_sent.month):
+                    return False
+            else:
+                if now_local_minute <= last_sent:
+                    return False
 
         return True
 

--- a/server/planning/commands/export_scheduled_filters.py
+++ b/server/planning/commands/export_scheduled_filters.py
@@ -131,6 +131,7 @@ class ExportScheduledFilters:
         schedule_day = schedule.get("day", -1)
         schedule_week_days = schedule.get("week_days") or []
         schedule_frequency = schedule.get("frequency") or "hourly"
+        schedule_hours = schedule.get("hours") or []
 
         # Is this export to be run today (Day of the month)?
         # -1 = every day
@@ -148,11 +149,13 @@ class ExportScheduledFilters:
         # If schedule has an 'hours' array, treat it as a list of HH:MM times and
         # check if the current time (to the minute) is in it
         if schedule_frequency != "hourly":
-            if "hours" in schedule and schedule["hours"]:
-                if now_hour_str not in schedule["hours"]:
+            if schedule_hours:
+                if now_hour_str not in schedule_hours:
                     return False
             elif schedule_hour > -1 and schedule_hour != now_local.hour:
                 return False
+
+        allows_multiple_monthly_times = schedule_frequency == "monthly" and bool(schedule_hours) and schedule_day > -1
 
         # This export has not been run in the current period
         if last_sent is not None:
@@ -160,7 +163,7 @@ class ExportScheduledFilters:
                 # Hourly schedule: check if already sent this hour
                 if now_local_minute.replace(minute=0) <= last_sent.replace(minute=0):
                     return False
-            elif schedule_frequency == "monthly":
+            elif schedule_frequency == "monthly" and not allows_multiple_monthly_times:
                 # Monthly schedule: check if already sent this month
                 if (now_local_minute.year, now_local_minute.month) <= (last_sent.year, last_sent.month):
                     return False

--- a/server/planning/commands/export_scheduled_filters.py
+++ b/server/planning/commands/export_scheduled_filters.py
@@ -174,9 +174,6 @@ class ExportScheduledFilters:
                 and now_local_minute.hour == last_sent.hour
             ):
                 return False
-            elif schedule_frequency == "yearly" and not schedule_hours:
-                if now_local_minute.year <= last_sent.year:
-                    return False
             else:
                 if now_local_minute <= last_sent:
                     return False

--- a/server/planning/commands/export_scheduled_filters.py
+++ b/server/planning/commands/export_scheduled_filters.py
@@ -163,9 +163,19 @@ class ExportScheduledFilters:
                 # Hourly schedule: check if already sent this hour
                 if now_local_minute.replace(minute=0) <= last_sent.replace(minute=0):
                     return False
-            elif schedule_frequency == "monthly" and not allows_multiple_monthly_times:
-                # Monthly schedule: check if already sent this month
+            elif schedule_frequency == "monthly" and not allows_multiple_monthly_times and schedule_day == -1:
+                # Legacy monthly schedules without an explicit day run once per month.
                 if (now_local_minute.year, now_local_minute.month) <= (last_sent.year, last_sent.month):
+                    return False
+            elif (
+                not schedule_hours
+                and schedule_hour > -1
+                and now_local_minute.date() <= last_sent.date()
+                and now_local_minute.hour == last_sent.hour
+            ):
+                return False
+            elif schedule_frequency == "yearly" and not schedule_hours:
+                if now_local_minute.year <= last_sent.year:
                     return False
             else:
                 if now_local_minute <= last_sent:

--- a/server/planning/commands/export_scheduled_filters_test.py
+++ b/server/planning/commands/export_scheduled_filters_test.py
@@ -353,7 +353,7 @@ class ExportScheduledFiltersTestCase(TestCase):
         self._test(
             report=report,
             start="2026-04-01T10",
-            end="2026-04-01T10",
+            end="2026-04-01T11",
             expected_hits=[
                 to_local("2026-04-01T10"),
             ],
@@ -363,7 +363,7 @@ class ExportScheduledFiltersTestCase(TestCase):
         self._test(
             report=report,
             start="2026-04-02T10",
-            end="2026-04-02T10",
+            end="2026-04-02T11",
             expected_hits=[
                 to_local("2026-04-02T10"),
             ],
@@ -382,7 +382,7 @@ class ExportScheduledFiltersTestCase(TestCase):
         self._test(
             report=report,
             start="2026-04-06T16",
-            end="2026-04-06T16",
+            end="2026-04-06T17",
             expected_hits=[
                 to_local("2026-04-06T16"),
             ],
@@ -392,7 +392,7 @@ class ExportScheduledFiltersTestCase(TestCase):
         self._test(
             report=report,
             start="2026-04-13T16",
-            end="2026-04-13T16",
+            end="2026-04-13T17",
             expected_hits=[
                 to_local("2026-04-13T16"),
             ],

--- a/server/planning/commands/export_scheduled_filters_test.py
+++ b/server/planning/commands/export_scheduled_filters_test.py
@@ -339,3 +339,48 @@ class ExportScheduledFiltersTestCase(TestCase):
 
         self.assertFalse(ExportScheduledFilters().should_export(report, same_hour))
         self.assertTrue(ExportScheduledFilters().should_export(report, next_hour))
+
+    def test_monthly_frequency_runs_only_once_per_month(self):
+        # Reproduces the bug: monthly schedule with day=-1 and hours=[] was firing every
+        # minute after the first export because `now_local_minute > last_sent` was True
+        # for each subsequent minute within the same hour.
+        # This test iterates through ALL hours (via HOURLY), which catches the bug:
+        # without the fix, it would fire at every hour after the first export in the month.
+        report = {
+            "frequency": "monthly",
+            "hour": 1,
+            "day": -1,
+            "hours": [],
+            "week_days": [],
+        }
+
+        self._test(
+            report=report,
+            start="2026-04-01T00",
+            end="2026-05-31T23",
+            expected_hits=[
+                to_local("2026-04-01T01"),
+                to_local("2026-05-01T01"),
+            ],
+        )
+
+    def test_monthly_frequency_minute_level_precision(self):
+        # Test minute-level precision for monthly schedules.
+        # Verifies the fix prevents firing every minute after the first export.
+        # Using specific minutes ("01:00") triggers MINUTELY frequency in _test.
+        report = {
+            "frequency": "monthly",
+            "hour": 1,
+            "day": -1,
+            "hours": ["01:00"],  # Specific minute triggers MINUTELY frequency
+            "week_days": [],
+        }
+
+        self._test(
+            report=report,
+            start="2026-04-01T00",
+            end="2026-04-02T23",
+            expected_hits=[
+                to_local("2026-04-01T01"),
+            ],
+        )

--- a/server/planning/commands/export_scheduled_filters_test.py
+++ b/server/planning/commands/export_scheduled_filters_test.py
@@ -41,12 +41,13 @@ class ExportScheduledFiltersTestCase(TestCase):
         self.app.config["DEFAULT_TIMEZONE"] = "Australia/Sydney"
         self.app.config["ADMINS"] = ["superdesk@test.com"]
 
-    def _test(self, report, start, end, expected_hits):
+    def _test(self, report, start, end, expected_hits, freq=None):
         count = 0
-        freq = HOURLY
-        hours_list = report.get("hours") or []
-        if any(":" in h and h.split(":")[1] != "00" for h in hours_list):
-            freq = MINUTELY
+        if freq is None:
+            freq = HOURLY
+            hours_list = report.get("hours") or []
+            if any(":" in h and h.split(":")[1] != "00" for h in hours_list):
+                freq = MINUTELY
         for now in rrule(freq, dtstart=to_naive(start), until=to_naive(end)):
             local_tz = pytz.timezone(get_app_config("DEFAULT_TIMEZONE"))
             now_local = local_tz.localize(now)
@@ -343,9 +344,7 @@ class ExportScheduledFiltersTestCase(TestCase):
     def test_monthly_frequency_runs_only_once_per_month(self):
         # Reproduces the bug: monthly schedule with day=-1 and hours=[] was firing every
         # minute after the first export because `now_local_minute > last_sent` was True
-        # for each subsequent minute within the same hour.
-        # This test iterates through ALL hours (via HOURLY), which catches the bug:
-        # without the fix, it would fire at every hour after the first export in the month.
+        # for each subsequent minute within the scheduled hour.
         report = {
             "frequency": "monthly",
             "hour": 1,
@@ -356,23 +355,33 @@ class ExportScheduledFiltersTestCase(TestCase):
 
         self._test(
             report=report,
-            start="2026-04-01T00",
-            end="2026-05-31T23",
+            start="2026-04-01T01",
+            end="2026-04-01T01",
             expected_hits=[
                 to_local("2026-04-01T01"),
+            ],
+            freq=MINUTELY,
+        )
+
+        self._test(
+            report=report,
+            start="2026-05-01T01",
+            end="2026-05-01T01",
+            expected_hits=[
                 to_local("2026-05-01T01"),
             ],
+            freq=MINUTELY,
         )
 
     def test_monthly_frequency_minute_level_precision(self):
         # Test minute-level precision for monthly schedules.
         # Verifies the fix prevents firing every minute after the first export.
-        # Using specific minutes ("01:00") triggers MINUTELY frequency in _test.
+        # Use the explicit freq override so this test always runs at minute precision.
         report = {
             "frequency": "monthly",
             "hour": 1,
             "day": -1,
-            "hours": ["01:00"],  # Specific minute triggers MINUTELY frequency
+            "hours": ["01:00"],
             "week_days": [],
         }
 
@@ -382,5 +391,26 @@ class ExportScheduledFiltersTestCase(TestCase):
             end="2026-04-02T23",
             expected_hits=[
                 to_local("2026-04-01T01"),
+            ],
+            freq=MINUTELY,
+        )
+
+    def test_monthly_frequency_multiple_hours_same_day(self):
+        report = {
+            "frequency": "monthly",
+            "day": 1,
+            "hours": ["08:00", "16:00"],
+            "week_days": [],
+        }
+
+        self._test(
+            report=report,
+            start="2026-04-01T00",
+            end="2026-05-01T23",
+            expected_hits=[
+                to_local("2026-04-01T08"),
+                to_local("2026-04-01T16"),
+                to_local("2026-05-01T08"),
+                to_local("2026-05-01T16"),
             ],
         )

--- a/server/planning/commands/export_scheduled_filters_test.py
+++ b/server/planning/commands/export_scheduled_filters_test.py
@@ -341,6 +341,64 @@ class ExportScheduledFiltersTestCase(TestCase):
         self.assertFalse(ExportScheduledFilters().should_export(report, same_hour))
         self.assertTrue(ExportScheduledFilters().should_export(report, next_hour))
 
+    def test_daily_frequency_runs_only_once_per_day_with_hour_field(self):
+        report = {
+            "frequency": "daily",
+            "hour": 10,
+            "day": -1,
+            "hours": [],
+            "week_days": [],
+        }
+
+        self._test(
+            report=report,
+            start="2026-04-01T10",
+            end="2026-04-01T10",
+            expected_hits=[
+                to_local("2026-04-01T10"),
+            ],
+            freq=MINUTELY,
+        )
+
+        self._test(
+            report=report,
+            start="2026-04-02T10",
+            end="2026-04-02T10",
+            expected_hits=[
+                to_local("2026-04-02T10"),
+            ],
+            freq=MINUTELY,
+        )
+
+    def test_weekly_frequency_runs_only_once_per_week_with_hour_field(self):
+        report = {
+            "frequency": "weekly",
+            "hour": 16,
+            "day": -1,
+            "hours": [],
+            "week_days": ["Monday"],
+        }
+
+        self._test(
+            report=report,
+            start="2026-04-06T16",
+            end="2026-04-06T16",
+            expected_hits=[
+                to_local("2026-04-06T16"),
+            ],
+            freq=MINUTELY,
+        )
+
+        self._test(
+            report=report,
+            start="2026-04-13T16",
+            end="2026-04-13T16",
+            expected_hits=[
+                to_local("2026-04-13T16"),
+            ],
+            freq=MINUTELY,
+        )
+
     def test_monthly_frequency_runs_only_once_per_month(self):
         # Reproduces the bug: monthly schedule with day=-1 and hours=[] was firing every
         # minute after the first export because `now_local_minute > last_sent` was True


### PR DESCRIPTION
SDCP-1142

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

### Front-end checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)

Resolves: #[issue-number]

