### PR TITLE
fix etag syncing in events editor

### DIFF
--- a/client/components/Events/EventEditor/index.tsx
+++ b/client/components/Events/EventEditor/index.tsx
@@ -94,8 +94,15 @@ class EventEditorComponent extends React.PureComponent<IProps> {
             this.props.original?._etag != null &&
             prevProps.original._etag !== this.props.original._etag
         ) {
-            // Batch with other initialValues updates to avoid async setState races.
-            initialValueUpdates._etag = this.props.original._etag;
+            // Keep editor If-Match value current without triggering onChange/autosave side effects.
+            const managerState = this.props.itemManager.getState();
+
+            this.props.itemManager.setState({
+                initialValues: {
+                    ...managerState.initialValues,
+                    _etag: this.props.original._etag,
+                },
+            });
         }
 
         if (Object.keys(initialValueUpdates).length > 0) {

--- a/client/components/Events/EventEditor/index.tsx
+++ b/client/components/Events/EventEditor/index.tsx
@@ -94,15 +94,8 @@ class EventEditorComponent extends React.PureComponent<IProps> {
             this.props.original?._etag != null &&
             prevProps.original._etag !== this.props.original._etag
         ) {
-            // Keep editor If-Match value current without triggering onChange/autosave side effects.
-            const managerState = this.props.itemManager.getState();
-
-            this.props.itemManager.setState({
-                initialValues: {
-                    ...managerState.initialValues,
-                    _etag: this.props.original._etag,
-                },
-            });
+            // Batch with other initialValues updates to avoid async setState races.
+            initialValueUpdates._etag = this.props.original._etag;
         }
 
         if (Object.keys(initialValueUpdates).length > 0) {

--- a/client/components/Events/EventEditor/index.tsx
+++ b/client/components/Events/EventEditor/index.tsx
@@ -84,10 +84,29 @@ class EventEditorComponent extends React.PureComponent<IProps> {
             });
         }
 
+        const initialValueUpdates: Partial<IEventItem> = {};
+
         if (!isEqual(this.props.original?.planning_ids, prevProps.original?.planning_ids)) {
-            this.props.itemManager.forceUpdateInitialValues({
-                planning_ids: this.props.original?.planning_ids ?? [],
+            initialValueUpdates.planning_ids = this.props.original?.planning_ids ?? [];
+        }
+
+        if (prevProps.original?._etag != null &&
+            this.props.original?._etag != null &&
+            prevProps.original._etag !== this.props.original._etag
+        ) {
+            // Keep editor If-Match value current without triggering onChange/autosave side effects.
+            const managerState = this.props.itemManager.getState();
+
+            this.props.itemManager.setState({
+                initialValues: {
+                    ...managerState.initialValues,
+                    _etag: this.props.original._etag,
+                },
             });
+        }
+
+        if (Object.keys(initialValueUpdates).length > 0) {
+            this.props.itemManager.forceUpdateInitialValues(initialValueUpdates);
         }
     }
 


### PR DESCRIPTION
SDCP-1205

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

### Front-end checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)

Resolves: #[issue-number]

