### PR TITLE
[SDESK-7908] Add to Planning - Open Coverage hyperlink is not clickable

### DIFF
--- a/client/apps/Planning/AddToPlanningUi.tsx
+++ b/client/apps/Planning/AddToPlanningUi.tsx
@@ -42,6 +42,7 @@ export class AddToPlanningUi extends React.PureComponent<IProps> {
                     withArchiveItem: true,
                     archiveItem: addNewsItemToPlanning,
                     createPlanningOnly: true,
+                    hideOpenCoverageAction: true,
                 }}
 
                 ListPanel={PlanningList}

--- a/client/apps/Planning/PlanningSubNav.tsx
+++ b/client/apps/Planning/PlanningSubNav.tsx
@@ -19,6 +19,7 @@ import {appConfig} from 'appConfig';
 
 interface IProps extends ISubNavPanelProps {
     withArchiveItem?: boolean;
+    hideOpenCoverageAction?: boolean;
     archiveItem?: IArticle
     fullText?: string;
     currentView?: PLANNING_VIEW;
@@ -108,7 +109,10 @@ export class PlanningSubNavComponent extends React.PureComponent<IProps> {
         return (
             <React.Fragment>
                 {this.props.withArchiveItem !== true ? null : (
-                    <ArchiveItem item={this.props.archiveItem} />
+                    <ArchiveItem
+                        item={this.props.archiveItem}
+                        hideOpenCoverageAction={this.props.hideOpenCoverageAction}
+                    />
                 )}
                 <SubNav>
                     <MultiSelectActions />

--- a/client/components/Archive/ArchiveItem.tsx
+++ b/client/components/Archive/ArchiveItem.tsx
@@ -16,11 +16,20 @@ interface IProps {
     urgencies: any;
     urgencyLabel: any;
     use2Lines?: boolean;
+    hideOpenCoverageAction?: boolean;
     onClick?(): void;
     onDoubleClick?(): void;
 }
 
-export function ArchiveItemComponent({item, urgencies, urgencyLabel, use2Lines, onClick, onDoubleClick}: IProps) {
+export function ArchiveItemComponent({
+    item,
+    urgencies,
+    urgencyLabel,
+    use2Lines,
+    hideOpenCoverageAction,
+    onClick,
+    onDoubleClick,
+}: IProps) {
     const {gettext} = superdeskApi.localization;
     const stateProps: Label['props'] = ['PUBLISHED', 'SCHEDULED', 'CORRECTED'].includes(item.state) ? {
         type: 'success',
@@ -37,7 +46,7 @@ export function ArchiveItemComponent({item, urgencies, urgencyLabel, use2Lines, 
             onClick={onClick}
             onDoubleClick={onDoubleClick}
             locked={item.lock_action != null}
-            action={(
+            action={hideOpenCoverageAction === true ? null : (
                 <IconButton
                     icon="external"
                     ariaValue={gettext('Open Coverage')}


### PR DESCRIPTION
### Purpose
This PR hides the "Open Coverage" action from the component list item in the Add to Planning modal. 

### What has changed
- Added an optional `hideOpenCoverageAction` prop to ArchiveItem and passed that flag through the PlanningSubNav. 
- Enabled the flag only from `AddToPlanningUi`
- Left the Open Coverage action unchanged in the Assignments and archive preview flows

### Steps to test
1. Open an authoring item and choose Add to Planning from the 3-dot menu.
2. Confirm the Open Coverage button is no longer shown in item in the modal.

### Screenshots
<img width="1019" height="167" alt="2026-05-04_18-36-58" src="https://github.com/user-attachments/assets/c334d7aa-3b3f-46ca-b001-2095e9dcd722" />


Resolves: #[SDESK-7908](https://sofab.atlassian.net/browse/SDESK-7908)



[SDESK-7908]: https://sofab.atlassian.net/browse/SDESK-7908?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ