### PR TITLE
fix missing assignment validation error when updating planning item

### DIFF
--- a/server/planning/assignments/assignments.py
+++ b/server/planning/assignments/assignments.py
@@ -1302,6 +1302,15 @@ class AssignmentsService(superdesk.Service):
             delivery_service.delete_action(lookup={"assignment_id": ObjectId(assignment_id)})
 
     def on_deleted(self, doc):
+        logger.info(
+            "Assignment removed: assignment_id=%s planning_id=%s coverage_id=%s scheduled_update_id=%s to_delete=%s session=%s",
+            doc.get(config.ID_FIELD),
+            doc.get("planning_item"),
+            doc.get("coverage_item"),
+            doc.get("scheduled_update_id"),
+            doc.get("_to_delete"),
+            get_auth().get("_id"),
+        )
         deleted_assignments = [doc.get(config.ID_FIELD)]
         planning_service = get_resource_service("planning")
         self.archive_delete_assignment(doc)

--- a/server/planning/planning/planning.py
+++ b/server/planning/planning/planning.py
@@ -955,6 +955,14 @@ class PlanningService(superdesk.Service):
                 ]:
                     raise SuperdeskApiError.badRequestError("Coverage not in correct state to remove assignment.")
                 # Removing assignment
+                user = get_user(required=False) or {}
+                logger.info(
+                    "Removing assignment via planning patch: assignment_id=%s planning_id=%s coverage_id=%s user_id=%s",
+                    assigned_to.get("assignment_id"),
+                    planning_original.get(config.ID_FIELD),
+                    doc.get("coverage_id"),
+                    user.get(config.ID_FIELD),
+                )
                 assignment_service.delete(lookup={"_id": assigned_to.get("assignment_id")})
                 assignment = {
                     "planning_item": planning_original.get(config.ID_FIELD),
@@ -970,6 +978,22 @@ class PlanningService(superdesk.Service):
             original_assignment = assignment_service.find_one(req=None, _id=assigned_to.get("assignment_id"))
 
             if not original_assignment:
+                # Stale assignment reference: recreate assignment if assignee details still exist.
+                # This keeps planning edits functional when assignment was removed out-of-band.
+                assigned_to_updates = deepcopy(assigned_to)
+                assigned_to_updates.pop("assignment_id", None)
+                if any(assigned_to_updates.get(field) for field in ["user", "desk", "contact", "coverage_provider"]):
+                    updates["assigned_to"] = assigned_to_updates
+                    self._create_update_assignment(
+                        planning_original,
+                        planning_updates,
+                        updates,
+                        original,
+                        parent_coverage,
+                    )
+                    self.set_xmp_file_info(updates, original)
+                    return
+
                 raise SuperdeskApiError.badRequestError("Assignment related to the coverage does not exists.")
 
             # Check if coverage was cancelled

--- a/server/planning/planning/planning.py
+++ b/server/planning/planning/planning.py
@@ -982,7 +982,7 @@ class PlanningService(superdesk.Service):
                 # This keeps planning edits functional when assignment was removed out-of-band.
                 assigned_to_updates = deepcopy(assigned_to)
                 assigned_to_updates.pop("assignment_id", None)
-                if any(assigned_to_updates.get(field) for field in ["user", "desk", "contact", "coverage_provider"]):
+                if assigned_to_updates.get("user") or assigned_to_updates.get("desk"):
                     updates["assigned_to"] = assigned_to_updates
                     self._create_update_assignment(
                         planning_original,

--- a/server/planning/planning/planning.py
+++ b/server/planning/planning/planning.py
@@ -977,6 +977,22 @@ class PlanningService(superdesk.Service):
             # update the assignment using the coverage details
             original_assignment = assignment_service.find_one(req=None, _id=assigned_to.get("assignment_id"))
 
+            # Check if coverage was cancelled
+            coverage_cancel_state = get_coverage_status_from_cv("ncostat:notint")
+            coverage_cancel_state.pop("is_active", None)
+            if (
+                original.get("workflow_status") != updates.get("workflow_status")
+                and updates.get("workflow_status") == WORKFLOW_STATE.CANCELLED
+            ):
+                self.cancel_coverage(
+                    updates,
+                    coverage_cancel_state,
+                    original.get("workflow_status"),
+                    original_assignment,
+                    (updates.get("planning") or {}).get("workflow_status_reason"),
+                )
+                return
+
             if not original_assignment:
                 # Stale assignment reference: recreate assignment if assignee details still exist.
                 # This keeps planning edits functional when assignment was removed out-of-band.
@@ -995,22 +1011,6 @@ class PlanningService(superdesk.Service):
                     return
 
                 raise SuperdeskApiError.badRequestError("Assignment related to the coverage does not exists.")
-
-            # Check if coverage was cancelled
-            coverage_cancel_state = get_coverage_status_from_cv("ncostat:notint")
-            coverage_cancel_state.pop("is_active", None)
-            if (
-                original.get("workflow_status") != updates.get("workflow_status")
-                and updates.get("workflow_status") == WORKFLOW_STATE.CANCELLED
-            ):
-                self.cancel_coverage(
-                    updates,
-                    coverage_cancel_state,
-                    original.get("workflow_status"),
-                    original_assignment,
-                    updates.get("planning").get("workflow_status_reason"),
-                )
-                return
 
             assignment = {}
             if self.is_coverage_planning_modified(updates, original):

--- a/server/planning/planning/planning_tests.py
+++ b/server/planning/planning/planning_tests.py
@@ -162,7 +162,12 @@ class AssignmentRecoveryTestCase(TestCase):
             }
 
             with patch.object(planning_module, "get_resource_service", side_effect=_get_resource_service):
-                planning_service._create_update_assignment(planning_original, {}, updates, original)
+                with patch.object(
+                    planning_module,
+                    "get_coverage_status_from_cv",
+                    return_value={"qcode": "ncostat:notint", "is_active": False},
+                ):
+                    planning_service._create_update_assignment(planning_original, {}, updates, original)
 
             assignment_service.find_one.assert_called_once_with(req=None, _id="stale-assignment-id")
             assignment_service.post.assert_called_once()
@@ -209,8 +214,13 @@ class AssignmentRecoveryTestCase(TestCase):
             }
 
             with patch.object(planning_module, "get_resource_service", side_effect=_get_resource_service):
-                with self.assertRaises(SuperdeskApiError):
-                    planning_service._create_update_assignment(planning_original, {}, updates, original)
+                with patch.object(
+                    planning_module,
+                    "get_coverage_status_from_cv",
+                    return_value={"qcode": "ncostat:notint", "is_active": False},
+                ):
+                    with self.assertRaises(SuperdeskApiError):
+                        planning_service._create_update_assignment(planning_original, {}, updates, original)
 
             assignment_service.find_one.assert_called_once_with(req=None, _id="stale-assignment-id")
             assignment_service.post.assert_not_called()
@@ -265,7 +275,8 @@ class AssignmentRecoveryTestCase(TestCase):
                 ):
                     planning_service._create_update_assignment(planning_original, {}, updates, original)
 
-            assignment_service.find_one.assert_called_once_with(req=None, _id="stale-assignment-id")
+            self.assertEqual(assignment_service.find_one.call_count, 2)
+            assignment_service.find_one.assert_called_with(req=None, _id="stale-assignment-id")
             assignment_service.post.assert_not_called()
             assignment_service.cancel_assignment.assert_not_called()
             self.assertEqual(updates["workflow_status"], "cancelled")

--- a/server/planning/planning/planning_tests.py
+++ b/server/planning/planning/planning_tests.py
@@ -214,3 +214,62 @@ class AssignmentRecoveryTestCase(TestCase):
 
             assignment_service.find_one.assert_called_once_with(req=None, _id="stale-assignment-id")
             assignment_service.post.assert_not_called()
+
+    def test_stale_assignment_id_on_cancel_does_not_recreate_assignment(self):
+        with self.app.app_context():
+            planning_service = get_resource_service("planning")
+            real_get_resource_service = get_resource_service
+
+            assignment_service = MagicMock()
+            assignment_service.find_one.return_value = None
+
+            def _get_resource_service(resource_name):
+                if resource_name == "assignments":
+                    return assignment_service
+
+                return real_get_resource_service(resource_name)
+
+            planning_original = {
+                "_id": "plan1",
+                "state": "scheduled",
+            }
+            updates = {
+                "coverage_id": "cov1",
+                "workflow_status": "cancelled",
+                "planning": {
+                    "g2_content_type": "text",
+                    "workflow_status_reason": "coverage no longer needed",
+                },
+                "assigned_to": {
+                    "assignment_id": "stale-assignment-id",
+                    "desk": "desk1",
+                },
+            }
+            original = {
+                "coverage_id": "cov1",
+                "workflow_status": "active",
+                "planning": {
+                    "g2_content_type": "text",
+                },
+                "assigned_to": {
+                    "assignment_id": "stale-assignment-id",
+                    "desk": "desk1",
+                },
+            }
+
+            with patch.object(planning_module, "get_resource_service", side_effect=_get_resource_service):
+                with patch.object(
+                    planning_module,
+                    "get_coverage_status_from_cv",
+                    return_value={"qcode": "ncostat:notint", "is_active": False},
+                ):
+                    planning_service._create_update_assignment(planning_original, {}, updates, original)
+
+            assignment_service.find_one.assert_called_once_with(req=None, _id="stale-assignment-id")
+            assignment_service.post.assert_not_called()
+            assignment_service.cancel_assignment.assert_not_called()
+            self.assertEqual(updates["workflow_status"], "cancelled")
+            self.assertEqual(updates["previous_status"], "active")
+            self.assertEqual(updates["assigned_to"]["state"], "cancelled")
+            self.assertEqual(updates["news_coverage_status"]["qcode"], "ncostat:notint")
+            self.assertEqual(updates["planning"]["workflow_status_reason"], "coverage no longer needed")

--- a/server/planning/planning/planning_tests.py
+++ b/server/planning/planning/planning_tests.py
@@ -1,5 +1,8 @@
 from datetime import datetime
 import pytz
+from unittest.mock import MagicMock, patch
+
+from planning.planning import planning as planning_module
 from planning.tests import TestCase
 from superdesk import get_resource_service
 from superdesk.errors import SuperdeskApiError
@@ -113,3 +116,101 @@ class DuplicateCoverageTestCase(TestCase):
                 return
 
             self.assertFalse("Failed to raise an exception")
+
+
+class AssignmentRecoveryTestCase(TestCase):
+    def test_recreate_assignment_when_stale_assignment_id_is_sent(self):
+        with self.app.app_context():
+            planning_service = get_resource_service("planning")
+            real_get_resource_service = get_resource_service
+
+            assignment_service = MagicMock()
+            assignment_service.find_one.return_value = None
+            assignment_service.post.return_value = ["new-assignment-id"]
+
+            def _get_resource_service(resource_name):
+                if resource_name == "assignments":
+                    return assignment_service
+
+                return real_get_resource_service(resource_name)
+
+            planning_original = {
+                "_id": "plan1",
+                "state": "scheduled",
+            }
+            updates = {
+                "coverage_id": "cov1",
+                "workflow_status": "draft",
+                "planning": {
+                    "g2_content_type": "text",
+                },
+                "assigned_to": {
+                    "assignment_id": "stale-assignment-id",
+                    "desk": "desk1",
+                },
+            }
+            original = {
+                "coverage_id": "cov1",
+                "workflow_status": "draft",
+                "planning": {
+                    "g2_content_type": "text",
+                },
+                "assigned_to": {
+                    "assignment_id": "stale-assignment-id",
+                    "desk": "desk1",
+                },
+            }
+
+            with patch.object(planning_module, "get_resource_service", side_effect=_get_resource_service):
+                planning_service._create_update_assignment(planning_original, {}, updates, original)
+
+            assignment_service.find_one.assert_called_once_with(req=None, _id="stale-assignment-id")
+            assignment_service.post.assert_called_once()
+            self.assertEqual(updates["assigned_to"]["assignment_id"], "new-assignment-id")
+            self.assertEqual(updates["assigned_to"]["state"], "draft")
+
+    def test_stale_assignment_id_without_assignee_still_fails(self):
+        with self.app.app_context():
+            planning_service = get_resource_service("planning")
+            real_get_resource_service = get_resource_service
+
+            assignment_service = MagicMock()
+            assignment_service.find_one.return_value = None
+
+            def _get_resource_service(resource_name):
+                if resource_name == "assignments":
+                    return assignment_service
+
+                return real_get_resource_service(resource_name)
+
+            planning_original = {
+                "_id": "plan1",
+                "state": "scheduled",
+            }
+            updates = {
+                "coverage_id": "cov1",
+                "workflow_status": "draft",
+                "planning": {
+                    "g2_content_type": "text",
+                },
+                "assigned_to": {
+                    "assignment_id": "stale-assignment-id",
+                },
+            }
+            original = {
+                "coverage_id": "cov1",
+                "workflow_status": "draft",
+                "planning": {
+                    "g2_content_type": "text",
+                },
+                "assigned_to": {
+                    "assignment_id": "stale-assignment-id",
+                },
+            }
+
+            with patch.object(planning_module, "get_resource_service", side_effect=_get_resource_service):
+                with self.assertRaises(SuperdeskApiError):
+                    planning_service._create_update_assignment(planning_original, {}, updates, original)
+
+            assignment_service.find_one.assert_called_once_with(req=None, _id="stale-assignment-id")
+            assignment_service.post.assert_not_called()


### PR DESCRIPTION
handle missing assignment gracefuly and create it if missing.

SDBELGA-1103

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

### Front-end checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)

Resolves: #[issue-number]

