### PR TITLE
[STT-1635] - Event location and contact not highlighted when required and empty

### DIFF
--- a/client/components/Contacts/ContactField.interface.ts
+++ b/client/components/Contacts/ContactField.interface.ts
@@ -4,6 +4,9 @@ import {IContact} from 'superdesk-api';
 interface IBaseProps extends IContactReduxStateProps, IContactReduxDispatchProps {
     field: string;
     label?: string;
+    required?: boolean;
+    message?: string;
+    invalid?: boolean;
     querySearch?: boolean;
     readOnly?: boolean;
     paddingTop?: boolean;

--- a/client/components/Contacts/ContactField.tsx
+++ b/client/components/Contacts/ContactField.tsx
@@ -96,6 +96,9 @@ class ContactFieldComponent extends React.Component<IContactFieldProps> {
             onPopupOpen,
             onPopupClose,
             readOnly,
+            required,
+            message,
+            invalid,
         } = this.props;
 
         let value: Array<IContact['_id']>;
@@ -122,6 +125,9 @@ class ContactFieldComponent extends React.Component<IContactFieldProps> {
                                 label={label}
                                 onChange={this.onChange}
                                 value={value}
+                                required={required}
+                                message={message}
+                                invalid={invalid}
                                 onAdd={privileges.contacts ? this.showEditModal : undefined}
                                 onAddText={privileges.contacts ? gettext('Add Contact') : null}
                                 onFocus={onFocus}

--- a/client/components/Contacts/SelectSearchContactsField/index.tsx
+++ b/client/components/Contacts/SelectSearchContactsField/index.tsx
@@ -10,6 +10,8 @@ interface IProps {
     readOnly?: boolean;
     onChange: (contact: IContact) => void;
     required?: boolean;
+    message?: string;
+    invalid?: boolean;
     onAdd?: (...args: any) => void;
     onAddText?: string;
     onFocus?: (...args: any) => void;
@@ -49,13 +51,22 @@ export class SelectSearchContactsField extends React.Component<IProps, {openSele
             minLengthPopup = 1,
             placeholder,
             noMargin,
+            message,
+            invalid,
             ...props
         } = this.props;
 
         const hasLabel = (label ?? '').trim();
 
         return (
-            <LineInput readOnly={readOnly} {...props} noLabel={!hasLabel} noMargin={noMargin}>
+            <LineInput
+                readOnly={readOnly}
+                {...props}
+                message={message}
+                invalid={invalid}
+                noLabel={!hasLabel}
+                noMargin={noMargin}
+            >
                 {hasLabel && (
                     <Label text={label} />
                 )}

--- a/client/components/fields/editor/Contacts.tsx
+++ b/client/components/fields/editor/Contacts.tsx
@@ -11,6 +11,8 @@ export class EditorFieldContacts extends React.PureComponent<IEditorFieldProps> 
         const {gettext} = superdeskApi.localization;
         const field = this.props.field ?? 'contacts';
         const value = get(this.props.item, field, this.props.defaultValue ?? []);
+        const error = get(this.props.errors ?? {}, field);
+        const invalid = this.props.invalid ?? (error != null && this.props.showErrors);
 
         return (
             <ContactField
@@ -19,6 +21,9 @@ export class EditorFieldContacts extends React.PureComponent<IEditorFieldProps> 
                 label={this.props.label ?? gettext('Contacts')}
                 value={value}
                 onChange={this.props.onChange}
+                required={this.props.schema?.required}
+                message={this.props.showErrors ? error : undefined}
+                invalid={invalid}
                 readOnly={this.props.disabled}
                 singleValue={false}
             />

--- a/client/components/fields/editor/Location.tsx
+++ b/client/components/fields/editor/Location.tsx
@@ -16,6 +16,8 @@ export class EditorFieldLocation extends React.PureComponent<IEditorFieldLocatio
         const {gettext} = superdeskApi.localization;
         const field = this.props.field ?? 'location';
         const props = this.props;
+        const error = get(props.errors ?? {}, field);
+        const invalid = props.invalid ?? (error != null && props.showErrors);
 
         const originalValue = get(props.item, field);
         const valueSingle = props.storeAsArray === true ? originalValue?.[0] : originalValue;
@@ -47,6 +49,9 @@ export class EditorFieldLocation extends React.PureComponent<IEditorFieldLocatio
                         onChange={onChange} // overwrites onChange from props spread above
                         field={field}
                         label={props.label ?? gettext('Location')}
+                        required={props.schema?.required}
+                        message={props.showErrors ? error : undefined}
+                        invalid={invalid}
                         value={valueSingle}
                         disableSearch={!props.enableExternalSearch}
                         disableAddLocation={props.disableAddLocation}


### PR DESCRIPTION
### Purpose
This PR fixes the event editor so required location and contacts fields are highlighted as invalid when they are empty apart from showing the alert

### What has changed
- Wired validation state into the custom event location and contacts editor wrappers to pass down the `errors`, `showErrors`, `invalid` and `required` states

### Steps to test
1. Open planning. Go to the event profile and make sure that contacts and location are marked as required.
2. Create a new event and leave Location and Contacts empty.
3. Save the event.
4. Confirm both fields now show the red invalid highlight and required-field messaging
5. Fill both fields and confirm the red state clears normally.

### Screenshots

#### Before the missing indicators were missing
<img width="1151" height="381" alt="image" src="https://github.com/user-attachments/assets/12be1b5d-43a9-4bae-bf32-8abbb343dbb9" />

#### Now the missing indicators are present
<img width="819" height="402" alt="2026-05-07_17-11-36" src="https://github.com/user-attachments/assets/0245fec4-2016-4455-9e25-eb41a0d4650f" />



Resolves: #[STT-1635](https://sofab.atlassian.net/browse/STT-1635)



[STT-1635]: https://sofab.atlassian.net/browse/STT-1635?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ