### PR TITLE
[SDESK-7901] Fix datepicker popup clipped in Manage Events & Planning Filters modal

### DIFF
--- a/client/components/EventsPlanningFilters/EditFilter.tsx
+++ b/client/components/EventsPlanningFilters/EditFilter.tsx
@@ -24,8 +24,6 @@ interface IState {
 }
 
 export class EditFilter extends React.Component<IEventsPlanningContentPanelProps, IState> {
-    private popupContainer: React.RefObject<HTMLDivElement>;
-
     constructor(props) {
         super(props);
         const filter = this.props.filter != null ?
@@ -39,8 +37,6 @@ export class EditFilter extends React.Component<IEventsPlanningContentPanelProps
             errors: {},
             profile: this.getProfile(filter.item_type),
         };
-
-        this.popupContainer = React.createRef();
     }
 
     getProfile = (itemType: FILTER_TYPE = FILTER_TYPE.COMBINED) => {
@@ -57,10 +53,6 @@ export class EditFilter extends React.Component<IEventsPlanningContentPanelProps
     onTypeChanged = (field: string, value: FILTER_TYPE) => {
         this.setState({profile: this.getProfile(value)});
         this.onFilterChange(field, value);
-    }
-
-    getPopupContainer = () => {
-        return this.popupContainer.current;
     }
 
     isPristine = (updates: Partial<ISearchFilter> = null) => {
@@ -216,7 +208,6 @@ export class EditFilter extends React.Component<IEventsPlanningContentPanelProps
                                 },
                                 {
                                     onChange: this.onFilterChange,
-                                    popupContainer: this.getPopupContainer,
                                     language: getUserInterfaceLanguageFromCV(),
                                     item: this.state.filter,
                                 },
@@ -238,13 +229,11 @@ export class EditFilter extends React.Component<IEventsPlanningContentPanelProps
                                 onChange={this.onParamChange}
                                 onChangeMultiple={this.onMultiParamChange}
                                 searchProfile={profile}
-                                popupContainer={this.getPopupContainer}
                                 enabledField="filter_enabled"
                             />
                         </SidePanel.ContentBlockInner>
                     </SidePanel.ContentBlock>
                 </SidePanel.Content>
-                <div ref={this.popupContainer} />
             </React.Fragment>
         );
     }


### PR DESCRIPTION
### Purpose
Remove popupContainer from EditFilter so date/time popups render to document.body via the default Portal behavior. The popupContainer div was nested inside multiple `overflow: auto/hidden` ancestors introduced when `ManageFiltersModal` switched to the `superdesk-ui-framework` Modal (PrimeReact Dialog), causing the datepicker calendar to be cut off and shifted to the right. Without a `popupContainer`, the Portal renders at the body level where the popup z-index (9000) safely exceeds the modal z-index (~1101).

<img width="794" height="750" alt="image" src="https://github.com/user-attachments/assets/56b99361-2291-4b11-b360-9d6976c8aafe" />

Resolves: [SDESK-7901]


[SDESK-7901]: https://sofab.atlassian.net/browse/SDESK-7901?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ