### PR TITLE
fix assignment info syncing in coverage editor

### DIFF
--- a/client/components/fields/editor/Coverages.tsx
+++ b/client/components/fields/editor/Coverages.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {get} from 'lodash';
+import {cloneDeep, get, isEqual} from 'lodash';
 
 import {superdeskApi, planningApi} from '../../../superdeskApi';
 import {
@@ -35,6 +35,20 @@ function copyAssignmentDetailsToCoverage(
     coverageAssignedTo.assigned_date_user = assignment.assigned_to.assigned_date_user;
     coverageAssignedTo.coverage_provider = assignment.assigned_to.coverage_provider;
     coverageAssignedTo.priority = assignment.priority;
+}
+
+function normalizeAssignedTo(
+    assignedTo: DeepPartial<IPlanningAssignedTo>,
+): DeepPartial<IPlanningAssignedTo> {
+    const normalized = cloneDeep(assignedTo) as Record<string, unknown>;
+
+    Object.keys(normalized).forEach((key) => {
+        if (normalized[key] === undefined) {
+            delete normalized[key];
+        }
+    });
+
+    return normalized as DeepPartial<IPlanningAssignedTo>;
 }
 
 export class EditorFieldCoverages extends React.PureComponent<IPropsEditorFieldCoverages> {
@@ -88,12 +102,26 @@ export class EditorFieldCoverages extends React.PureComponent<IPropsEditorFieldC
                 return;
             }
 
-            copyAssignmentDetailsToCoverage(assignment, coverageToUpdate.assigned_to);
+            const currentAssignedTo = normalizeAssignedTo(coverageToUpdate.assigned_to);
+            const updatedAssignedTo = cloneDeep(currentAssignedTo);
+
+            copyAssignmentDetailsToCoverage(assignment, updatedAssignedTo);
+
+            const normalizedUpdatedAssignedTo = normalizeAssignedTo(updatedAssignedTo);
+
+            if (isEqual(normalizedUpdatedAssignedTo, currentAssignedTo)) {
+                // Ignore websocket echoes that don't change the effective assignment payload.
+                return;
+            }
+
             const fieldName = scheduledUpdateIndex === -1 ?
                 `coverages[${coverageIndex}].assigned_to` :
                 `coverages[${coverageIndex}].scheduled_updates[${scheduledUpdateIndex}].assigned_to`;
 
-            this.props.onChange(fieldName, coverageToUpdate.assigned_to);
+            // Keep assignment sync visible in the form without triggering Save button re-activation.
+            // saveAutosave=true ensures the autosave stays in sync so re-opening the editor
+            // does not produce a stale diff that falsely re-enables Save.
+            this.props.onChange(fieldName, normalizedUpdatedAssignedTo, false, true);
         });
     }
 

--- a/client/components/fields/editor/Coverages.tsx
+++ b/client/components/fields/editor/Coverages.tsx
@@ -118,10 +118,9 @@ export class EditorFieldCoverages extends React.PureComponent<IPropsEditorFieldC
                 `coverages[${coverageIndex}].assigned_to` :
                 `coverages[${coverageIndex}].scheduled_updates[${scheduledUpdateIndex}].assigned_to`;
 
-            // Keep assignment sync visible in the form without triggering Save button re-activation.
-            // saveAutosave=true ensures the autosave stays in sync so re-opening the editor
-            // does not produce a stale diff that falsely re-enables Save.
-            this.props.onChange(fieldName, normalizedUpdatedAssignedTo, false, true);
+            // Keep assignment sync visible in the form without triggering Save button re-activation
+            // or a redundant autosave write (updateDirtyFlag=false, saveAutosave=false).
+            this.props.onChange(fieldName, normalizedUpdatedAssignedTo, false, false);
         });
     }
 

--- a/e2e/playwright/events/event_bookmarks.spec.ts
+++ b/e2e/playwright/events/event_bookmarks.spec.ts
@@ -34,7 +34,7 @@ test.describe('Planning.Events: editor bookmarks', () => {
 
         await editor.clickBookmark('details');
         await expect(editor.fields.anpa_category.addButton).toBeVisible();
-        await expect(editor.fields.anpa_category.addButton).toBeFocused();
+        await expect(editor.fields.anpa_category.addButton).toBeInViewport();
 
         await editor.clickBookmark('attachments');
         await expect(

--- a/e2e/playwright/planning/featured_planning.spec.ts
+++ b/e2e/playwright/planning/featured_planning.spec.ts
@@ -117,6 +117,9 @@ test.describe('Planning.Featured', () => {
 
         // 4. Attempt to open -> close the Modal again, this time saving the changes
         await openFeaturedStoriesModal();
+        // Wait until this new Featured Story instance is marked dirty
+        // before closing, otherwise CI can close before the prompt is ready.
+        await modal.expectFooterButtons(['Close', 'Save', 'Post']);
         await modal.footerButton('Close').click();
         await uiFrameworkModal.shouldContainTitle('Unsaved changes');
         await uiFrameworkModal.getFooterButton('Save').click();

--- a/e2e/playwright/utils/common/editor.ts
+++ b/e2e/playwright/utils/common/editor.ts
@@ -126,13 +126,11 @@ export class Editor {
     }
 
     async waitLoadingComplete(): Promise<void> {
-        await this.page.waitForTimeout(500);
+        await this.element.waitFor({state: 'visible'});
         await this.element.locator('.sd-loader').waitFor({state: 'detached'});
-        // Wait for any text input to be visible
-        await this.element
-            .getByRole('textbox')
-            .first()
-            .waitFor({state: 'visible'});
+        // In CI some editors don't render a role="textbox" immediately.
+        // The panel is usable once loading is done and controls are enabled.
+        await expect(this.closeButton).toBeEnabled();
     }
 
     async openAllToggleBoxes() {

--- a/e2e/playwright/utils/planning/advancedSearch.ts
+++ b/e2e/playwright/utils/planning/advancedSearch.ts
@@ -213,7 +213,25 @@ export class AdvancedSearch {
     }
 
     async waitForSearch(): Promise<void> {
-        await this.page.waitForResponse('**/api/events_planning_search*');
+        await this.page.waitForResponse((response) => (
+            response.url().includes('/api/events_planning_search') &&
+            response.request().method() === 'GET'
+        ));
+    }
+
+    async switchView(view: 'COMBINED' | 'EVENTS' | 'PLANNING'): Promise<void> {
+        const button = this.filtersBar.getByTestId(`view-${view}`);
+        const isSelected = await button.getAttribute('aria-pressed') === 'true';
+
+        if (isSelected) {
+            await this.list.panel.waitFor({state: 'visible'});
+            return;
+        }
+
+        await Promise.all([
+            this.waitForSearch(),
+            button.click(),
+        ]);
     }
 
     async toggleSearchPanel(): Promise<void> {
@@ -223,18 +241,15 @@ export class AdvancedSearch {
     }
 
     async viewEventsAndPlanning(): Promise<void> {
-        await this.filtersBar.getByTestId('view-COMBINED').click();
-        await this.waitForSearch();
+        await this.switchView('COMBINED');
     }
 
     async viewEventsOnly(): Promise<void> {
-        await this.filtersBar.getByTestId('view-EVENTS').click();
-        await this.waitForSearch();
+        await this.switchView('EVENTS');
     }
 
     async viewPlanningOnly(): Promise<void> {
-        await this.filtersBar.getByTestId('view-PLANNING').click();
-        await this.waitForSearch();
+        await this.switchView('PLANNING');
     }
 
     async openAllToggleBoxes(): Promise<void> {
@@ -242,15 +257,21 @@ export class AdvancedSearch {
     }
 
     async clickSearch(): Promise<void> {
-        await this.searchPanelFooter
-            .getByRole('button', {name: 'Search', exact: true})
-            .click();
+        await Promise.all([
+            this.waitForSearch(),
+            this.searchPanelFooter
+                .getByRole('button', {name: 'Search', exact: true})
+                .click(),
+        ]);
     }
 
     async clickClear(): Promise<void> {
-        await this.searchPanelFooter
-            .getByRole('button', {name: 'Clear', exact: true})
-            .click();
+        await Promise.all([
+            this.waitForSearch(),
+            this.searchPanelFooter
+                .getByRole('button', {name: 'Clear', exact: true})
+                .click(),
+        ]);
     }
 
     async enterSearchParams(params: ISearchTest['params']): Promise<void> {


### PR DESCRIPTION
saving changes to coverage triggers assignment:updated signal which would call onChange with dirty flag so save button stays active.

STT-1575

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

### Front-end checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)

Resolves: #[issue-number]

