### PR TITLE
Fix: Add focus method to EditorFieldTreeSelect for bookmark navigation

### DIFF
--- a/client/components/fields/editor/base/treeSelect.tsx
+++ b/client/components/fields/editor/base/treeSelect.tsx
@@ -34,6 +34,8 @@ export interface IEditorFieldTreeSelectProps<T = any, IItem = any> extends IEdit
 }
 
 export class EditorFieldTreeSelect<T> extends React.PureComponent<IEditorFieldTreeSelectProps<T>> {
+    private rowRef: React.RefObject<HTMLDivElement>;
+
     static defaultProps = {
         defaultValue: [],
     }
@@ -41,7 +43,13 @@ export class EditorFieldTreeSelect<T> extends React.PureComponent<IEditorFieldTr
     constructor(props: IEditorFieldTreeSelectProps) {
         super(props);
 
+        this.rowRef = React.createRef();
         this.onChange = this.onChange.bind(this);
+    }
+
+    // TODO: Replace with a public focus() method on the UIFramework's TreeSelect component
+    focus() {
+        this.rowRef.current?.querySelector<HTMLButtonElement>('button')?.focus();
     }
 
     onChange(values: Array<any>) {
@@ -102,7 +110,7 @@ export class EditorFieldTreeSelect<T> extends React.PureComponent<IEditorFieldTr
         const error = get(this.props.errors ?? {}, field);
 
         return (
-            <Row testId={this.props.testId} smallPadding={this.props.smallPadding}>
+            <Row testId={this.props.testId} smallPadding={this.props.smallPadding} refNode={this.rowRef}>
                 <TreeSelect
                     kind="synchronous"
                     value={this.getViewValue()}


### PR DESCRIPTION
### Purpose
PR #2818 replaced `EditorFieldCategories` with `EditorFieldTreeSelect` for the `anpa_category` field. `SelectMetaTermsInput` had a `focus()` method that EditorGroup relied on to focus the first field when clicking editor bookmarks. `EditorFieldTreeSelect` was missing this method, causing the "details" bookmark to not focus the `anpa_category` button.

Since then, E2E tests were failing with the error below. This PR fixes the problem. 

```typescript
1) [chromium] › playwright/events/event_bookmarks.spec.ts:19:9 › Planning.Events: editor bookmarks › can scroll to each bookmark 

    Error: expect(locator).toBeFocused() failed

    Locator:  locator('.sd-edit-panel').locator('[data-test-id="field-anpa_category"] button')
    Expected: focused
    Received: inactive
    Timeout:  10000ms

    Call log:
      - Expect "toBeFocused" with timeout 10000ms
      - waiting for locator('.sd-edit-panel').locator('[data-test-id="field-anpa_category"] button')
        14 × locator resolved to <button class="tags-input__overlay-button"></button>
           - unexpected value "inactive"


      35 |         await editor.clickBookmark('details');
      36 |         await expect(editor.fields.anpa_category.addButton).toBeVisible();
    > 37 |         await expect(editor.fields.anpa_category.addButton).toBeFocused();
         |                                                             ^
      38 |
      39 |         await editor.clickBookmark('attachments');
      40 |         await expect(
        at /home/runner/work/superdesk-planning/superdesk-planning/e2e/playwright/events/event_bookmarks.spec.ts:37:61
```

Reference broken build https://github.com/superdesk/superdesk-planning/actions/runs/25153687903/job/73730053810
