### PR TITLE
ignore scheme in categories field when removing values

### DIFF
--- a/client/components/UI/Form/SelectMetaTermsInput/index.tsx
+++ b/client/components/UI/Form/SelectMetaTermsInput/index.tsx
@@ -29,6 +29,7 @@ export interface IProps {
     maxLength?: number;
     language?: string;
     invalid?: boolean;
+    ignoreScheme?: boolean;
 }
 
 interface IState {
@@ -73,11 +74,13 @@ export class SelectMetaTermsInput extends React.Component<IProps, IState> {
         if (term.scheme != null || term.qcode != null) {
             const termScheme = term.scheme ?? null;
             const termQcode = term.qcode ?? null;
+            const updatedValue = value.filter(({scheme = null, qcode = null}) => {
+                if (this.props.ignoreScheme && termQcode != null) {
+                    return termQcode !== qcode;
+                }
 
-            // fallback to `null` when destructuring, since this is a strict comparison
-            const updatedValue = value.filter(({scheme = null, qcode = null}) =>
-                !(termScheme === scheme && termQcode === qcode)
-            );
+                return !(termScheme === scheme && termQcode === qcode);
+            });
 
             onChange(
                 field,

--- a/client/components/UI/Form/SelectMetaTermsInput/index_test.tsx
+++ b/client/components/UI/Form/SelectMetaTermsInput/index_test.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import {mount} from 'enzyme';
+import sinon from 'sinon';
+
+import {SelectMetaTermsInput} from './index';
+import TermsList from '../../TermsList';
+
+describe('SelectMetaTermsInput', () => {
+    const value = [
+        {
+            name: 'Entertainment',
+            qcode: 'e',
+            scheme: 'categories',
+        },
+        {
+            name: 'Lifestyle',
+            qcode: 'l',
+            scheme: 'categories',
+        },
+    ];
+    const options = [
+        {
+            name: 'Entertainment',
+            qcode: 'e',
+        },
+        {
+            name: 'Lifestyle',
+            qcode: 'l',
+        },
+    ];
+
+    it('keeps the existing remove matching by default', () => {
+        const onChange = sinon.spy();
+
+        const wrapper = mount(
+            <SelectMetaTermsInput
+                field="anpa_category"
+                label="ANPA Category"
+                onChange={onChange}
+                options={options}
+                value={value}
+            />
+        );
+
+        wrapper.find(TermsList).prop('onClick')(0, options[0]);
+
+        expect(onChange.callCount).toBe(1);
+        expect(onChange.args[0]).toEqual(['anpa_category', value]);
+    });
+
+    it('removes stored values by qcode when ignoreScheme is enabled', () => {
+        const onChange = sinon.spy();
+
+        const wrapper = mount(
+            <SelectMetaTermsInput
+                field="anpa_category"
+                label="ANPA Category"
+                onChange={onChange}
+                options={options}
+                value={value}
+                ignoreScheme={true}
+            />
+        );
+
+        wrapper.find(TermsList).prop('onClick')(0, options[0]);
+
+        expect(onChange.callCount).toBe(1);
+        expect(onChange.args[0]).toEqual(['anpa_category', [value[1]]]);
+    });
+});

--- a/client/components/fields/editor/Categories.tsx
+++ b/client/components/fields/editor/Categories.tsx
@@ -25,6 +25,7 @@ export class EditorFieldCategoriesComponent extends React.PureComponent<IProps> 
                 field={this.props.field ?? 'anpa_category'}
                 label={vocabulary.display_name ?? gettext('ANPA Category')}
                 options={this.props.categories}
+                ignoreScheme={true}
                 singleSelect={this.props.singleSelect ?? (vocabulary.selection_type !== 'multi selection')}
             />
         );

--- a/client/components/fields/editor/base/vocabulary.tsx
+++ b/client/components/fields/editor/base/vocabulary.tsx
@@ -13,6 +13,7 @@ export interface IEditorFieldVocabularyProps extends IEditorFieldProps {
     noMargin?: boolean; // defaults to true
     valueAsString?: boolean;
     singleSelect?: boolean;
+    ignoreScheme?: boolean;
 }
 
 export class EditorFieldVocabulary extends React.PureComponent<IEditorFieldVocabularyProps> {
@@ -75,6 +76,7 @@ export class EditorFieldVocabulary extends React.PureComponent<IEditorFieldVocab
                     required={this.props.required ?? this.props.schema?.required}
                     onChange={this.onChange}
                     singleSelect={this.props.singleSelect}
+                    ignoreScheme={this.props.ignoreScheme}
                 />
             </Row>
         );


### PR DESCRIPTION
SDCP-1169

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

### Front-end checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)

Resolves: #[issue-number]

