### PR TITLE
[SDBELGA-1062] - Repeating events: "Ends on date" behaves different for all day and regular events

### DIFF
--- a/server/planning/events/events.py
+++ b/server/planning/events/events.py
@@ -930,7 +930,7 @@ def generate_recurring_dates(
             pass
         start = start.astimezone(tz).replace(tzinfo=None)
         if until:
-            until = get_date(until).astimezone(tz).replace(tzinfo=None)
+            until = get_date(until).astimezone(tz).replace(tzinfo=None, hour=23, minute=59, second=59)
 
     if frequency == "DAILY":
         byday = None


### PR DESCRIPTION
### Purpose
This PR fix the recurring event "Ends on" date being exclusive for timed events from before where a recurring timed-event, the last occurrence on the "Ends on" date was excluded.

### What has changed
- `generate_recurring_dates()` now sets the until time to end of day (23:59:59) in the event's timezone, ensuring the "Ends on" date is always inclusive. 

### Steps to test
1. Create a timed recurring event with a specific "Ends on" date 
2. Create an all-day recurring event with the same "Ends on" date
3. Verify both events show occurrences through and including the last day

Resolves: #[SDBELGA-1062](https://sofab.atlassian.net/browse/SDBELGA-1062)



[SDBELGA-1062]: https://sofab.atlassian.net/browse/SDBELGA-1062?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ