### PR TITLE
[SDESK-7907] Localize user-facing strings with gettext

### DIFF
--- a/client/actions/agenda.ts
+++ b/client/actions/agenda.ts
@@ -40,7 +40,7 @@ const createOrUpdateAgenda = (newAgenda) => (
 
         return api('agenda').save(originalAgenda, diff)
             .then((agenda) => {
-                notify.success('The agenda has been created/updated.');
+                notify.success(gettext('The agenda has been created/updated.'));
                 dispatch(addOrReplaceAgenda(agenda));
             }, (error) => {
                 let errorMessage = get(error, 'data._issues.name.unique') ?
@@ -368,7 +368,7 @@ const deleteAgenda = (agenda) => (
     (dispatch, getState, {api, notify}) => (
         api('agenda').remove(agenda)
             .then(() => {
-                notify.success('The agenda has been deleted.');
+                notify.success(gettext('The agenda has been deleted.'));
             }, (error) => {
                 notify.error(getErrorMessage(
                     error,

--- a/client/actions/assignments/api.ts
+++ b/client/actions/assignments/api.ts
@@ -292,7 +292,7 @@ const loadArchiveItem = (assignment) => (
         const assignmentId = get(assignment, '_id', null);
 
         if (!assignmentId) {
-            notify.error('Incorrect Assignment');
+            notify.error(gettext('Incorrect Assignment'));
             return Promise.reject('Incorrect Assignment');
         }
 
@@ -317,7 +317,7 @@ const loadArchiveItem = (assignment) => (
                 const item = get(data, '_items[0]', null);
 
                 if (!item) {
-                    notify.error('Content item not found!');
+                    notify.error(gettext('Content item not found!'));
                     return Promise.reject('Content item not found!');
                 }
 

--- a/client/actions/assignments/ui.ts
+++ b/client/actions/assignments/ui.ts
@@ -491,7 +491,7 @@ const onFulFilAssignment = (assignment) => (
         dispatch(actions.actionInProgress(true));
         return dispatch(assignments.api.link(assignment, newsItem, reassign))
             .then((item) => {
-                notify.success('Assignment is fulfilled.');
+                notify.success(gettext('Assignment is fulfilled.'));
                 $scope.resolve();
                 dispatch(actions.actionInProgress(false));
                 return Promise.resolve(item);
@@ -512,7 +512,7 @@ function complete(item: IAssignmentItem) {
             .then((lockedItem) => {
                 dispatch(assignments.api.complete(lockedItem))
                     .then((lockedItem) => {
-                        notify.success('The assignment has been completed.');
+                        notify.success(gettext('The assignment has been completed.'));
                         return Promise.resolve(lockedItem);
                     }, (error) => {
                         notify.error(getErrorMessage(error, 'Failed to complete the assignment.'));
@@ -782,7 +782,7 @@ function removeAssignment(assignment: IAssignmentItem) {
     return (dispatch, getState, {notify}) => (
         dispatch(assignments.api.removeAssignment(assignment))
             .then(() => {
-                notify.success('Assignment removed');
+                notify.success(gettext('Assignment removed'));
                 return Promise.resolve();
             }, (error) => {
                 notify.error(

--- a/client/actions/planning/ui.ts
+++ b/client/actions/planning/ui.ts
@@ -529,7 +529,7 @@ const saveFromAuthoring = (original, updates?: Partial<IPlanningItem>) => (
 
                 return dispatch(actions.assignments.api.link(coverage.assigned_to, newsItem, reassign))
                     .then(() => {
-                        notify.success('Content linked to the planning item.');
+                        notify.success(gettext('Content linked to the planning item.'));
 
                         return Promise.resolve(newPlan);
                     })

--- a/client/apps/Planning/PlanningListSubNav.tsx
+++ b/client/apps/Planning/PlanningListSubNav.tsx
@@ -268,7 +268,7 @@ class PlanningListSubNavComponent extends React.Component<IProps, IState> {
                                 {this.state.viewSize === 'compact' ? null : (
                                     <React.Fragment>
                                         <IconButton
-                                            ariaValue="back"
+                                            ariaValue={gettext('back')}
                                             onClick={() => this.props.jumpTo('BACK')}
                                             icon="chevron-left-thin"
                                         />
@@ -281,7 +281,7 @@ class PlanningListSubNavComponent extends React.Component<IProps, IState> {
                                             onClick={() => this.props.jumpTo('TODAY')}
                                         />
                                         <IconButton
-                                            ariaValue="forward"
+                                            ariaValue={gettext('forward')}
                                             onClick={() => this.props.jumpTo('FORWARD')}
                                             icon="chevron-right-thin"
                                         />

--- a/client/components/ContentProfiles/GroupTab/index.tsx
+++ b/client/components/ContentProfiles/GroupTab/index.tsx
@@ -212,11 +212,12 @@ export class GroupTabComponent extends React.Component<IProps, IState> {
     }
 
     saveGroup() {
+        const {gettext} = superdeskApi.localization;
         const {notify} = superdeskApi.ui;
         const errors = this.validateCurrentGroup();
 
         if (Object.keys(errors).length) {
-            notify.error('Failed to save group');
+            notify.error(gettext('Failed to save group'));
         } else {
             const group = this.state.selectedGroup;
             // Make sure to not change the current index of this field

--- a/client/components/fields/editor/EventRelatedPlannings/CoverageRowForm.tsx
+++ b/client/components/fields/editor/EventRelatedPlannings/CoverageRowForm.tsx
@@ -9,6 +9,7 @@ import {
     ISearchProfile
 } from '../../../../interfaces';
 
+import {superdeskApi} from '../../../../superdeskApi';
 import {planningUtils} from '../../../../utils';
 import {getVocabularyItemFieldTranslated} from '../../../../utils/vocabularies';
 import {getUserInterfaceLanguageFromCV} from '../../../../utils/users';
@@ -79,6 +80,8 @@ export class CoverageRowForm extends React.PureComponent<IProps> {
     }
 
     render() {
+        const {gettext} = superdeskApi.localization;
+
         return (
             <div
                 data-test-id={`coverage_${this.props.index}`}
@@ -120,13 +123,13 @@ export class CoverageRowForm extends React.PureComponent<IProps> {
                         {this.props.typeCount < 2 ? null : (
                             <IconButton
                                 icon="trash"
-                                ariaValue="Remove Coverage"
+                                ariaValue={gettext('Remove Coverage')}
                                 onClick={this.remove}
                             />
                         )}
                         <IconButton
                             icon="plus-sign"
-                            ariaValue="Duplicate"
+                            ariaValue={gettext('Duplicate')}
                             onClick={this.duplicate}
                         />
                     </List.ActionMenu>

--- a/client/controllers/UnlinkAssignmentController.tsx
+++ b/client/controllers/UnlinkAssignmentController.tsx
@@ -85,7 +85,7 @@ export function UnlinkAssignmentController(
                     item_id: newsItem._id,
                 })
                     .then(() => {
-                        notify.success('Item unlinked from coverage.');
+                        notify.success(gettext('Item unlinked from coverage.'));
                         // update the scope item.
                         data.item.assignment_id = null;
 

--- a/server/planning/assignments/assignments.py
+++ b/server/planning/assignments/assignments.py
@@ -246,7 +246,7 @@ class AssignmentsService(AsyncBaseService):
         assigned_to = updates.get("assigned_to") or {}
         if (assigned_to.get("user") or assigned_to.get("contact")) and planning_auto_assign_to_workflow():
             if not assigned_to.get("desk"):
-                raise SuperdeskApiError.badRequestError(message="Assignment should have a desk.")
+                raise SuperdeskApiError.badRequestError(message=gettext("Assignment should have a desk."))
 
         multi_content_disabled = not assignment_allows_multiple_content_linked(original)
         desk_changed = original.get("assigned_to", {}).get("desk") != assigned_to.get("desk")
@@ -263,7 +263,7 @@ class AssignmentsService(AsyncBaseService):
         if assignment.get("_to_delete"):
             plan = await get_resource_service("planning").find_one_async(req=None, _id=assignment.get("planning_item"))
             state = "unposted" if (plan or {}).get("state") == WORKFLOW_STATE.KILLED else (plan or {}).get("state")
-            raise SuperdeskApiError.forbiddenError("Action failed. Related planning item is {}".format(state))
+            raise SuperdeskApiError.forbiddenError(gettext("Action failed. Related planning item is {}").format(state))
 
     def notify(self, event_name, updates, original):
         # No notifications for 'draft' assignments
@@ -1141,18 +1141,18 @@ class AssignmentsService(AsyncBaseService):
 
             delivery = await delivery_service.find_one_async(req=None, item_id=original_item[ID_FIELD])
             if not delivery:
-                raise SuperdeskApiError.badRequestError("Delivery record not found.")
+                raise SuperdeskApiError.badRequestError(gettext("Delivery record not found."))
 
             planning = await planning_service.find_one_async(req=None, _id=delivery.get("planning_id"))
             if not planning:
-                raise SuperdeskApiError.badRequestError("Planning does not exist")
+                raise SuperdeskApiError.badRequestError(gettext("Planning does not exist"))
 
             coverage = None
             coverages = planning.get("coverages") or []
             try:
                 coverage = next(c for c in coverages if c.get("coverage_id") == delivery.get("coverage_id"))
             except StopIteration:
-                raise SuperdeskApiError.badRequestError("Coverage does not exist")
+                raise SuperdeskApiError.badRequestError(gettext("Coverage does not exist"))
 
             # Link only if linking updates are enabled
             if (coverage.get("flags") or {}).get("no_content_linking"):
@@ -1169,7 +1169,7 @@ class AssignmentsService(AsyncBaseService):
 
             assignment = await self.find_one_async(req=None, _id=str(assignment_id))
             if not assignment:
-                raise SuperdeskApiError.badRequestError("Assignment not found.")
+                raise SuperdeskApiError.badRequestError(gettext("Assignment not found."))
 
             await assignment_link_service.post_async(
                 [
@@ -1227,7 +1227,7 @@ class AssignmentsService(AsyncBaseService):
             and assignment.get("lock_action") != "content_edit"
             and (assignment["lock_session"] != get_auth()["_id"] or assignment["lock_user"] != user_id)
         ):
-            raise SuperdeskApiError.badRequestError(message="Lock Failed: Related assignment is locked.")
+            raise SuperdeskApiError.badRequestError(message=gettext("Lock Failed: Related assignment is locked."))
 
     async def sync_assignment_lock(self, item, user_id):
         # If more than one archive item is associated with the assignment
@@ -1294,7 +1294,7 @@ class AssignmentsService(AsyncBaseService):
         planning_item = await planning_service.find_one_async(req=None, _id=doc.get("planning_item"))
 
         if not planning_item:
-            raise SuperdeskApiError.badRequestError(message="Failed to find Planning item.")
+            raise SuperdeskApiError.badRequestError(message=gettext("Failed to find Planning item."))
 
         # Make sure either the Assignment or Planning item is locked by this user and session
         assignment_linked_to_coverage = any(
@@ -1303,14 +1303,14 @@ class AssignmentsService(AsyncBaseService):
             if str((coverage.get("assigned_to") or {}).get("assignment_id")) == str(doc["_id"])
         )
         if assignment_linked_to_coverage and not is_locked_in_this_session(doc):
-            raise SuperdeskApiError.forbiddenError(message="Lock is not obtained on the Assignment item")
+            raise SuperdeskApiError.forbiddenError(message=gettext("Lock is not obtained on the Assignment item"))
 
         # Make sure the content linked to assignment (if) is also not locked
         # This is needed when the planing item is being unposted/spiked
         archive_items = await self.get_archive_items_for_assignment(doc)
         async for archive_item in archive_items:
             if archive_item.get("lock_user") and not is_locked_in_this_session(archive_item):
-                raise SuperdeskApiError.forbiddenError(message="Associated archive item is locked")
+                raise SuperdeskApiError.forbiddenError(message=gettext("Associated archive item is locked"))
 
         # Make sure we cannot delete a completed Assignment
         # This should not be needed, as you cannot obtain a lock on an Assignment that is completed

--- a/server/planning/assignments/assignments_complete.py
+++ b/server/planning/assignments/assignments_complete.py
@@ -11,6 +11,8 @@
 from copy import deepcopy
 
 from superdesk.resource_fields import ID_FIELD
+from quart_babel import gettext as _
+
 from superdesk import get_resource_service
 from superdesk.eve_async.service import AsyncBaseService
 from superdesk.notification import push_notification
@@ -79,9 +81,9 @@ class AssignmentsCompleteService(AsyncBaseService):
                     ASSIGNMENT_WORKFLOW_STATE.SUBMITTED,
                     ASSIGNMENT_WORKFLOW_STATE.IN_PROGRESS,
                 ]:
-                    raise SuperdeskApiError.forbiddenError("Update Assignment not in correct state.")
+                    raise SuperdeskApiError.forbiddenError(_("Update Assignment not in correct state."))
             elif not original.get("scheduled_update_id") and assignment_state != ASSIGNMENT_WORKFLOW_STATE.IN_PROGRESS:
-                raise SuperdeskApiError.forbiddenError("Assignment not in progress.")
+                raise SuperdeskApiError.forbiddenError(_("Assignment not in progress."))
         elif assignment_state not in [
             ASSIGNMENT_WORKFLOW_STATE.ASSIGNED,
             ASSIGNMENT_WORKFLOW_STATE.SUBMITTED,
@@ -95,7 +97,7 @@ class AssignmentsCompleteService(AsyncBaseService):
         # if the completion is being done by an external application then ensure that it is not locked
         if "proxy_user" in updates:
             if original.get("lock_user"):
-                raise SuperdeskApiError.forbiddenError("Assignment is locked")
+                raise SuperdeskApiError.forbiddenError(_("Assignment is locked"))
             user = updates.pop("proxy_user", None)
             proxy_user = True
         else:

--- a/server/planning/assignments/assignments_content.py
+++ b/server/planning/assignments/assignments_content.py
@@ -11,6 +11,8 @@
 from copy import deepcopy
 
 from superdesk.resource_fields import ID_FIELD, VERSION
+from quart_babel import gettext as _
+
 from superdesk.flask import request
 from superdesk import get_resource_service, Resource
 from superdesk.eve_async.service import AsyncBaseService
@@ -180,7 +182,7 @@ class AssignmentsContentService(AsyncBaseService):
                 archive_item = await self.get_latest_news_item_for_coverage(assignment)
 
                 if not archive_item:
-                    raise SuperdeskApiError.badRequestError("Archive item not found to create a rewrite.")
+                    raise SuperdeskApiError.badRequestError(_("Archive item not found to create a rewrite."))
 
                 # create a rewrite
                 request.view_args["original_id"] = archive_item.get(ID_FIELD)
@@ -282,7 +284,7 @@ class AssignmentsContentService(AsyncBaseService):
         assignment_service = get_resource_service("assignments")
         assignment = await assignment_service.find_one_async(req=None, _id=doc.get("assignment_id"))
         if not assignment:
-            raise SuperdeskApiError.badRequestError("Assignment not found.")
+            raise SuperdeskApiError.badRequestError(_("Assignment not found."))
 
         await assignment_service.validate_assignment_action(assignment)
 
@@ -292,22 +294,22 @@ class AssignmentsContentService(AsyncBaseService):
             workflow_state = ASSIGNMENT_WORKFLOW_STATE.DRAFT
 
         if workflow_state == ASSIGNMENT_WORKFLOW_STATE.DRAFT:
-            raise SuperdeskApiError.badRequestError("Cannot create content from a draft Assignment.")
+            raise SuperdeskApiError.badRequestError(_("Cannot create content from a draft Assignment."))
         elif not assignment_allows_multiple_content_linked(assignment):
             if workflow_state != ASSIGNMENT_WORKFLOW_STATE.ASSIGNED:
-                raise SuperdeskApiError.badRequestError("Assignment workflow started. Cannot create content.")
+                raise SuperdeskApiError.badRequestError(_("Assignment workflow started. Cannot create content."))
 
             delivery_service = get_resource_service("delivery")
             if await delivery_service.count_async({"assignment_id": assignment.get(ID_FIELD)}) > 0:
                 raise SuperdeskApiError.badRequestError(
-                    "Content already exists for the assignment. Cannot create content."
+                    _("Content already exists for the assignment. Cannot create content.")
                 )
         elif workflow_state not in [
             ASSIGNMENT_WORKFLOW_STATE.ASSIGNED,
             ASSIGNMENT_WORKFLOW_STATE.IN_PROGRESS,
             ASSIGNMENT_WORKFLOW_STATE.SUBMITTED,
         ]:
-            raise SuperdeskApiError.badRequestError("Assignment workflow completed. Cannot create content.")
+            raise SuperdeskApiError.badRequestError(_("Assignment workflow completed. Cannot create content."))
 
         # Handle schedule_updates validation
         if assignment.get("scheduled_update_id"):
@@ -319,7 +321,7 @@ class AssignmentsContentService(AsyncBaseService):
                 ASSIGNMENT_WORKFLOW_STATE.COMPLETED,
             ]
             if (coverage.get("assigned_to") or {}).get("state") not in allowed_states:
-                raise SuperdeskApiError.badRequestError("Coverage not linked to news item yet.")
+                raise SuperdeskApiError.badRequestError(_("Coverage not linked to news item yet."))
 
             # Since scheduled_updates are cronologically indexed, check all previous scheduled_updates
             for s in coverage.get("scheduled_updates") or []:
@@ -327,7 +329,7 @@ class AssignmentsContentService(AsyncBaseService):
                     break
 
                 if (s.get("assigned_to") or {}).get("state") not in allowed_states:
-                    raise SuperdeskApiError.badRequestError("Previous scheduled update not linked to news item yet.")
+                    raise SuperdeskApiError.badRequestError(_("Previous scheduled update not linked to news item yet."))
 
 
 class AssignmentsContentResource(Resource):

--- a/server/planning/assignments/assignments_link.py
+++ b/server/planning/assignments/assignments_link.py
@@ -158,12 +158,12 @@ class AssignmentsLinkService(AsyncBaseService):
         assignment = await get_resource_service("assignments").find_one_async(req=None, _id=doc.get("assignment_id"))
 
         if not assignment:
-            raise SuperdeskApiError.badRequestError("Assignment not found.")
+            raise SuperdeskApiError.badRequestError(_("Assignment not found."))
 
         item = await get_resource_service("archive").find_one_async(req=None, _id=doc.get("item_id"))
 
         if not item:
-            raise SuperdeskApiError.badRequestError("Content item not found.")
+            raise SuperdeskApiError.badRequestError(_("Content item not found."))
 
         if not is_content_link_to_coverage_allowed(item):
             raise SuperdeskApiError.badRequestError(
@@ -175,21 +175,23 @@ class AssignmentsLinkService(AsyncBaseService):
 
         if not doc.get("force") and item.get("assignment_id"):
             raise SuperdeskApiError.badRequestError(
-                "Content is already linked to an assignment. Cannot link assignment and content."
+                _("Content is already linked to an assignment. Cannot link assignment and content.")
             )
 
         if not is_assigned_to_a_desk(item):
-            raise SuperdeskApiError.badRequestError("Content not in workflow. Cannot link assignment and content.")
+            raise SuperdeskApiError.badRequestError(_("Content not in workflow. Cannot link assignment and content."))
 
         if not item.get("rewrite_of") and not assignment_allows_multiple_content_linked(assignment):
             if await get_resource_service("delivery").count_async({"assignment_id": doc.get("assignment_id")}) > 0:
                 raise SuperdeskApiError.badRequestError(
-                    "Content already exists for the assignment. Cannot link assignment and content."
+                    _("Content already exists for the assignment. Cannot link assignment and content.")
                 )
 
             # scheduled update validation
             if assignment.get("scheduled_update_id"):
-                raise SuperdeskApiError.badRequestError("Only updates can be linked to a scheduled update assignment")
+                raise SuperdeskApiError.badRequestError(
+                    _("Only updates can be linked to a scheduled update assignment")
+                )
 
         coverage = await get_coverage_for_assignment(assignment)
         allowed_states = [

--- a/server/planning/assignments/assignments_lock.py
+++ b/server/planning/assignments/assignments_lock.py
@@ -11,6 +11,8 @@
 import logging
 from copy import deepcopy
 
+from quart_babel import gettext as _
+
 from superdesk.resource_fields import ID_FIELD
 from superdesk.flask import request
 from superdesk import get_resource_service
@@ -76,7 +78,7 @@ class AssignmentsLockService(AsyncBaseService):
             ASSIGNMENT_WORKFLOW_STATE.ASSIGNED,
             ASSIGNMENT_WORKFLOW_STATE.COMPLETED,
         ]:
-            raise SuperdeskApiError.badRequestError(message="Assignment workflow state error.")
+            raise SuperdeskApiError.badRequestError(message=_("Assignment workflow state error."))
 
         if item.get("assigned_to").get("state") == ASSIGNMENT_WORKFLOW_STATE.IN_PROGRESS:
             archive_item = await get_resource_service("archive").find_one_async(
@@ -84,7 +86,7 @@ class AssignmentsLockService(AsyncBaseService):
             )
             if archive_item and archive_item.get("lock_user") and archive_item["lock_user"] != user_id:
                 # archive item it locked by another user
-                raise SuperdeskApiError.badRequestError(message="Archive item is locked by another user.")
+                raise SuperdeskApiError.badRequestError(message=_("Archive item is locked by another user."))
 
 
 class AssignmentsUnlockResource(Resource):

--- a/server/planning/assignments/assignments_revert.py
+++ b/server/planning/assignments/assignments_revert.py
@@ -11,6 +11,8 @@
 from copy import deepcopy
 
 from superdesk.resource_fields import ID_FIELD
+from quart_babel import gettext as _
+
 from superdesk import get_resource_service
 from superdesk.eve_async.service import AsyncBaseService
 from superdesk.notification import push_notification
@@ -52,10 +54,10 @@ class AssignmentsRevertService(AsyncBaseService):
         if not assignment_allows_multiple_content_linked(original) and await assignments_service.is_text_assignment(
             original
         ):
-            raise SuperdeskApiError.forbiddenError("Cannot revert text assignments.")
+            raise SuperdeskApiError.forbiddenError(_("Cannot revert text assignments."))
 
         if assignment_state != ASSIGNMENT_WORKFLOW_STATE.COMPLETED:
-            raise SuperdeskApiError.forbiddenError("Cannot revert an assignment which is not yet confirmed.")
+            raise SuperdeskApiError.forbiddenError(_("Cannot revert an assignment which is not yet confirmed."))
 
         updates["assigned_to"] = deepcopy(original).get("assigned_to")
         updates["assigned_to"]["revert_state"] = None

--- a/server/planning/assignments/assignments_unlink.py
+++ b/server/planning/assignments/assignments_unlink.py
@@ -7,6 +7,8 @@
 # at https://www.sourcefabric.org/superdesk/license
 from copy import deepcopy
 
+from quart_babel import gettext as _
+
 from superdesk.resource_fields import ID_FIELD
 from superdesk import Resource, get_resource_service
 from superdesk.eve_async.service import AsyncBaseService
@@ -146,7 +148,7 @@ class AssignmentsUnlinkService(AsyncBaseService):
         session_id = session.get(ID_FIELD)
 
         if not assignment:
-            raise SuperdeskApiError.badRequestError("Assignment not found.")
+            raise SuperdeskApiError.badRequestError(_("Assignment not found."))
 
         if assignment.get(LOCK_USER):
             if str(assignment.get(LOCK_USER)) != str(user_id):
@@ -165,7 +167,7 @@ class AssignmentsUnlinkService(AsyncBaseService):
         if not item:
             item = get_resource_service("archived").find_one(req=None, _id=doc.get("item_id"))
             if not item:
-                raise SuperdeskApiError.badRequestError("Content item not found.")
+                raise SuperdeskApiError.badRequestError(_("Content item not found."))
 
         # If the item is locked, then check to see if it is locked by the
         # current user in their current session
@@ -186,7 +188,7 @@ class AssignmentsUnlinkService(AsyncBaseService):
             )
 
         if str(item.get("assignment_id")) != str(assignment.get(ID_FIELD)):
-            raise SuperdeskApiError.badRequestError("Assignment and Content are not linked.")
+            raise SuperdeskApiError.badRequestError(_("Assignment and Content are not linked."))
 
         deliveries = await get_resource_service("delivery").get_async(
             req=None, lookup={"assignment_id": assignment.get(ID_FIELD)}

--- a/server/planning/autosave_service.py
+++ b/server/planning/autosave_service.py
@@ -2,6 +2,8 @@ import logging
 
 from bson import ObjectId
 
+from quart_babel import gettext as _
+
 from superdesk import get_resource_service
 from superdesk.core.resources import AsyncResourceService
 from superdesk.errors import SuperdeskApiError
@@ -38,10 +40,10 @@ class AutosaveAsyncService(AsyncResourceService):
         """Validate the autosave to ensure it contains user/session"""
 
         if not doc.lock_user:
-            raise SuperdeskApiError.badRequestError(message="Autosave failed, User not supplied")
+            raise SuperdeskApiError.badRequestError(message=_("Autosave failed, User not supplied"))
 
         if not doc.lock_session:
-            raise SuperdeskApiError.badRequestError(message="Autosave failed, User Session not supplied")
+            raise SuperdeskApiError.badRequestError(message=_("Autosave failed, User Session not supplied"))
 
 
 async def on_item_unlocked(resource: str, item: dict, user_id: ObjectId) -> None:

--- a/server/planning/common.py
+++ b/server/planning/common.py
@@ -287,7 +287,9 @@ def get_coverage_status_from_cv(qcode: str):
     coverage_states = get_resource_service("vocabularies").find_one(req=None, _id="newscoveragestatus")
 
     if not coverage_states or not len(coverage_states.get("items", [])):
-        raise SuperdeskApiError.notConfiguredError(message="newscoveragestatus CV not found in DB or has no items")
+        raise SuperdeskApiError.notConfiguredError(
+            message=gettext("newscoveragestatus CV not found in DB or has no items")
+        )
 
     coverage_status = next((state for state in coverage_states["items"] if state.get("qcode") == qcode), None)
     if coverage_status:

--- a/server/planning/events/events.py
+++ b/server/planning/events/events.py
@@ -38,6 +38,8 @@ from dateutil.rrule import (
     SU,
 )
 
+from quart_babel import gettext as _
+
 import superdesk
 from superdesk.core import get_app_config, get_current_app
 from superdesk.resource_fields import ID_FIELD
@@ -585,7 +587,7 @@ class EventsService(AsyncBaseService):
         str_user_id = str(user.get(ID_FIELD)) if user_id else None
 
         if lock_user and str(lock_user) != str_user_id:
-            raise SuperdeskApiError.forbiddenError("The item was locked by another user")
+            raise SuperdeskApiError.forbiddenError(_("The item was locked by another user"))
 
         # If only the `recurring_rule` was provided, then fill in the rest from the original
         # This can happen, for example, when converting a single Event to a series of Recurring Events
@@ -781,7 +783,7 @@ class EventsService(AsyncBaseService):
         if event.get("recurrence_id"):
             if not mark_complete_validated:
                 if event["dates"]["start"].date() > updates["actioned_date"].date():
-                    raise SuperdeskApiError.badRequestError("Recurring series has not started.")
+                    raise SuperdeskApiError.badRequestError(_("Recurring series has not started."))
 
             # If we are marking an event as completed
             # Update only those which are behind the 'actioned_date'
@@ -852,7 +854,7 @@ class EventsService(AsyncBaseService):
         planning_item = await planning_service.find_one_async(req=None, _id=plan_id)
 
         if not planning_item:
-            raise SuperdeskApiError.badRequestError("Planning item not found")
+            raise SuperdeskApiError.badRequestError(_("Planning item not found"))
 
         updates = {"related_events": planning_item.get("related_events") or []}
         event_link_method = get_planning_event_link_method()

--- a/server/planning/events/events_cancel.py
+++ b/server/planning/events/events_cancel.py
@@ -11,6 +11,8 @@
 from copy import deepcopy
 from typing import Any
 
+from quart_babel import gettext as _
+
 from planning.events.events_utils import (
     get_recurring_timeline,
     get_update_method,
@@ -87,7 +89,7 @@ async def cancel_event_plannings(updates: dict[str, Any], original: dict[str, An
 
 def set_event_cancelled(updates: dict[str, Any], original: dict[str, Any], occur_cancel_state):
     if not validate_states(original):
-        raise SuperdeskApiError.badRequestError("Event not in valid state for cancellation")
+        raise SuperdeskApiError.badRequestError(_("Event not in valid state for cancellation"))
 
     remove_lock_information(updates)
     updates.update(

--- a/server/planning/events/events_files.py
+++ b/server/planning/events/events_files.py
@@ -10,6 +10,8 @@
 
 import logging
 
+from quart_babel import gettext as _
+
 from superdesk import Resource, get_resource_service
 from superdesk.core import get_current_app
 from superdesk.errors import SuperdeskApiError
@@ -68,4 +70,4 @@ class EventsFilesService(AsyncBaseService):
 
     async def on_delete_async(self, doc):
         if await get_resource_service("events").count_async({"files": doc.get("_id")}) > 0:
-            raise SuperdeskApiError.forbiddenError("Delete failed. File still used by other events.")
+            raise SuperdeskApiError.forbiddenError(_("Delete failed. File still used by other events."))

--- a/server/planning/events/events_service.py
+++ b/server/planning/events/events_service.py
@@ -18,6 +18,8 @@ from superdesk.notification import push_notification
 from superdesk.core.utils import date_to_str, generate_guid
 
 
+from quart_babel import gettext as _
+
 from planning import signals
 from planning.types import (
     PLANNING_RELATED_EVENT_LINK_TYPE,
@@ -240,7 +242,7 @@ class EventsAsyncService(BasePlanningAsyncService[EventResourceModel]):
                 parent_id = doc.duplicate_from
                 parent_event = await self.find_by_id(parent_id)
                 if not parent_event:
-                    raise SuperdeskApiError.badRequestError("Parent event not found")
+                    raise SuperdeskApiError.badRequestError(_("Parent event not found"))
 
                 await history_service.on_item_updated({"duplicate_id": event_id}, parent_event.to_dict(), "duplicate")
                 await history_service.on_item_updated({"duplicate_id": parent_id}, doc.to_dict(), "duplicate_from")
@@ -289,7 +291,7 @@ class EventsAsyncService(BasePlanningAsyncService[EventResourceModel]):
         str_user_id = str(user.get(ID_FIELD)) if user_id else None
 
         if lock_user and str(lock_user) != str_user_id:
-            raise SuperdeskApiError.forbiddenError("The item was locked by another user")
+            raise SuperdeskApiError.forbiddenError(_("The item was locked by another user"))
 
         # If only the `recurring_rule` was provided, then fill in the rest from the original
         # this can happen, for example, when converting a single Event to a series of Recurring Events
@@ -318,7 +320,7 @@ class EventsAsyncService(BasePlanningAsyncService[EventResourceModel]):
         original_event = await self.find_by_id(event_id)
 
         if original_event is None:
-            raise SuperdeskApiError.badRequestError("Event not found")
+            raise SuperdeskApiError.badRequestError(_("Event not found"))
 
         # Extract the ``embedded_planning`` from the updates
         embedded_planning = get_events_embedded_planning(updates)
@@ -619,7 +621,7 @@ class EventsAsyncService(BasePlanningAsyncService[EventResourceModel]):
         if event.recurrence_id:
             if not mark_complete_validated:
                 if event.dates.start.date() > updates["actioned_date"].date():
-                    raise SuperdeskApiError.badRequestError("Recurring series has not started.")
+                    raise SuperdeskApiError.badRequestError(_("Recurring series has not started."))
 
             # If we are marking an event as completed
             # Update only those which are behind the 'actioned_date'
@@ -812,7 +814,7 @@ class EventsAsyncService(BasePlanningAsyncService[EventResourceModel]):
         planning_item = await planning_service.find_by_id(event.planning_item)
 
         if not planning_item:
-            raise SuperdeskApiError.badRequestError("Planning item not found")
+            raise SuperdeskApiError.badRequestError(_("Planning item not found"))
 
         updates = {"related_events": planning_item.get("related_events") or []}
         event_link_method = get_planning_event_link_method()

--- a/server/planning/events/events_spike.py
+++ b/server/planning/events/events_spike.py
@@ -1,5 +1,7 @@
 from typing import Any
 
+from quart_babel import gettext as _
+
 from superdesk import get_resource_service
 from apps.auth import get_auth, get_user
 
@@ -88,19 +90,19 @@ def spike_event(updates: dict[str, Any], original: dict[str, Any]) -> None:
 def validate_event_states(event: dict[str, Any]) -> None:
     # Public Events (except unposted) cannot be spiked
     if event.get("pubstatus") and event.get("state") != WORKFLOW_STATE.KILLED:
-        raise SuperdeskApiError.badRequestError(message="Spike failed. Posted Events cannot be spiked.")
+        raise SuperdeskApiError.badRequestError(message=_("Spike failed. Posted Events cannot be spiked."))
 
     # Posted Events with Planning items cannot be spiked
     elif event.get("pubstatus") and event_has_planning_items(event[ID_FIELD], "primary"):
-        raise SuperdeskApiError.badRequestError(message="Spike failed. Event has an associated Planning item.")
+        raise SuperdeskApiError.badRequestError(message=_("Spike failed. Event has an associated Planning item."))
 
     # Event was created from a 'Reschedule' action or is 'Rescheduled'
     elif event.get("reschedule_from") or event.get(ITEM_STATE) == WORKFLOW_STATE.RESCHEDULED:
-        raise SuperdeskApiError.badRequestError(message="Spike failed. Rescheduled Events cannot be spiked.")
+        raise SuperdeskApiError.badRequestError(message=_("Spike failed. Rescheduled Events cannot be spiked."))
 
     # Event already spiked
     elif event.get(ITEM_STATE) == WORKFLOW_STATE.SPIKED:
-        raise SuperdeskApiError.badRequestError(message="Spike failed. Event is already spiked.")
+        raise SuperdeskApiError.badRequestError(message=_("Spike failed. Event is already spiked."))
 
 
 async def validate_spike_event(event: dict[str, Any]) -> None:
@@ -124,11 +126,11 @@ async def validate_recurring_event(original: dict[str, Any], recurrence_id: str)
             continue
 
         if event.get(LOCK_USER) or event.get(LOCK_SESSION):
-            raise SuperdeskApiError.forbiddenError(message="Spike failed. An event in the series is locked.")
+            raise SuperdeskApiError.forbiddenError(message=_("Spike failed. An event in the series is locked."))
 
     async for planning in await planning_service.find_async({"recurrence_id": recurrence_id}):
         if planning.get(LOCK_USER) or planning.get(LOCK_SESSION):
-            raise SuperdeskApiError.forbiddenError(message="Spike failed. A related planning item is locked.")
+            raise SuperdeskApiError.forbiddenError(message=_("Spike failed. A related planning item is locked."))
 
         first_event_id = get_first_related_event_id_for_planning(planning, "primary")
         if first_event_id not in events_with_plans:

--- a/server/planning/events/events_utils.py
+++ b/server/planning/events/events_utils.py
@@ -12,6 +12,8 @@ from eve.utils import ParsedRequest
 from apps.archive.common import get_auth
 from apps.auth import get_user_id
 
+from quart_babel import gettext as _
+
 from superdesk import get_resource_service, json
 from superdesk.core.types import SortParam, SortListParam
 from superdesk.errors import SuperdeskApiError
@@ -300,10 +302,10 @@ async def validate_event_action(
         raise SuperdeskApiError.notFoundError()
 
     if not await is_valid_event_planning_reason(updates, original):
-        raise SuperdeskApiError.badRequestError(message="Reason is required field.")
+        raise SuperdeskApiError.badRequestError(message=_("Reason is required field."))
 
     if original.get("state") == WORKFLOW_STATE.CANCELLED:
-        raise SuperdeskApiError.badRequestError(message="Aborted. Event is already cancelled")
+        raise SuperdeskApiError.badRequestError(message=_("Aborted. Event is already cancelled"))
 
     if require_lock:
         user_id = get_user_id()
@@ -314,14 +316,14 @@ async def validate_event_action(
         lock_action = original.get(LOCK_ACTION, None)
 
         if not lock_user:
-            raise SuperdeskApiError.badRequestError(message="The event must be locked")
+            raise SuperdeskApiError.badRequestError(message=_("The event must be locked"))
         elif str(lock_user) != str(user_id):
-            raise SuperdeskApiError.badRequestError(message="The event is locked by another user")
+            raise SuperdeskApiError.badRequestError(message=_("The event is locked by another user"))
         elif str(lock_session) != str(session_id):
-            raise SuperdeskApiError.badRequestError(message="The event is locked by you in another session")
+            raise SuperdeskApiError.badRequestError(message=_("The event is locked by you in another session"))
         elif str(lock_action) != ACTION:
             raise SuperdeskApiError.badRequestError(
-                message="The lock must be for the `{}` action".format(ACTION.lower().replace("_", " "))
+                message=_("The lock must be for the `{}` action").format(ACTION.lower().replace("_", " "))
             )
 
     event_service.validate_event(updates, original)

--- a/server/planning/item_lock.py
+++ b/server/planning/item_lock.py
@@ -10,6 +10,8 @@
 
 import logging
 
+from quart_babel import gettext as _
+
 import superdesk
 from superdesk.resource_fields import ID_FIELD
 from superdesk.errors import SuperdeskApiError
@@ -68,7 +70,7 @@ class LockService(BaseComponent):
 
         # get the lock it not raise forbidden exception
         if not lock(lock_id, expire=5):
-            raise SuperdeskApiError.forbiddenError(message="Item is locked by another user.")
+            raise SuperdeskApiError.forbiddenError(message=_("Item is locked by another user."))
 
         try:
             can_user_lock, error_message = self.can_lock(item, user_id, session_id, resource)

--- a/server/planning/planning/planning.py
+++ b/server/planning/planning/planning.py
@@ -18,6 +18,8 @@ from datetime import datetime
 from itertools import chain
 from io import BytesIO
 
+from quart_babel import gettext as _
+
 from lxml import etree
 from bson import ObjectId
 from eve.methods.common import resolve_document_etag
@@ -305,7 +307,7 @@ class PlanningService(AsyncBaseService):
         str_user_id = str(user.get(ID_FIELD)) if user else None
 
         if lock_user and str(lock_user) != str_user_id:
-            raise SuperdeskApiError.forbiddenError("The item was locked by another user")
+            raise SuperdeskApiError.forbiddenError(_("The item was locked by another user"))
 
         await self.validate_planning(updates, original)
 
@@ -315,7 +317,7 @@ class PlanningService(AsyncBaseService):
         if (not original and not updates.get("planning_date")) or (
             "planning_date" in updates and updates["planning_date"] is None
         ):
-            raise SuperdeskApiError(message="Planning item should have a date")
+            raise SuperdeskApiError(message=_("Planning item should have a date"))
 
         sanitize_input_data(updates)
 
@@ -326,10 +328,10 @@ class PlanningService(AsyncBaseService):
         for agenda_id in updates.get("agendas", []):
             agenda = await agenda_service.find_one(req=None, _id=agenda_id)
             if not agenda:
-                raise SuperdeskApiError.forbiddenError("Agenda '{}' does not exist".format(agenda_id))
+                raise SuperdeskApiError.forbiddenError(_("Agenda '{}' does not exist").format(agenda_id))
 
             if not agenda.is_enabled and (original is None or agenda_id not in original.get("agendas", [])):
-                raise SuperdeskApiError.forbiddenError("Agenda '{}' is not enabled".format(agenda.name))
+                raise SuperdeskApiError.forbiddenError(_("Agenda '{}' is not enabled").format(agenda.name))
 
         # Remove duplicate agendas
         if len(updates.get("agendas", [])) > 0:
@@ -669,7 +671,9 @@ class PlanningService(AsyncBaseService):
 
     async def remove_coverage_entity(self, coverage_entity, original_planning, entity_type="coverage"):
         if original_planning.get("state") == WORKFLOW_STATE.CANCELLED:
-            raise SuperdeskApiError.badRequestError("Cannot remove {} of a cancelled planning item".format(entity_type))
+            raise SuperdeskApiError.badRequestError(
+                _("Cannot remove {} of a cancelled planning item").format(entity_type)
+            )
 
         assignment = coverage_entity.get("assigned_to", None)
         if assignment and assignment.get("state") not in [
@@ -968,7 +972,7 @@ class PlanningService(AsyncBaseService):
         planning.update(planning_updates)
         planning_id = planning.get(ID_FIELD)
         if not planning_id:
-            raise SuperdeskApiError.badRequestError("Planning item is required to create assignments.")
+            raise SuperdeskApiError.badRequestError(_("Planning item is required to create assignments."))
 
         assignment_service = get_resource_service("assignments")
         updated_coverage = deepcopy(original)
@@ -1001,7 +1005,7 @@ class PlanningService(AsyncBaseService):
                 if planning_original.get("state") == WORKFLOW_STATE.CANCELLED or updated_coverage.get(
                     "workflow_status"
                 ) not in [WORKFLOW_STATE.CANCELLED, WORKFLOW_STATE.DRAFT]:
-                    raise SuperdeskApiError.badRequestError("Coverage not in correct state to remove assignment.")
+                    raise SuperdeskApiError.badRequestError(_("Coverage not in correct state to remove assignment."))
 
                 # Return now, we will process the assignment after the DB is updated
                 return
@@ -1163,13 +1167,13 @@ class PlanningService(AsyncBaseService):
         planning = await self.find_one_async(req=None, _id=planning_id)
 
         if not planning:
-            raise SuperdeskApiError.badRequestError("Planning does not exist")
+            raise SuperdeskApiError.badRequestError(_("Planning does not exist"))
 
         coverages = planning.get("coverages") or []
         try:
             coverage = next(c for c in coverages if c.get("coverage_id") == coverage_id)
         except StopIteration:
-            raise SuperdeskApiError.badRequestError("Coverage does not exist")
+            raise SuperdeskApiError.badRequestError(_("Coverage does not exist"))
 
         coverage_planning = coverage.get("planning") or {}
         updates_planning = updates.get("planning") or {}
@@ -1193,7 +1197,7 @@ class PlanningService(AsyncBaseService):
         try:
             new_coverage = next(c for c in new_plan["coverages"] if c.get("coverage_id") not in coverage_ids)
         except StopIteration:
-            raise SuperdeskApiError.badRequestError("New coverage was not found!")
+            raise SuperdeskApiError.badRequestError(_("New coverage was not found!"))
 
         planning.update(new_plan)
         return planning, new_coverage
@@ -1209,7 +1213,7 @@ class PlanningService(AsyncBaseService):
         try:
             coverage_item = next(c for c in coverages if c.get("coverage_id") == coverage_id)
         except StopIteration:
-            raise SuperdeskApiError.badRequestError("Coverage does not exist")
+            raise SuperdeskApiError.badRequestError(_("Coverage does not exist"))
 
         if not coverage_item.get("assigned_to"):
             # Assignment was already removed (unposting a planning item scenario)

--- a/server/planning/planning/planning_cancel.py
+++ b/server/planning/planning/planning_cancel.py
@@ -8,6 +8,8 @@
 # AUTHORS and LICENSE files distributed with this source code, or
 # at https://www.sourcefabric.org/superdesk/license
 
+from quart_babel import gettext as _
+
 from superdesk.eve_async.service import AsyncBaseService
 from superdesk.flask import request
 from superdesk.resource_fields import ID_FIELD
@@ -54,7 +56,7 @@ class PlanningCancelResource(PlanningResource):
 class PlanningCancelService(AsyncBaseService):
     async def on_update_async(self, updates, original):
         if not await is_valid_event_planning_reason(updates, original):
-            raise SuperdeskApiError.badRequestError(message="Reason is required field.")
+            raise SuperdeskApiError.badRequestError(message=_("Reason is required field."))
 
     async def update_async(self, id, updates, original):
         user = get_user(required=True).get(ID_FIELD, "")

--- a/server/planning/planning/planning_featured_async_service.py
+++ b/server/planning/planning/planning_featured_async_service.py
@@ -1,6 +1,8 @@
 from typing import Any
 from copy import deepcopy
 
+from quart_babel import gettext as _
+
 from apps.auth import get_user_id
 from bson import ObjectId
 from planning.core.service import BasePlanningAsyncService
@@ -24,7 +26,7 @@ class PlanningFeaturedAsyncService(BasePlanningAsyncService[PlanningFeaturedReso
         for doc in docs:
             items = await super().find({"_id": doc.id})
             if await items.count() > 0:
-                raise SuperdeskApiError.badRequestError(message="Featured story already exists for this date.")
+                raise SuperdeskApiError.badRequestError(message=_("Featured story already exists for this date."))
 
             await self.validate_featured_attrribute(doc.items)
             await self.post_featured_planning(doc)
@@ -85,7 +87,7 @@ class PlanningFeaturedAsyncService(BasePlanningAsyncService[PlanningFeaturedReso
         for planning_id in planning_ids:
             planning_item = await planning_service.find_by_id_raw(planning_id)
             if planning_item and not planning_item.get("featured"):
-                raise SuperdeskApiError.badRequestError(message="A planning item in the list is not featured.")
+                raise SuperdeskApiError.badRequestError(message=_("A planning item in the list is not featured."))
 
     async def validate_post_status(self, planning_ids: list):
         planning_service = PlanningAsyncService()

--- a/server/planning/planning/planning_featured_lock.py
+++ b/server/planning/planning/planning_featured_lock.py
@@ -8,6 +8,8 @@
 # AUTHORS and LICENSE files distributed with this source code, or
 # at https://www.sourcefabric.org/superdesk/license
 
+from quart_babel import gettext as _
+
 from superdesk.eve_async.service import AsyncBaseService
 from superdesk.metadata.utils import generate_guid
 from superdesk.metadata.item import GUID_NEWSML, metadata_schema
@@ -56,7 +58,7 @@ class PlanningFeaturedLockService(AsyncBaseService):
 
         # get the lock if not raise forbidden exception
         if not lock(LOCK_ID, expire=5):
-            raise SuperdeskApiError.forbiddenError(message="Unable to obtain lock on Featured stories.")
+            raise SuperdeskApiError.forbiddenError(message=_("Unable to obtain lock on Featured stories."))
 
         for doc in docs:
             doc["_id"] = generate_guid(type=GUID_NEWSML)

--- a/server/planning/planning/planning_files.py
+++ b/server/planning/planning/planning_files.py
@@ -8,6 +8,8 @@
 
 """Superdesk Files"""
 
+from quart_babel import gettext as _
+
 import superdesk
 from superdesk import get_resource_service
 from superdesk.errors import SuperdeskApiError
@@ -65,4 +67,4 @@ class PlanningFilesService(AsyncBaseService):
         }
         plannings_using_file = await get_resource_service("planning").find_async(where=find_clause)
         if await plannings_using_file.count() > 0:
-            raise SuperdeskApiError.forbiddenError("Delete failed. File still used by other planning items.")
+            raise SuperdeskApiError.forbiddenError(_("Delete failed. File still used by other planning items."))

--- a/server/planning/planning/planning_service.py
+++ b/server/planning/planning/planning_service.py
@@ -983,7 +983,7 @@ class PlanningAsyncService(BasePlanningAsyncService[PlanningResourceModel]):
             # update the assignment using the coverage details
             original_assignment = assignment_service.find_one(req=None, _id=assignment_id)
             if not original_assignment:
-                raise SuperdeskApiError.badRequestError(_("Assignment related to the coverage does not exists."))
+                raise SuperdeskApiError.badRequestError(_("Assignment related to the coverage does not exist."))
 
             # check if coverage was cancelled
             is_coverage_cancelled = self._cancel_coverage_if_needed(

--- a/server/planning/planning/planning_service.py
+++ b/server/planning/planning/planning_service.py
@@ -20,6 +20,8 @@ from superdesk.notification import push_notification
 from superdesk import get_resource_service, get_app_config
 from superdesk.core.utils import date_to_str, generate_guid
 
+from quart_babel import gettext as _
+
 from planning.planning_notifications import PlanningNotifications
 from planning.content_profiles.utils import is_field_enabled
 from planning.events.events_utils import get_recurring_timeline
@@ -263,7 +265,7 @@ class PlanningAsyncService(BasePlanningAsyncService[PlanningResourceModel]):
         str_user_id = str(user.get(ID_FIELD)) if user else None
 
         if lock_user and str(lock_user) != str_user_id:
-            raise SuperdeskApiError.forbiddenError("The item was locked by another user")
+            raise SuperdeskApiError.forbiddenError(_("The item was locked by another user"))
 
         await self.validate_planning(updates, original)
 
@@ -483,12 +485,12 @@ class PlanningAsyncService(BasePlanningAsyncService[PlanningResourceModel]):
         for agenda_id in updated_planning.get("agendas", []):
             agenda = await agenda_service.find_one(req=None, _id=agenda_id)
             if not agenda:
-                raise SuperdeskApiError.forbiddenError("Agenda '{}' does not exist".format(agenda_id))
+                raise SuperdeskApiError.forbiddenError(_("Agenda '{}' does not exist").format(agenda_id))
 
             if not agenda.get("is_enabled", False) and (
                 original is None or agenda_id not in original.get("agendas", [])
             ):
-                raise SuperdeskApiError.forbiddenError("Agenda '{}' is not enabled".format(agenda.get("name")))
+                raise SuperdeskApiError.forbiddenError(_("Agenda '{}' is not enabled").format(agenda.get("name")))
 
         # Validate scheduled updates
         for coverage in updated_planning.get("coverages") or []:
@@ -944,7 +946,7 @@ class PlanningAsyncService(BasePlanningAsyncService[PlanningResourceModel]):
             return
 
         if not planning.id:
-            raise SuperdeskApiError.badRequestError("Planning item is required to create assignments.")
+            raise SuperdeskApiError.badRequestError(_("Planning item is required to create assignments."))
 
         # Coverage is draft if original was draft and updates is still maintaining that state
         coverage_status = coverage_updates.get("workflow_status", original_coverage.get("workflow_status"))
@@ -974,14 +976,14 @@ class PlanningAsyncService(BasePlanningAsyncService[PlanningResourceModel]):
                     WorkflowStates.CANCELLED,
                     WorkflowStates.DRAFT,
                 ]:
-                    raise SuperdeskApiError.badRequestError("Coverage not in correct state to remove assignment.")
+                    raise SuperdeskApiError.badRequestError(_("Coverage not in correct state to remove assignment."))
 
                 return await self._remove_assignment(coverage_doc, original_planning, assignment_id)
 
             # update the assignment using the coverage details
             original_assignment = assignment_service.find_one(req=None, _id=assignment_id)
             if not original_assignment:
-                raise SuperdeskApiError.badRequestError("Assignment related to the coverage does not exists.")
+                raise SuperdeskApiError.badRequestError(_("Assignment related to the coverage does not exists."))
 
             # check if coverage was cancelled
             is_coverage_cancelled = self._cancel_coverage_if_needed(

--- a/server/planning/planning/planning_spike.py
+++ b/server/planning/planning/planning_spike.py
@@ -1,6 +1,8 @@
 from copy import deepcopy
 from typing import Any
 
+from quart_babel import gettext as _
+
 from superdesk import get_resource_service
 from superdesk.resource_fields import ID_FIELD
 from superdesk.notification import push_notification
@@ -102,7 +104,7 @@ async def process_spike_planning_item(updates: dict[str, Any], original: dict[st
         WORKFLOW_STATE.POSTPONED,
         WORKFLOW_STATE.CANCELLED,
     ]:
-        raise SuperdeskApiError.badRequestError(message="Spike failed. Planning item in invalid state for spiking.")
+        raise SuperdeskApiError.badRequestError(message=_("Spike failed. Planning item in invalid state for spiking."))
 
     user = get_user()
 
@@ -164,7 +166,7 @@ async def process_unspike_planning_item(updates: dict[str, Any], original: dict[
     if first_event_id:
         event = await events_service.find_one_async(req=None, _id=first_event_id)
         if event and event.get("state") == WORKFLOW_STATE.SPIKED:
-            raise SuperdeskApiError.badRequestError(message="Unspike failed. Associated event is spiked.")
+            raise SuperdeskApiError.badRequestError(message=_("Unspike failed. Associated event is spiked."))
 
     updates[ITEM_STATE] = original.get("revert_state", WORKFLOW_STATE.DRAFT)
     updates["revert_state"] = None

--- a/server/planning/planning_article_export.py
+++ b/server/planning/planning_article_export.py
@@ -15,6 +15,8 @@ from superdesk.eve_async.service import AsyncBaseService
 from superdesk.resource_fields import VERSION
 from superdesk.flask import render_template_string, render_template
 
+from quart_babel import gettext as _
+
 from superdesk.utc import utc_to_local, get_timezone_offset, utcnow
 from superdesk import get_resource_service, Resource
 from superdesk.errors import SuperdeskApiError
@@ -258,7 +260,7 @@ async def enhance_coverage(planning, item, users, desks, text_users, text_desks)
 async def generate_text_item(items, template_name, resource_type):
     template = await get_resource_service("planning_export_templates").get_export_template(template_name, resource_type)
     if not template:
-        raise SuperdeskApiError.badRequestError("Invalid template selected")
+        raise SuperdeskApiError.badRequestError(_("Invalid template selected"))
 
     for item in items:
         # Create list of assignee with preference to coverage_provider, if not, assigned user

--- a/server/planning/planning_notifications.py
+++ b/server/planning/planning_notifications.py
@@ -11,6 +11,8 @@
 """Superdesk Planning"""
 import logging
 
+from quart_babel import gettext as _
+
 from superdesk.core import get_app_config, get_current_app
 from superdesk.resource_fields import ID_FIELD
 from superdesk.flask import render_template
@@ -184,7 +186,7 @@ class PlanningNotifications:
                             updates["slack_user_id"] = slack_user.get("id")
                             updates["slack_username"] = slack_user.get("name")
                         else:
-                            raise SuperdeskApiError.badRequestError(message="Unable to find matching Slack user")
+                            raise SuperdeskApiError.badRequestError(message=_("Unable to find matching Slack user"))
                 else:
                     updates["slack_user_id"] = None
                     updates["slack_username"] = None

--- a/server/planning/search/eventsplanning_search.py
+++ b/server/planning/search/eventsplanning_search.py
@@ -18,6 +18,8 @@ from copy import deepcopy
 from werkzeug.datastructures import MultiDict, ImmutableMultiDict
 from eve.utils import ParsedRequest
 
+from quart_babel import gettext as _
+
 from superdesk import Resource, get_resource_service
 from superdesk.eve_async.service import AsyncBaseService
 from superdesk.resource import build_custom_hateoas
@@ -94,7 +96,7 @@ class EventsPlanningService(AsyncBaseService):
 
         for param_name in params.keys():
             if param_name not in whitelist:
-                raise SuperdeskApiError.badRequestError(message="Unexpected parameter ({})".format(param_name))
+                raise SuperdeskApiError.badRequestError(message=_("Unexpected parameter ({})").format(param_name))
 
             if len(params.getlist(param_name)) > 1:
                 desc = "Multiple values received for parameter ({})"
@@ -320,7 +322,7 @@ class EventsPlanningService(AsyncBaseService):
         search_filter = await EventsPlanningFiltersAsyncService().find_by_id_raw(filter_id)
 
         if not search_filter:
-            raise SuperdeskApiError.notFoundError("EventPlanning Filter {} not found".format(filter_id))
+            raise SuperdeskApiError.notFoundError(_("EventPlanning Filter {} not found").format(filter_id))
 
         if args is None:
             args = {}

--- a/server/planning/search/queries/common.py
+++ b/server/planning/search/queries/common.py
@@ -13,6 +13,8 @@ from inspect import isawaitable
 import logging
 from datetime import datetime
 
+from quart_babel import gettext as _
+
 from eve.utils import str_to_date as _str_to_date, date_to_str
 
 from superdesk import get_resource_service
@@ -75,7 +77,7 @@ def get_date_params(params: Dict[str, Any]):
                 start_date = date_to_str(start_date)
     except Exception as e:
         logger.exception(e)
-        raise SuperdeskApiError.badRequestError("Invalid value for start date")
+        raise SuperdeskApiError.badRequestError(_("Invalid value for start date"))
 
     try:
         end_date = params.get("end_date")
@@ -92,7 +94,7 @@ def get_date_params(params: Dict[str, Any]):
                 end_date = date_to_str(end_date)
     except Exception as e:
         logger.exception(e)
-        raise SuperdeskApiError.badRequestError("Invalid value for end date")
+        raise SuperdeskApiError.badRequestError(_("Invalid value for end date"))
 
     return date_filter, start_date, end_date, time_zone
 


### PR DESCRIPTION
### Purpose
Replace hard-coded English messages with `gettext`/`_` calls to enable `i18n` across client and server. Client-side notify and ariaValue strings now use gettext (via `superdeskApi.localization` where required) and CoverageRowForm imports superdeskApi. Server-side updates add `quart_babel.gettext as _` and wrap error/validation messages in `_()`.

Changes touch planning, events, assignments, autosave, item lock, files, search and various UI components. No functional logic changes; this is an internationalization preparation change.

[SDESK-7907]


[SDESK-7907]: https://sofab.atlassian.net/browse/SDESK-7907?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ