### PR TITLE
fix removing of assignment info from coverages

### DIFF
--- a/server/planning/planning/planning.py
+++ b/server/planning/planning/planning.py
@@ -1017,7 +1017,8 @@ class PlanningService(AsyncBaseService):
                     updates["assigned_to"] = None
                     await self.set_xmp_file_info(updates, original)
                 else:
-                    del updates["assigned_to"]
+                    updates["assigned_to"] = deepcopy(updated_coverage.get("assigned_to") or updates["assigned_to"])
+                    updates["assigned_to"].pop("assignment_id", None)
                 return
 
             # Check if the coverage was cancelled

--- a/server/planning/planning/planning.py
+++ b/server/planning/planning/planning.py
@@ -1006,8 +1006,6 @@ class PlanningService(AsyncBaseService):
                 # Return now, we will process the assignment after the DB is updated
                 return
 
-            await self.set_xmp_file_info(updates, original)
-
             existing_assignment_id = ObjectId(assigned_to["assignment_id"])
             original_assignment = await assignment_service.find_one_async(req=None, _id=existing_assignment_id)
             if not original_assignment:
@@ -1015,11 +1013,12 @@ class PlanningService(AsyncBaseService):
                 # so the user can continue editing the coverage
                 if not updates.get("assigned_to"):
                     updates["assigned_to"] = None
-                    await self.set_xmp_file_info(updates, original)
                 else:
                     updates["assigned_to"] = deepcopy(updated_coverage.get("assigned_to") or updates["assigned_to"])
                     updates["assigned_to"].pop("assignment_id", None)
                 return
+
+            await self.set_xmp_file_info(updates, original)
 
             # Check if the coverage was cancelled
             if (

--- a/server/planning/tests/coverage_assignments_sync_test.py
+++ b/server/planning/tests/coverage_assignments_sync_test.py
@@ -1,9 +1,11 @@
 from bson import ObjectId
+from unittest import mock
 from superdesk.utc import utcnow
 from superdesk import get_resource_service
 from superdesk.tests import utils as test_utils, fixtures
 from superdesk.tests import setup_db_user
 
+from planning.planning.planning import PlanningService
 from planning.tests import TestCase
 
 
@@ -170,6 +172,64 @@ class SyncAssignmentCoverageTest(TestCase):
                 ]
             },
         )
+
+        updated_assigned_to = updated["coverages"][0].get("assigned_to") or {}
+        self.assertEqual(updated_assigned_to.get("desk"), assigned_to.get("desk"))
+        self.assertEqual(updated_assigned_to.get("user"), assigned_to.get("user"))
+        self.assertEqual(updated_assigned_to.get("state"), assigned_to.get("state"))
+        self.assertIsNone(updated_assigned_to.get("assignment_id"))
+
+    async def test_planning_patch_does_not_touch_xmp_when_assignment_is_missing(self):
+        self.app.config["PLANNING_AUTO_ASSIGN_TO_WORKFLOW"] = True
+        await test_utils.post_items("users", [fixtures.users.admin().to_dict()])
+        await test_utils.post_items("desks", [fixtures.desks.sports_desk().to_dict()])
+        await test_utils.post_items("stages", [fixtures.stages.sports_working_stage()])
+
+        await test_utils.post_items(
+            "planning",
+            [
+                {
+                    "guid": "p5",
+                    "slugline": "test",
+                    "planning_date": now,
+                    "coverages": [
+                        {
+                            "coverage_id": "c5",
+                            "workflow_status": "draft",
+                            "news_coverage_status": {"qcode": "ncostat:int"},
+                            "planning": {"scheduled": now},
+                            "assigned_to": {
+                                "desk": fixtures.desks.SPORTS_DESK_ID,
+                                "user": fixtures.users.ADMIN_USER_ID,
+                                "state": "draft",
+                            },
+                        }
+                    ],
+                }
+            ],
+        )
+
+        original = await test_utils.find_by_id("planning", "p5")
+        assigned_to = dict(original["coverages"][0]["assigned_to"])
+        self.app.data.remove("assignments", {"_id": ObjectId(assigned_to["assignment_id"])})
+
+        with mock.patch.object(PlanningService, "set_xmp_file_info", new_callable=mock.AsyncMock) as set_xmp_mock:
+            updated = await get_resource_service("planning").patch_async(
+                "p5",
+                {
+                    "coverages": [
+                        {
+                            "coverage_id": "c5",
+                            "planning": {"scheduled": now},
+                            "workflow_status": original["coverages"][0]["workflow_status"],
+                            "news_coverage_status": original["coverages"][0]["news_coverage_status"],
+                            "assigned_to": assigned_to,
+                        }
+                    ]
+                },
+            )
+
+        set_xmp_mock.assert_not_awaited()
 
         updated_assigned_to = updated["coverages"][0].get("assigned_to") or {}
         self.assertEqual(updated_assigned_to.get("desk"), assigned_to.get("desk"))

--- a/server/planning/tests/coverage_assignments_sync_test.py
+++ b/server/planning/tests/coverage_assignments_sync_test.py
@@ -1,6 +1,8 @@
 from bson import ObjectId
 from superdesk.utc import utcnow
+from superdesk import get_resource_service
 from superdesk.tests import utils as test_utils, fixtures
+from superdesk.tests import setup_db_user
 
 from planning.tests import TestCase
 
@@ -9,6 +11,172 @@ now = utcnow()
 
 
 class SyncAssignmentCoverageTest(TestCase):
+    async def test_planning_patch_preserves_coverage_assigned_to(self):
+        self.app.config["PLANNING_AUTO_ASSIGN_TO_WORKFLOW"] = True
+        await test_utils.post_items("users", [fixtures.users.admin().to_dict()])
+        await test_utils.post_items("desks", [fixtures.desks.sports_desk().to_dict()])
+        await test_utils.post_items("stages", [fixtures.stages.sports_working_stage()])
+
+        await test_utils.post_items(
+            "planning",
+            [
+                {
+                    "guid": "p2",
+                    "slugline": "test",
+                    "planning_date": now,
+                    "coverages": [
+                        {
+                            "coverage_id": "c2",
+                            "workflow_status": "draft",
+                            "news_coverage_status": {"qcode": "ncostat:int"},
+                            "planning": {"scheduled": now},
+                            "assigned_to": {
+                                "desk": fixtures.desks.SPORTS_DESK_ID,
+                                "user": fixtures.users.ADMIN_USER_ID,
+                                "state": "draft",
+                            },
+                        }
+                    ],
+                }
+            ],
+        )
+
+        original = await test_utils.find_by_id("planning", "p2")
+        assigned_to = dict(original["coverages"][0]["assigned_to"])
+
+        updated = await get_resource_service("planning").patch_async(
+            "p2",
+            {
+                "coverages": [
+                    {
+                        "coverage_id": "c2",
+                        "planning": {"scheduled": now},
+                        "workflow_status": original["coverages"][0]["workflow_status"],
+                        "news_coverage_status": original["coverages"][0]["news_coverage_status"],
+                        "assigned_to": assigned_to,
+                    }
+                ]
+            },
+        )
+
+        self.assertEqual(updated["coverages"][0].get("assigned_to"), assigned_to)
+
+        persisted = await test_utils.find_by_id("planning", "p2")
+        self.assertEqual(persisted["coverages"][0].get("assigned_to"), assigned_to)
+
+    async def test_planning_http_patch_preserves_coverage_assigned_to_in_response(self):
+        self.app.config["PLANNING_AUTO_ASSIGN_TO_WORKFLOW"] = True
+        self.headers = []
+        await test_utils.post_items("users", [fixtures.users.admin().to_dict()])
+        await test_utils.post_items("desks", [fixtures.desks.sports_desk().to_dict()])
+        await test_utils.post_items("stages", [fixtures.stages.sports_working_stage()])
+        await setup_db_user(self, fixtures.users.admin().to_dict())
+
+        await test_utils.post_items(
+            "planning",
+            [
+                {
+                    "guid": "p3",
+                    "slugline": "test",
+                    "planning_date": now,
+                    "coverages": [
+                        {
+                            "coverage_id": "c3",
+                            "workflow_status": "draft",
+                            "news_coverage_status": {"qcode": "ncostat:int"},
+                            "planning": {"scheduled": now},
+                            "assigned_to": {
+                                "desk": fixtures.desks.SPORTS_DESK_ID,
+                                "user": fixtures.users.ADMIN_USER_ID,
+                                "state": "draft",
+                            },
+                        }
+                    ],
+                }
+            ],
+        )
+
+        original = await test_utils.find_by_id("planning", "p3")
+        assigned_to = dict(original["coverages"][0]["assigned_to"])
+        response = await self.test_client.patch(
+            "/api/planning/p3",
+            json={
+                "coverages": [
+                    {
+                        "coverage_id": "c3",
+                        "planning": {"scheduled": now},
+                        "workflow_status": original["coverages"][0]["workflow_status"],
+                        "news_coverage_status": original["coverages"][0]["news_coverage_status"],
+                        "assigned_to": assigned_to,
+                    }
+                ]
+            },
+            headers=self.headers + [("If-Match", original["_etag"])],
+        )
+
+        self.assertEqual(response.status_code, 200)
+        body = await response.get_json()
+        response_assigned_to = body["coverages"][0].get("assigned_to") or {}
+        self.assertEqual(response_assigned_to.get("assignment_id"), assigned_to.get("assignment_id"))
+        self.assertEqual(response_assigned_to.get("desk"), str(assigned_to.get("desk")))
+        self.assertEqual(response_assigned_to.get("user"), str(assigned_to.get("user")))
+        self.assertEqual(response_assigned_to.get("state"), assigned_to.get("state"))
+
+    async def test_planning_patch_preserves_assignee_fields_when_assignment_is_missing(self):
+        self.app.config["PLANNING_AUTO_ASSIGN_TO_WORKFLOW"] = True
+        await test_utils.post_items("users", [fixtures.users.admin().to_dict()])
+        await test_utils.post_items("desks", [fixtures.desks.sports_desk().to_dict()])
+        await test_utils.post_items("stages", [fixtures.stages.sports_working_stage()])
+
+        await test_utils.post_items(
+            "planning",
+            [
+                {
+                    "guid": "p4",
+                    "slugline": "test",
+                    "planning_date": now,
+                    "coverages": [
+                        {
+                            "coverage_id": "c4",
+                            "workflow_status": "draft",
+                            "news_coverage_status": {"qcode": "ncostat:int"},
+                            "planning": {"scheduled": now},
+                            "assigned_to": {
+                                "desk": fixtures.desks.SPORTS_DESK_ID,
+                                "user": fixtures.users.ADMIN_USER_ID,
+                                "state": "draft",
+                            },
+                        }
+                    ],
+                }
+            ],
+        )
+
+        original = await test_utils.find_by_id("planning", "p4")
+        assigned_to = dict(original["coverages"][0]["assigned_to"])
+        self.app.data.remove("assignments", {"_id": ObjectId(assigned_to["assignment_id"])})
+
+        updated = await get_resource_service("planning").patch_async(
+            "p4",
+            {
+                "coverages": [
+                    {
+                        "coverage_id": "c4",
+                        "planning": {"scheduled": now},
+                        "workflow_status": original["coverages"][0]["workflow_status"],
+                        "news_coverage_status": original["coverages"][0]["news_coverage_status"],
+                        "assigned_to": assigned_to,
+                    }
+                ]
+            },
+        )
+
+        updated_assigned_to = updated["coverages"][0].get("assigned_to") or {}
+        self.assertEqual(updated_assigned_to.get("desk"), assigned_to.get("desk"))
+        self.assertEqual(updated_assigned_to.get("user"), assigned_to.get("user"))
+        self.assertEqual(updated_assigned_to.get("state"), assigned_to.get("state"))
+        self.assertIsNone(updated_assigned_to.get("assignment_id"))
+
     async def test_planning_etag_not_changed_after_sync_assignment_coverage(self):
         self.app.config["PLANNING_AUTO_ASSIGN_TO_WORKFLOW"] = True
         await test_utils.post_items("users", [fixtures.users.admin().to_dict()])


### PR DESCRIPTION
STT-1679

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

### Front-end checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)

Resolves: #[issue-number]

