### PR TITLE
fix assignment removal when adding event to planning item

### DIFF
--- a/server/planning/planning/planning.py
+++ b/server/planning/planning/planning.py
@@ -506,6 +506,11 @@ class PlanningService(AsyncBaseService):
         return len(changed_ids) > 0
 
     async def _process_removed_assignments(self, updates: dict, original: dict) -> None:
+        if "coverages" not in updates:
+            # Non-coverage updates (for example linking related events) must not
+            # be treated as coverage removals.
+            return
+
         assignment_service = get_resource_service("assignments")
         planning_item = deepcopy(original)
         planning_item.update(deepcopy(updates))

--- a/server/planning/planning/planning_tests.py
+++ b/server/planning/planning/planning_tests.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 import pytz
+from bson import ObjectId
 
 from superdesk import get_resource_service
 from superdesk.errors import SuperdeskApiError
@@ -91,3 +92,39 @@ class DuplicateCoverageTestCase(TestCase):
             return
 
         self.assertFalse("Failed to raise an exception")
+
+    async def test_non_coverage_update_does_not_remove_assignment(self):
+        planning_service = get_resource_service("planning")
+        assignments_service = get_resource_service("assignments")
+        assignment_id = ObjectId()
+
+        original = {
+            "_id": "plan_keep_assignment",
+            "coverages": [
+                {
+                    "coverage_id": "coverage_keep_assignment",
+                    "workflow_status": "draft",
+                    "assigned_to": {"assignment_id": str(assignment_id)},
+                }
+            ],
+        }
+        self.app.data.insert("planning", [original])
+        self.app.data.insert(
+            "assignments",
+            [
+                {
+                    "_id": assignment_id,
+                    "planning_item": "plan_keep_assignment",
+                    "coverage_item": "coverage_keep_assignment",
+                    "assigned_to": {"state": "draft"},
+                }
+            ],
+        )
+
+        await planning_service._process_removed_assignments(
+            {"related_events": [{"_id": "event1", "link_type": "primary"}]},
+            original,
+        )
+
+        assignment = await assignments_service.find_one_async(req=None, _id=assignment_id)
+        self.assertIsNotNone(assignment)

--- a/server/planning/planning/planning_tests.py
+++ b/server/planning/planning/planning_tests.py
@@ -93,6 +93,13 @@ class DuplicateCoverageTestCase(TestCase):
 
         self.assertFalse("Failed to raise an exception")
 
+
+class RemovedAssignmentsTestCase(TestCase):
+    async def asyncSetUp(self):
+        await super().asyncSetUp()
+        await test_utils.post_items("users", fixtures.users.all_users())
+        g.user = fixtures.users.admin().to_dict()
+
     async def test_non_coverage_update_does_not_remove_assignment(self):
         planning_service = get_resource_service("planning")
         assignments_service = get_resource_service("assignments")
@@ -100,6 +107,7 @@ class DuplicateCoverageTestCase(TestCase):
 
         original = {
             "_id": "plan_keep_assignment",
+            "slugline": "original slugline",
             "coverages": [
                 {
                     "coverage_id": "coverage_keep_assignment",
@@ -121,9 +129,9 @@ class DuplicateCoverageTestCase(TestCase):
             ],
         )
 
-        await planning_service._process_removed_assignments(
-            {"related_events": [{"_id": "event1", "link_type": "primary"}]},
-            original,
+        await planning_service.patch_async(
+            "plan_keep_assignment",
+            {"slugline": "updated slugline"},
         )
 
         assignment = await assignments_service.find_one_async(req=None, _id=assignment_id)


### PR DESCRIPTION
STT-1679

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

### Front-end checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)

Resolves: #[issue-number]

