### PR TITLE
[STT-1582] fix: Allow desk re-assignment if multiple_content is enabled

### DIFF
--- a/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx
+++ b/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx
@@ -3,7 +3,7 @@ import {connect} from 'react-redux';
 import {get} from 'lodash';
 import {IPlanningCoverageItem, ICoverageScheduledUpdate, ILockedItems} from '../../../interfaces';
 import {IArticle, IDesk, IUser} from 'superdesk-api';
-import {getCreator, getItemInArrayById, gettext, onEventCapture} from '../../../utils';
+import {getCreator, getItemInArrayById, gettext, onEventCapture, assignmentUtils} from '../../../utils';
 import {Item, Border, Column, Row as ListRow} from '../../UI/List';
 import {UserAvatar} from '../../../components/UserAvatar';
 import {StateLabel} from '../../StateLabel';
@@ -60,15 +60,14 @@ class CoverageFormHeaderComponent extends React.PureComponent<IProps> {
             field: this.props.field,
             value: this.props.value,
             onChange: this.props.onChange,
-            disableDeskSelection: this.props.addNewsItemToPlanning != null || (
-                this.props.value.assigned_to?.state != null
-                && ![
-                    ASSIGNMENTS.WORKFLOW_STATE.DRAFT,
-                    ASSIGNMENTS.WORKFLOW_STATE.ASSIGNED,
-                    ASSIGNMENTS.WORKFLOW_STATE.SUBMITTED,
-                ].includes(this.props.value.assigned_to.state)
+            disableDeskSelection: (
+                this.props.addNewsItemToPlanning != null
+                || !assignmentUtils.canEditDesk(this.props.value)
             ),
-            disableUserSelection: this.props.addNewsItemToPlanning != null,
+            disableUserSelection: (
+                this.props.addNewsItemToPlanning != null
+                || this.props.value.planning?.multiple_content !== true
+            ),
             priorityPrefix: 'assigned_to.',
         });
     }

--- a/client/interfaces.ts
+++ b/client/interfaces.ts
@@ -666,6 +666,7 @@ export interface ICoverageScheduledUpdate {
             name: string;
         }>;
         workflow_status_reason: string;
+        multiple_content?: false;
     };
 }
 

--- a/client/utils/assignments.ts
+++ b/client/utils/assignments.ts
@@ -11,6 +11,8 @@ import {
     IG2ContentType,
     IItemAction,
     IPlanningItem,
+    IPlanningCoverageItem,
+    ICoverageScheduledUpdate,
 } from '../interfaces';
 
 import {ASSIGNMENTS, PRIVILEGES} from '../constants';
@@ -397,12 +399,16 @@ const getAssignmentGroupsByStates = (groups, states) => {
     return groupKeys;
 };
 
-const canEditDesk = (assignment) => {
-    const state = get(assignment, 'assigned_to.state');
-
-    return state !== ASSIGNMENTS.WORKFLOW_STATE.SUBMITTED &&
-        state !== ASSIGNMENTS.WORKFLOW_STATE.IN_PROGRESS;
-};
+function canEditDesk(assignment: IAssignmentItem | IPlanningCoverageItem | ICoverageScheduledUpdate): boolean {
+    return (
+        assignment.planning?.multiple_content === true
+        || assignment.assigned_to?.state == null
+        || [
+            ASSIGNMENTS.WORKFLOW_STATE.DRAFT,
+            ASSIGNMENTS.WORKFLOW_STATE.ASSIGNED,
+        ].includes(assignment.assigned_to.state)
+    );
+}
 
 const isAssignmentLocked = (assignment, locks) =>
     !isNil(assignment) && (


### PR DESCRIPTION
### Purpose
When a Coverage/Assignment has the `multiple_content` attribute enabled, the user should be able to re-assign to another Desk when it's in progress, but this is not the case.

### What has changed
* Use common assignment util to determine if a Desk can be edited
* Update the util to include check for `multiple_content`

### Front-end checklist
- [x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [x] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [x] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)

Resolves: [STT-1582](https://sofab.atlassian.net/browse/STT-1582)



[STT-1582]: https://sofab.atlassian.net/browse/STT-1582?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ