### PR TITLE
handle version field so it can filter out duplicated in publish queue

### DIFF
--- a/server/planning/assignments/assignments.py
+++ b/server/planning/assignments/assignments.py
@@ -13,6 +13,7 @@
 from typing import Dict, Any
 from copy import deepcopy
 import logging
+import time
 
 from bson import ObjectId
 from icalendar import Calendar, Event
@@ -62,6 +63,7 @@ from planning.common import (
     TO_BE_CONFIRMED_FIELD,
     TO_BE_CONFIRMED_FIELD_SCHEMA,
     update_assignment_on_link_unlink,
+    sync_assignment_details_to_coverages,
     get_notify_self_on_assignment,
     planning_auto_assign_to_workflow,
     get_config_assignment_manual_reassignment_only,
@@ -1444,10 +1446,38 @@ class AssignmentsService(AsyncBaseService):
             if not planning_item or not published_planning_item or planning_item.get("state") == WORKFLOW_STATE.KILLED:
                 return
 
-            async def _publish_planning(item):
-                item.pop(VERSION, None)
+            async def _publish_planning(item, last_published_version=None):
                 item.pop("item_id", None)
+
+                # Re-sync assignment state/details into planning coverages before
+                # formatting/publishing so transmitted payload reflects current
+                # assignment fields.
+                sync_assignment_details_to_coverages(item)
+
+                # Keep generated versions ahead of the last published planning
+                # version so publish queue dedupe doesn't suppress retransmits.
+                try:
+                    normalized_last_published = int(last_published_version)
+                except (TypeError, ValueError):
+                    normalized_last_published = None
+
+                try:
+                    current_item_version = int(item.get(VERSION))
+                except (TypeError, ValueError):
+                    current_item_version = None
+
+                # Use a high-resolution seed so repeated assignment-triggered
+                # republishes in the same second still get distinct versions.
+                version_seed = int(time.time_ns())
+
+                if normalized_last_published is not None:
+                    version_seed = max(version_seed, normalized_last_published)
+
+                if current_item_version is None or current_item_version < version_seed:
+                    item[VERSION] = version_seed
+
                 version, item = get_version_item_for_post(item)
+                item["version"] = version
 
                 # Create an entry in the planning versions collection for this published version
                 version_id = await published_service.post_async(
@@ -1466,7 +1496,7 @@ class AssignmentsService(AsyncBaseService):
                 else:
                     logger.error("Failed to save planning version for planning item id {}".format(item["_id"]))
 
-            await _publish_planning(planning_item)
+            await _publish_planning(planning_item, published_planning_item.get("version"))
         except Exception:
             logger.exception("Failed to publish assignment for planning.")
 

--- a/server/planning/common.py
+++ b/server/planning/common.py
@@ -425,9 +425,9 @@ def get_version_item_for_post(item: Dict[str, Any]) -> tuple[int, Dict[str, Any]
     """Compute and assign the publish version for a planning/event item.
 
     The returned version is strictly monotonic for a given item and is stored
-    in both ``_current_version`` and ``version`` fields. To remain compatible
-    with Elasticsearch ``integer`` mappings, the value is constrained to the
-    signed int32 range.
+    in ``_current_version`` (``VERSION``). To remain compatible with
+    Elasticsearch ``integer`` mappings, the value is constrained to the signed
+    int32 range.
 
     If the current version has already reached int32 max (or the next computed
     value would exceed int32 max), this function raises
@@ -435,7 +435,9 @@ def get_version_item_for_post(item: Dict[str, Any]) -> tuple[int, Dict[str, Any]
     number, so version ordering is never reversed.
 
     :param item: Planning or event item to publish.
-    :return: Tuple of ``(version, item)`` with updated version fields.
+    The business ``version`` field is preserved when already present.
+
+    :return: Tuple of ``(version, item)`` with updated publish version field.
     """
     max_int32 = 2_147_483_647
     # Keep a time-based seed for ordering and delay int32 overflow horizon.
@@ -468,7 +470,7 @@ def get_version_item_for_post(item: Dict[str, Any]) -> tuple[int, Dict[str, Any]
         )
 
     item[VERSION] = version
-    item["version"] = version
+    item.setdefault("version", version)
     item.setdefault("item_id", item["_id"])
     return version, item
 

--- a/server/planning/common.py
+++ b/server/planning/common.py
@@ -421,19 +421,51 @@ def update_returned_document(doc, item, custom_hateoas):
     return [doc["_id"]]
 
 
-def get_version_item_for_post(item):
-    version = int(time.time())
+def get_version_item_for_post(item: Dict[str, Any]) -> tuple[int, Dict[str, Any]]:
+    """Compute and assign the publish version for a planning/event item.
+
+    The returned version is strictly monotonic for a given item and is stored
+    in both ``_current_version`` and ``version`` fields. To remain compatible
+    with Elasticsearch ``integer`` mappings, the value is constrained to the
+    signed int32 range.
+
+    If the current version has already reached int32 max (or the next computed
+    value would exceed int32 max), this function raises
+    ``SuperdeskApiError.badRequestError`` instead of wrapping to a smaller
+    number, so version ordering is never reversed.
+
+    :param item: Planning or event item to publish.
+    :return: Tuple of ``(version, item)`` with updated version fields.
+    """
+    max_int32 = 2_147_483_647
+    # Keep a time-based seed for ordering and delay int32 overflow horizon.
+    # 2024-01-01T00:00:00Z
+    version_seed = int(time.time()) - 1_704_067_200
+    version = max(1, version_seed)
     current_version = item.get(VERSION)
 
     # Always generate a fresh version and keep it monotonic for rapid updates.
     # Some code paths store VERSION as a numeric string, so normalize first.
-    try:
-        normalized_current_version = int(current_version)
-    except (TypeError, ValueError):
+    normalized_current_version: Optional[int]
+    if current_version is None:
         normalized_current_version = None
+    else:
+        try:
+            normalized_current_version = int(current_version)
+        except (TypeError, ValueError):
+            normalized_current_version = None
 
-    if normalized_current_version is not None and 0 < normalized_current_version:
+    if normalized_current_version is not None and 0 < normalized_current_version < max_int32:
         version = max(version, normalized_current_version + 1)
+    elif normalized_current_version == max_int32:
+        raise SuperdeskApiError.badRequestError(
+            message="Version has reached the maximum value for int32. Migrate the mapping to long to continue."
+        )
+
+    if version > max_int32:
+        raise SuperdeskApiError.badRequestError(
+            message="Version exceeded the maximum value for int32. Migrate the mapping to long to continue."
+        )
 
     item[VERSION] = version
     item["version"] = version

--- a/server/planning/common.py
+++ b/server/planning/common.py
@@ -422,8 +422,21 @@ def update_returned_document(doc, item, custom_hateoas):
 
 
 def get_version_item_for_post(item):
-    version = int(time.time())
-    item.setdefault(VERSION, version)
+    version = int(time.time_ns())
+    current_version = item.get(VERSION)
+
+    # Always generate a fresh version and keep it monotonic for rapid updates.
+    # Some code paths store VERSION as a numeric string, so normalize first.
+    try:
+        normalized_current_version = int(current_version)
+    except (TypeError, ValueError):
+        normalized_current_version = None
+
+    if normalized_current_version is not None:
+        version = max(version, normalized_current_version + 1)
+
+    item[VERSION] = version
+    item["version"] = version
     item.setdefault("item_id", item["_id"])
     return version, item
 
@@ -800,24 +813,35 @@ def _sync_coverage_assigned_to(coverages, lookup_field, id_field):
     if not coverages:
         return
 
-    assignments = {
-        str(assignment[ID_FIELD]): assignment
-        for assignment in get_resource_service("assignments").get_from_mongo(
-            req=None,
-            lookup={lookup_field: {"$in": [coverage[id_field] for coverage in coverages]}},
-        )
-    }
+    lookup_values = [coverage.get(id_field) for coverage in coverages if coverage.get(id_field)]
+    assignments_by_id = {}
+    assignments_by_lookup_value = {}
+
+    for assignment in get_resource_service("assignments").get_from_mongo(
+        req=None,
+        lookup={lookup_field: {"$in": lookup_values}},
+    ):
+        assignments_by_id[str(assignment[ID_FIELD])] = assignment
+
+        assignment_lookup_value = assignment.get(lookup_field)
+        if assignment_lookup_value is not None:
+            assignments_by_lookup_value[str(assignment_lookup_value)] = assignment
 
     for coverage in coverages:
-        if not coverage.get("assigned_to"):
-            coverage["assigned_to"] = {}
-            continue
+        assigned_to = coverage.get("assigned_to") or {}
+        assignment = None
 
-        assignment = assignments.get(str(coverage["assigned_to"].get("assignment_id")))
+        if assigned_to.get("assignment_id") is not None:
+            assignment = assignments_by_id.get(str(assigned_to.get("assignment_id")))
+
+        if assignment is None and coverage.get(id_field) is not None:
+            assignment = assignments_by_lookup_value.get(str(coverage.get(id_field)))
 
         if not assignment:
+            coverage.setdefault("assigned_to", {})
             continue
 
+        coverage.setdefault("assigned_to", {})
         copy_assignment_details_to_coverage(assignment, coverage)
 
 

--- a/server/planning/common.py
+++ b/server/planning/common.py
@@ -422,7 +422,7 @@ def update_returned_document(doc, item, custom_hateoas):
 
 
 def get_version_item_for_post(item):
-    version = int(time.time_ns())
+    version = int(time.time())
     current_version = item.get(VERSION)
 
     # Always generate a fresh version and keep it monotonic for rapid updates.
@@ -432,7 +432,7 @@ def get_version_item_for_post(item):
     except (TypeError, ValueError):
         normalized_current_version = None
 
-    if normalized_current_version is not None:
+    if normalized_current_version is not None and 0 < normalized_current_version:
         version = max(version, normalized_current_version + 1)
 
     item[VERSION] = version


### PR DESCRIPTION
SDCP-1208

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

### Front-end checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)

Resolves: #[issue-number]

