### PR TITLE
[STT-1670] - Issues during file upload

### DIFF
--- a/client/actions/events/api.ts
+++ b/client/actions/events/api.ts
@@ -524,7 +524,7 @@ const fetchEventHistory = (eventId) => (
     ));
 
 const uploadFiles = (event) => (
-    (dispatch) => {
+    (dispatch, getState, {upload}) => {
         const clonedEvent = cloneDeep(event);
 
         // If no files, do nothing
@@ -543,6 +543,7 @@ const uploadFiles = (event) => (
 
         return Promise.all(filesToUpload.map((file) => (
             uploadFileWithRetry<IFile>(
+                upload,
                 '/events_files/',
                 file,
                 {timeoutMs: 90000, retries: 2},

--- a/client/actions/events/api.ts
+++ b/client/actions/events/api.ts
@@ -5,6 +5,7 @@ import {
     ISearchSpikeState,
     IEventSearchParams,
     IEventItem,
+    IFile,
     IPlanningItem,
     IEventTemplate,
     IEventUpdateMethod,
@@ -27,6 +28,7 @@ import {
     isPublishedItemId,
     gettext,
 } from '../../utils';
+import {uploadFileWithRetry} from '../../utils/upload';
 
 import planningApis from '../planning/api';
 import eventsUi from './ui';
@@ -522,7 +524,7 @@ const fetchEventHistory = (eventId) => (
     ));
 
 const uploadFiles = (event) => (
-    (dispatch, getState, {upload}) => {
+    (dispatch) => {
         const clonedEvent = cloneDeep(event);
 
         // If no files, do nothing
@@ -540,16 +542,14 @@ const uploadFiles = (event) => (
         }
 
         return Promise.all(filesToUpload.map((file) => (
-            upload.start({
-                method: 'POST',
-                url: appConfig.server.url + '/events_files/',
-                headers: {'Content-Type': 'multipart/form-data'},
-                data: {media: [file]},
-                arrayKey: '',
-            })
+            uploadFileWithRetry<IFile>(
+                '/events_files/',
+                file,
+                {timeoutMs: 90000, retries: 2},
+            )
         )))
             .then((results) => {
-                const files = results.map((res) => res.data);
+                const files = results;
 
                 if (get(files, 'length', 0) > 0) {
                     dispatch({

--- a/client/actions/events/api.ts
+++ b/client/actions/events/api.ts
@@ -546,7 +546,7 @@ const uploadFiles = (event) => (
                 upload,
                 '/events_files/',
                 file,
-                {timeoutMs: 90000, retries: 2},
+                {retries: 2},
             )
         )))
             .then((results) => {

--- a/client/actions/planning/api.ts
+++ b/client/actions/planning/api.ts
@@ -698,7 +698,7 @@ const uploadFiles = (planning) => (
                 upload,
                 '/planning_files/',
                 file,
-                {timeoutMs: 90000, retries: 2},
+                {retries: 2},
             )
         )))
             .then((results) => {

--- a/client/actions/planning/api.ts
+++ b/client/actions/planning/api.ts
@@ -1,5 +1,5 @@
 import {get, cloneDeep, pickBy, every} from 'lodash';
-import {IEventItem, IPlanningSearchParams, IPlanningItem} from '../../interfaces';
+import {IEventItem, IPlanningSearchParams, IPlanningItem, IFile} from '../../interfaces';
 import {appConfig} from 'appConfig';
 import {planningApi} from '../../superdeskApi';
 import * as actions from '../../actions';
@@ -25,6 +25,7 @@ import {planningParamsToSearchParams} from '../../utils/search';
 import {getRelatedEventIdsForPlanning} from '../../utils/planning';
 import moment from 'moment';
 import planningUi from './ui';
+import {uploadFileWithRetry} from '../../utils/upload';
 
 /**
  * Action dispatcher that marks a Planning item as spiked
@@ -675,7 +676,7 @@ const markPlanningPostponed = (plan, reason) => ({
 });
 
 const uploadFiles = (planning) => (
-    (dispatch, getState, {upload}) => {
+    (dispatch) => {
         const clonedPlanning = cloneDeep(planning);
 
         // If no files, do nothing
@@ -693,16 +694,14 @@ const uploadFiles = (planning) => (
         }
 
         return Promise.all(filesToUpload.map((file) => (
-            upload.start({
-                method: 'POST',
-                url: appConfig.server.url + '/planning_files/',
-                headers: {'Content-Type': 'multipart/form-data'},
-                data: {media: [file]},
-                arrayKey: '',
-            })
+            uploadFileWithRetry(
+                '/planning_files/',
+                file,
+                {timeoutMs: 90000, retries: 2},
+            )
         )))
             .then((results) => {
-                const files = results.map((res) => res.data);
+                const files: Array<IFile> = results;
 
                 if (get(files, 'length', 0) > 0) {
                     dispatch({

--- a/client/actions/planning/api.ts
+++ b/client/actions/planning/api.ts
@@ -676,7 +676,7 @@ const markPlanningPostponed = (plan, reason) => ({
 });
 
 const uploadFiles = (planning) => (
-    (dispatch) => {
+    (dispatch, getState, {upload}) => {
         const clonedPlanning = cloneDeep(planning);
 
         // If no files, do nothing
@@ -695,6 +695,7 @@ const uploadFiles = (planning) => (
 
         return Promise.all(filesToUpload.map((file) => (
             uploadFileWithRetry(
+                upload,
                 '/planning_files/',
                 file,
                 {timeoutMs: 90000, retries: 2},

--- a/client/components/Main/ItemEditorModal/EditorModalPanel.tsx
+++ b/client/components/Main/ItemEditorModal/EditorModalPanel.tsx
@@ -60,9 +60,15 @@ export class EditorModalPanel extends React.Component<IProps, IState> {
 
     onDragEvents(e) {
         e.preventDefault();
-        if (e.target.className.indexOf('basic-drag-block') < 0) {
+        const target = e.target as HTMLElement | null;
+        const insideDropZone = target?.closest?.('.basic-drag-block') != null;
+
+        if (!insideDropZone) {
             e.dataTransfer.effectAllowed = 'none';
             e.dataTransfer.dropEffect = 'none';
+        } else {
+            e.dataTransfer.effectAllowed = 'copy';
+            e.dataTransfer.dropEffect = 'copy';
         }
     }
 

--- a/client/components/UI/Form/FileInput.tsx
+++ b/client/components/UI/Form/FileInput.tsx
@@ -63,6 +63,8 @@ export class FileInput extends React.PureComponent<IProps> {
     }
 
     onDragEnter(e) {
+        e.preventDefault();
+        e.stopPropagation();
         e.dataTransfer.dropEffect = 'copy';
     }
 
@@ -192,7 +194,11 @@ export class FileInput extends React.PureComponent<IProps> {
                         ref={this.dom.container}
                         onDrop={this.onDrop}
                         onDragEnter={this.onDragEnter}
-                        onDragOver={(e) => e.preventDefault()}
+                        onDragOver={(e) => {
+                            e.preventDefault();
+                            e.stopPropagation();
+                            e.dataTransfer.dropEffect = 'copy';
+                        }}
                         className="basic-drag-block"
                         onKeyDown={this.handleKeyDown}
                     >

--- a/client/utils/upload.ts
+++ b/client/utils/upload.ts
@@ -1,0 +1,150 @@
+import ng from 'core/services/ng';
+
+import {appConfig} from 'appConfig';
+
+type IUploadMethod = 'POST' | 'PATCH';
+
+export interface IUploadOptions {
+    onProgress?: (event: ProgressEvent) => void;
+    timeoutMs?: number;
+    retries?: number;
+    retryDelayMs?: number;
+    method?: IUploadMethod;
+    etag?: string;
+}
+
+const DEFAULT_TIMEOUT_MS = 90000;
+const DEFAULT_RETRY_DELAY_MS = 500;
+
+function wait(ms: number) {
+    return new Promise<void>((resolve) => {
+        window.setTimeout(resolve, ms);
+    });
+}
+
+function createUploadError(message: string, extra: Record<string, unknown> = {}) {
+    return Object.assign(new Error(message), extra);
+}
+
+function getResponseMessage(responseText: string, status: number) {
+    if (!responseText) {
+        return `Upload failed with status ${status}`;
+    }
+
+    try {
+        const parsed = JSON.parse(responseText);
+
+        return parsed?._message ?? parsed?._error?.message ?? parsed?.message ?? `Upload failed with status ${status}`;
+    } catch (_e) {
+        return responseText;
+    }
+}
+
+function isRetryableUploadError(error: any) {
+    return error?.retryable === true || error?.timeout === true || error?.name === 'ProgressEvent';
+}
+
+async function uploadOnce<T>(
+    token: string,
+    endpoint: string,
+    data: FormData,
+    options: Required<Pick<IUploadOptions, 'method' | 'timeoutMs'>> & Pick<IUploadOptions, 'onProgress' | 'etag'>,
+): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+        const request = new XMLHttpRequest();
+        const url = appConfig.server.url + endpoint;
+
+        request.open(options.method, url);
+        request.setRequestHeader('Authorization', token);
+        request.timeout = options.timeoutMs;
+
+        if (options.method === 'PATCH' && options.etag != null) {
+            request.setRequestHeader('If-Match', options.etag);
+        }
+
+        if (options.onProgress != null) {
+            request.upload.onprogress = options.onProgress;
+        }
+
+        request.onload = function() {
+            const responseText = this.responseText ?? '';
+
+            if (this.status >= 200 && this.status < 300) {
+                if (!responseText) {
+                    resolve(undefined as T);
+                    return;
+                }
+
+                try {
+                    resolve(JSON.parse(responseText));
+                } catch (_e) {
+                    reject(createUploadError('Upload failed: invalid JSON response', {
+                        status: this.status,
+                        responseText: responseText,
+                        retryable: false,
+                    }));
+                }
+            } else {
+                reject(createUploadError(getResponseMessage(responseText, this.status), {
+                    status: this.status,
+                    responseText: responseText,
+                    retryable: this.status >= 500,
+                }));
+            }
+        };
+
+        request.onerror = function() {
+            reject(createUploadError('Upload failed because the network request errored.', {
+                retryable: true,
+            }));
+        };
+
+        request.ontimeout = function() {
+            reject(createUploadError('Upload timed out.', {
+                timeout: true,
+                retryable: true,
+            }));
+        };
+
+        request.onabort = function() {
+            reject(createUploadError('Upload was aborted.', {
+                aborted: true,
+                retryable: false,
+            }));
+        };
+
+        request.send(data);
+    });
+}
+
+export async function uploadFileWithRetry<T>(
+    endpoint: string,
+    file: File | Array<File>,
+    options: IUploadOptions = {},
+): Promise<T> {
+    const {timeoutMs = DEFAULT_TIMEOUT_MS, retries = 1, retryDelayMs = DEFAULT_RETRY_DELAY_MS} = options;
+    const session = await ng.getService('session');
+    const uploadData = new FormData();
+    const mediaFile = Array.isArray(file) ? file[0] : file;
+
+    uploadData.append('media', mediaFile);
+
+    for (let attempt = 0; attempt <= retries; attempt += 1) {
+        try {
+            return await uploadOnce<T>(session.token, endpoint, uploadData, {
+                method: options.method ?? 'POST',
+                etag: options.etag,
+                onProgress: options.onProgress,
+                timeoutMs: timeoutMs,
+            });
+        } catch (error) {
+            if (attempt < retries && isRetryableUploadError(error)) {
+                await wait(retryDelayMs * (attempt + 1));
+            } else {
+                throw error;
+            }
+        }
+    }
+
+    throw createUploadError('Upload failed unexpectedly.');
+}

--- a/client/utils/upload.ts
+++ b/client/utils/upload.ts
@@ -1,4 +1,5 @@
 import {appConfig} from 'appConfig';
+import {gettext} from './index';
 
 type IUploadMethod = 'POST' | 'PATCH';
 
@@ -73,7 +74,7 @@ async function uploadOnce<T>(
                 uploadPromise.abort();
             }
 
-            reject(createUploadError('Upload timed out.', {timeout: true}));
+            reject(createUploadError(gettext('Upload timed out.'), {timeout: true}));
         }, options.timeoutMs);
 
         if (options.onProgress != null) {

--- a/client/utils/upload.ts
+++ b/client/utils/upload.ts
@@ -73,7 +73,7 @@ async function uploadOnce<T>(
                 uploadPromise.abort();
             }
 
-            reject(createUploadError('Upload timed out.'));
+            reject(createUploadError('Upload timed out.', {timeout: true}));
         }, options.timeoutMs);
 
         if (options.onProgress != null) {

--- a/client/utils/upload.ts
+++ b/client/utils/upload.ts
@@ -1,8 +1,10 @@
-import ng from 'core/services/ng';
-
 import {appConfig} from 'appConfig';
 
 type IUploadMethod = 'POST' | 'PATCH';
+
+interface IUploadService {
+    start(config: Record<string, any>): Promise<{data: any}>;
+}
 
 export interface IUploadOptions {
     onProgress?: (event: ProgressEvent) => void;
@@ -18,7 +20,7 @@ const DEFAULT_RETRY_DELAY_MS = 500;
 
 function wait(ms: number) {
     return new Promise<void>((resolve) => {
-        window.setTimeout(resolve, ms);
+        setTimeout(resolve, ms);
     });
 }
 
@@ -26,122 +28,83 @@ function createUploadError(message: string, extra: Record<string, unknown> = {})
     return Object.assign(new Error(message), extra);
 }
 
-function getResponseMessage(responseText: string, status: number) {
-    if (!responseText) {
-        return `Upload failed with status ${status}`;
-    }
-
-    try {
-        const parsed = JSON.parse(responseText);
-
-        return parsed?._message ?? parsed?._error?.message ?? parsed?.message ?? `Upload failed with status ${status}`;
-    } catch (_e) {
-        return responseText;
-    }
+function isRetryableUploadError(error: any) {
+    return error?.timeout === true || error?.retryable === true || error?.status >= 500;
 }
 
-function isRetryableUploadError(error: any) {
-    return error?.retryable === true || error?.timeout === true || error?.name === 'ProgressEvent';
+function toUploadError(error: any) {
+    return error;
+}
+
+function buildUploadConfig(endpoint: string, file: File | Array<File>, method: IUploadMethod, etag?: string) {
+    const mediaFile = Array.isArray(file) ? file[0] : file;
+    const headers: Record<string, string> = {'Content-Type': 'multipart/form-data'};
+    const data = {media: [mediaFile]};
+
+    if (method === 'PATCH' && etag != null) {
+        headers['If-Match'] = etag;
+    }
+
+    return {
+        method: method,
+        url: appConfig.server.url + endpoint,
+        headers: headers,
+        data: data,
+        arrayKey: '',
+    };
 }
 
 async function uploadOnce<T>(
-    token: string,
+    upload: IUploadService,
     endpoint: string,
-    data: FormData,
+    file: File | Array<File>,
     options: Required<Pick<IUploadOptions, 'method' | 'timeoutMs'>> & Pick<IUploadOptions, 'onProgress' | 'etag'>,
 ): Promise<T> {
-    return new Promise<T>((resolve, reject) => {
-        const request = new XMLHttpRequest();
-        const url = appConfig.server.url + endpoint;
+    const uploadPromise = upload.start(buildUploadConfig(endpoint, file, options.method, options.etag));
 
-        request.open(options.method, url);
-        request.setRequestHeader('Authorization', token);
-        request.timeout = options.timeoutMs;
+    if (options.onProgress != null) {
+        uploadPromise.then(undefined, undefined, options.onProgress);
+    }
 
-        if (options.method === 'PATCH' && options.etag != null) {
-            request.setRequestHeader('If-Match', options.etag);
-        }
-
-        if (options.onProgress != null) {
-            request.upload.onprogress = options.onProgress;
-        }
-
-        request.onload = function() {
-            const responseText = this.responseText ?? '';
-
-            if (this.status >= 200 && this.status < 300) {
-                if (!responseText) {
-                    resolve(undefined as T);
-                    return;
-                }
-
-                try {
-                    resolve(JSON.parse(responseText));
-                } catch (_e) {
-                    reject(createUploadError('Upload failed: invalid JSON response', {
-                        status: this.status,
-                        responseText: responseText,
-                        retryable: false,
-                    }));
-                }
-            } else {
-                reject(createUploadError(getResponseMessage(responseText, this.status), {
-                    status: this.status,
-                    responseText: responseText,
-                    retryable: this.status >= 500,
-                }));
-            }
-        };
-
-        request.onerror = function() {
-            reject(createUploadError('Upload failed because the network request errored.', {
-                retryable: true,
-            }));
-        };
-
-        request.ontimeout = function() {
+    const timeoutPromise = new Promise<never>((_, reject) => {
+        setTimeout(() => {
             reject(createUploadError('Upload timed out.', {
                 timeout: true,
                 retryable: true,
             }));
-        };
-
-        request.onabort = function() {
-            reject(createUploadError('Upload was aborted.', {
-                aborted: true,
-                retryable: false,
-            }));
-        };
-
-        request.send(data);
+        }, options.timeoutMs);
     });
+
+    const response = await Promise.race([uploadPromise, timeoutPromise]);
+
+    return response.data;
 }
 
 export async function uploadFileWithRetry<T>(
+    upload: IUploadService,
     endpoint: string,
     file: File | Array<File>,
     options: IUploadOptions = {},
 ): Promise<T> {
     const {timeoutMs = DEFAULT_TIMEOUT_MS, retries = 1, retryDelayMs = DEFAULT_RETRY_DELAY_MS} = options;
-    const session = await ng.getService('session');
-    const uploadData = new FormData();
-    const mediaFile = Array.isArray(file) ? file[0] : file;
-
-    uploadData.append('media', mediaFile);
 
     for (let attempt = 0; attempt <= retries; attempt += 1) {
         try {
-            return await uploadOnce<T>(session.token, endpoint, uploadData, {
+            const etag = options.etag;
+
+            return await uploadOnce<T>(upload, endpoint, file, {
                 method: options.method ?? 'POST',
-                etag: options.etag,
+                etag: etag,
                 onProgress: options.onProgress,
                 timeoutMs: timeoutMs,
             });
         } catch (error) {
-            if (attempt < retries && isRetryableUploadError(error)) {
+            const normalizedError = toUploadError(error);
+
+            if (attempt < retries && isRetryableUploadError(normalizedError)) {
                 await wait(retryDelayMs * (attempt + 1));
             } else {
-                throw error;
+                throw normalizedError;
             }
         }
     }

--- a/client/utils/upload.ts
+++ b/client/utils/upload.ts
@@ -37,9 +37,8 @@ function toUploadError(error: any) {
 }
 
 function buildUploadConfig(endpoint: string, file: File | Array<File>, method: IUploadMethod, etag?: string) {
-    const mediaFile = Array.isArray(file) ? file[0] : file;
     const headers: Record<string, string> = {'Content-Type': 'multipart/form-data'};
-    const data = {media: [mediaFile]};
+    const data = {media: [file]};
 
     if (method === 'PATCH' && etag != null) {
         headers['If-Match'] = etag;

--- a/client/utils/upload.ts
+++ b/client/utils/upload.ts
@@ -32,10 +32,6 @@ function isRetryableUploadError(error: any) {
     return error?.timeout === true || error?.retryable === true || error?.status >= 500;
 }
 
-function toUploadError(error: any) {
-    return error;
-}
-
 function buildUploadConfig(endpoint: string, file: File | Array<File>, method: IUploadMethod, etag?: string) {
     const headers: Record<string, string> = {'Content-Type': 'multipart/form-data'};
     const data = {media: [file]};
@@ -67,10 +63,7 @@ async function uploadOnce<T>(
 
     const timeoutPromise = new Promise<never>((_, reject) => {
         setTimeout(() => {
-            reject(createUploadError('Upload timed out.', {
-                timeout: true,
-                retryable: true,
-            }));
+            reject(createUploadError('Upload timed out.'));
         }, options.timeoutMs);
     });
 
@@ -98,12 +91,10 @@ export async function uploadFileWithRetry<T>(
                 timeoutMs: timeoutMs,
             });
         } catch (error) {
-            const normalizedError = toUploadError(error);
-
-            if (attempt < retries && isRetryableUploadError(normalizedError)) {
+            if (attempt < retries && isRetryableUploadError(error)) {
                 await wait(retryDelayMs * (attempt + 1));
             } else {
-                throw normalizedError;
+                throw error;
             }
         }
     }

--- a/client/utils/upload.ts
+++ b/client/utils/upload.ts
@@ -6,6 +6,10 @@ interface IUploadService {
     start(config: Record<string, any>): Promise<{data: any}>;
 }
 
+interface IUploadPromise<T> extends Promise<T> {
+    abort?: () => void;
+}
+
 export interface IUploadOptions {
     onProgress?: (event: ProgressEvent) => void;
     timeoutMs?: number;
@@ -55,21 +59,43 @@ async function uploadOnce<T>(
     file: File | Array<File>,
     options: Required<Pick<IUploadOptions, 'method' | 'timeoutMs'>> & Pick<IUploadOptions, 'onProgress' | 'etag'>,
 ): Promise<T> {
-    const uploadPromise = upload.start(buildUploadConfig(endpoint, file, options.method, options.etag));
+    const uploadPromise = upload.start(
+        buildUploadConfig(endpoint, file, options.method, options.etag)
+    ) as IUploadPromise<{data: any}>;
 
-    if (options.onProgress != null) {
-        uploadPromise.then(undefined, undefined, options.onProgress);
-    }
+    return await new Promise<T>((resolve, reject) => {
+        let settled = false;
 
-    const timeoutPromise = new Promise<never>((_, reject) => {
-        setTimeout(() => {
+        const timeoutId = setTimeout(() => {
+            settled = true;
+
+            if (typeof uploadPromise.abort === 'function') {
+                uploadPromise.abort();
+            }
+
             reject(createUploadError('Upload timed out.'));
         }, options.timeoutMs);
+
+        if (options.onProgress != null) {
+            uploadPromise.then(undefined, undefined, options.onProgress);
+        }
+
+        uploadPromise.then((response) => {
+            if (settled) {
+                return;
+            }
+
+            clearTimeout(timeoutId);
+            resolve(response.data);
+        }, (error) => {
+            if (settled) {
+                return;
+            }
+
+            clearTimeout(timeoutId);
+            reject(error);
+        });
     });
-
-    const response = await Promise.race([uploadPromise, timeoutPromise]);
-
-    return response.data;
 }
 
 export async function uploadFileWithRetry<T>(


### PR DESCRIPTION
### Purpose
This PR tries to improve attachment uploads in event and planning editors, especially drag-and-drop behavior and upload failure handling. Although not fully reproduced locally, the changes help make it more robust

### What has changed
- Hardened drag/drop handling in the shared file input.
- Replaced modal drag-target detection with closest().
- Added shared upload retry and timeout handling for event and planning file uploads.

### Steps to test
1. Open an event or planning item and use Attached Files.
2. Upload a file via drag-and-drop and via browse.
3. Confirm the file attaches successfully and the UI does not hang.
4. Throttle or interrupt the network and confirm the upload fails cleanly and retries once before showing an error.


Resolves: #[STT-1670](https://sofab.atlassian.net/browse/STT-1670)



[STT-1670]: https://sofab.atlassian.net/browse/STT-1670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ