### PR TITLE
[STT-1582] fix: Desk re-assignment allowed when multiple_content enabled

### DIFF
--- a/server/features/assignments_multi_content.feature
+++ b/server/features/assignments_multi_content.feature
@@ -649,3 +649,42 @@ Feature: Assignment with multiple linked content
         """
         {"task": {"desk": "#desks_0._id#"}}
         """
+
+    @auth
+    @vocabularies
+    Scenario: Desk re-assignment not allowed if multiple_content disabled when assignment is in progress or submitted
+        When we patch "/planning/#planning._id#"
+        """
+        {"coverages": [{
+            "coverage_id": "#COVERAGE_ID#",
+            "planning": {
+                "slugline": "test slugline",
+                "g2_content_type": "text",
+                "multiple_content": false
+            },
+            "assigned_to": {
+                "assignment_id": "#ASSIGNMENT_ID#",
+                "desk": "#desks._id#",
+                "user": "#CONTEXT_USER_ID#"
+            },
+            "news_coverage_status": {"qcode": "ncostat:int"},
+            "workflow_status": "assigned"
+        }]}
+        """
+        Then we get OK response
+
+        When we post to "/assignments/content"
+        """
+        [{"assignment_id": "#ASSIGNMENT_ID#"}]
+        """
+        Then we get OK response
+        When we get "/assignments/#ASSIGNMENT_ID#"
+        Then we get existing resource
+        """
+        {"assigned_to": {"state": "in_progress"}}
+        """
+        When we patch "/assignments/#ASSIGNMENT_ID#"
+        """
+        {"assigned_to": {"desk": "#desks_0._id#", "user": "#CONTEXT_USER_ID#"}}
+        """
+        Then we get error 400

--- a/server/planning/assignments/assignments.py
+++ b/server/planning/assignments/assignments.py
@@ -248,14 +248,16 @@ class AssignmentsService(AsyncBaseService):
             if not assigned_to.get("desk"):
                 raise SuperdeskApiError.badRequestError(message="Assignment should have a desk.")
 
-        if original.get("assigned_to", {}).get("desk") != assigned_to.get("desk"):
-            if original.get("assigned_to", {}).get("state") in [
-                ASSIGNMENT_WORKFLOW_STATE.IN_PROGRESS,
-                ASSIGNMENT_WORKFLOW_STATE.SUBMITTED,
-            ]:
-                raise SuperdeskApiError.forbiddenError(
-                    message="Assignment linked to content. Desk reassignment not allowed."
-                )
+        multi_content_disabled = not assignment_allows_multiple_content_linked(original)
+        desk_changed = original.get("assigned_to", {}).get("desk") != assigned_to.get("desk")
+        in_progress_or_submitted = original.get("assigned_to", {}).get("state") in [
+            ASSIGNMENT_WORKFLOW_STATE.IN_PROGRESS,
+            ASSIGNMENT_WORKFLOW_STATE.SUBMITTED,
+        ]
+        if multi_content_disabled and desk_changed and in_progress_or_submitted:
+            raise SuperdeskApiError.forbiddenError(
+                message="Assignment linked to content. Desk reassignment not allowed."
+            )
 
     async def validate_assignment_action(self, assignment: dict) -> None:
         if assignment.get("_to_delete"):

--- a/server/planning/assignments/assignments.py
+++ b/server/planning/assignments/assignments.py
@@ -17,7 +17,7 @@ import logging
 from bson import ObjectId
 from icalendar import Calendar, Event
 from eve.utils import ParsedRequest
-from quart_babel import lazy_gettext
+from quart_babel import lazy_gettext, gettext
 
 import superdesk
 from superdesk.eve_async.service import AsyncBaseService
@@ -256,7 +256,7 @@ class AssignmentsService(AsyncBaseService):
         ]
         if multi_content_disabled and desk_changed and in_progress_or_submitted:
             raise SuperdeskApiError.forbiddenError(
-                message="Assignment linked to content. Desk reassignment not allowed."
+                message=gettext("Assignment linked to content. Desk reassignment not allowed.")
             )
 
     async def validate_assignment_action(self, assignment: dict) -> None:


### PR DESCRIPTION
### Purpose
When attempting to change the Desk of an Assignment that is in progress, the backend raises an error. We should allow this for Assignments with the `multiple_content` enabled

### What has changed
* Check Assignment multiple_content attribute when validating desk change

Resolves: [STT-1582](https://sofab.atlassian.net/browse/STT-1582)



[STT-1582]: https://sofab.atlassian.net/browse/STT-1582?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ