### PR TITLE
fix race condition when editing coverage in planning

### DIFF
--- a/client/actions/assignments/notifications.ts
+++ b/client/actions/assignments/notifications.ts
@@ -201,8 +201,17 @@ const updatePlanningRelatedToAssignment = (data) => (
 
         let coverages = get(planningItem, 'coverages') || [];
         let coverage = coverages.find((cov) => cov.coverage_id === data.coverage);
+        const currentEditedPlanningId = selectors.forms.currentEditedPlanningId(state);
+        const isSamePlanningOpenInEditor = currentEditedPlanningId === data.planning;
 
         if (!coverage) return;
+
+        if (data.source === 'planning' && isSamePlanningOpenInEditor) {
+            // Planning save already owns the editor state. Avoid reloading the planning item
+            // from the assignment websocket and overwriting the in-flight planning update.
+            await dispatch(main.fetchItemHistory(planningItem));
+            return;
+        }
 
         await dispatch(planningApis.loadPlanningByIds([data.planning]));
         await dispatch(main.fetchItemHistory(planningItem));

--- a/client/actions/assignments/tests/notification_test.ts
+++ b/client/actions/assignments/tests/notification_test.ts
@@ -233,6 +233,60 @@ describe('actions.assignments.notification', () => {
                 })
                 .catch(done.fail);
         });
+
+        it('does not reload planning when assignment update originated from planning', (done) => {
+            sinon.stub(main, 'fetchItemHistory').callsFake(
+                () => (Promise.resolve())
+            );
+            store.initialState.workspace.currentDeskId = 'desk1';
+            store.initialState.forms.editors.panel.itemId = 'p1';
+            store.initialState.forms.editors.panel.itemType = 'planning';
+
+            const payload = {
+                item: 'as1',
+                assigned_desk: 'desk2',
+                coverage: 'c1',
+                planning: 'p1',
+                original_assigned_desk: 'desk1',
+                assignment_state: 'assigned',
+                source: 'planning',
+            };
+
+            return store.test(done, assignmentNotifications.onAssignmentUpdated({}, payload))
+                .then(() => {
+                    expect(planningApis.loadPlanningByIds.callCount).toBe(0);
+                    expect(main.fetchItemHistory.callCount).toBe(1);
+                    done();
+                })
+                .catch(done.fail);
+        });
+
+        it('reloads planning when assignment update originated from planning but planning is not being edited',
+            (done) => {
+                sinon.stub(main, 'fetchItemHistory').callsFake(
+                    () => (Promise.resolve())
+                );
+                store.initialState.workspace.currentDeskId = 'desk1';
+
+                const payload = {
+                    item: 'as1',
+                    assigned_desk: 'desk2',
+                    coverage: 'c1',
+                    planning: 'p1',
+                    original_assigned_desk: 'desk1',
+                    assignment_state: 'assigned',
+                    source: 'planning',
+                };
+
+                return store.test(done, assignmentNotifications.onAssignmentUpdated({}, payload))
+                    .then(() => {
+                        expect(planningApis.loadPlanningByIds.callCount).toBe(1);
+                        expect(main.fetchItemHistory.callCount).toBe(1);
+                        done();
+                    })
+                    .catch(done.fail);
+            }
+        );
     });
 
     describe('`assignment lock`', () => {

--- a/client/interfaces.ts
+++ b/client/interfaces.ts
@@ -2300,6 +2300,7 @@ export interface IWebsocketMessageData {
         assignment_state: IAssignmentItem['assigned_to']['state'];
         lock_user: IAssignmentItem['lock_user'];
         session: ISession['sessionId'];
+        source?: string;
     };
     ASSIGNMENT_REMOVED: {
         item: IAssignmentItem['_id'];

--- a/client/selectors/forms.ts
+++ b/client/selectors/forms.ts
@@ -135,6 +135,26 @@ export const currentItemModal = createSelector(
         getcurrentItem(itemId, itemType, events, plannings, values, true)
     ));
 
+export const currentEditedPlanningId = createSelector(
+    [currentItemType, currentItemId, currentItemTypeModal, currentItemIdModal],
+    (panelItemType, panelItemId, modalItemType, modalItemId) => {
+        if (modalItemType === ITEM_TYPE.PLANNING) {
+            return modalItemId;
+        }
+
+        if (panelItemType === ITEM_TYPE.PLANNING) {
+            return panelItemId;
+        }
+
+        return null;
+    }
+);
+
+export const currentEditedPlanningItem = createSelector(
+    [currentEditedPlanningId, storedPlannings],
+    (planningId, plannings) => (planningId ? get(plannings, planningId) || null : null)
+);
+
 export const currentAutosaveModal = createSelector(
     [autosaves, currentItemIdModal],
     (autosaveItems, itemId) => (

--- a/server/planning/assignments/assignments.py
+++ b/server/planning/assignments/assignments.py
@@ -265,7 +265,7 @@ class AssignmentsService(AsyncBaseService):
             state = "unposted" if (plan or {}).get("state") == WORKFLOW_STATE.KILLED else (plan or {}).get("state")
             raise SuperdeskApiError.forbiddenError("Action failed. Related planning item is {}".format(state))
 
-    def notify(self, event_name, updates, original):
+    def notify(self, event_name, updates, original, source: str | None = None):
         # No notifications for 'draft' assignments
         if self.is_assignment_draft(updates, original):
             return
@@ -296,6 +296,7 @@ class AssignmentsService(AsyncBaseService):
             "assignment_state": assigned_to["state"],
             "lock_user": lock_user,
             "session": get_auth().get("_id"),
+            "source": source,
         }
 
         if event_name == "assignments:updated" and not updates.get("assigned_to") and updates.get("priority"):
@@ -304,7 +305,8 @@ class AssignmentsService(AsyncBaseService):
         push_notification(event_name, **kwargs)
 
     async def on_updated_async(self, updates, original):
-        self.notify("assignments:updated", updates, original)
+        source = updates.pop("_notification_source", None)
+        self.notify("assignments:updated", updates, original, source=source)
         await self.send_assignment_notification(updates, original)
 
         assignment = deepcopy(original)
@@ -332,10 +334,21 @@ class AssignmentsService(AsyncBaseService):
 
         return False
 
-    async def system_update_async(self, id, updates, original, skip_planning_sync: bool = False, **kwargs):
+    async def system_update_async(
+        self,
+        id,
+        updates,
+        original,
+        skip_planning_sync: bool = False,
+        notification_source: str | None = None,
+        **kwargs,
+    ):
         self._skip_planning_sync = skip_planning_sync
+        updates_to_apply = deepcopy(updates)
+        if notification_source is not None:
+            updates_to_apply["_notification_source"] = notification_source
         try:
-            rtn = await super().system_update_async(id, updates, original, **kwargs)
+            rtn = await super().system_update_async(id, updates_to_apply, original, **kwargs)
             if self.is_assignment_being_activated(updates, original):
                 doc = deepcopy(original)
                 doc.update(updates)

--- a/server/planning/assignments/assignments.py
+++ b/server/planning/assignments/assignments.py
@@ -13,6 +13,7 @@
 from typing import Dict, Any
 from copy import deepcopy
 import logging
+from contextvars import ContextVar
 
 from bson import ObjectId
 from icalendar import Calendar, Event
@@ -87,6 +88,7 @@ from planning.coverage_assignments import update_planning_from_assignment_change
 logger = logging.getLogger(__name__)
 planning_type = deepcopy(superdesk.Resource.rel("planning", type="string", required=True))
 planning_type["mapping"] = not_analyzed
+notification_source_ctx: ContextVar[str | None] = ContextVar("assignment_notification_source", default=None)
 
 
 class AssignmentsService(AsyncBaseService):
@@ -296,8 +298,10 @@ class AssignmentsService(AsyncBaseService):
             "assignment_state": assigned_to["state"],
             "lock_user": lock_user,
             "session": get_auth().get("_id"),
-            "source": source,
         }
+
+        if source is not None:
+            kwargs["source"] = source
 
         if event_name == "assignments:updated" and not updates.get("assigned_to") and updates.get("priority"):
             kwargs["priority"] = doc.get("priority")
@@ -305,7 +309,7 @@ class AssignmentsService(AsyncBaseService):
         push_notification(event_name, **kwargs)
 
     async def on_updated_async(self, updates, original):
-        source = updates.pop("_notification_source", None)
+        source = notification_source_ctx.get()
         self.notify("assignments:updated", updates, original, source=source)
         await self.send_assignment_notification(updates, original)
 
@@ -345,8 +349,7 @@ class AssignmentsService(AsyncBaseService):
     ):
         self._skip_planning_sync = skip_planning_sync
         updates_to_apply = deepcopy(updates)
-        if notification_source is not None:
-            updates_to_apply["_notification_source"] = notification_source
+        notification_source_token = notification_source_ctx.set(notification_source)
         try:
             rtn = await super().system_update_async(id, updates_to_apply, original, **kwargs)
             if self.is_assignment_being_activated(updates, original):
@@ -362,6 +365,7 @@ class AssignmentsService(AsyncBaseService):
                 app = get_current_app().as_any()
                 await app.on_updated_assignments.call_async(updates, original)
         finally:
+            notification_source_ctx.reset(notification_source_token)
             self._skip_planning_sync = False
         return rtn
 

--- a/server/planning/assignments/assignments_content.py
+++ b/server/planning/assignments/assignments_content.py
@@ -30,6 +30,7 @@ from planning.common import (
     get_coverage_for_assignment,
     get_archive_items_for_assignment,
     assignment_allows_multiple_content_linked,
+    get_config_assignment_manual_reassignment_only,
 )
 from planning.planning_notifications import PlanningNotifications
 from planning.archive import create_item_from_template
@@ -217,11 +218,14 @@ class AssignmentsContentService(AsyncBaseService):
                 )
 
             updates = {"assigned_to": deepcopy(assignment.get("assigned_to"))}
-            updates["assigned_to"]["user"] = str(item.get("task").get("user"))
-            updates["assigned_to"]["desk"] = str(item.get("task").get("desk"))
+
+            if not get_config_assignment_manual_reassignment_only():
+                updates["assigned_to"]["user"] = str(item.get("task").get("user"))
+                updates["assigned_to"]["desk"] = str(item.get("task").get("desk"))
+                updates["assigned_to"]["assignor_user"] = str(item.get("task").get("user"))
+                updates["assigned_to"]["assigned_date_user"] = utcnow()
+
             updates["assigned_to"]["state"] = get_next_assignment_status(updates, ASSIGNMENT_WORKFLOW_STATE.IN_PROGRESS)
-            updates["assigned_to"]["assignor_user"] = str(item.get("task").get("user"))
-            updates["assigned_to"]["assigned_date_user"] = utcnow()
 
             if not assignment.get("scheduled_update_id"):
                 # set the assignment to in progress

--- a/server/planning/coverage_assignments.py
+++ b/server/planning/coverage_assignments.py
@@ -13,6 +13,7 @@ from planning.common import (
     ASSIGNMENT_WORKFLOW_STATE,
     DEFAULT_ASSIGNMENT_PRIORITY,
     TO_BE_CONFIRMED_FIELD,
+    get_config_assignment_manual_reassignment_only,
 )
 from planning.types import PlanningAutosaveResourceModel
 
@@ -183,7 +184,7 @@ def get_metadata_updates_between_entities(
         if _copy_translated_values_to_assignment(updates, planning):
             destination_updated = True
 
-        if _set_assignment_state(updates, coverage):
+        if _set_assignment_state(updates, coverage, assignment):
             destination_updated = True
 
     if not updates.get("assigned_to"):
@@ -316,7 +317,7 @@ def _get_coverage_planning_metadata(planning: dict, coverage: dict) -> dict:
     return planning_metadata
 
 
-def _set_assignment_state(updates: dict, coverage: dict) -> bool:
+def _set_assignment_state(updates: dict, coverage: dict, assignment: dict) -> bool:
     """
     Determines and updates the assignment state based on the current coverage
     workflow status and state.
@@ -327,10 +328,22 @@ def _set_assignment_state(updates: dict, coverage: dict) -> bool:
     """
 
     assign_state = ASSIGNMENT_WORKFLOW_STATE.ASSIGNED
+    coverage_assigned_to = coverage.get("assigned_to") or {}
+    assignment_assigned_to = (assignment or {}).get("assigned_to") or {}
+
     if coverage.get("workflow_status") == WORKFLOW_STATE.DRAFT:
         assign_state = ASSIGNMENT_WORKFLOW_STATE.DRAFT
-    elif coverage["assigned_to"].get("state") and coverage["assigned_to"]["state"] != ASSIGNMENT_WORKFLOW_STATE.DRAFT:
-        assign_state = coverage["assigned_to"]["state"]
+    else:
+        assignee_changed = any(
+            coverage_assigned_to.get(field) != assignment_assigned_to.get(field)
+            for field in ("desk", "user", "contact", "coverage_provider")
+        )
+
+        if assignee_changed and get_config_assignment_manual_reassignment_only():
+            # Reassignment should move the item back to To Do.
+            assign_state = ASSIGNMENT_WORKFLOW_STATE.ASSIGNED
+        elif coverage_assigned_to.get("state") and coverage_assigned_to["state"] != ASSIGNMENT_WORKFLOW_STATE.DRAFT:
+            assign_state = coverage_assigned_to["state"]
 
     if updates["assigned_to"]["state"] != assign_state:
         updates["assigned_to"]["state"] = assign_state

--- a/server/planning/coverage_assignments.py
+++ b/server/planning/coverage_assignments.py
@@ -319,11 +319,11 @@ def _get_coverage_planning_metadata(planning: dict, coverage: dict) -> dict:
 
 def _set_assignment_state(updates: dict, coverage: dict, assignment: dict) -> bool:
     """
-    Determines and updates the assignment state based on the current coverage
-    workflow status and state.
+    Determine and update assignment state from coverage workflow and assignee changes.
 
     :param updates: A dictionary to store the updated assignment state.
     :param coverage: A dictionary containing coverage details.
+    :param assignment: A dictionary containing the current assignment details.
     :return: A boolean indicating whether the assignment state was updated.
     """
 

--- a/server/planning/planning/planning.py
+++ b/server/planning/planning/planning.py
@@ -1062,6 +1062,7 @@ class PlanningService(AsyncBaseService):
                     assignment_updates,
                     original_assignment,
                     skip_planning_sync=True,
+                    notification_source="planning",
                 )
 
             # If there has been a change in the planning internal note then notify the assigned users/desk
@@ -1333,7 +1334,11 @@ class PlanningService(AsyncBaseService):
                 original_assigment = await assignment_service.find_one_async(req=None, _id=assign_id)
                 if original_assigment:
                     await assignment_service.system_update_async(
-                        ObjectId(assign_id), {"_to_delete": True}, original_assigment, skip_planning_sync=True
+                        ObjectId(assign_id),
+                        {"_to_delete": True},
+                        original_assigment,
+                        skip_planning_sync=True,
+                        notification_source="planning",
                     )
 
         if request:

--- a/server/planning/planning/planning_utils.py
+++ b/server/planning/planning/planning_utils.py
@@ -66,7 +66,11 @@ async def delete_assignments_for_coverages(coverages: list[dict[str, Any]], noti
             original_assigment = await assignment_service.find_one_async(req=None, _id=assign_id)
             if original_assigment:
                 await assignment_service.system_update_async(
-                    ObjectId(assign_id), {"_to_delete": True}, original_assigment, skip_planning_sync=True
+                    ObjectId(assign_id),
+                    {"_to_delete": True},
+                    original_assigment,
+                    skip_planning_sync=True,
+                    notification_source="planning",
                 )
 
     if request:

--- a/server/planning/tests/coverage_assignments_sync_test.py
+++ b/server/planning/tests/coverage_assignments_sync_test.py
@@ -6,6 +6,7 @@ from superdesk.tests import utils as test_utils, fixtures
 from superdesk.tests import setup_db_user
 
 from planning.planning.planning import PlanningService
+from planning.coverage_assignments import get_metadata_updates_between_entities
 from planning.tests import TestCase
 
 
@@ -287,3 +288,69 @@ class SyncAssignmentCoverageTest(TestCase):
 
         planning = await test_utils.find_by_id("planning", "p1")
         self.assertEqual(original_planning_etag, planning["_etag"])
+
+
+def test_reassignment_resets_assignment_state_to_assigned():
+    assignment = {
+        "_id": "as1",
+        "assigned_to": {
+            "desk": "desk-1",
+            "user": "user-1",
+            "state": "in_progress",
+        },
+        "planning": {},
+    }
+    planning = {"_id": "plan-1"}
+    coverage = {
+        "coverage_id": "cov-1",
+        "workflow_status": "active",
+        "assigned_to": {
+            "assignment_id": "as1",
+            "desk": "desk-1",
+            "user": None,
+            "state": "in_progress",
+        },
+        "planning": {},
+    }
+
+    with mock.patch("planning.coverage_assignments.get_user", return_value=None), mock.patch(
+        "planning.coverage_assignments.get_config_assignment_manual_reassignment_only",
+        return_value=True,
+    ):
+        updates = get_metadata_updates_between_entities(assignment, planning, coverage, destination="assignment")
+
+    assert updates["assigned_to"]["user"] is None
+    assert updates["assigned_to"]["state"] == "assigned"
+
+
+def test_reassignment_does_not_reset_state_when_manual_reassignment_disabled():
+    assignment = {
+        "_id": "as1",
+        "assigned_to": {
+            "desk": "desk-1",
+            "user": "user-1",
+            "state": "in_progress",
+        },
+        "planning": {},
+    }
+    planning = {"_id": "plan-1"}
+    coverage = {
+        "coverage_id": "cov-1",
+        "workflow_status": "active",
+        "assigned_to": {
+            "assignment_id": "as1",
+            "desk": "desk-1",
+            "user": None,
+            "state": "in_progress",
+        },
+        "planning": {},
+    }
+
+    with mock.patch("planning.coverage_assignments.get_user", return_value=None), mock.patch(
+        "planning.coverage_assignments.get_config_assignment_manual_reassignment_only",
+        return_value=False,
+    ):
+        updates = get_metadata_updates_between_entities(assignment, planning, coverage, destination="assignment")
+
+    assert updates["assigned_to"]["user"] is None
+    assert updates["assigned_to"]["state"] == "in_progress"


### PR DESCRIPTION
there is a notification sent which makes the client sync changes and that makes the ui blink and generates unsaved changes right after saving. ignore the notification if the source is from planning.

STT-1693

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

### Front-end checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)

Resolves: #[issue-number]

