### PR TITLE
[SDBELGA-1079] fix: Translated Event definition_short fails to sync to Planning description_text

### DIFF
--- a/server/features/event_sync_to_planning.feature
+++ b/server/features/event_sync_to_planning.feature
@@ -10,7 +10,8 @@ Feature: Sync Event metadata To Planning
                 "name": {"enabled": true},
                 "slugline": {"enabled": true},
                 "ednote": {"enabled": true},
-                "anpa_category": {"enabled": true}
+                "anpa_category": {"enabled": true},
+                "definition_short": {"enabled": true}
             },
             "schema": {
                 "language": {
@@ -20,7 +21,8 @@ Feature: Sync Event metadata To Planning
                     "required": true
                 },
                 "name": {"multilingual": true},
-                "slugline": {"multilingual": true}
+                "slugline": {"multilingual": true},
+                "definition_short": {"multilingual": true}
             }
         }, {
             "_id": "planing",
@@ -30,7 +32,8 @@ Feature: Sync Event metadata To Planning
                 "name": {"enabled": true},
                 "slugline": {"enabled": true},
                 "ednote": {"enabled": true},
-                "anpa_category": {"enabled": true}
+                "anpa_category": {"enabled": true},
+                "description_text": {"enabled": true}
             },
             "schema": {
                 "language": {
@@ -40,7 +43,8 @@ Feature: Sync Event metadata To Planning
                     "required": true
                 },
                 "name": {"multilingual": true},
-                "slugline": {"multilingual": true}
+                "slugline": {"multilingual": true},
+                "description_text": {"multilingual": true}
             }
         }, {
             "_id": "coverage",
@@ -275,6 +279,148 @@ Feature: Sync Event metadata To Planning
                     "g2_content_type": "text",
                     "language": "nl",
                     "slugline": "slugline-nl-2",
+                    "ednote": "event editorial note"
+                }
+            }]
+        }
+        """
+
+    @auth
+    @vocabulary
+    Scenario: Sync Event multilingual fields to Planning
+        Given config update
+        """
+        {"SYNC_EVENT_FIELDS_TO_PLANNING": ["slugline", "name", "definition_short", "language"]}
+        """
+        When we post to "/events"
+        """
+        [{
+            "guid": "event1",
+            "slugline": "slugline-nl",
+            "name": "name-nl",
+            "definition_short": "desc-nl",
+            "ednote": "event editorial note",
+            "dates": {
+                "start": "2029-11-21T12:00:00+0000",
+                "end": "2029-11-21T14:00:00+0000",
+                "tz": "Australia/Sydney"
+            },
+            "language": "nl",
+            "languages": ["nl", "fr"],
+            "translations": [
+                {"field": "name", "language": "nl", "value": "name-nl"},
+                {"field": "name", "language": "fr", "value": "name-fr"},
+                {"field": "slugline", "language": "nl", "value": "slugline-nl"},
+                {"field": "slugline", "language": "fr", "value": "slugline-fr"},
+                {"field": "definition_short", "language": "nl", "value": "desc-nl"},
+                {"field": "definition_short", "language": "fr", "value": "desc-fr"}
+            ],
+            "embedded_planning": [{
+                "coverages": [{
+                    "g2_content_type": "text",
+                    "language": "nl",
+                    "news_coverage_status": "ncostat:int",
+                    "scheduled": "2029-11-21T15:00:00+0000"
+                }, {
+                    "g2_content_type": "text",
+                    "language": "fr",
+                    "news_coverage_status": "ncostat:onreq",
+                    "scheduled": "2029-11-21T16:00:00+0000"
+                }]
+            }]
+        }]
+        """
+        Then we get OK response
+        And we store "EVENT_ID" with value "#events._id#" to context
+        When we get "/events_planning_search?repo=planning&only_future=false&event_item=event1"
+        Then we get list with 1 items
+        """
+        {"_items": [{
+            "slugline": "slugline-nl",
+            "name": "name-nl",
+            "description_text": "desc-nl",
+            "ednote": "event editorial note",
+            "language": "nl",
+            "languages": ["nl", "fr"],
+            "translations": [
+                {"field": "name", "language": "nl", "value": "name-nl"},
+                {"field": "name", "language": "fr", "value": "name-fr"},
+                {"field": "slugline", "language": "nl", "value": "slugline-nl"},
+                {"field": "slugline", "language": "fr", "value": "slugline-fr"},
+                {"field": "description_text", "language": "nl", "value": "desc-nl"},
+                {"field": "description_text", "language": "fr", "value": "desc-fr"}
+            ],
+            "coverages": [{
+                "news_coverage_status": {"qcode": "ncostat:int"},
+                "planning": {
+                    "g2_content_type": "text",
+                    "language": "nl",
+                    "slugline": "slugline-nl",
+                    "ednote": "event editorial note"
+                }
+            }, {
+                "news_coverage_status": {"qcode": "ncostat:onreq"},
+                "planning": {
+                    "g2_content_type": "text",
+                    "language": "fr",
+                    "slugline": "slugline-fr",
+                    "ednote": "event editorial note"
+                }
+            }]
+        }]}
+        """
+        And we store "PLAN1" with first item
+        And we store coverage id in "COVERAGE1_ID" from plan 0 coverage 0
+        And we store coverage id in "COVERAGE2_ID" from plan 0 coverage 1
+
+        When we patch "/events/#EVENT_ID#"
+        """
+        {
+            "slugline": "slugline-nl-2",
+            "name": "name-nl-2",
+            "ednote": "event editorial note 2",
+            "languages": ["nl", "fr"],
+            "translations": [
+                {"field": "name", "language": "nl", "value": "name-nl-2"},
+                {"field": "name", "language": "fr", "value": "name-fr-2"},
+                {"field": "slugline", "language": "nl", "value": "slugline-nl-2"},
+                {"field": "slugline", "language": "fr", "value": "slugline-fr-2"},
+                {"field": "definition_short", "language": "nl", "value": "desc-nl-2"},
+                {"field": "definition_short", "language": "fr", "value": "desc-fr-2"}
+            ]
+        }
+        """
+        Then we get OK response
+        When we get "/planning/#PLAN1._id#"
+        Then we get existing resource
+        """
+        {
+            "_id": "#PLAN1._id#",
+            "languages": ["nl", "fr"],
+            "translations": [
+                {"field": "name", "language": "nl", "value": "name-nl-2"},
+                {"field": "name", "language": "fr", "value": "name-fr-2"},
+                {"field": "slugline", "language": "nl", "value": "slugline-nl-2"},
+                {"field": "slugline", "language": "fr", "value": "slugline-fr-2"},
+                {"field": "description_text", "language": "nl", "value": "desc-nl-2"},
+                {"field": "description_text", "language": "fr", "value": "desc-fr-2"}
+            ],
+            "coverages": [{
+                "coverage_id": "#COVERAGE1_ID#",
+                "news_coverage_status": {"qcode": "ncostat:int"},
+                "planning": {
+                    "g2_content_type": "text",
+                    "language": "nl",
+                    "slugline": "slugline-nl-2",
+                    "ednote": "event editorial note"
+                }
+            }, {
+                "coverage_id": "#COVERAGE2_ID#",
+                "news_coverage_status": {"qcode": "ncostat:onreq"},
+                "planning": {
+                    "g2_content_type": "text",
+                    "language": "fr",
+                    "slugline": "slugline-fr-2",
                     "ednote": "event editorial note"
                 }
             }]

--- a/server/planning/events/events_sync/__init__.py
+++ b/server/planning/events/events_sync/__init__.py
@@ -37,6 +37,26 @@ def get_translated_fields(translations: List[StringFieldTranslation]) -> Dict[st
     return fields
 
 
+def _field_in_updates(updates: dict, field: str) -> bool:
+    """
+    Determines if a specified field exists in the updates dictionary or among translated fields.
+
+    Checks if the given field is either directly present in the dictionary or indirectly
+    present in the list of translated fields within the dictionary.
+
+    :param updates: A dictionary containing update information.
+                    It may include a list of translated fields under the key 'translations'.
+    :param field: The name of the field to search for within the updates dictionary or the translated fields.
+    :return: True if the specified field exists in the updates dictionary or among the translated fields; otherwise, False.
+    """
+
+    if field in updates:
+        return True
+
+    translated_fields = set([item.get("field") for item in updates.get("translations") or []])
+    return field in translated_fields
+
+
 def sync_event_metadata_with_planning_items(
     original: Optional[Event], updates: Event, embedded_planning: List[EmbeddedPlanning]
 ):
@@ -81,7 +101,7 @@ def sync_event_metadata_with_planning_items(
 
     planning_service = get_resource_service("planning")
     sync_fields_config = get_config_event_fields_to_sync_with_planning()
-    sync_fields = set(field for field in sync_fields_config if field in updates)
+    sync_fields = set(field for field in sync_fields_config if _field_in_updates(updates, field))
 
     if not len(sync_fields):
         # There are no fields to sync with the Event

--- a/server/planning/events/events_sync/planning_sync.py
+++ b/server/planning/events/events_sync/planning_sync.py
@@ -34,6 +34,10 @@ def get_normalised_field_value(item, field):
         return value
 
 
+def _get_planning_field_from_event(field: str) -> str:
+    return "description_text" if field == "definition_short" else field
+
+
 def _sync_planning_field(sync_data: SyncData, field: str):
     original_value_normalised = get_normalised_field_value(sync_data.event.original, field)
     updated_value_normalised = get_normalised_field_value(sync_data.event.updates, field)
@@ -43,7 +47,7 @@ def _sync_planning_field(sync_data: SyncData, field: str):
         return
 
     planning_value_normalised = get_normalised_field_value(
-        sync_data.planning.original, "description_text" if field == "definition_short" else field
+        sync_data.planning.original, _get_planning_field_from_event(field)
     )
 
     if planning_value_normalised != original_value_normalised:
@@ -62,10 +66,11 @@ def _sync_planning_field(sync_data: SyncData, field: str):
 
 
 def _sync_planning_multilingual_field(sync_data: SyncData, field: str, profiles: AllContentProfileData):
+    planning_field = _get_planning_field_from_event(field)
     if (
         field not in sync_data.event.updated_translations
         or field not in profiles.events.multilingual_fields
-        or field not in profiles.planning.multilingual_fields
+        or planning_field not in profiles.planning.multilingual_fields
     ):
         return
 
@@ -76,15 +81,14 @@ def _sync_planning_multilingual_field(sync_data: SyncData, field: str, profiles:
             original_value = ""
 
         try:
-            planning_value = sync_data.planning.original_translations[field][language]
+            planning_value = sync_data.planning.original_translations[planning_field][language]
         except KeyError:
             planning_value = ""
 
         if original_value == updated_value or planning_value != original_value:
             continue
 
-        sync_data.planning.updated_translations.setdefault(field, {})
-        sync_data.planning.updated_translations[field][language] = updated_value
+        sync_data.planning.updated_translations.setdefault(planning_field, {})[language] = updated_value
         sync_data.update_translations = True
 
 


### PR DESCRIPTION
### Purpose
The the Event `definition_short`  fails to sync to Planning `description_text` if the fields are multilingual.

### What has changed
* When checking which fields have changed, also check the `translations` dictionary
* When syncing the translated fields, make sure to use `description_text` instead of `definition_short` on the Planning item

Resolves: [SDBELGA-1079](https://sofab.atlassian.net/browse/SDBELGA-1079)



[SDBELGA-1079]: https://sofab.atlassian.net/browse/SDBELGA-1079?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ