### PR TITLE
fix onclusive changes manually unposted events

### DIFF
--- a/server/planning/events/events.py
+++ b/server/planning/events/events.py
@@ -870,11 +870,12 @@ class EventsService(AsyncBaseService):
 
         Allows updates when:
         - Event doesn't exist locally
-        - Event never manually edited (version_creator is None), even if cancelled/killed
-        - Event manually edited but not cancelled/killed
+        - Event is not cancelled/killed
+        - Event is cancelled/killed but has no manual editor marker
 
-        Key behavior: Ingest feeds can update cancelled/killed events only if never manually
-        touched. Once user-edited, cancelled/killed events won't be updated from feeds.
+        Key behavior: Ingest feeds must not update manually unposted events.
+        Provider-origin cancellations remain ingest-updatable, so cancelled/killed
+        alone does not block updates.
 
         Args:
             old_item: Existing event (None if doesn't exist)
@@ -884,16 +885,15 @@ class EventsService(AsyncBaseService):
         Returns:
             True if should update, False otherwise
         """
-        return (
-            old_item is None
-            or old_item.get("version_creator") is None
-            or not any(
-                [
-                    old_item.get("pubstatus") == "cancelled",
-                    old_item.get("state") == "killed",
-                ]
-            )
-        )
+        if old_item is None:
+            return True
+
+        is_cancelled_or_killed = old_item.get("pubstatus") == "cancelled" or old_item.get("state") == "killed"
+        if not is_cancelled_or_killed:
+            return True
+
+        manually_touched = old_item.get("version_creator") is not None
+        return not manually_touched
 
 
 class EventsResource(superdesk.Resource):

--- a/server/planning/events/events_post.py
+++ b/server/planning/events/events_post.py
@@ -16,6 +16,7 @@ from superdesk.resource import Resource, not_analyzed
 from superdesk.notification import push_notification
 from superdesk.users import user_metrics
 from superdesk.utc import utcnow
+from apps.auth import get_user
 
 from .events import EventsResource
 from planning.common import (
@@ -195,6 +196,10 @@ class EventsPostService(AsyncBaseService):
 
         new_item_state = get_item_post_state(event, new_post_state, repost)
         updates = {"state": new_item_state, "pubstatus": new_post_state}
+        user = get_user()
+        if user and user.get(ID_FIELD):
+            updates["version_creator"] = user.get(ID_FIELD)
+
         if not event.get("firstpublished"):
             updates["firstpublished"] = utcnow()
 

--- a/server/planning/tests/events_service_test.py
+++ b/server/planning/tests/events_service_test.py
@@ -85,3 +85,23 @@ def test_should_update():
         "state": "killed",
     }
     assert not service.should_update(old_event, new_event, provider={})
+
+    # Test: should_update returns True when cancelled/killed with no manual marker
+    # (e.g. provider-origin cancellation that may later be reposted to usable)
+    old_event = {
+        "versioncreated": datetime.now(),
+        "version_creator": None,
+        "pubstatus": "cancelled",
+        "state": "killed",
+    }
+    assert service.should_update(old_event, new_event, provider={})
+
+    # Test: should_update returns False when manually unposted
+    # (cancelled/killed item with manual marker)
+    old_event = {
+        "versioncreated": datetime.now(),
+        "version_creator": "user_id",
+        "pubstatus": "cancelled",
+        "state": "killed",
+    }
+    assert not service.should_update(old_event, new_event, provider={})


### PR DESCRIPTION
when event is manually unposted, it shouldn't get
updates from Onclusive.

SDCP-1183

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

### Front-end checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)

Resolves: #[issue-number]

