### PR TITLE
[SDESK-7852] Strip deprecated ~ prefix from SCSS imports

### DIFF
--- a/client/apps/style.scss
+++ b/client/apps/style.scss
@@ -1,5 +1,5 @@
-@import '~superdesk-ui-framework/app/styles/variables/_colors.scss';
-@import '~superdesk-ui-framework/app/styles/variables/_dimensions.scss';
+@import 'superdesk-ui-framework/app/styles/variables/_colors.scss';
+@import 'superdesk-ui-framework/app/styles/variables/_dimensions.scss';
 
 /* ui fixes for planning redesign - should be avoided */
 .sd-searchbar {

--- a/client/components/Archive/ArchivePreview/style.scss
+++ b/client/components/Archive/ArchivePreview/style.scss
@@ -1,5 +1,5 @@
-@import '~superdesk-core/styles/sass/mixins.scss';
-@import '~superdesk-core/styles/sass/variables.scss';
+@import 'superdesk-core/styles/sass/mixins.scss';
+@import 'superdesk-core/styles/sass/variables.scss';
 
 .ArchivePreview {
     // Fix issue with box header having white background

--- a/client/components/Contacts/SelectSearchContactsField/style.scss
+++ b/client/components/Contacts/SelectSearchContactsField/style.scss
@@ -1,6 +1,6 @@
-@import '~superdesk-core/styles/sass/mixins.scss';
-@import '~superdesk-core/styles/sass/variables.scss';
-@import '~superdesk-core/styles/sass/media-archive.scss';
+@import 'superdesk-core/styles/sass/mixins.scss';
+@import 'superdesk-core/styles/sass/variables.scss';
+@import 'superdesk-core/styles/sass/media-archive.scss';
 
 .Select {
 	&__dropdownToggle {

--- a/client/components/Datetime/style.scss
+++ b/client/components/Datetime/style.scss
@@ -1,4 +1,4 @@
-@import '~superdesk-core/styles/sass/variables.scss';
+@import 'superdesk-core/styles/sass/variables.scss';
 
 .Datetime {
     &--dark-text {

--- a/client/components/Events/style.scss
+++ b/client/components/Events/style.scss
@@ -1,4 +1,4 @@
-@import '~superdesk-ui-framework/app/styles/variables/_colors.scss';
+@import 'superdesk-ui-framework/app/styles/variables/_colors.scss';
 
 .EventDateTime {
     time {

--- a/client/components/GeoLookupInput/style.scss
+++ b/client/components/GeoLookupInput/style.scss
@@ -1,5 +1,5 @@
-@import '~superdesk-core/styles/sass/mixins.scss';
-@import '~superdesk-core/styles/sass/variables.scss';
+@import 'superdesk-core/styles/sass/mixins.scss';
+@import 'superdesk-core/styles/sass/variables.scss';
 
 .geolookup {
     display: none !important;

--- a/client/components/InternalNoteLabel/style.scss
+++ b/client/components/InternalNoteLabel/style.scss
@@ -1,4 +1,4 @@
-@import '~superdesk-ui-framework/app/styles/variables/_colors.scss';
+@import 'superdesk-ui-framework/app/styles/variables/_colors.scss';
 
 .internal-note__label {
     vertical-align: middle;

--- a/client/components/Label/style.scss
+++ b/client/components/Label/style.scss
@@ -1,4 +1,4 @@
-@import '~superdesk-core/styles/sass/variables.scss';
+@import 'superdesk-core/styles/sass/variables.scss';
 
 .label--clickable {
     cursor: pointer;

--- a/client/components/Main/style.scss
+++ b/client/components/Main/style.scss
@@ -1,4 +1,4 @@
-@import '~superdesk-ui-framework/app/styles/_variables.scss';
+@import 'superdesk-ui-framework/app/styles/_variables.scss';
 
 .event-toggle {
     .sd-line-input__label {

--- a/client/components/Modal/style.scss
+++ b/client/components/Modal/style.scss
@@ -1,7 +1,7 @@
-@import '~superdesk-core/styles/sass/mixins.scss';
-@import '~superdesk-core/styles/sass/variables.scss';
+@import 'superdesk-core/styles/sass/mixins.scss';
+@import 'superdesk-core/styles/sass/variables.scss';
 // required for extending .modal__backdrop :
-@import '~superdesk-ui-framework/app/styles/_variables.scss';
+@import 'superdesk-ui-framework/app/styles/_variables.scss';
 
 .modal__backdrop {
     position: fixed;

--- a/client/components/UI/Form/ColouredValueInput/style.scss
+++ b/client/components/UI/Form/ColouredValueInput/style.scss
@@ -1,5 +1,5 @@
-@import '~superdesk-ui-framework/app/styles/_mixins.scss';
-@import '~superdesk-ui-framework/app/styles/variables/_colors.scss';
+@import 'superdesk-ui-framework/app/styles/_mixins.scss';
+@import 'superdesk-ui-framework/app/styles/variables/_colors.scss';
 
 .select-coloured-value {
     &__input {

--- a/client/components/UI/Form/DateInput/style.scss
+++ b/client/components/UI/Form/DateInput/style.scss
@@ -1,6 +1,6 @@
-@import '~superdesk-ui-framework/app/styles/_mixins.scss';
-@import '~superdesk-ui-framework/app/styles/variables/_colors.scss';
-@import '~superdesk-ui-framework/app/styles/variables/_dimensions.scss';
+@import 'superdesk-ui-framework/app/styles/_mixins.scss';
+@import 'superdesk-ui-framework/app/styles/variables/_colors.scss';
+@import 'superdesk-ui-framework/app/styles/variables/_dimensions.scss';
 
 .date-popup {
     width: 280px !important;

--- a/client/components/UI/Form/DateTimeInput/style.scss
+++ b/client/components/UI/Form/DateTimeInput/style.scss
@@ -1,4 +1,4 @@
-@import '~superdesk-ui-framework/app/styles/variables/_colors.scss';
+@import 'superdesk-ui-framework/app/styles/variables/_colors.scss';
 
 .date-time-input__row {
     &--required {

--- a/client/components/UI/Form/SelectMetaTermsInput/style.scss
+++ b/client/components/UI/Form/SelectMetaTermsInput/style.scss
@@ -1,5 +1,5 @@
-@import '~superdesk-ui-framework/app/styles/_mixins.scss';
-@import '~superdesk-ui-framework/app/styles/variables/_colors.scss';
+@import 'superdesk-ui-framework/app/styles/_mixins.scss';
+@import 'superdesk-ui-framework/app/styles/variables/_colors.scss';
 
 .Select {
 	&__dropdownToggle {

--- a/client/components/UI/Form/SelectTagInput/style.scss
+++ b/client/components/UI/Form/SelectTagInput/style.scss
@@ -1,5 +1,5 @@
-@import '~superdesk-ui-framework/app/styles/_mixins.scss';
-@import '~superdesk-ui-framework/app/styles/variables/_colors.scss';
+@import 'superdesk-ui-framework/app/styles/_mixins.scss';
+@import 'superdesk-ui-framework/app/styles/variables/_colors.scss';
 
 .select-tag__popup {
     margin-top: 1px;

--- a/client/components/UI/Form/TimeInput/style.scss
+++ b/client/components/UI/Form/TimeInput/style.scss
@@ -1,5 +1,5 @@
-@import '~superdesk-ui-framework/app/styles/_mixins.scss';
-@import '~superdesk-ui-framework/app/styles/variables/_colors.scss';
+@import 'superdesk-ui-framework/app/styles/_mixins.scss';
+@import 'superdesk-ui-framework/app/styles/variables/_colors.scss';
 
 .time-popup {
     width: 220px;

--- a/client/components/UI/Form/ToggleInput/style.scss
+++ b/client/components/UI/Form/ToggleInput/style.scss
@@ -1,5 +1,5 @@
-@import '~superdesk-ui-framework/app/styles/_mixins.scss';
-@import '~superdesk-ui-framework/app/styles/_variables.scss';
+@import 'superdesk-ui-framework/app/styles/_mixins.scss';
+@import 'superdesk-ui-framework/app/styles/_variables.scss';
 
 .sd-line-input__toggle {
     .sd-line-input__label {

--- a/client/components/UI/Form/style.scss
+++ b/client/components/UI/Form/style.scss
@@ -1,4 +1,4 @@
-@import '~superdesk-ui-framework/app/styles/variables/_colors.scss';
+@import 'superdesk-ui-framework/app/styles/variables/_colors.scss';
 
 // Add some padding to the right for long filenames
 // so that the trash icon is still visible

--- a/client/components/UI/Popup/style.scss
+++ b/client/components/UI/Popup/style.scss
@@ -1,7 +1,7 @@
-@import '~superdesk-ui-framework/app/styles/_mixins.scss';
-@import '~superdesk-ui-framework/app/styles/variables/_colors.scss';
-@import '~superdesk-ui-framework/app/styles/variables/_dimensions.scss';
-@import '~superdesk-ui-framework/app/styles/dropdowns/_basic-dropdown.scss';
+@import 'superdesk-ui-framework/app/styles/_mixins.scss';
+@import 'superdesk-ui-framework/app/styles/variables/_colors.scss';
+@import 'superdesk-ui-framework/app/styles/variables/_dimensions.scss';
+@import 'superdesk-ui-framework/app/styles/dropdowns/_basic-dropdown.scss';
 
 .popup {
     &__menu {

--- a/client/components/UI/SubNav/style.scss
+++ b/client/components/UI/SubNav/style.scss
@@ -1,4 +1,4 @@
-@import '~superdesk-ui-framework/app/styles/variables/_colors.scss';
+@import 'superdesk-ui-framework/app/styles/variables/_colors.scss';
 
 .sliding-toolbar__info-tools {
     a { cursor: pointer; }

--- a/client/components/UI/Toggle/style.scss
+++ b/client/components/UI/Toggle/style.scss
@@ -1,5 +1,5 @@
-@import '~superdesk-ui-framework/app/styles/_mixins.scss';
-@import '~superdesk-ui-framework/app/styles/_variables.scss';
+@import 'superdesk-ui-framework/app/styles/_mixins.scss';
+@import 'superdesk-ui-framework/app/styles/_variables.scss';
 
 .sd-toggle {
     &--disabled {

--- a/client/components/UI/ToggleBox/style.scss
+++ b/client/components/UI/ToggleBox/style.scss
@@ -1,4 +1,4 @@
-@import '~superdesk-ui-framework/app/styles/variables/_colors.scss';
+@import 'superdesk-ui-framework/app/styles/variables/_colors.scss';
 
 .toggle-box {
     .toggle-box__header--focus {

--- a/client/components/UI/style.scss
+++ b/client/components/UI/style.scss
@@ -1,6 +1,6 @@
-@import '~superdesk-ui-framework/app/styles/_mixins.scss';
-@import '~superdesk-ui-framework/app/styles/variables/_colors.scss';
-@import '~superdesk-ui-framework/app/styles/variables/_dimensions.scss';
+@import 'superdesk-ui-framework/app/styles/_mixins.scss';
+@import 'superdesk-ui-framework/app/styles/variables/_colors.scss';
+@import 'superdesk-ui-framework/app/styles/variables/_dimensions.scss';
 
 time.Datetime {
     padding-left: 0;

--- a/client/components/fields/editor/EventRelatedPlannings/style.scss
+++ b/client/components/fields/editor/EventRelatedPlannings/style.scss
@@ -1,4 +1,4 @@
-@import '~superdesk-ui-framework/app/styles/variables/_colors.scss';
+@import 'superdesk-ui-framework/app/styles/variables/_colors.scss';
 
 .related-plannings {
     .planning-item {

--- a/client/styles/index.scss
+++ b/client/styles/index.scss
@@ -1,7 +1,7 @@
-@import '~superdesk-core/styles/sass/mixins.scss';
-@import '~superdesk-core/styles/sass/variables.scss';
-@import '~superdesk-ui-framework/app/styles/variables/_colors.scss';
-@import '~@sourcefabric/common/dist/src/index.css';
+@import 'superdesk-core/styles/sass/mixins.scss';
+@import 'superdesk-core/styles/sass/variables.scss';
+@import 'superdesk-ui-framework/app/styles/variables/_colors.scss';
+@import '@sourcefabric/common/dist/src/index.css';
 
 @mixin absolute0 {
     position: absolute;


### PR DESCRIPTION
### Purpose
The `~` prefix on `@import` paths is deprecated in `sass-loader` 10 and removed in `sass-loader` 16. Stripping it now keeps planning building when client-core eventually moves to `sass-loader` 16. The compiled CSS is unchanged: webpack still resolves bare specifiers (`mixins.scss`, `superdesk-core/styles/sass/variables.scss`, etc.) via `resolve.modules` and aliases.

### What has changed
Removed the leading `~` from 48 `@import` statements across 25 SCSS files. Nothing else.

### Out of scope
Part of a coordinated rollout with companion PRs in analytics, publisher, and client-core, ending with client-core bumping `sass-loader` from 10 to 16.

### Steps to test
- Planning's own CI build (still on `sass-loader` 10) should go green. That's the verification that bare specifiers still resolve.
- Integrated superdesk dev build (`npm run start` from `superdesk/client`): planning views render as before.

