### PR TITLE
[SDCP-1195] Recreate embedded planning autosave when the document is missing

### DIFF
--- a/client/components/editor-standalone/authoring-autosave.ts
+++ b/client/components/editor-standalone/authoring-autosave.ts
@@ -28,61 +28,75 @@ export class AutoSaveHttp<T extends IBaseRestApiResponse & IEventOrPlanningItem>
         this.autoSaveThrottled = throttle(this.autosave, delay, {leading: false});
     }
 
-    private autosave(getItem: () => T, previousAutosavedItem: T, callback: (autosaved: T) => void) {
+    private updateAutosave(item: T, previousAutosavedItem: T): Promise<T> {
         const {httpRequestJsonLocal} = superdeskApi;
+        const {lock_action, lock_user, lock_session, lock_time} = previousAutosavedItem;
 
-        const item: T = this.modifyForServer(getItem());
-        let result: Promise<T>;
-
-        if (previousAutosavedItem != null) {
-            const {
+        return httpRequestJsonLocal<T>({
+            method: 'PATCH',
+            path: `/${this.resource}/${item._id}`,
+            payload: {
+                ...omitFields(item, true),
                 lock_action,
                 lock_user,
                 lock_session,
                 lock_time,
-            } = previousAutosavedItem;
-
-            result = httpRequestJsonLocal<T>({
-                method: 'PATCH',
-                path: `/${this.resource}/${item._id}`,
-                payload: {
-                    ...omitFields(item, true),
-                    lock_action,
-                    lock_user,
-                    lock_session,
-                    lock_time,
-                },
-                headers: {
-                    'If-Match': previousAutosavedItem._etag,
-                },
-            });
-        } else {
-            const {getState} = planningApi.redux.store;
-
-            const lockInfo = {
-                lock_action: 'edit',
-                lock_user: selectors.general.currentUserId(getState()),
-                lock_session: selectors.general.sessionId(getState()),
-                lock_time: moment(),
-            };
-
-            result = httpRequestJsonLocal<T>({
-                method: 'POST',
-                path: `/${this.resource}`,
-                payload: omitFields({
-                    ...item,
-                    ...lockInfo,
-                }),
-            });
-        }
-
-        this.autosavePromise = result.then((res) => {
-            this.autosavePromise = null;
-
-            const result = this.modifyForClient(res);
-
-            callback(result);
+            },
+            headers: {
+                'If-Match': previousAutosavedItem._etag,
+            },
         });
+    }
+
+    private createAutosave(item: T): Promise<T> {
+        const {httpRequestJsonLocal} = superdeskApi;
+        const {getState} = planningApi.redux.store;
+
+        const lockInfo = {
+            lock_action: 'edit',
+            lock_user: selectors.general.currentUserId(getState()),
+            lock_session: selectors.general.sessionId(getState()),
+            lock_time: moment(),
+        };
+
+        return httpRequestJsonLocal<T>({
+            method: 'POST',
+            path: `/${this.resource}`,
+            payload: omitFields({
+                ...item,
+                ...lockInfo,
+            }),
+        });
+    }
+
+    private autosave(getItem: () => T, previousAutosavedItem: T, callback: (autosaved: T) => void) {
+        const item: T = this.modifyForServer(getItem());
+
+        const request = previousAutosavedItem == null
+            ? this.createAutosave(item)
+            : this.updateAutosave(item, previousAutosavedItem).catch((error) => {
+                // The autosave document may no longer exist on the server, e.g. it was deleted
+                // by a manual save or purged once its lock expired. Recreate it rather than
+                // failing the autosave with a 404.
+                if (error?.internal_error === 404) {
+                    return this.createAutosave(item);
+                }
+
+                return Promise.reject(error);
+            });
+
+        this.autosavePromise = request
+            .then((res) => {
+                callback(this.modifyForClient(res));
+            })
+            .catch((error) => {
+                // Autosave is best-effort: keep failures out of the uncaught-rejection channel
+                // while still surfacing them for debugging.
+                console.error(`${this.resource} autosave failed`, error);
+            })
+            .then(() => {
+                this.autosavePromise = null;
+            });
     }
 
     public get(id: T['_id']) {

--- a/client/components/editor-standalone/authoring-autosave.ts
+++ b/client/components/editor-standalone/authoring-autosave.ts
@@ -77,8 +77,9 @@ export class AutoSaveHttp<T extends IBaseRestApiResponse & IEventOrPlanningItem>
             : this.updateAutosave(item, previousAutosavedItem).catch((error) => {
                 // The autosave document may no longer exist on the server, e.g. it was deleted
                 // by a manual save or purged once its lock expired. Recreate it rather than
-                // failing the autosave with a 404.
-                if (error?.internal_error === 404) {
+                // failing the autosave with a 404. Match both error shapes the local http
+                // helper can surface (`internal_error` and the Eve `_error.code`).
+                if (error?.internal_error === 404 || error?._error?.code === 404) {
                     return this.createAutosave(item);
                 }
 


### PR DESCRIPTION
### Purpose

Fix autosave breaking in the Event editor under Related Planning > Coverages. After saving a coverage, the next autosave issued a `PATCH /api/planning_autosave/{id}` against a document that no longer exists on the server, returning 404. This surfaced as an uncaught promise rejection and stopped autosaving every subsequent change.

The autosave document can go missing because a manual save deletes it, or because the server purges it when its lock expires (therefore the seemingly "random" trigger).

Companion PR (client-core): https://github.com/superdesk/superdesk-client-core/pull/5244 . 

### What has changed

In the embedded planning `AutoSaveHttp`:

- On a 404 from the PATCH, recreate the autosave via POST instead of failing. This also recovers if the document is purged externally.
- Route autosave failures through `console.error` rather than leaving an unhandled promise rejection.

### Steps to test
- Please follow the steps/video in the ticket [SDCP-1195]

Resolves: [SDCP-1195]


[SDCP-1195]: https://sofab.atlassian.net/browse/SDCP-1195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ