### PR TITLE
make coverage.assigned_to optional

### DIFF
--- a/client/actions/events/api.ts
+++ b/client/actions/events/api.ts
@@ -812,8 +812,8 @@ const createEventTemplate = (item: IEventItem) => (dispatch, getState, {api, mod
                                 coverages: planning.coverages.map((coverage) => ({
                                     coverage_id: coverage.coverage_id,
                                     g2_content_type: coverage.planning.g2_content_type,
-                                    desk: coverage.assigned_to.desk,
-                                    user: coverage.assigned_to.user,
+                                    desk: coverage.assigned_to?.desk,
+                                    user: coverage.assigned_to?.user,
                                     language: coverage.planning.language,
                                     news_coverage_status: coverage.news_coverage_status.qcode,
                                     scheduled: coverage.planning.scheduled,

--- a/client/actions/users.ts
+++ b/client/actions/users.ts
@@ -41,14 +41,19 @@ const updatePreferences = (updates, key) => (
 const setCoverageDefaultDesk = (coverage: IPlanningCoverageItem) => (
     (dispatch, getState) => {
         const coverageProfileId = coverage.profile ?? coverage.planning?.g2_content_type;
+        const coverageDeskId = coverage.assigned_to?.desk;
         const coverageDeskPref = preferredCoverageDesks(getState());
 
-        if (coverageDeskPref.desks?.[coverageProfileId] !== coverage.assigned_to?.desk) {
+        if (!coverageProfileId || !coverageDeskId) {
+            return Promise.resolve();
+        }
+
+        if (coverageDeskPref.desks?.[coverageProfileId] !== coverageDeskId) {
             const update = {
                 [COVERAGES.DEFAULT_DESK_PREFERENCE]: {
                     desks: {
                         ...(coverageDeskPref.desks ?? {}),
-                        [coverageProfileId]: coverage.assigned_to.desk,
+                        [coverageProfileId]: coverageDeskId,
                     },
                 },
             };

--- a/client/api/events.ts
+++ b/client/api/events.ts
@@ -150,8 +150,8 @@ function create(updates: Partial<IEventItem>): Promise<Array<IEventItem>> {
             coverages: planning.coverages.map((coverage) => ({
                 coverage_id: coverage.coverage_id,
                 g2_content_type: coverage.planning.g2_content_type,
-                desk: coverage.assigned_to.desk,
-                user: coverage.assigned_to.user,
+                desk: coverage.assigned_to?.desk,
+                user: coverage.assigned_to?.user,
                 language: coverage.planning.language,
                 news_coverage_status: coverage.news_coverage_status.qcode,
                 scheduled: coverage.planning.scheduled,
@@ -160,7 +160,7 @@ function create(updates: Partial<IEventItem>): Promise<Array<IEventItem>> {
                 ednote: coverage.planning.ednote,
                 internal_note: coverage.planning.internal_note,
                 headline: coverage.planning.headline,
-                coverage_provider: coverage.assigned_to.coverage_provider
+                coverage_provider: coverage.assigned_to?.coverage_provider
             })),
         })),
         update_method: updates.update_method?.value ?? updates.update_method
@@ -201,8 +201,8 @@ function update(original: IEventItem, updates: Partial<IEventItem>): Promise<Arr
             coverages: planning.coverages.map((coverage) => ({
                 coverage_id: coverage.coverage_id,
                 g2_content_type: coverage.planning.g2_content_type,
-                desk: coverage.assigned_to.desk,
-                user: coverage.assigned_to.user,
+                desk: coverage.assigned_to?.desk,
+                user: coverage.assigned_to?.user,
                 language: coverage.planning.language,
                 news_coverage_status: coverage.news_coverage_status.qcode,
                 scheduled: coverage.planning.scheduled,
@@ -211,7 +211,7 @@ function update(original: IEventItem, updates: Partial<IEventItem>): Promise<Arr
                 ednote: coverage.planning.ednote,
                 internal_note: coverage.planning.internal_note,
                 headline: coverage.planning.headline,
-                coverage_provider: coverage.assigned_to.coverage_provider
+                coverage_provider: coverage.assigned_to?.coverage_provider
             })),
         })),
         update_method: updates.update_method?.value ?? updates.update_method ?? original.update_method

--- a/client/interfaces.ts
+++ b/client/interfaces.ts
@@ -409,8 +409,8 @@ export type IDateTime = moment.MomentInput;
 export interface IEmbeddedCoverageItem {
     coverage_id?: IPlanningCoverageItem['coverage_id'];
     g2_content_type: ICoveragePlanningDetails['g2_content_type'];
-    desk: IPlanningAssignedTo['desk'];
-    user: IPlanningAssignedTo['user'];
+    desk?: IPlanningAssignedTo['desk'];
+    user?: IPlanningAssignedTo['user'];
     language: ICoveragePlanningDetails['language'];
     news_coverage_status: IPlanningNewsCoverageStatus['qcode'];
     scheduled: ICoveragePlanningDetails['scheduled'];
@@ -654,7 +654,7 @@ export interface ICoverageScheduledUpdate {
     scheduled_update_id: string;
     coverage_id: string;
     workflow_status: IPlanningWorkflowStatus;
-    assigned_to: IPlanningAssignedTo;
+    assigned_to?: IPlanningAssignedTo;
     previous_status: IPlanningWorkflowStatus;
     news_coverage_status: IPlanningNewsCoverageStatus;
     planning: {
@@ -686,7 +686,7 @@ export interface IPlanningCoverageItem {
     news_coverage_status: IPlanningNewsCoverageStatus;
     workflow_status: IPlanningWorkflowStatus;
     previous_status: IPlanningWorkflowStatus;
-    assigned_to: IPlanningAssignedTo;
+    assigned_to?: IPlanningAssignedTo;
     flags: {
         no_content_linking: boolean;
     };

--- a/client/utils/planning.tsx
+++ b/client/utils/planning.tsx
@@ -1469,7 +1469,7 @@ function getCoverageIconColor(item: IPlanningCoverageItem): string | undefined {
         return 'var(--sd-colour-state--completed)';
     }
 
-    if (item.assigned_to.user != null || item.assigned_to.desk != null) {
+    if (item.assigned_to?.user != null || item.assigned_to?.desk != null) {
         return 'var(--sd-colour-state--assigned)';
     } else {
         return 'var(--sd-colour-state--unassigned)';


### PR DESCRIPTION
atm saving event with embedded planning item with coverages missing assigned_to fails

STT-1666

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

### Front-end checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)

Resolves: #[issue-number]

