### PR TITLE
[SDBELGA-1061] Issue with setting the TBC timestamp for the repeating events

### DIFF
--- a/server/planning/events/events.py
+++ b/server/planning/events/events.py
@@ -68,6 +68,7 @@ from planning.common import (
     is_new_version,
     update_ingest_on_patch,
     TEMP_ID_PREFIX,
+    TO_BE_CONFIRMED_FIELD,
 )
 from .events_base_service import EventsBaseService
 from .events_schema import events_schema
@@ -1016,7 +1017,7 @@ def generate_recurring_events(event, recurrence_id=None):
 
         # Remove fields not required by the new events
         for key in list(new_event.keys()):
-            if key.startswith("_") or key.startswith("lock_"):
+            if (key.startswith("_") and key != TO_BE_CONFIRMED_FIELD) or key.startswith("lock_"):
                 new_event.pop(key)
             elif key == "embedded_planning":
                 if not embedded_planning_added:

--- a/server/planning/events/events_reschedule.py
+++ b/server/planning/events/events_reschedule.py
@@ -19,6 +19,7 @@ from planning.common import (
     remove_lock_information,
     set_original_creator,
     set_actioned_date_to_event,
+    TO_BE_CONFIRMED_FIELD,
 )
 from copy import deepcopy
 from .events import EventsResource, events_schema, generate_recurring_dates
@@ -283,7 +284,7 @@ class EventsRescheduleService(EventsBaseService):
 
             # Remove fields not required by the new events
             for key in list(new_event.keys()):
-                if key.startswith("_"):
+                if key.startswith("_") and key != TO_BE_CONFIRMED_FIELD:
                     new_event.pop(key)
                 elif key.startswith("lock_"):
                     new_event.pop(key)

--- a/server/planning/events/events_tests.py
+++ b/server/planning/events/events_tests.py
@@ -491,23 +491,24 @@ class EventPlanningSchedule(TestCase):
             schedule["recurring_rule"]["count"] = 5
 
             update_repetitions = get_resource_service("events_update_repetitions")
-            update_repetitions.REQUIRE_LOCK = False
             is_original_event_func = update_repetitions.is_original_event
+            update_repetitions.REQUIRE_LOCK = False
             update_repetitions.is_original_event = Mock(return_value=False)
-            update_repetitions.patch(events[0].get("_id"), {"dates": schedule})
+            try:
+                update_repetitions.patch(events[0].get("_id"), {"dates": schedule})
 
-            events = list(service.get_from_mongo(req=None, lookup=None))
-            self.assertPlanningSchedule(events, 5)
+                events = list(service.get_from_mongo(req=None, lookup=None))
+                self.assertPlanningSchedule(events, 5)
 
-            for evt in events:
-                self.assertTrue(
-                    evt.get(TO_BE_CONFIRMED_FIELD),
-                    f"Event {evt.get('_id')} should have _time_to_be_confirmed=True, "
-                    f"got {evt.get(TO_BE_CONFIRMED_FIELD)}",
-                )
-
-            update_repetitions.is_original_event = is_original_event_func
-            update_repetitions.REQUIRE_LOCK = True
+                for evt in events:
+                    self.assertTrue(
+                        evt.get(TO_BE_CONFIRMED_FIELD),
+                        f"Event {evt.get('_id')} should have _time_to_be_confirmed=True, "
+                        f"got {evt.get(TO_BE_CONFIRMED_FIELD)}",
+                    )
+            finally:
+                update_repetitions.is_original_event = is_original_event_func
+                update_repetitions.REQUIRE_LOCK = True
 
     def test_tbc_preserved_for_reschedule_event(self):
         with self.app.app_context():
@@ -541,25 +542,25 @@ class EventPlanningSchedule(TestCase):
 
             schedule = deepcopy(events[0].get("dates"))
             schedule["start"] = datetime(2099, 11, 21, 12, 00, 00, tzinfo=pytz.UTC) + timedelta(days=5)
-            schedule["end"] = datetime(2099, 11, 21, 12, 00, 00, tzinfo=pytz.UTC) + timedelta(days=5)
+            schedule["end"] = schedule["start"] + timedelta(hours=2)
 
             reschedule = get_resource_service("events_reschedule")
-            reschedule.REQUIRE_LOCK = False
             is_original_event_func = reschedule.is_original_event
+            reschedule.REQUIRE_LOCK = False
             reschedule.is_original_event = Mock(return_value=False)
+            try:
+                reschedule.patch(events[0].get("_id"), {"dates": schedule})
 
-            reschedule.patch(events[0].get("_id"), {"dates": schedule})
-
-            events = list(service.get_from_mongo(req=None, lookup=None))
-            for evt in events:
-                self.assertTrue(
-                    evt.get(TO_BE_CONFIRMED_FIELD),
-                    f"Event {evt.get('_id')} should have _time_to_be_confirmed=True after reschedule, "
-                    f"got {evt.get(TO_BE_CONFIRMED_FIELD)}",
-                )
-
-            reschedule.is_original_event = is_original_event_func
-            reschedule.REQUIRE_LOCK = True
+                events = list(service.get_from_mongo(req=None, lookup=None))
+                for evt in events:
+                    self.assertTrue(
+                        evt.get(TO_BE_CONFIRMED_FIELD),
+                        f"Event {evt.get('_id')} should have _time_to_be_confirmed=True after reschedule, "
+                        f"got {evt.get(TO_BE_CONFIRMED_FIELD)}",
+                    )
+            finally:
+                reschedule.is_original_event = is_original_event_func
+                reschedule.REQUIRE_LOCK = True
 
 
 def generate_recurring_events(num_events):

--- a/server/planning/events/events_tests.py
+++ b/server/planning/events/events_tests.py
@@ -6,7 +6,7 @@ from mock import Mock, patch
 from superdesk import get_resource_service
 from superdesk.utc import utcnow
 from planning.tests import TestCase
-from planning.common import format_address, POST_STATE
+from planning.common import format_address, POST_STATE, TO_BE_CONFIRMED_FIELD
 from planning.item_lock import LockService
 from planning.events.events import generate_recurring_dates
 from werkzeug.exceptions import BadRequest
@@ -433,6 +433,133 @@ class EventPlanningSchedule(TestCase):
         service.patch(events[0].get("_id"), {"_id": events[0].get("_id"), "dates": schedule})
         events = list(service.get(req=None, lookup=None))
         self.assertPlanningSchedule(events, 3)
+
+    def test_tbc_preserved_for_recurring_event_creation(self):
+        with self.app.app_context():
+            service = get_resource_service("events")
+            event = {
+                "name": "TBC Recurring Event",
+                "_time_to_be_confirmed": True,
+                "dates": {
+                    "start": datetime(2099, 11, 21, 12, 00, 00, tzinfo=pytz.UTC),
+                    "end": datetime(2099, 11, 21, 14, 00, 00, tzinfo=pytz.UTC),
+                    "tz": "Australia/Sydney",
+                    "recurring_rule": {
+                        "frequency": "DAILY",
+                        "interval": 1,
+                        "count": 3,
+                        "endRepeatMode": "count",
+                    },
+                },
+            }
+
+            service.post([event])
+            events = list(service.get_from_mongo(req=None, lookup=None))
+            self.assertPlanningSchedule(events, 3)
+
+            for evt in events:
+                self.assertTrue(
+                    evt.get(TO_BE_CONFIRMED_FIELD),
+                    f"Event {evt.get('_id')} should have _time_to_be_confirmed=True, "
+                    f"got {evt.get(TO_BE_CONFIRMED_FIELD)}",
+                )
+
+    def test_tbc_preserved_for_update_repetitions(self):
+        with self.app.app_context():
+            service = get_resource_service("events")
+            event = {
+                "name": "TBC Update Repetitions",
+                "_time_to_be_confirmed": True,
+                "dates": {
+                    "start": datetime(2099, 11, 21, 12, 00, 00, tzinfo=pytz.UTC),
+                    "end": datetime(2099, 11, 21, 14, 00, 00, tzinfo=pytz.UTC),
+                    "tz": "Australia/Sydney",
+                    "recurring_rule": {
+                        "frequency": "DAILY",
+                        "interval": 1,
+                        "count": 3,
+                        "endRepeatMode": "count",
+                    },
+                },
+            }
+
+            service.post([event])
+            events = list(service.get_from_mongo(req=None, lookup=None))
+            self.assertPlanningSchedule(events, 3)
+
+            schedule = deepcopy(events[0].get("dates"))
+            schedule["recurring_rule"]["count"] = 5
+
+            update_repetitions = get_resource_service("events_update_repetitions")
+            update_repetitions.REQUIRE_LOCK = False
+            is_original_event_func = update_repetitions.is_original_event
+            update_repetitions.is_original_event = Mock(return_value=False)
+            update_repetitions.patch(events[0].get("_id"), {"dates": schedule})
+
+            events = list(service.get_from_mongo(req=None, lookup=None))
+            self.assertPlanningSchedule(events, 5)
+
+            for evt in events:
+                self.assertTrue(
+                    evt.get(TO_BE_CONFIRMED_FIELD),
+                    f"Event {evt.get('_id')} should have _time_to_be_confirmed=True, "
+                    f"got {evt.get(TO_BE_CONFIRMED_FIELD)}",
+                )
+
+            update_repetitions.is_original_event = is_original_event_func
+            update_repetitions.REQUIRE_LOCK = True
+
+    def test_tbc_preserved_for_reschedule_event(self):
+        with self.app.app_context():
+            service = get_resource_service("events")
+            event = {
+                "name": "TBC Reschedule Event",
+                "_time_to_be_confirmed": True,
+                "dates": {
+                    "start": datetime(2099, 11, 21, 12, 00, 00, tzinfo=pytz.UTC),
+                    "end": datetime(2099, 11, 21, 14, 00, 00, tzinfo=pytz.UTC),
+                    "tz": "Australia/Sydney",
+                    "recurring_rule": {
+                        "frequency": "DAILY",
+                        "interval": 1,
+                        "count": 3,
+                        "endRepeatMode": "count",
+                    },
+                },
+            }
+
+            service.post([event])
+            events = list(service.get_from_mongo(req=None, lookup=None))
+            self.assertPlanningSchedule(events, 3)
+
+            for evt in events:
+                self.assertTrue(
+                    evt.get(TO_BE_CONFIRMED_FIELD),
+                    f"Event {evt.get('_id')} should have _time_to_be_confirmed=True after creation, "
+                    f"got {evt.get(TO_BE_CONFIRMED_FIELD)}",
+                )
+
+            schedule = deepcopy(events[0].get("dates"))
+            schedule["start"] = datetime(2099, 11, 21, 12, 00, 00, tzinfo=pytz.UTC) + timedelta(days=5)
+            schedule["end"] = datetime(2099, 11, 21, 12, 00, 00, tzinfo=pytz.UTC) + timedelta(days=5)
+
+            reschedule = get_resource_service("events_reschedule")
+            reschedule.REQUIRE_LOCK = False
+            is_original_event_func = reschedule.is_original_event
+            reschedule.is_original_event = Mock(return_value=False)
+
+            reschedule.patch(events[0].get("_id"), {"dates": schedule})
+
+            events = list(service.get_from_mongo(req=None, lookup=None))
+            for evt in events:
+                self.assertTrue(
+                    evt.get(TO_BE_CONFIRMED_FIELD),
+                    f"Event {evt.get('_id')} should have _time_to_be_confirmed=True after reschedule, "
+                    f"got {evt.get(TO_BE_CONFIRMED_FIELD)}",
+                )
+
+            reschedule.is_original_event = is_original_event_func
+            reschedule.REQUIRE_LOCK = True
 
 
 def generate_recurring_events(num_events):

--- a/server/planning/events/events_update_repetitions.py
+++ b/server/planning/events/events_update_repetitions.py
@@ -19,6 +19,7 @@ from planning.common import (
     POST_STATE,
     get_max_recurrent_events,
     set_original_creator,
+    TO_BE_CONFIRMED_FIELD,
 )
 from .events import EventsResource, generate_recurring_dates
 from .events_base_service import EventsBaseService
@@ -169,7 +170,7 @@ class EventsUpdateRepetitionsService(EventsBaseService):
 
         new_event["state"] = WORKFLOW_STATE.DRAFT
         for key in list(new_event.keys()):
-            if key.startswith("_") or key.startswith("lock_"):
+            if (key.startswith("_") and key != TO_BE_CONFIRMED_FIELD) or key.startswith("lock_"):
                 new_event.pop(key)
 
         # Set the new start and end dates, as well as the _id and guid fields


### PR DESCRIPTION
### Purpose
This PR fix TBC timestamp not persisting for repeating events and instead showing 0:00 - 0:00

### What has changed
- Excluded `_time_to_be_confirmed` from the underscore-prefix cleanup loop events creation/updating repetition and reschedule
- Added 3 tests covering creation, repetition updates, and rescheduling.

### Steps to test
1. Create a repeating event with TBC selected. Verify all instances show "TBC"
2. Reschedule a TBC repeating event. Verify TBC is preserved
3. Update repetitions of a TBC event. Verify TBC is preserved