### PR TITLE
[STT-1668] Clearing created date filter doesn't reset it

### DIFF
--- a/client/actions/eventsPlanning/tests/api_test.ts
+++ b/client/actions/eventsPlanning/tests/api_test.ts
@@ -82,6 +82,30 @@ describe('actions.eventsplanning.api', () => {
                 })
                 .catch(done.fail);
         });
+
+        it('cleared created date does not fall back to nested advancedSearch value', (done) => {
+            const params = {
+                created_start_date: null,
+                created_end_date: null,
+                advancedSearch: {
+                    created_start_date: moment('2026-04-09T00:00:00+0000'),
+                    created_end_date: moment('2026-04-09T23:59:59+0000'),
+                },
+            };
+
+            store.test(done, eventsPlanningApi.query(params))
+                .then(() => {
+                    expect(planningApis.combined.search.callCount).toBe(1);
+
+                    const request = planningApis.combined.search.args[0][0];
+
+                    expect(request.created_start_date).toBeNull();
+                    expect(request.created_end_date).toBeNull();
+
+                    done();
+                })
+                .catch(done.fail);
+        });
     });
 
     describe('refetch', () => {

--- a/client/api/search.ts
+++ b/client/api/search.ts
@@ -31,8 +31,12 @@ export function arrayToString(items?: Array<string | number>): string {
 }
 
 export function convertCommonParams(params: ISearchParams): Partial<ISearchAPIParams> {
-    const createdStartDate = params.created_start_date ?? params.advancedSearch?.created_start_date;
-    const createdEndDate = params.created_end_date ?? params.advancedSearch?.created_end_date;
+    const createdStartDate = params.created_start_date !== undefined ?
+        params.created_start_date :
+        params.advancedSearch?.created_start_date;
+    const createdEndDate = params.created_end_date !== undefined ?
+        params.created_end_date :
+        params.advancedSearch?.created_end_date;
 
     return {
         item_ids: arrayToString(params.item_ids),

--- a/client/interfaces.ts
+++ b/client/interfaces.ts
@@ -1438,6 +1438,7 @@ export interface IFormAutosave {
 
 export interface ISearchParams {
     ednote?: string;
+    advancedSearch?: ICommonAdvancedSearchParams;
     // Common Params
     item_ids?: Array<string>;
     name?: string;

--- a/client/utils/search.ts
+++ b/client/utils/search.ts
@@ -17,8 +17,12 @@ import {getTimeZoneOffset, timeUtils} from './index';
 import {appConfig} from 'appConfig';
 
 function commonParamsToSearchParams(params: ICommonSearchParams<IEventOrPlanningItem>): ISearchParams {
-    const createdStartDate = params.created_start_date ?? params.advancedSearch?.created_start_date;
-    const createdEndDate = params.created_end_date ?? params.advancedSearch?.created_end_date;
+    const createdStartDate = params.created_start_date !== undefined ?
+        params.created_start_date :
+        params.advancedSearch?.created_start_date;
+    const createdEndDate = params.created_end_date !== undefined ?
+        params.created_end_date :
+        params.advancedSearch?.created_end_date;
 
     return {
         item_ids: params.itemIds,
@@ -57,8 +61,12 @@ function commonParamsToSearchParams(params: ICommonSearchParams<IEventOrPlanning
 }
 
 function searchParamsToCommonParams(params: ISearchParams): ICommonSearchParams<IEventOrPlanningItem> {
-    const createdStartDate = params.created_start_date != undefined ? moment(params.created_start_date) : undefined;
-    const createdEndDate = params.created_end_date != undefined ? moment(params.created_end_date) : undefined;
+    const createdStartDate = params.created_start_date !== undefined ?
+        params.created_start_date :
+        params.advancedSearch?.created_start_date;
+    const createdEndDate = params.created_end_date !== undefined ?
+        params.created_end_date :
+        params.advancedSearch?.created_end_date;
 
     return {
         itemIds: params.item_ids,


### PR DESCRIPTION
### Purpose
Fix created-date filtering so clearing using the "X" button on the filter does not keep reusing the previously selected dates in the next search request.

### What has changed
- Updated search to treat an explicit null created date as a real cleared value instead of the fallback.
- Added a regression test

### Steps to test
1. Open the Events/Planning search panel.
2. Set a created date range and confirm the request includes created_start_date / created_end_date.
3. Clear both created date fields using the X buttons. Alternatively you can use the "Clear" button in the advanced filter section or the "Clear filters" button in the navigation 
4. Click Search again.
5. Verify the request no longer reuses the old created date range and results reflect the cleared filter state.

Resolves: #[STT-1668](https://sofab.atlassian.net/browse/STT-1668)


[STT-1668]: https://sofab.atlassian.net/browse/STT-1668?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ