### PR TITLE
[SDESK-7802] - Migrate planning actions to IAuthoringActionGroup

### DIFF
--- a/client/planning-extension/src/extension.ts
+++ b/client/planning-extension/src/extension.ts
@@ -127,6 +127,11 @@ const extension: IExtension = {
         const {gettext} = superdesk.localization;
         const {article: superdeskArticleApi} = superdesk.entities;
         const planningActionsGroupId = 'planning-actions';
+        const planningActionsGroup = {
+            id: 'planning-actions',
+            label: gettext('Planning'),
+            priority: 10,
+        };
         const {getItemPlanningInfo} = extensionBridge.planning;
         const canAddToPlanning = (item: IArticle) => (
             superdesk.privileges.hasPrivilege('planning_planning_management') &&
@@ -174,6 +179,7 @@ const extension: IExtension = {
                 permittedActions.push({
                     label: gettext('Add to Planning'),
                     groupId: planningActionsGroupId,
+                    group: planningActionsGroup,
                     icon: 'icon-calendar-list',
                     onTrigger: () => {
                         const customEvent = new CustomEvent('planning:addToPlanning', {detail: item});
@@ -187,6 +193,7 @@ const extension: IExtension = {
                 permittedActions.push({
                     label: gettext('Unlink as Coverage'),
                     groupId: planningActionsGroupId,
+                    group: planningActionsGroup,
                     icon: 'icon-cut',
                     onTrigger: () => {
                         superdesk.entities.article.get(item._id).then((_item) => {
@@ -203,6 +210,7 @@ const extension: IExtension = {
                 permittedActions.push({
                     label: superdesk.localization.gettext('Link to Assignment'),
                     groupId: planningActionsGroupId,
+                    group: planningActionsGroup,
                     icon: 'icon-calendar-list',
                     onTrigger: () => {
                         superdesk.entities.article.get(item._id).then((_item) => {

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -13046,7 +13046,7 @@
         },
         "node_modules/superdesk-core": {
             "version": "3.5.0-dev",
-            "resolved": "git+ssh://git@github.com/superdesk/superdesk-client-core.git#eac63d33fd7c30c67424a213f9c2c015d27ecae3",
+            "resolved": "git+ssh://git@github.com/superdesk/superdesk-client-core.git#0b5ee88ee0f55fe48acca1a57e23fbfc9dd4c625",
             "hasInstallScript": true,
             "license": "AGPL-3.0",
             "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15770,7 +15770,7 @@
     },
     "node_modules/superdesk-core": {
       "version": "3.5.0-dev",
-      "resolved": "git+ssh://git@github.com/superdesk/superdesk-client-core.git#eac63d33fd7c30c67424a213f9c2c015d27ecae3",
+      "resolved": "git+ssh://git@github.com/superdesk/superdesk-client-core.git#0b5ee88ee0f55fe48acca1a57e23fbfc9dd4c625",
       "dev": true,
       "hasInstallScript": true,
       "license": "AGPL-3.0",


### PR DESCRIPTION
### Purpose
This PR adopt the new `IAuthoringActionGroup` so planning actions render with a labeled "PLANNING" group header in the React authoring menu instead of using the fallback currently in place.

### What has changed
- Added `planningActionsGroup` constant
- Set group on all three authoring actions 

### Steps to test
1. Open an article in React authoring with planning enabled
2. Open the actions menu
3. Verify a "PLANNING" group header appears above the planning actions

This PR depends on [superdesk/superdesk-client-core#5243](https://github.com/superdesk/superdesk-client-core/pull/5243)


Resolves: [SDESK-7802](https://sofab.atlassian.net/browse/SDESK-7802)



[SDESK-7802]: https://sofab.atlassian.net/browse/SDESK-7802?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ