### PR TITLE
planning commands using planning_cli were not registered

### DIFF
--- a/server/planning/commands/delete_spiked_items.py
+++ b/server/planning/commands/delete_spiked_items.py
@@ -20,13 +20,13 @@ from superdesk.celery_task_utils import get_lock_id
 from superdesk.lock import lock, unlock, remove_locks
 from planning.common import WORKFLOW_STATE
 from planning.events.events_utils import get_recurring_timeline
-from .async_cli import planning_cli
+from superdesk.commands import cli
 
 
 log_msg_context: ContextVar[str] = ContextVar("log_msg", default="")
 
 
-@planning_cli.command("planning:delete_spiked")
+@cli.command("planning:delete_spiked")
 async def delete_spiked_items_command():
     """
     Delete expired spiked `Events` and `Planning` items.

--- a/server/planning/commands/flag_expired_items.py
+++ b/server/planning/commands/flag_expired_items.py
@@ -13,7 +13,7 @@ from superdesk.utc import utcnow
 from superdesk.celery_task_utils import get_lock_id
 from superdesk.lock import lock, unlock, remove_locks
 from superdesk.notification import push_notification
-from .async_cli import planning_cli
+from superdesk.commands import cli
 
 from planning.utils import get_related_planning_for_events_async, get_related_event_ids_for_planning
 
@@ -21,7 +21,7 @@ from planning.utils import get_related_planning_for_events_async, get_related_ev
 log_msg_context: ContextVar[str] = ContextVar("log_msg", default="")
 
 
-@planning_cli.command("planning:flag_expired")
+@cli.command("planning:flag_expired")
 async def flag_expired_items_command():
     """
     Flag expired `Events` and `Planning` items with `{'expired': True}`.

--- a/server/planning/commands/purge_expired_locks.py
+++ b/server/planning/commands/purge_expired_locks.py
@@ -22,12 +22,12 @@ from planning.item_lock import LOCK_ACTION, LOCK_SESSION, LOCK_TIME, LOCK_USER
 from planning.utils import get_service, try_cast_object_id
 from planning.events import EventsAutosaveAsyncService
 from planning.planning import PlanningAutosaveAsyncService
-from .async_cli import planning_cli
+from superdesk.commands import cli
 
 logger = logging.getLogger(__name__)
 
 
-@planning_cli.command("planning:purge_expired_locks")
+@cli.command("planning:purge_expired_locks")
 @click.option(
     "--resource",
     "-r",


### PR DESCRIPTION
### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

### Front-end checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)

Resolves: #[issue-number]

