### PR TITLE
[SDBELGA-1109] - Handling due date disparity between edit panel and "Add Coverages" modal

### DIFF
--- a/client/components/Planning/PlanningItem.tsx
+++ b/client/components/Planning/PlanningItem.tsx
@@ -462,7 +462,7 @@ class PlanningItemComponent extends React.Component<IProps, IState> {
                             value={get(item, 'coverages', [])}
                             onSave={this.onCoverageModalSave}
                             createCoverage={(qcode) => {
-                                const eventItem = this.props.events[item.event_item];
+                                const eventItem = item.event_item ? this.props.events[item.event_item] : undefined;
 
                                 return planningApi.planning.coverages.setDefaultValues(item, eventItem, qcode);
                             }}

--- a/client/components/Planning/PlanningItem.tsx
+++ b/client/components/Planning/PlanningItem.tsx
@@ -9,7 +9,8 @@ import {
     IPlanningListItemProps,
     LIST_VIEW_TYPE,
     SORT_FIELD,
-    IPlanningNewsCoverageStatus
+    IPlanningNewsCoverageStatus,
+    IEventItem
 } from '../../interfaces';
 import {PLANNING, EVENTS, MAIN, ICON_COLORS, WORKFLOW_STATE} from '../../constants';
 
@@ -48,6 +49,7 @@ interface IState {
 interface IReduxStateProps {
     newsCoverageStatus: Array<IPlanningNewsCoverageStatus>;
     coverageAddAdvancedMode: boolean;
+    events: {[key: string]: IEventItem};
 }
 
 interface IProps extends IPlanningListItemProps, IReduxStateProps {
@@ -459,13 +461,11 @@ class PlanningItemComponent extends React.Component<IProps, IState> {
                             field="coverages"
                             value={get(item, 'coverages', [])}
                             onSave={this.onCoverageModalSave}
-                            createCoverage={(qcode) => ({
-                                planning: {
-                                    g2_content_type: qcode,
-                                    language: null,
-                                },
-                                workflow_status: 'draft',
-                            })}
+                            createCoverage={(qcode) => {
+                                const eventItem = this.props.events[item.event_item];
+
+                                return planningApi.planning.coverages.setDefaultValues(item, eventItem, qcode);
+                            }}
                             users={users}
                             desks={desks}
                             coverageAddAdvancedMode={this.props.coverageAddAdvancedMode}
@@ -481,6 +481,7 @@ class PlanningItemComponent extends React.Component<IProps, IState> {
 const mapStateToProps = (state) => ({
     newsCoverageStatus: selectors.general.newsCoverageStatus(state),
     coverageAddAdvancedMode: selectors.general.coverageAddAdvancedMode(state),
+    events: selectors.events.storedEvents(state),
 });
 
 export const PlanningItem = connect(mapStateToProps)(PlanningItemComponent);

--- a/client/utils/planning.ts
+++ b/client/utils/planning.ts
@@ -1430,10 +1430,6 @@ function defaultCoverageValues(
         newCoverage.planning.priority = planningItem.priority;
     }
 
-    if (planningItem?._time_to_be_confirmed) {
-        newCoverage._time_to_be_confirmed = planningItem._time_to_be_confirmed;
-    }
-
     if (planningItem) {
         const getCoverageDueDateStrategy = planningConfig.coverage?.getDueDateStrategy || getDefaultCoverageDueDate;
         const coverageTime = getCoverageDueDateStrategy(planningItem as IPlanningItem, eventItem);

--- a/server/planning/planning/planning.py
+++ b/server/planning/planning/planning.py
@@ -585,10 +585,6 @@ class PlanningService(superdesk.Service):
             return
 
         planning_date = original.get("planning_date") or updates.get("planning_date")
-        event_id = original.get("event_item") or updates.get("event_item")
-        event = None
-        if event_id:
-            event = get_resource_service("events").find_one(req=None, _id=event_id)
 
         original_coverage_ids = [
             coverage["coverage_id"] for coverage in original.get("coverages") or [] if coverage.get("coverage_id")
@@ -608,10 +604,16 @@ class PlanningService(superdesk.Service):
                 # Make sure the coverage has a ``scheduled`` date
                 # If none was supplied, fallback to the event end date or planning_date
                 coverage.setdefault("planning", {})
-                if event and event.get("dates", {}).get("end"):
-                    coverage["planning"].setdefault("scheduled", event["dates"]["end"])
-                else:
-                    coverage["planning"].setdefault("scheduled", planning_date)
+                if not coverage["planning"].get("scheduled"):
+                    event_id = original.get("event_item") or updates.get("event_item")
+                    event = None
+                    if event_id:
+                        event = get_resource_service("events").find_one(req=None, _id=event_id)
+
+                    if event and event.get("dates", {}).get("end"):
+                        coverage["planning"].setdefault("scheduled", event["dates"]["end"])
+                    else:
+                        coverage["planning"].setdefault("scheduled", planning_date)
 
                 set_original_creator(coverage)
                 self.set_coverage_active(coverage, updates)

--- a/server/planning/planning/planning.py
+++ b/server/planning/planning/planning.py
@@ -585,6 +585,11 @@ class PlanningService(superdesk.Service):
             return
 
         planning_date = original.get("planning_date") or updates.get("planning_date")
+        event_id = original.get("event_item") or updates.get("event_item")
+        event = None
+        if event_id:
+            event = get_resource_service("events").find_one(req=None, _id=event_id)
+
         original_coverage_ids = [
             coverage["coverage_id"] for coverage in original.get("coverages") or [] if coverage.get("coverage_id")
         ]
@@ -601,9 +606,12 @@ class PlanningService(superdesk.Service):
                 coverage["firstcreated"] = utcnow()
 
                 # Make sure the coverage has a ``scheduled`` date
-                # If none was supplied, fallback to to ``planning.planning_date``
+                # If none was supplied, fallback to the event end date or planning_date
                 coverage.setdefault("planning", {})
-                coverage["planning"].setdefault("scheduled", planning_date)
+                if event and event.get("dates", {}).get("end"):
+                    coverage["planning"].setdefault("scheduled", event["dates"]["end"])
+                else:
+                    coverage["planning"].setdefault("scheduled", planning_date)
 
                 set_original_creator(coverage)
                 self.set_coverage_active(coverage, updates)


### PR DESCRIPTION
### Purpose
This PR fixes the coverage due time inconsistency between adding a coverage from the planning editor and from the "Edit Coverages" (advanced mode) modal

### What has changed
- Changed the `createCoverage` to use `planningApi.planning.coverages.setDefaultValues()`. This ensures the modal uses the same coverage due time logic as the editor. 

### Steps to test
1. Create an all-day event and add a planning item from it.
2. Add a coverage via the "Edit Coverages" (advanced mode) modal from the planning list view and verify the coverage due time is 20:00 of the same day.
3. Create an event with TBC time and add a planning item.
4. Add a coverage via the modal and verify the coverage due time is 20:00 and shows the actual time in the UI.
5. Create a timed event (e.g., 10:00-16:00) and add a planning item.
6. Add a coverage via the modal and verify the coverage due time is 17:00 (end time + 1 hour).

### Video
https://github.com/user-attachments/assets/5f684e86-6f3d-46ff-a0fd-84b124d4c1f7


Note: This PR is linked to this [PR in superdesk-belga](https://github.com/superdesk/superdesk-belga/pull/992) where their custom `getCoverageDueDate` is defined. 

Resolves: #[SDBELGA-1109](https://sofab.atlassian.net/browse/SDBELGA-1109)



[SDBELGA-1109]: https://sofab.atlassian.net/browse/SDBELGA-1109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ