### PR TITLE
[SDCP-1195] Recreate embedded planning autosave + e2e regression (forward-port of #2873)

### DIFF
--- a/client/components/editor-standalone/authoring-autosave.ts
+++ b/client/components/editor-standalone/authoring-autosave.ts
@@ -28,61 +28,76 @@ export class AutoSaveHttp<T extends IBaseRestApiResponse & IEventOrPlanningItem>
         this.autoSaveThrottled = throttle(this.autosave, delay, {leading: false});
     }
 
-    private autosave(getItem: () => T, previousAutosavedItem: T, callback: (autosaved: T) => void) {
+    private updateAutosave(item: T, previousAutosavedItem: T): Promise<T> {
         const {httpRequestJsonLocal} = superdeskApi;
+        const {lock_action, lock_user, lock_session, lock_time} = previousAutosavedItem;
 
-        const item: T = this.modifyForServer(getItem());
-        let result: Promise<T>;
-
-        if (previousAutosavedItem != null) {
-            const {
+        return httpRequestJsonLocal<T>({
+            method: 'PATCH',
+            path: `/${this.resource}/${item._id}`,
+            payload: {
+                ...omitFields(item, true),
                 lock_action,
                 lock_user,
                 lock_session,
                 lock_time,
-            } = previousAutosavedItem;
-
-            result = httpRequestJsonLocal<T>({
-                method: 'PATCH',
-                path: `/${this.resource}/${item._id}`,
-                payload: {
-                    ...omitFields(item, true),
-                    lock_action,
-                    lock_user,
-                    lock_session,
-                    lock_time,
-                },
-                headers: {
-                    'If-Match': previousAutosavedItem._etag,
-                },
-            });
-        } else {
-            const {getState} = planningApi.redux.store;
-
-            const lockInfo = {
-                lock_action: 'edit',
-                lock_user: selectors.general.currentUserId(getState()),
-                lock_session: selectors.general.sessionId(getState()),
-                lock_time: moment(),
-            };
-
-            result = httpRequestJsonLocal<T>({
-                method: 'POST',
-                path: `/${this.resource}`,
-                payload: omitFields({
-                    ...item,
-                    ...lockInfo,
-                }),
-            });
-        }
-
-        this.autosavePromise = result.then((res) => {
-            this.autosavePromise = null;
-
-            const result = this.modifyForClient(res);
-
-            callback(result);
+            },
+            headers: {
+                'If-Match': previousAutosavedItem._etag,
+            },
         });
+    }
+
+    private createAutosave(item: T): Promise<T> {
+        const {httpRequestJsonLocal} = superdeskApi;
+        const {getState} = planningApi.redux.store;
+
+        const lockInfo = {
+            lock_action: 'edit',
+            lock_user: selectors.general.currentUserId(getState()),
+            lock_session: selectors.general.sessionId(getState()),
+            lock_time: moment(),
+        };
+
+        return httpRequestJsonLocal<T>({
+            method: 'POST',
+            path: `/${this.resource}`,
+            payload: omitFields({
+                ...item,
+                ...lockInfo,
+            }),
+        });
+    }
+
+    private autosave(getItem: () => T, previousAutosavedItem: T, callback: (autosaved: T) => void) {
+        const item: T = this.modifyForServer(getItem());
+
+        const request = previousAutosavedItem == null
+            ? this.createAutosave(item)
+            : this.updateAutosave(item, previousAutosavedItem).catch((error) => {
+                // The autosave document may no longer exist on the server, e.g. it was deleted
+                // by a manual save or purged once its lock expired. Recreate it rather than
+                // failing the autosave with a 404. Match both error shapes the local http
+                // helper can surface (`internal_error` and the Eve `_error.code`).
+                if (error?.internal_error === 404 || error?._error?.code === 404) {
+                    return this.createAutosave(item);
+                }
+
+                return Promise.reject(error);
+            });
+
+        this.autosavePromise = request
+            .then((res) => {
+                callback(this.modifyForClient(res));
+            })
+            .catch((error) => {
+                // Autosave is best-effort: keep failures out of the uncaught-rejection channel
+                // while still surfacing them for debugging.
+                console.error(`${this.resource} autosave failed`, error);
+            })
+            .then(() => {
+                this.autosavePromise = null;
+            });
     }
 
     public get(id: T['_id']) {

--- a/e2e/playwright/events/embedded_planning_autosave.spec.ts
+++ b/e2e/playwright/events/embedded_planning_autosave.spec.ts
@@ -1,0 +1,72 @@
+import {test, expect} from '@playwright/test';
+
+import {setup, login, waitForPageLoad, addItems} from '../utils/common';
+import {EventEditor, PlanningList, EmbeddedCoverageEditor} from '../page-object-models/planning';
+import {createEventFor} from '../utils/fixtures/events';
+
+test.describe('Planning.Events: embedded planning autosave', () => {
+    let editor: EventEditor;
+    let embedded: EmbeddedCoverageEditor;
+    let list: PlanningList;
+
+    test.beforeEach(async ({page}) => {
+        editor = new EventEditor(page);
+        embedded = new EmbeddedCoverageEditor(editor);
+        list = new PlanningList(page);
+
+        await setup(page, 'planning_prepopulate_data', '/#/planning');
+        await login(page);
+        await waitForPageLoad.planning(page);
+    });
+
+    // Saving an embedded planning deletes its autosave document. The bug was that the
+    // editor kept referencing the deleted document, so the next change PATCHed a 404 and
+    // was never autosaved. Two save cycles reach that state; the final change is only
+    // autosaved, so its survival across a reload is the assertion.
+    test('an autosave-only change survives reload after repeated saves', async ({page}) => {
+        test.setTimeout(150000);
+
+        await addItems(page.request, 'events', [createEventFor.today({
+            type: 'event',
+            state: 'draft',
+            name: 'Autosave regression',
+            slugline: 'autosave',
+        })]);
+
+        await list.item(0).dblclick();
+        await editor.waitTillOpen();
+        await editor.waitLoadingComplete();
+
+        await editor.clickBookmark('add_planning');
+        await editor.waitForAutosave();
+        await expect(embedded.getPlanningItem(0)).toBeVisible();
+
+        // Saving the temporary planning moves it onto the HTTP autosave path.
+        await embedded.appendToSlugline(0, '-a');
+        await embedded.save(0);
+
+        // This save deletes the autosave document.
+        const created = embedded.waitForAutosaved(page, 'POST');
+
+        await embedded.appendToSlugline(0, '-b');
+        await created;
+        await embedded.save(0);
+
+        // Only autosaved, never manually saved, so it is lost on reload unless the
+        // deleted autosave document is recreated.
+        const recreated = embedded.waitForAutosaved(page, 'POST');
+
+        await embedded.appendToSlugline(0, '-keep');
+        await recreated;
+
+        await page.reload();
+        await waitForPageLoad.planning(page);
+
+        await list.item(0).dblclick();
+        await editor.waitTillOpen();
+        await editor.waitLoadingComplete();
+
+        await embedded.expand(0);
+        await expect(embedded.slugline(0)).toContainText('autosave-a-b-keep');
+    });
+});

--- a/e2e/playwright/page-object-models/planning/events/embeddedCoverageEditor.ts
+++ b/e2e/playwright/page-object-models/planning/events/embeddedCoverageEditor.ts
@@ -1,4 +1,5 @@
-import {Locator} from '@playwright/test';
+import {expect} from '@playwright/test';
+import type {Locator, Page, Response} from '@playwright/test';
 
 import {EventEditor} from './eventEditor';
 import {SelectInput, NewCheckboxInput, CoverageUserSelectInput} from '../../../utils/common';
@@ -16,6 +17,50 @@ export class EmbeddedCoverageEditor {
 
     getPlanningItem(index: number): Locator {
         return this.element.getByTestId(`editor--planning-item__${index}`);
+    }
+
+    // An embedded planning renders collapsed with its fields present but not
+    // interactable; expand it before touching any field.
+    async expand(index: number): Promise<void> {
+        const showMore = this.getPlanningItem(index).getByRole('button', {name: 'Show more'});
+
+        if (await showMore.isVisible().catch(() => false)) {
+            await showMore.click();
+        }
+    }
+
+    slugline(index: number): Locator {
+        return this.getPlanningItem(index).getByTestId('editor3').locator('[contenteditable="true"]').first();
+    }
+
+    async appendToSlugline(index: number, text: string): Promise<void> {
+        await this.expand(index);
+
+        const field = this.slugline(index);
+
+        await field.scrollIntoViewIfNeeded();
+        await field.click();
+        await field.page().keyboard.press('End');
+        await field.page().keyboard.type(text);
+    }
+
+    async save(index: number): Promise<void> {
+        const planning = this.getPlanningItem(index);
+
+        await planning.getByRole('button', {name: 'Save', exact: true}).first().click();
+
+        // Done once no enabled Save button remains: the first save persists a temporary
+        // item and remounts the card collapsed (button gone), later saves just grey it out.
+        await expect(planning.locator('button:enabled', {hasText: 'Save'})).toHaveCount(0, {timeout: 20000});
+    }
+
+    // Resolves once an autosave request of the given method has completed
+    // successfully, so callers can reload without racing the pending write.
+    waitForAutosaved(page: Page, method: 'POST' | 'PATCH'): Promise<Response> {
+        return page.waitForResponse((res) =>
+            res.url().includes('/api/planning_autosave') &&
+            res.request().method() === method &&
+            res.status() < 400);
     }
 
     getAddCoverageForm(index: number): Locator {


### PR DESCRIPTION
### Purpose
Forward-port of #2873 to `develop`, plus the Playwright regression test that could not live on release/3.1 (its e2e suite is Cypress; Playwright is develop-only).

### What has changed
- Cherry-pick of the already-merged fix from #2873.
- New `events/embedded_planning_autosave.spec.ts` plus `expand`/`appendToSlugline`/`save`/`waitForAutosaved` helpers on `EmbeddedCoverageEditor`, covering the embedded planning autosave-after-save path that previously had no coverage.

Resolves: [SDCP-1195]


[SDCP-1195]: https://sofab.atlassian.net/browse/SDCP-1195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ