### PR TITLE
[STT-1683] - Issue with the same Assignment ID

### DIFF
--- a/server/planning/planning/planning_duplicate.py
+++ b/server/planning/planning/planning_duplicate.py
@@ -106,6 +106,9 @@ def duplicate_planning_item(original: dict[str, Any]) -> dict:
         if not get_config_planning_duplicate_retain_assignee_details():
             cov["assigned_to"] = {}
 
+        # Clear the assignment link so the duplicate gets its own assignment.
+        cov.get("assigned_to", {}).pop("assignment_id", None)
+
     return new_plan
 
 

--- a/server/planning/tests/planning_duplicate_tests.py
+++ b/server/planning/tests/planning_duplicate_tests.py
@@ -40,6 +40,7 @@ class PlanningDuplicateTestCase(TestCase):
                     "assigned_to": {
                         "user": fixtures.users.ADMIN_USER_ID,
                         "desk": "desk1",
+                        "assignment_id": "assignment1",
                         "state": "completed",
                         "priority": 2,
                     },
@@ -110,6 +111,7 @@ class PlanningDuplicateTestCase(TestCase):
         self.assertEqual(coverage["assigned_to"]["desk"], "desk1")
         self.assertEqual(coverage["assigned_to"]["state"], "completed")
         self.assertEqual(coverage["assigned_to"]["priority"], 2)
+        self.assertIsNone(coverage["assigned_to"].get("assignment_id"))
 
     async def test_duplicate_planning_item_with_both_configs_true(self):
         """Test that both coverage status and assignee details are retained when both configs are True."""
@@ -130,6 +132,7 @@ class PlanningDuplicateTestCase(TestCase):
         self.assertEqual(coverage["news_coverage_status"]["qcode"], "ncostat:onreq")
         self.assertEqual(coverage["assigned_to"]["user"], fixtures.users.ADMIN_USER_ID)
         self.assertEqual(coverage["assigned_to"]["desk"], "desk1")
+        self.assertIsNone(coverage["assigned_to"].get("assignment_id"))
 
         # Workflow status should still be reset to draft regardless of config
         self.assertEqual(coverage["workflow_status"], "draft")


### PR DESCRIPTION
### Purpose
This PR fixed duplicated planning items reusing the original assignment link. When a coverage is copied, and `PLANNING_DUPLICATE_RETAIN_ASSIGNEE_DETAILS` is TRUE,  it should keep the assignee details but get its own `assignment_id`

### What has changed
- Updated planning duplication logic to always clear assigned_to.assignment_id on duplicated overages 
- Added regression tests to verify duplicated coverages do not retain the original assignment_id.

### Steps to test
1. Create a planning item with a coverage assigned to a desk/user.
2. Duplicate the planning item.
3. Verify the duplicate keeps the coverage status and assignee details.
4. Verify the duplicate coverage has a different `assigned_to.assignment_id` from the original.
5. Open the Assignments page and confirm the original and duplicate now show separate assignments.
6. Edit one coverage and confirm it no longer updates the other item.

Resolves: #[STT-1683](https://sofab.atlassian.net/browse/STT-1683)



[STT-1683]: https://sofab.atlassian.net/browse/STT-1683?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ