### PR TITLE
[SDBELGA-1079] fix: Copy translated field value to root level field

### DIFF
--- a/server/features/event_sync_to_planning.feature
+++ b/server/features/event_sync_to_planning.feature
@@ -73,8 +73,6 @@ Feature: Sync Event metadata To Planning
         """
         [{
             "guid": "event1",
-            "slugline": "slugline-en",
-            "name": "name-en",
             "ednote": "event editorial note",
             "dates": {
                 "start": "2029-11-21T12:00:00+0000",
@@ -145,8 +143,6 @@ Feature: Sync Event metadata To Planning
         When we patch "/events/#EVENT_ID#"
         """
         {
-            "slugline": "slugline-en-2",
-            "name": "name-en-2",
             "ednote": "event editorial note 2",
             "languages": ["en", "nl"],
             "anpa_category": [
@@ -245,15 +241,12 @@ Feature: Sync Event metadata To Planning
         # Now update the Event's slugline
         When we patch "/events/#EVENT_ID#"
         """
-        {
-            "slugline": "slugline-en-3",
-            "translations": [
-                {"field": "name", "language": "en", "value": "name-en-3"},
-                {"field": "name", "language": "nl", "value": "name-nl-2"},
-                {"field": "slugline", "language": "en", "value": "slugline-en-3"},
-                {"field": "slugline", "language": "nl", "value": "slugline-nl-2"}
-            ]
-        }
+        {"translations": [
+            {"field": "name", "language": "en", "value": "name-en-3"},
+            {"field": "name", "language": "nl", "value": "name-nl-2"},
+            {"field": "slugline", "language": "en", "value": "slugline-en-3"},
+            {"field": "slugline", "language": "nl", "value": "slugline-nl-2"}
+        ]}
         """
         Then we get OK response
         # Now make sure the 1st Coverage's slugline does not change
@@ -296,9 +289,6 @@ Feature: Sync Event metadata To Planning
         """
         [{
             "guid": "event1",
-            "slugline": "slugline-nl",
-            "name": "name-nl",
-            "definition_short": "desc-nl",
             "ednote": "event editorial note",
             "dates": {
                 "start": "2029-11-21T12:00:00+0000",
@@ -375,20 +365,14 @@ Feature: Sync Event metadata To Planning
 
         When we patch "/events/#EVENT_ID#"
         """
-        {
-            "slugline": "slugline-nl-2",
-            "name": "name-nl-2",
-            "ednote": "event editorial note 2",
-            "languages": ["nl", "fr"],
-            "translations": [
-                {"field": "name", "language": "nl", "value": "name-nl-2"},
-                {"field": "name", "language": "fr", "value": "name-fr-2"},
-                {"field": "slugline", "language": "nl", "value": "slugline-nl-2"},
-                {"field": "slugline", "language": "fr", "value": "slugline-fr-2"},
-                {"field": "definition_short", "language": "nl", "value": "desc-nl-2"},
-                {"field": "definition_short", "language": "fr", "value": "desc-fr-2"}
-            ]
-        }
+        {"translations": [
+            {"field": "name", "language": "nl", "value": "name-nl-2"},
+            {"field": "name", "language": "fr", "value": "name-fr-2"},
+            {"field": "slugline", "language": "nl", "value": "slugline-nl-2"},
+            {"field": "slugline", "language": "fr", "value": "slugline-fr-2"},
+            {"field": "definition_short", "language": "nl", "value": "desc-nl-2"},
+            {"field": "definition_short", "language": "fr", "value": "desc-fr-2"}
+        ]}
         """
         Then we get OK response
         When we get "/planning/#PLAN1._id#"
@@ -396,6 +380,9 @@ Feature: Sync Event metadata To Planning
         """
         {
             "_id": "#PLAN1._id#",
+            "slugline": "slugline-nl-2",
+            "name": "name-nl-2",
+            "description_text": "desc-nl-2",
             "languages": ["nl", "fr"],
             "translations": [
                 {"field": "name", "language": "nl", "value": "name-nl-2"},
@@ -426,3 +413,11 @@ Feature: Sync Event metadata To Planning
             }]
         }
         """
+        # Make sure we can lock the Planning and create an autosave from it
+        When we post to "/planning/#PLAN1._id#/lock"
+        """
+        {"lock_action": "edit"}
+        """
+        Then we store response in "PLAN1"
+        When we create "planning" autosave from context item "PLAN1"
+        Then we get OK response

--- a/server/planning/common.py
+++ b/server/planning/common.py
@@ -893,4 +893,4 @@ def copy_translated_values_to_root_level_fields(item: dict, language: str) -> No
 
     for translation in item["translations"]:
         if translation.get("language") == language:
-            item[translation["field"]] = translation["value"]
+            item.setdefault(translation["field"], translation["value"])

--- a/server/planning/common.py
+++ b/server/planning/common.py
@@ -876,3 +876,21 @@ def get_coverage_from_planning(planning_item: Planning, coverage_id: str) -> Opt
 def prepare_ingested_item_for_storage(doc: Union[Event, Planning]) -> None:
     doc.setdefault("state", "ingested")
     doc["ingest_pubstatus"] = doc.pop("pubstatus", "usable")  # pubstatus is set when posted
+
+
+def copy_translated_values_to_root_level_fields(item: dict, language: str) -> None:
+    """
+    Copies translated values from the 'translations' nested structure to the root level fields
+    in the given item. This ensures that language-specific values are set directly in
+    the item based on the provided language.
+
+    :param item: The item to update
+    :param language: The language code used to filter translations for copying to root level.
+    """
+
+    if not item.get("translations"):
+        return
+
+    for translation in item["translations"]:
+        if translation.get("language") == language:
+            item[translation["field"]] = translation["value"]

--- a/server/planning/events/events.py
+++ b/server/planning/events/events.py
@@ -69,6 +69,7 @@ from planning.common import (
     update_ingest_on_patch,
     TEMP_ID_PREFIX,
     TO_BE_CONFIRMED_FIELD,
+    copy_translated_values_to_root_level_fields,
 )
 from .events_base_service import EventsBaseService
 from .events_schema import events_schema
@@ -293,6 +294,7 @@ class EventsService(superdesk.Service):
 
             set_planning_schedule(event)
             planning_item = event.get("_planning_item")
+            copy_translated_values_to_root_level_fields(event, event["language"])
 
             # validate event
             self.validate_event(event)
@@ -545,6 +547,8 @@ class EventsService(superdesk.Service):
             new_dates = deepcopy(original["dates"])
             new_dates.update(updates["dates"])
             updates["dates"] = new_dates
+
+        copy_translated_values_to_root_level_fields(updates, updates.get("language", original.get("language")))
 
         # validate event
         self.validate_event(updates, original)

--- a/server/planning/planning/planning.py
+++ b/server/planning/planning/planning.py
@@ -62,6 +62,7 @@ from planning.common import (
     UPDATE_FUTURE,
     UPDATE_ALL,
     POST_STATE,
+    copy_translated_values_to_root_level_fields,
 )
 from superdesk.utc import utcnow
 from itertools import chain
@@ -170,6 +171,8 @@ class PlanningService(superdesk.Service):
             self.set_planning_schedule(doc)
             # set timestamps
             update_dates_for(doc)
+
+            copy_translated_values_to_root_level_fields(doc, doc["language"])
 
             is_ingested = doc["state"] == "ingested"
             if is_ingested:
@@ -289,6 +292,7 @@ class PlanningService(superdesk.Service):
 
         self._set_coverage(updates, original)
         self.set_planning_schedule(updates, original)
+        copy_translated_values_to_root_level_fields(updates, updates.get("language", original.get("language")))
 
         if update_method and update_method != UPDATE_SINGLE:
             self._update_recurring_planning_items(updates, original, update_method)


### PR DESCRIPTION
### Purpose
There is code in the front-end that copies the translated fields to the parent level field with the same name. This is so the item validates against the schema, so formatters continue to work without change etc.

We never had this on the back-end, and causes issues when we manipulate those translations (such as copying from Event to Planning). This was causing schema validation errors after that sync happened.

### What has changed
* Create a new function that copies the translated fields to the parent level
* Run this function for Events & Planning on their `on_create` | `on_update` methods, so these are saved into the DB (and used for sync later).
* Remove the parent level fields from the request body in the behave tests
* Add test for creating Planning autosave after Event to Planning sync

Resolves: [SDBELGA-1079](https://sofab.atlassian.net/browse/SDBELGA-1079)



[SDBELGA-1079]: https://sofab.atlassian.net/browse/SDBELGA-1079?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ