### PR TITLE
[SDCP-1162] fix: `event` KeyError on enhance ProdAPI Assignment

### DIFF
--- a/server/planning/prod_api/events/utils.py
+++ b/server/planning/prod_api/events/utils.py
@@ -26,7 +26,7 @@ def construct_event_link(event_id: str):
 def add_related_event_links(item: Union[ArchiveItem, Assignment, Planning], planning: Planning):
     for related_event in get_related_event_links_for_planning(planning):
         event_link = construct_event_link(related_event["_id"])
-        if related_event["link_type"] == "primary" and not item[LINKS]["event"]:
+        if related_event["link_type"] == "primary" and not item[LINKS].get("event"):
             item[LINKS]["event"] = event_link
         else:
             item[LINKS].setdefault("related_events", []).append(event_link)


### PR DESCRIPTION
### Purpose
When fetching an Assignment (or related article) from the Production API, a `KeyError` exception is raised if the HATEOAS links does not currently contain `event`.

### What has changed
* Use `.get` instead of bracket notation to check existence and value of the `event` key

Resolves: SDCP-1162

