### PR TITLE
[SDBELGA-1053] Changes required for belga async

### DIFF
--- a/server/planning/assignments/assignments_content.py
+++ b/server/planning/assignments/assignments_content.py
@@ -150,14 +150,7 @@ async def get_item_from_assignment(assignment, template=None):
     if language:
         item["language"] = language
 
-    assignment_content_create.send(
-        None,
-        assignment=assignment,
-        planning=planning,
-        item=item,
-        content_profile=content_profile,
-    )
-
+    await assignment_content_create.send(assignment, planning, item, content_profile)
     return item, translations
 
 

--- a/server/planning/signals.py
+++ b/server/planning/signals.py
@@ -29,7 +29,12 @@ planning_created = signals.signal("planning:created")
 #: param original: Original Planning item dict (if updating), else None
 planning_ingested = AsyncSignal[dict, dict | None]("planning:ingested")
 
-assignment_content_create = signals.signal("planning:assignment_content_create")
+#: Signal for them content is created from an Assignment
+#: param assignment: The Assignment item dict
+#: param planning: The Planning item dict
+#: param item: The content item to be created
+#: param content_profile: The ContentProfile of the item
+assignment_content_create = AsyncSignal[dict, dict, dict, dict]("planning:assignment_content_create")
 
 
 #: Signal for when an Event is about to be updated in the DB

--- a/server/planning/utils.py
+++ b/server/planning/utils.py
@@ -262,6 +262,41 @@ def get_related_event_items_for_planning(
     return events
 
 
+async def get_related_event_items_for_planning_async(
+    plan: Planning, link_type: Optional[PLANNING_RELATED_EVENT_LINK_TYPE] = None
+) -> List[Event]:
+    """
+    Retrieve related event items asynchronously for a given planning object.
+
+    This function retrieves event items related to a specified planning object, optionally filtered
+    by a specific link type. It returns a list of related event objects. If some events are not found
+    in the database, a warning is logged with the relevant details.
+
+    :param plan: The planning item for which related events are being retrieved.
+    :param link_type: An optional link type to filter the related events. If not provided, all related events are retrieved.
+    :return: List of Events related to the given planning object.
+    """
+
+    event_ids = get_related_event_ids_for_planning(plan, link_type)
+    if not len(event_ids):
+        return []
+
+    cursor = await get_resource_service("events").find_async(where={"_id": {"$in": event_ids}})
+    events = await cursor.to_list()
+
+    if len(event_ids) != len(events):
+        logger.warning(
+            "Not all Events were found for the Planning item",
+            extra=dict(
+                plan_id=plan[ID_FIELD],
+                event_ids_requested=event_ids,
+                events_ids_found=[event[ID_FIELD] for event in events],
+            ),
+        )
+
+    return events
+
+
 def get_first_event_item_for_planning_id(
     planning_id: str, link_type: Optional[PLANNING_RELATED_EVENT_LINK_TYPE] = None
 ) -> Optional[Event]:


### PR DESCRIPTION
### Purpose
Changes in core are required for Belga search providers and signals

### What has changed
* Convert `assignment_content_create` to async signal
* Copy `get_related_event_items_for_planning` and make async version

Resolves: [SDBELGA-1053](https://sofab.atlassian.net/browse/SDBELGA-1053)



[SDBELGA-1053]: https://sofab.atlassian.net/browse/SDBELGA-1053?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ