### PR TITLE
fix editing of related planning item after event posting

### DIFF
--- a/client/api/locks.ts
+++ b/client/api/locks.ts
@@ -99,6 +99,13 @@ function setItemAsLocked(data: IWebsocketMessageData['ITEM_LOCKED']): void {
 function softLockItem(options: ISoftLockItemData): void {
     const {item} = options;
 
+    if (item.lock_user == null && item.lock_session == null && item.lock_action == null) {
+        // The source item carries no lock (e.g. its lock fields were stripped after
+        // posting). Propagating it would overwrite the existing valid lock in the store
+        // with an empty one, incorrectly flipping the editor to read-only.
+        return;
+    }
+
     return setItemAsLocked({
         item: item._id,
         type: item.type,

--- a/client/api/tests/api_locks_test.ts
+++ b/client/api/tests/api_locks_test.ts
@@ -4,7 +4,7 @@ import {cloneDeep} from 'lodash';
 
 import {superdeskApi, planningApi} from '../../superdeskApi';
 import {IPlanningAppState} from '../../interfaces';
-import {EVENTS, PLANNING, ASSIGNMENTS} from '../../constants';
+import {EVENTS, PLANNING, ASSIGNMENTS, LOCKS} from '../../constants';
 
 import * as testDataOriginal from '../../utils/testData';
 import {restoreSinonStub} from '../../utils/testUtils';
@@ -63,6 +63,23 @@ describe('planningApi.locks', () => {
             assignment: {},
             recurring: {},
         });
+    });
+
+    it('softLockItem does not dispatch SET_ITEM_AS_LOCKED for empty lock fields', () => {
+        const itemWithoutLock = {
+            ...testData.events[0],
+            lock_user: null,
+            lock_session: undefined,
+            lock_action: null,
+        };
+
+        planningApi.locks.softLockItem({
+            type: 'event',
+            item: itemWithoutLock,
+            plan_ids: [],
+        });
+
+        expect(redux.dispatch.args.some(([action]) => action.type === LOCKS.ACTIONS.SET_ITEM_AS_LOCKED)).toBe(false);
     });
 
     it('lockItemById attempts to load the item by id before locking it', (done) => {

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -23,7 +23,7 @@
             }
         },
         "..": {
-            "version": "3.4.0",
+            "version": "3.5.3",
             "license": "AGPL-3.0",
             "dependencies": {
                 "@sourcefabric/common": "0.0.69",

--- a/e2e/playwright/events/event_embedded_coverage.spec.ts
+++ b/e2e/playwright/events/event_embedded_coverage.spec.ts
@@ -162,6 +162,58 @@ test.describe('Planning.Events: embedded coverage', () => {
         await expect(embeddedCoverages.getPlanningItem(0)).toBeVisible();
     });
 
+    test('can add planning items while event is posted', async ({page}) => {
+        await setupPlanningPublishing(page.request);
+        await addItems(
+            page.request,
+            'events',
+            [createEventFor.today({
+                type: 'event',
+                occur_status: {
+                    name: 'Planned, occurs certainly',
+                    label: 'Confirmed',
+                    qcode: 'eocstat:eos5',
+                },
+                calendars: [],
+                state: 'draft',
+                place: [],
+                name: 'Posted Event',
+                slugline: 'posted event with related planning',
+            })]
+        );
+
+        await list.item(0).dblclick();
+        await editor.waitTillOpen();
+        await editor.waitLoadingComplete();
+
+        // Post the event while keeping the editor open
+        await editor.postButton.click();
+        await editor.waitLoadingComplete();
+
+        // The editor must stay editable after posting in place
+        await expect(editor.updateButton).toBeVisible();
+
+        // Adding a related planning item to the still-open, posted event
+        // must keep the editor editable and render the new planning item
+        // (previously the editor incorrectly flipped to read-only).
+        await editor.clickBookmark('add_planning');
+        await editor.waitForAutosave();
+
+        await expect(embeddedCoverages.getPlanningItem(0)).toBeVisible();
+        await expect(editor.updateButton).toBeVisible();
+
+        // A posted event is saved via the "Update" button (Save & Post),
+        // not the "Save" button which only exists for drafts.
+        await editor.updateButton.click();
+        await editor.waitLoadingComplete();
+
+        await editor.closeButton.click();
+        await editor.waitTillClosed();
+
+        await list.toggleAssociatedPlanning(0);
+        await expect(list.nestedPlanningItems(0)).toHaveCount(1);
+    });
+
     // TODO: consider re-enabling in the future when event syncing is reimplemented
     test.skip('update new Planning when event dates changes', async () => {
         await subnav.createEvent();

--- a/e2e/playwright/utils/common/editor.ts
+++ b/e2e/playwright/utils/common/editor.ts
@@ -30,6 +30,10 @@ export class Editor {
         return this.element.getByRole('button', {name: 'Save', exact: true});
     }
 
+    get updateButton(): Locator {
+        return this.element.getByRole('button', {name: 'Update', exact: true});
+    }
+
     get postButton(): Locator {
         return this.element.getByRole('button', {name: /Save & Post|Post/, exact: true});
     }


### PR DESCRIPTION
lock info got lost there so it became uneditable.

STT-1729

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

### Front-end checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)

Resolves: #[issue-number]

