### PR TITLE
[SDBELGA-1087] fix: Don't validate event times if time TBC

### DIFF
--- a/client/validators/events.ts
+++ b/client/validators/events.ts
@@ -37,11 +37,13 @@ const validateRequiredDates = ({value, errors, messages, diff}) => {
     }
 };
 
-const validateDateRange = ({value, errors, messages}) => {
+const validateDateRange = ({value, errors, messages, diff}) => {
     let startDate = moment(value.start);
     let endDate = moment(value.end);
 
     if (!self.valdiateStartEndDateValues(value, startDate, endDate)) {
+        return;
+    } else if (diff[TO_BE_CONFIRMED_FIELD] === true) {
         return;
     }
 
@@ -168,6 +170,7 @@ const validateDates = ({getState, value, errors, messages, diff}) => {
         value: value,
         errors: newErrors,
         messages: messages,
+        diff: diff,
     });
 
     // we don't have to validate all recurring form update time action

--- a/client/validators/events.ts
+++ b/client/validators/events.ts
@@ -43,7 +43,7 @@ const validateDateRange = ({value, errors, messages, diff}) => {
 
     if (!self.valdiateStartEndDateValues(value, startDate, endDate)) {
         return;
-    } else if (diff[TO_BE_CONFIRMED_FIELD] === true) {
+    } else if (diff?.[TO_BE_CONFIRMED_FIELD] === true) {
         return;
     }
 

--- a/client/validators/tests/events_test.ts
+++ b/client/validators/tests/events_test.ts
@@ -49,6 +49,7 @@ describe('eventValidators', () => {
             value: value,
             errors: errors,
             messages: errorMessages,
+            diff: event,
         });
         expect(errors).toEqual(response);
         expect(errorMessages).toEqual(messages);

--- a/client/validators/tests/events_test.ts
+++ b/client/validators/tests/events_test.ts
@@ -4,6 +4,7 @@ import eventValidators from '../events';
 import moment from 'moment';
 import {initialState} from '../../utils/testData';
 import {cloneDeep} from 'lodash';
+import {TO_BE_CONFIRMED_FIELD} from '../../constants';
 
 describe('eventValidators', () => {
     let event;
@@ -114,6 +115,12 @@ describe('eventValidators', () => {
                 {dates: {end: {date: 'End date should be after start date'}}},
                 ['END DATE should be after START DATE']
             );
+        });
+
+        it('pass if time to be confirmed and end time is after start time', () => {
+            event.dates.end = moment('2094-10-15T11:01:11');
+            event[TO_BE_CONFIRMED_FIELD] = true;
+            testValidate(eventValidators.validateDates, 'dates', {}, []);
         });
     });
 


### PR DESCRIPTION
### Purpose
When rescheduling an Event that has time TBC and the underlying time values are invalid, the form will show the state as invalid and now allow saving the action.

### What has changed
* Don't validate Event start/end times if time is to be confirmed

Resolves: [SDBELGA-1087](https://sofab.atlassian.net/browse/SDBELGA-1087)



[SDBELGA-1087]: https://sofab.atlassian.net/browse/SDBELGA-1087?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ