### PR TITLE
fix weekly/monthly scheduled export with no time defined

### DIFF
--- a/server/planning/commands/export_scheduled_filters.py
+++ b/server/planning/commands/export_scheduled_filters.py
@@ -133,6 +133,11 @@ class ExportScheduledFilters:
         schedule_frequency = schedule.get("frequency") or "hourly"
         schedule_hours = schedule.get("hours") or []
 
+        # For non-hourly schedules, default to midnight when no explicit time is provided.
+        effective_schedule_hour = schedule_hour
+        if schedule_frequency != "hourly" and not schedule_hours and schedule_hour == -1:
+            effective_schedule_hour = 0
+
         # Is this export to be run today (Day of the month)?
         # -1 = every day
         if schedule_day > -1 and schedule_day != now_local.day:
@@ -152,7 +157,7 @@ class ExportScheduledFilters:
             if schedule_hours:
                 if now_hour_str not in schedule_hours:
                     return False
-            elif schedule_hour > -1 and schedule_hour != now_local.hour:
+            elif effective_schedule_hour > -1 and effective_schedule_hour != now_local.hour:
                 return False
 
         allows_multiple_monthly_times = schedule_frequency == "monthly" and bool(schedule_hours) and schedule_day > -1
@@ -169,7 +174,7 @@ class ExportScheduledFilters:
                     return False
             elif (
                 not schedule_hours
-                and schedule_hour > -1
+                and effective_schedule_hour > -1
                 and now_local_minute.date() <= last_sent.date()
                 and now_local_minute.hour == last_sent.hour
             ):

--- a/server/planning/commands/export_scheduled_filters_test.py
+++ b/server/planning/commands/export_scheduled_filters_test.py
@@ -389,13 +389,40 @@ class ExportScheduledFiltersTestCase(TestCase):
             freq=MINUTELY,
         )
 
+    def test_weekly_frequency_defaults_to_midnight_when_no_hour_defined(self):
+        report = {
+            "frequency": "weekly",
+            "hour": -1,
+            "day": -1,
+            "hours": [],
+            "week_days": ["Monday"],
+        }
+
+        self._test(
+            report=report,
+            start="2026-04-06T00",
+            end="2026-04-06T01",
+            expected_hits=[
+                to_local("2026-04-06T00"),
+            ],
+            freq=MINUTELY,
+        )
+
+        self._test(
+            report=report,
+            start="2026-04-13T00",
+            end="2026-04-13T01",
+            expected_hits=[
+                to_local("2026-04-13T00"),
+            ],
+            freq=MINUTELY,
+        )
+
         self._test(
             report=report,
             start="2026-04-13T16",
             end="2026-04-13T17",
-            expected_hits=[
-                to_local("2026-04-13T16"),
-            ],
+            expected_hits=[],
             freq=MINUTELY,
         )
 
@@ -471,4 +498,33 @@ class ExportScheduledFiltersTestCase(TestCase):
                 to_local("2026-05-01T08"),
                 to_local("2026-05-01T16"),
             ],
+        )
+
+    def test_monthly_frequency_defaults_to_midnight_when_no_hour_defined(self):
+        report = {
+            "frequency": "monthly",
+            "hour": -1,
+            "day": 1,
+            "hours": [],
+            "week_days": [],
+        }
+
+        self._test(
+            report=report,
+            start="2026-04-01T00",
+            end="2026-04-01T01",
+            expected_hits=[
+                to_local("2026-04-01T00"),
+            ],
+            freq=MINUTELY,
+        )
+
+        self._test(
+            report=report,
+            start="2026-05-01T00",
+            end="2026-05-01T01",
+            expected_hits=[
+                to_local("2026-05-01T00"),
+            ],
+            freq=MINUTELY,
         )


### PR DESCRIPTION
SDCP-1142

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

### Front-end checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)

Resolves: #[issue-number]

