### PR TITLE
[SDBELGA-1064] - Change the behavior of the "Events and Planning filters" in the Planning UI

### DIFF
--- a/client/components/Main/FilterSubnavDropdown.tsx
+++ b/client/components/Main/FilterSubnavDropdown.tsx
@@ -79,10 +79,7 @@ class FilterSubnavDropdownComponent extends React.PureComponent<IProps> {
         return filters.map((filter) => ({
             id: filter._id,
             label: filter.name,
-            action: () => planningApi.ui.list.changeFilterId(
-                filter._id,
-                {advancedSearch: {dates: {range: filter?.params?.date_filter}}}
-            ),
+            action: () => planningApi.ui.list.changeFilterId(filter._id),
             group: gettext('Search Filters'),
         }));
     }


### PR DESCRIPTION
### Purpose
This PR prevents the manual search filters from being lost when a saved Events & Planning filter is selected in the Planning UI.

### What has changed
- Updated call to`planningApi.ui.list.changeFilterId(filter._id)` without passing replacement search params which then preserves the existing combined search state, including manual date filters and other active fields like name, subject, slugline, and state.

### Steps to test
1. Open Planning in Events & Planning view.
2. Set a manual search filter, for example a date filter or another advanced search field.
3. Select a saved combined filter from the Events and Planning filters dropdown.
4. Confirm the request keeps the existing search params and adds filter_id.
5. Confirm results are filtered by both the saved filter and the current manual search state.

Resolves: #[SDBELGA-1064](https://sofab.atlassian.net/browse/SDBELGA-1064)


[SDBELGA-1064]: https://sofab.atlassian.net/browse/SDBELGA-1064?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ