### PR TITLE
SDESK-7948 Add e2e test conventions to WRITING_TESTS

### DIFF
--- a/e2e/WRITING_TESTS.md
+++ b/e2e/WRITING_TESTS.md
@@ -155,11 +155,36 @@ avoided because macOS AirPlay Receiver answers on it.
   `data-test-id` attribute. Anything more belongs in a separate PR with product
   review.
 
+## Comments
+
+Comment the non-obvious *why*, not the *what*. A reader can see what
+`getByTestId('save').click()` does; they cannot see why an action needs a
+workaround, why a call is stubbed, or why a selector has an unusual shape.
+Reserve comments for those: workarounds, async timing, app quirks.
+
+Do not narrate the steps (`// open the modal`) or restate the QA case
+(`// Expected: item is unlocked`). The scenario mapping belongs in the
+`describe`/`test` titles, which are the first thing a reviewer reads.
+
 ## Reference specs
 
 When writing a new spec, start from the closest of these curated examples, copy
-its structure, and adapt:
+its structure, and adapt. Planning's specs are already native (`getByTestId`,
+Page Objects), so use them directly:
 
-<!-- TODO(exemplar): add the path(s) to the native reference spec(s) produced
-     from a real QA test case (workstream W2). Until then, fall back to the
-     closest existing spec under playwright/. -->
+- `playwright/item_locks.spec.ts` - the broadest reference. It shows the full
+  planning fixture pattern: `setup(page, 'planning_prepopulate_data', ...)` in
+  `beforeEach`, then per-test `addItems(page.request, 'events'|'planning', [...])`
+  from `utils/fixtures`, then `login(page)` and `waitForPageLoad`. It drives the
+  list and editor through Page Objects (`PlanningList`, `EventEditor`, `Modal`),
+  asserts with web-first assertions, and uses `forceUnlockItem` via
+  `page.request` to simulate a second user.
+- `playwright/modals.spec.ts` - a smaller starting point when the scenario is a
+  single dialog interaction rather than a full editor flow.
+
+Note the cross-repo difference: planning resets state per test with
+`setup`/`addItems` and logs in explicitly, whereas client-core relies on a
+committed `storageState` session plus `restoreDatabaseSnapshot()`. Do not copy
+client-core's auth/reset pattern here. The companion
+`superdesk-client-core/e2e/WRITING_TESTS.md` documents a worked example
+(`edit-embed.spec.ts`) for that repo.


### PR DESCRIPTION
### Purpose

Document e2e test-writing conventions in planning's `e2e/WRITING_TESTS.md`. Part of the same effort as the new `superdesk-e2e` skill, which points test authors at this doc.

### What has changed

- `e2e/WRITING_TESTS.md`:
  - New "Comments" section: comment the non-obvious why, not the what; the scenario mapping belongs in the `describe`/`test` titles.
  - "Reference specs" section filled in, pointing at the existing native specs (`item_locks.spec.ts` as the broad reference, `modals.spec.ts` for a simpler dialog flow), with a note on the cross-repo auth/reset difference versus client-core.

Docs only, no code changes.

### Steps to test

Read `e2e/WRITING_TESTS.md` and confirm the "Comments" and "Reference specs" sections read correctly and the referenced spec files exist.

<!-- The template's "Front-end checklist" is not relevant here: this is a docs-only change, no app code. Omitted intentionally. -->

### Related

Companion to superdesk/skills#1 (the `superdesk-e2e` skill that points authors at this doc) and superdesk/superdesk-client-core#5222 (the client-core exemplar and matching conventions). Link: https://github.com/superdesk/skills/pull/1

Resolves: SDESK-7948
