### PR TITLE
[SDESK-7925] Update package.json main and scripts

### DIFF
--- a/.github/workflows/ci-client.yml
+++ b/.github/workflows/ci-client.yml
@@ -35,6 +35,6 @@ jobs:
       - name: install
         working-directory: client/planning-extension
         run: npm ci
-      - name: compile
+      - name: typecheck
         working-directory: client/planning-extension
-        run: npm run compile
+        run: npx tsc --noEmit -p src/tsconfig.json

--- a/client/planning-extension/package.json
+++ b/client/planning-extension/package.json
@@ -1,12 +1,9 @@
 {
   "private": true,
   "name": "superdesk-planning-extension",
-  "main": "dist/planning-extension/src/extension.js",
+  "main": "src/extension.ts",
   "scripts": {
-    "compile": "tsc -p src",
-    "compile-e2e": "echo 'No end-to-end tests defined'",
-    "prepublish": "rm -rf dist && npm run compile && cp src/index.css dist",
-    "watch": "tsc -watch -p src"
+    "compile-e2e": "echo 'No end-to-end tests defined'"
   },
   "devDependencies": {
     "@types/angular": "1.6.50",


### PR DESCRIPTION
### Purpose
Point package main to the TypeScript source (`src/extension.ts`) and remove build-related npm scripts (compile, prepublish, watch). This reflects the move away from referencing the prebuilt `dist` entry and removes local compile/watch steps from the package.json.

This PR depends on https://github.com/superdesk/superdesk-client-core/pull/5177

[SDESK-7925]


[SDESK-7925]: https://sofab.atlassian.net/browse/SDESK-7925?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ