### PR TITLE
[SDBELGA-1087] fix: TBC not removed with reschedule action

### DIFF
--- a/client/actions/events/api.ts
+++ b/client/actions/events/api.ts
@@ -354,18 +354,19 @@ const cancelEvent = (original, updates) => (
 );
 
 const rescheduleEvent = (original, updates) => (
-    (dispatch, getState, {api}) => (
-        api.update(
-            'events_reschedule',
-            original,
-            {
-                update_method: get(updates, 'update_method.value', EVENTS.UPDATE_METHODS[0].value),
-                dates: updates.dates,
-                [TO_BE_CONFIRMED_FIELD]: updates[TO_BE_CONFIRMED_FIELD] ?? original[TO_BE_CONFIRMED_FIELD] ?? false,
-                reason: get(updates, 'reason', null),
-            }
-        )
-    )
+    (dispatch, getState, {api}) => {
+        const body = {
+            update_method: get(updates, 'update_method.value', EVENTS.UPDATE_METHODS[0].value),
+            dates: updates.dates,
+            reason: get(updates, 'reason', null),
+        };
+
+        if (TO_BE_CONFIRMED_FIELD in updates) {
+            body[TO_BE_CONFIRMED_FIELD] = updates[TO_BE_CONFIRMED_FIELD];
+        }
+
+        return api.update('events_reschedule', original, body);
+    }
 );
 
 const postponeEvent = (original, updates) => (

--- a/client/actions/events/api.ts
+++ b/client/actions/events/api.ts
@@ -361,6 +361,7 @@ const rescheduleEvent = (original, updates) => (
             {
                 update_method: get(updates, 'update_method.value', EVENTS.UPDATE_METHODS[0].value),
                 dates: updates.dates,
+                [TO_BE_CONFIRMED_FIELD]: updates[TO_BE_CONFIRMED_FIELD] ?? original[TO_BE_CONFIRMED_FIELD] ?? false,
                 reason: get(updates, 'reason', null),
             }
         )

--- a/client/actions/events/tests/api_test.ts
+++ b/client/actions/events/tests/api_test.ts
@@ -428,7 +428,6 @@ describe('actions.events.api', () => {
                                 tz: 'Australia/Sydney',
                             },
                             update_method: 'single',
-                            _time_to_be_confirmed: false,
                             reason: 'Changing the day',
                         },
                     ]);

--- a/client/actions/events/tests/api_test.ts
+++ b/client/actions/events/tests/api_test.ts
@@ -428,6 +428,71 @@ describe('actions.events.api', () => {
                                 tz: 'Australia/Sydney',
                             },
                             update_method: 'single',
+                            _time_to_be_confirmed: false,
+                            reason: 'Changing the day',
+                        },
+                    ]);
+
+                    done();
+                })
+                .catch(done.fail);
+        });
+
+        it('can reschedule an event - setting TBC flag', (done) => {
+            store.test(done, eventsApi.rescheduleEvent(data.events[1], {
+                dates: {
+                    start: '2014-10-16T14:01:11+0000',
+                    end: '2014-10-16T15:01:11+0000',
+                    tz: 'Australia/Sydney',
+                },
+                _time_to_be_confirmed: true,
+                reason: 'Changing the day',
+            }))
+                .then(() => {
+                    expect(services.api.update.callCount).toBe(1);
+                    expect(services.api.update.args[0]).toEqual([
+                        'events_reschedule',
+                        data.events[1],
+                        {
+                            dates: {
+                                start: '2014-10-16T14:01:11+0000',
+                                end: '2014-10-16T15:01:11+0000',
+                                tz: 'Australia/Sydney',
+                            },
+                            update_method: 'single',
+                            _time_to_be_confirmed: true,
+                            reason: 'Changing the day',
+                        },
+                    ]);
+
+                    done();
+                })
+                .catch(done.fail);
+        });
+
+        it('can reschedule an event - unsetting TBC flag', (done) => {
+            store.test(done, eventsApi.rescheduleEvent(data.events[1], {
+                dates: {
+                    start: '2014-10-16T14:01:11+0000',
+                    end: '2014-10-16T15:01:11+0000',
+                    tz: 'Australia/Sydney',
+                },
+                _time_to_be_confirmed: false,
+                reason: 'Changing the day',
+            }))
+                .then(() => {
+                    expect(services.api.update.callCount).toBe(1);
+                    expect(services.api.update.args[0]).toEqual([
+                        'events_reschedule',
+                        data.events[1],
+                        {
+                            dates: {
+                                start: '2014-10-16T14:01:11+0000',
+                                end: '2014-10-16T15:01:11+0000',
+                                tz: 'Australia/Sydney',
+                            },
+                            update_method: 'single',
+                            _time_to_be_confirmed: false,
                             reason: 'Changing the day',
                         },
                     ]);


### PR DESCRIPTION
### Purpose
If an Event (recurring or single) has the time set to TBC, when rescheduling and setting a time the TBC flag is note removed.

### What has changed
Pass through the TBC flag to the backend

Resolves: [SDBELGA-1087](https://sofab.atlassian.net/browse/SDBELGA-1087)



[SDBELGA-1087]: https://sofab.atlassian.net/browse/SDBELGA-1087?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ