### PR TITLE
Fix file provider tests for async aiohttp http_push

### DIFF
--- a/server/planning/tests/output_formatters/file_providers_test.py
+++ b/server/planning/tests/output_formatters/file_providers_test.py
@@ -12,6 +12,10 @@ from io import BytesIO
 from unittest import mock
 import hmac
 
+import aiohttp
+from aioresponses import aioresponses
+from yarl import URL
+
 from planning.tests import TestCase
 from superdesk.publish import TransmitterFileEntry
 from superdesk.publish.transmitters.ftp import FTPPublishService
@@ -19,24 +23,18 @@ from superdesk.publish.transmitters.http_push import HTTPPushService
 from planning.output_formatters.file_providers import get_event_planning_files_for_transmission
 
 
-class NotFoundResponse:
-    status_code = 404
-
-
-class CreatedResponse:
-    status_code = 201
-
-
 class TestEventMedia(BytesIO):
     _id = "event_file"
     filename = "event_file.csv"
     mimetype = "text/csv"
+    content_type = "text/csv"
 
 
 class TestPlanningMedia(BytesIO):
     _id = "plan_file"
     filename = "plan_file.csv"
     mimetype = "text/csv"
+    content_type = "text/csv"
 
 
 class MockMedia:
@@ -116,49 +114,68 @@ class FileProvidersTestCase(TestCase):
         planning_item = {"type": "planning", "files": ["fileid"]}
         self.assertEqual({}, get_event_planning_files_for_transmission(HTTPPushService.NAME, planning_item))
 
-    @mock.patch(
-        "superdesk.publish.transmitters.http_push.get_current_app", return_value=MockApp(TestEventMedia(b"bin"))
-    )
-    @mock.patch("superdesk.publish.transmitters.http_push.get_app_config", return_value=(5, 30))
-    @mock.patch("superdesk.publish.transmitters.http_push.requests.Session.send", return_value=CreatedResponse)
-    @mock.patch("requests.get", return_value=NotFoundResponse)
-    async def test_push_event_files(self, get_mock, send_mock, mock_config, get_mock_app):
+    async def test_push_event_files(self):
+        test_file = TestEventMedia(b"bin")
+        mock_app = MockApp(test_file)
         dest = {"config": {"assets_url": "http://example.com", "secret_token": "foo"}}
-        service = HTTPPushService()
-        await service._copy_published_media_files(self.event_item, dest)
-        get_mock_app().media.get.assert_called_with("event_file", resource="events_files")
-        get_mock.assert_called_with("http://example.com/event_file", timeout=(5, 30))
-        send_mock.assert_called_once_with(mock.ANY, timeout=(5, 30))
-        request = send_mock.call_args[0][0]
-        self.assertEqual("http://example.com/", request.url)
-        self.assertEqual("POST", request.method)
-        self.assertIn(b"bin", request.body)
-        self.assertIn(b"event_file", request.body)
-        self.assertIn("x-superdesk-signature", request.headers)
-        self.assertEqual(
-            request.headers["x-superdesk-signature"], "sha1=%s" % hmac.new(b"foo", request.body, "sha1").hexdigest()
-        )
 
-    @mock.patch(
-        "superdesk.publish.transmitters.http_push.get_current_app", return_value=MockApp(TestPlanningMedia(b"bin"))
-    )
-    @mock.patch("superdesk.publish.transmitters.http_push.get_app_config", return_value=(5, 30))
-    @mock.patch("superdesk.publish.transmitters.http_push.requests.Session.send", return_value=CreatedResponse)
-    @mock.patch("requests.get", return_value=NotFoundResponse)
-    async def test_push_planning_files(self, get_mock, send_mock, mock_config, get_mock_app):
-        app_mock = get_mock_app()
+        with aioresponses() as http_mock, mock.patch(
+            "superdesk.publish.transmitters.http_push.get_current_app", return_value=mock_app
+        ):
+            http_mock.get("http://example.com/event_file", repeat=True, status=404, payload={})
+            http_mock.post("http://example.com", repeat=True, status=201, payload={})
+
+            service = HTTPPushService()
+            await service._copy_published_media_files(self.event_item, dest)
+
+            mock_app.media.get.assert_called_with("event_file", resource="events_files")
+            http_mock.assert_called_with("http://example.com/event_file", method="GET")
+
+            post_requests = http_mock.requests[("POST", URL("http://example.com"))]
+            self.assertEqual(len(post_requests), 1)
+
+            request_body = post_requests[0].kwargs["data"]
+            self.assertIsInstance(request_body, aiohttp.FormData)
+
+            request_body_bytes = await request_body().as_bytes()
+            self.assertIn(b"bin", request_body_bytes)
+            self.assertIn(b"event_file", request_body_bytes)
+
+            headers = post_requests[0].kwargs["headers"]
+            self.assertEqual(
+                headers["x-superdesk-signature"],
+                "sha1=%s" % hmac.new(b"foo", request_body_bytes, "sha1").hexdigest(),
+            )
+
+    async def test_push_planning_files(self):
+        test_file = TestPlanningMedia(b"bin")
+        mock_app = MockApp(test_file)
         dest = {"config": {"assets_url": "http://example.com", "secret_token": "foo"}}
-        service = HTTPPushService()
-        await service._copy_published_media_files(self.plan_item, dest)
-        app_mock.media.get.assert_called_with("plan_file", resource="planning_files")
-        get_mock.assert_called_with("http://example.com/plan_file", timeout=(5, 30))
-        send_mock.assert_called_once_with(mock.ANY, timeout=(5, 30))
-        request = send_mock.call_args[0][0]
-        self.assertEqual("http://example.com/", request.url)
-        self.assertEqual("POST", request.method)
-        self.assertIn(b"bin", request.body)
-        self.assertIn(b"plan_file", request.body)
-        self.assertIn("x-superdesk-signature", request.headers)
-        self.assertEqual(
-            request.headers["x-superdesk-signature"], "sha1=%s" % hmac.new(b"foo", request.body, "sha1").hexdigest()
-        )
+
+        with aioresponses() as http_mock, mock.patch(
+            "superdesk.publish.transmitters.http_push.get_current_app", return_value=mock_app
+        ):
+            http_mock.get("http://example.com/plan_file", repeat=True, status=404, payload={})
+            http_mock.post("http://example.com", repeat=True, status=201, payload={})
+
+            service = HTTPPushService()
+            await service._copy_published_media_files(self.plan_item, dest)
+
+            mock_app.media.get.assert_called_with("plan_file", resource="planning_files")
+            http_mock.assert_called_with("http://example.com/plan_file", method="GET")
+
+            post_requests = http_mock.requests[("POST", URL("http://example.com"))]
+            self.assertEqual(len(post_requests), 1)
+
+            request_body = post_requests[0].kwargs["data"]
+            self.assertIsInstance(request_body, aiohttp.FormData)
+
+            request_body_bytes = await request_body().as_bytes()
+            self.assertIn(b"bin", request_body_bytes)
+            self.assertIn(b"plan_file", request_body_bytes)
+
+            headers = post_requests[0].kwargs["headers"]
+            self.assertEqual(
+                headers["x-superdesk-signature"],
+                "sha1=%s" % hmac.new(b"foo", request_body_bytes, "sha1").hexdigest(),
+            )


### PR DESCRIPTION
### Purpose
Fix the `server-pytest` failure on `develop` caused by superdesk-core migrating the `http_push` transmitter from sync `requests` to async `aiohttp`. 
```shell
AttributeError: module 'superdesk.publish.transmitters.http_push' has no attribute 'requests'
```
### What has changed
- Rewrote `test_push_event_files` / `test_push_planning_files` in `file_providers_test.py` to mock the aiohttp layer with `aioresponses`, instead of the removed `http_push.requests`.
- Production code is unchanged: the file provider is a plain sync function; its other tests already pass.


