### PR TITLE
some events without end time were not visible

### DIFF
--- a/client/components/Events/EventDateTime.tsx
+++ b/client/components/Events/EventDateTime.tsx
@@ -26,10 +26,12 @@ export class EventDateTime extends React.PureComponent<IProps> {
         const {gettext} = superdeskApi.localization;
         const {hasStartDateContext = false} = this.props;
         const {item} = this.props;
+        const noEndTime = item.dates?.no_end_time;
+        const isFullDay = item.dates?.all_day;
         const start = eventUtils.getStartDate(item);
         const end = eventUtils.getEndDate(item);
         const isAllDay = eventUtils.isEventAllDay(item);
-        const multiDay = !isSameDay(start, end);
+        const multiDay = noEndTime && end.isBefore(start) ? false : !isSameDay(start, end);
         const showEventStartDate = !hasStartDateContext;
         const isRemoteTimeZone = timeUtils.isEventInDifferentTimeZone(item);
         const withYear = !hasStartDateContext || (multiDay && start.year() !== end.year());
@@ -60,9 +62,6 @@ export class EventDateTime extends React.PureComponent<IProps> {
                 </span>
             );
         }
-
-        const noEndTime = item.dates?.no_end_time;
-        const isFullDay = item.dates?.all_day;
 
         const commonProps = {
             padLeft: false,

--- a/client/utils/events.tsx
+++ b/client/utils/events.tsx
@@ -748,7 +748,7 @@ function getDateStringForEvent(
     const localStart = timeUtils.getLocalDate(start, tz);
     const isFullDay = event?.dates?.all_day;
     const noEndTime = event?.dates?.no_end_time;
-    const multiDay = !start.isSame(end, 'day');
+    const multiDay = noEndTime && end.isBefore(start) ? false : !start.isSame(end, 'day');
 
     let dateString, timezoneString = '';
 
@@ -1137,8 +1137,15 @@ function getLocalStartDate(event: IEventItem): moment.Moment {
 }
 
 function getLocalEndDate(event: IEventItem): moment.Moment {
-    if (event.dates.all_day || event.dates.no_end_time) {
+    if (event.dates.all_day) {
         return moment(moment.utc(event.dates.end).format('YYYY-MM-DD')).endOf('day');
+    }
+
+    if (event.dates.no_end_time) {
+        const localStartDate = getLocalStartDate(event);
+        const localEndDate = moment(moment.utc(event.dates.end).format('YYYY-MM-DD')).endOf('day');
+
+        return localEndDate.isBefore(localStartDate) ? localStartDate.clone().endOf('day') : localEndDate;
     }
 
     return moment(event.dates.end);
@@ -1198,9 +1205,12 @@ function modifyForClient(event: Partial<IEventItem>): Partial<IEventItem> {
     convertEventDatesForTimezone(event);
 
     if (event.dates?.end != null) {
-        event.dates.end = timeUtils.getDateInRemoteTimeZone(event.dates.end, timeUtils.localTimeZone());
-        event._endTime = event.dates.all_day || event.dates.no_end_time ? null
-            : timeUtils.getDateInRemoteTimeZone(event.dates.end, timeUtils.localTimeZone());
+        if (event.dates.all_day || event.dates.no_end_time) {
+            event._endTime = null;
+        } else {
+            event.dates.end = timeUtils.getDateInRemoteTimeZone(event.dates.end, timeUtils.localTimeZone());
+            event._endTime = timeUtils.getDateInRemoteTimeZone(event.dates.end, timeUtils.localTimeZone());
+        }
     }
 
     setRecurringEventUntilDate(event);

--- a/client/utils/tests/events_test.ts
+++ b/client/utils/tests/events_test.ts
@@ -555,6 +555,53 @@ describe('EventUtils', () => {
                 }
             });
         });
+
+        it('shows a no_end_time event when raw end date is before local start day after conversion', () => {
+            const event = eventUtils.modifyForClient({
+                _id: 'e1',
+                dates: {
+                    start: '2026-06-19T22:00:00+0000',
+                    end: '2026-06-19T00:00:00+0000',
+                    tz: 'America/Vancouver',
+                    all_day: false,
+                    no_end_time: true,
+                },
+            });
+
+            const eventsDateGroup = eventUtils.getEventsByDate(
+                [event as any],
+                moment('2026-06-19T00:00:00+0000'),
+                moment('2026-06-21T23:59:59+0000')
+            );
+
+            expect(Object.keys(eventsDateGroup).length).toBeGreaterThan(0);
+            Object.keys(eventsDateGroup).forEach((key) => {
+                expect(eventPresentInGroup(eventsDateGroup[key], event)).toBe(true);
+            });
+        });
+
+        it('treats all_day as authoritative when all_day and no_end_time are both set', () => {
+            const event = eventUtils.modifyForClient({
+                _id: 'e1',
+                dates: {
+                    start: '2026-06-19T22:00:00+0000',
+                    end: '2026-06-19T00:00:00+0000',
+                    tz: 'America/Vancouver',
+                    all_day: true,
+                    no_end_time: true,
+                },
+            });
+
+            const eventsDateGroup = eventUtils.getEventsByDate(
+                [event as any],
+                moment('2026-06-18T00:00:00+0000'),
+                moment('2026-06-20T23:59:59+0000')
+            );
+
+            expect(eventsDateGroup.length).toBe(1);
+            expect(eventsDateGroup[0].date).toBe('2026-06-19');
+            expect(eventPresentInGroup(eventsDateGroup[0], event)).toBe(true);
+        });
     });
 
     describe('modifyForClient', () => {


### PR DESCRIPTION
events which would have start on next day with local timezone were not visible

SDCP-1194

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

### Front-end checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)

Resolves: #[issue-number]

