### PR TITLE
[STT-1681] - Incorrect sorting in the Planning module

### DIFF
--- a/client/components/Main/ListPanel.tsx
+++ b/client/components/Main/ListPanel.tsx
@@ -97,6 +97,7 @@ const END_OF_LIST_OFFSET = 100;
 export class ListPanel extends React.Component<IProps, IState> {
     dom: {list?: any};
     memoizedSort: ((items: Array<IEventOrPlanningItem>) => Array<IEventOrPlanningItem>) & MemoizedFunction;
+    memoizedDefaultSort: ((items: Array<IEventOrPlanningItem>) => Array<IEventOrPlanningItem>) & MemoizedFunction;
 
     constructor(props) {
         super(props);
@@ -118,16 +119,19 @@ export class ListPanel extends React.Component<IProps, IState> {
 
         const extensionConfig: IPlanningExtensionConfigurationOptions = superdeskApi.getExtensionConfig();
 
-        this.memoizedSort = memoize((items) =>
+        const defaultSort = (items: Array<IEventOrPlanningItem>) => items.sort((x, y) => {
+            const item1Date = (x as IEventItem).dates?.start ?? (x as IPlanningItem).planning_date;
+            const item2Date = (y as IEventItem).dates?.start ?? (y as IPlanningItem).planning_date;
+
+            return item1Date.toString().localeCompare(item2Date.toString());
+        });
+
+        this.memoizedSort = memoize((items: Array<IEventOrPlanningItem>) =>
             extensionConfig?.comparePlanningItems != null
                 ? items.sort(extensionConfig.comparePlanningItems)
-                : items.sort((x, y) => {
-                    const item1Date = (x as IEventItem).dates?.start ?? (x as IPlanningItem).planning_date;
-                    const item2Date = (y as IEventItem).dates?.start ?? (y as IPlanningItem).planning_date;
-
-                    return item1Date.toString().localeCompare(item2Date.toString());
-                })
+                : defaultSort(items)
         );
+        this.memoizedDefaultSort = memoize(defaultSort);
     }
 
     componentWillReceiveProps(nextProps) {
@@ -379,7 +383,9 @@ export class ListPanel extends React.Component<IProps, IState> {
 
                             let listGroupProps: {[key: string]: any} = {
                                 name: group.date,
-                                items: this.memoizedSort(group.events),
+                                items: activeFilter === MAIN.FILTERS.PLANNING
+                                    ? this.memoizedSort(group.events)
+                                    : this.memoizedDefaultSort(group.events),
                                 onItemClick: this.onItemClick,
                                 onDoubleClick: onDoubleClick,
                                 onAddCoverageClick: onAddCoverageClick,

--- a/client/components/Main/ListPanel.tsx
+++ b/client/components/Main/ListPanel.tsx
@@ -16,6 +16,7 @@ import {
 
 import {KEYCODES, MAIN} from '../../constants';
 import {onEventCapture} from '../../utils';
+import {sortItems, defaultSort} from '../../utils/sort';
 
 import {ListGroup} from '.';
 import {PanelInfo} from '../UI';
@@ -118,18 +119,10 @@ export class ListPanel extends React.Component<IProps, IState> {
         this.onItemActivate = this.onItemActivate.bind(this);
 
         const extensionConfig: IPlanningExtensionConfigurationOptions = superdeskApi.getExtensionConfig();
-
-        const defaultSort = (items: Array<IEventOrPlanningItem>) => items.sort((x, y) => {
-            const item1Date = (x as IEventItem).dates?.start ?? (x as IPlanningItem).planning_date;
-            const item2Date = (y as IEventItem).dates?.start ?? (y as IPlanningItem).planning_date;
-
-            return item1Date.toString().localeCompare(item2Date.toString());
-        });
+        const customComparator = extensionConfig?.comparePlanningItems;
 
         this.memoizedSort = memoize((items: Array<IEventOrPlanningItem>) =>
-            extensionConfig?.comparePlanningItems != null
-                ? items.sort(extensionConfig.comparePlanningItems)
-                : defaultSort(items)
+            sortItems(items, MAIN.FILTERS.PLANNING, customComparator)
         );
         this.memoizedDefaultSort = memoize(defaultSort);
     }

--- a/client/components/Main/ListPanel.tsx
+++ b/client/components/Main/ListPanel.tsx
@@ -97,7 +97,7 @@ const END_OF_LIST_OFFSET = 100;
 
 export class ListPanel extends React.Component<IProps, IState> {
     dom: {list?: any};
-    memoizedSort: ((items: Array<IEventOrPlanningItem>) => Array<IEventOrPlanningItem>) & MemoizedFunction;
+    planningSort: ((items: Array<IEventOrPlanningItem>) => Array<IEventOrPlanningItem>) & MemoizedFunction;
     memoizedDefaultSort: ((items: Array<IEventOrPlanningItem>) => Array<IEventOrPlanningItem>) & MemoizedFunction;
 
     constructor(props) {
@@ -121,7 +121,7 @@ export class ListPanel extends React.Component<IProps, IState> {
         const extensionConfig: IPlanningExtensionConfigurationOptions = superdeskApi.getExtensionConfig();
         const customComparator = extensionConfig?.comparePlanningItems;
 
-        this.memoizedSort = memoize((items: Array<IEventOrPlanningItem>) =>
+        this.planningSort = memoize((items: Array<IEventOrPlanningItem>) =>
             sortItems(items, MAIN.FILTERS.PLANNING, customComparator)
         );
         this.memoizedDefaultSort = memoize(defaultSort);
@@ -377,7 +377,7 @@ export class ListPanel extends React.Component<IProps, IState> {
                             let listGroupProps: {[key: string]: any} = {
                                 name: group.date,
                                 items: activeFilter === MAIN.FILTERS.PLANNING
-                                    ? this.memoizedSort(group.events)
+                                    ? this.planningSort(group.events)
                                     : this.memoizedDefaultSort(group.events),
                                 onItemClick: this.onItemClick,
                                 onDoubleClick: onDoubleClick,

--- a/client/utils/sort.ts
+++ b/client/utils/sort.ts
@@ -1,0 +1,42 @@
+import {IEventItem, IEventOrPlanningItem, IPlanningItem} from '../interfaces';
+import {MAIN} from '../constants';
+
+/**
+ * Default chronological sort for the Planning list views.
+ *
+ * Sorts by Event `dates.start`, falling back to Planning `planning_date`,
+ * ascending string compare. This is the Superdesk default used when no
+ * custom comparator is registered (or for views that should not use one).
+ */
+export const defaultSort = (items: Array<IEventOrPlanningItem>): Array<IEventOrPlanningItem> =>
+    items.sort((x, y) => {
+        const item1Date = (x as IEventItem).dates?.start ?? (x as IPlanningItem).planning_date;
+        const item2Date = (y as IEventItem).dates?.start ?? (y as IPlanningItem).planning_date;
+
+        return item1Date.toString().localeCompare(item2Date.toString());
+    });
+
+/**
+ * Sort items for a given list view.
+ *
+ * When `activeFilter` is `PLANNING` and a custom `comparePlanningItems`
+ * comparator is supplied (e.g. by the STT deployment), the custom strategy
+ * is used. For every other view (`EVENTS`, `COMBINED`) — or when no custom
+ * comparator is registered — the default chronological sort is used.
+ *
+ * @param items               The items to sort (mutated in place, like Array.sort).
+ * @param activeFilter        The current list view (`MAIN.FILTERS.PLANNING|EVENTS|COMBINED`).
+ * @param comparePlanningItems Optional custom comparator supplied via extension config.
+ * @returns                   The sorted array.
+ */
+export const sortItems = (
+    items: Array<IEventOrPlanningItem>,
+    activeFilter: string,
+    comparePlanningItems?: (a: IPlanningItem, b: IPlanningItem) => number,
+): Array<IEventOrPlanningItem> => {
+    if (activeFilter === MAIN.FILTERS.PLANNING && comparePlanningItems != null) {
+        return items.sort(comparePlanningItems);
+    }
+
+    return defaultSort(items);
+};

--- a/client/utils/sort.ts
+++ b/client/utils/sort.ts
@@ -13,7 +13,7 @@ export const defaultSort = (items: Array<IEventOrPlanningItem>): Array<IEventOrP
         const item1Date = (x as IEventItem).dates?.start ?? (x as IPlanningItem).planning_date;
         const item2Date = (y as IEventItem).dates?.start ?? (y as IPlanningItem).planning_date;
 
-        return item1Date.toString().localeCompare(item2Date.toString());
+        return (item1Date ?? '').toString().localeCompare((item2Date ?? '').toString());
     });
 
 /**

--- a/client/utils/sort.ts
+++ b/client/utils/sort.ts
@@ -1,3 +1,5 @@
+import moment from 'moment';
+
 import {IEventItem, IEventOrPlanningItem, IPlanningItem} from '../interfaces';
 import {MAIN} from '../constants';
 
@@ -5,11 +7,11 @@ import {MAIN} from '../constants';
  * Default chronological sort for the Planning list views.
  *
  * Sorts by Event `dates.start`, falling back to Planning `planning_date`,
- * ascending string compare. This is the Superdesk default used when no
- * custom comparator is registered (or for views that should not use one).
+ * by comparing epoch milliseconds. This is the Superdesk default used when
+ * no custom comparator is registered (or for views that should not use one).
  */
 export const defaultSort = (items: Array<IEventOrPlanningItem>): Array<IEventOrPlanningItem> =>
-    [...items].sort((x, y) => {
+    items.sort((x, y) => {
         const item1Date = (x as IEventItem).dates?.start ?? (x as IPlanningItem).planning_date;
         const item2Date = (y as IEventItem).dates?.start ?? (y as IPlanningItem).planning_date;
 
@@ -18,7 +20,7 @@ export const defaultSort = (items: Array<IEventOrPlanningItem>): Array<IEventOrP
         if (item1Date == null) return 1;
         if (item2Date == null) return -1;
 
-        return item1Date.toString().localeCompare(item2Date.toString());
+        return moment(item1Date).valueOf() - moment(item2Date).valueOf();
     });
 
 /**
@@ -29,7 +31,7 @@ export const defaultSort = (items: Array<IEventOrPlanningItem>): Array<IEventOrP
  * is used. For every other view (`EVENTS`, `COMBINED`) — or when no custom
  * comparator is registered — the default chronological sort is used.
  *
- * @param items               The items to sort (a shallow copy is sorted, the input is not mutated).
+ * @param items               The items to sort (sorted in place, like Array.sort).
  * @param activeFilter        The current list view (`MAIN.FILTERS.PLANNING|EVENTS|COMBINED`).
  * @param comparePlanningItems Optional custom comparator supplied via extension config.
  * @returns                   The sorted array.
@@ -40,7 +42,7 @@ export const sortItems = (
     comparePlanningItems?: (a: IPlanningItem, b: IPlanningItem) => number,
 ): Array<IEventOrPlanningItem> => {
     if (activeFilter === MAIN.FILTERS.PLANNING && comparePlanningItems != null) {
-        return [...items].sort((a, b) => comparePlanningItems(a as IPlanningItem, b as IPlanningItem));
+        return items.sort((a, b) => comparePlanningItems(a as IPlanningItem, b as IPlanningItem));
     }
 
     return defaultSort(items);

--- a/client/utils/sort.ts
+++ b/client/utils/sort.ts
@@ -9,11 +9,16 @@ import {MAIN} from '../constants';
  * custom comparator is registered (or for views that should not use one).
  */
 export const defaultSort = (items: Array<IEventOrPlanningItem>): Array<IEventOrPlanningItem> =>
-    items.sort((x, y) => {
+    [...items].sort((x, y) => {
         const item1Date = (x as IEventItem).dates?.start ?? (x as IPlanningItem).planning_date;
         const item2Date = (y as IEventItem).dates?.start ?? (y as IPlanningItem).planning_date;
 
-        return (item1Date ?? '').toString().localeCompare((item2Date ?? '').toString());
+        // Sort items with missing dates last
+        if (item1Date == null && item2Date == null) return 0;
+        if (item1Date == null) return 1;
+        if (item2Date == null) return -1;
+
+        return item1Date.toString().localeCompare(item2Date.toString());
     });
 
 /**
@@ -24,7 +29,7 @@ export const defaultSort = (items: Array<IEventOrPlanningItem>): Array<IEventOrP
  * is used. For every other view (`EVENTS`, `COMBINED`) — or when no custom
  * comparator is registered — the default chronological sort is used.
  *
- * @param items               The items to sort (mutated in place, like Array.sort).
+ * @param items               The items to sort (a shallow copy is sorted, the input is not mutated).
  * @param activeFilter        The current list view (`MAIN.FILTERS.PLANNING|EVENTS|COMBINED`).
  * @param comparePlanningItems Optional custom comparator supplied via extension config.
  * @returns                   The sorted array.
@@ -35,7 +40,7 @@ export const sortItems = (
     comparePlanningItems?: (a: IPlanningItem, b: IPlanningItem) => number,
 ): Array<IEventOrPlanningItem> => {
     if (activeFilter === MAIN.FILTERS.PLANNING && comparePlanningItems != null) {
-        return items.sort(comparePlanningItems);
+        return [...items].sort((a, b) => comparePlanningItems(a as IPlanningItem, b as IPlanningItem));
     }
 
     return defaultSort(items);

--- a/client/utils/tests/sort_test.ts
+++ b/client/utils/tests/sort_test.ts
@@ -85,14 +85,18 @@ describe('utils.sort', () => {
             expect(labels).toEqual(['Event at 8', 'Plan at noon', 'Event at 15']);
         });
 
-        it('handles missing dates gracefully', () => {
+        it('handles missing dates gracefully and sorts them last', () => {
             const items = [
                 makePlanning('No date', undefined as unknown as string),
                 makeEvent('With date', '2026-07-14T08:00:00+0000'),
+                makeEvent('Earlier', '2026-07-14T06:00:00+0000'),
             ];
 
-            // Should not throw; undefined.toString() === 'undefined', sorts after a date string
-            expect(() => defaultSort([...items])).not.toThrow();
+            // Should not throw; items with missing dates sort last
+            const sorted = defaultSort([...items]);
+            const labels = sorted.map((i) => (i as any).name ?? (i as any).slugline);
+
+            expect(labels).toEqual(['Earlier', 'With date', 'No date']);
         });
     });
 

--- a/client/utils/tests/sort_test.ts
+++ b/client/utils/tests/sort_test.ts
@@ -1,0 +1,210 @@
+import {defaultSort, sortItems} from '../sort';
+import {MAIN} from '../../constants';
+import {IEventOrPlanningItem} from '../../interfaces';
+
+const PLANNING = MAIN.FILTERS.PLANNING;
+const EVENTS = MAIN.FILTERS.EVENTS;
+const COMBINED = MAIN.FILTERS.COMBINED;
+
+function makeEvent(name: string, start: string, catName?: string): IEventOrPlanningItem {
+    return {
+        _id: name,
+        type: 'event',
+        name: name,
+        dates: {start: start},
+        anpa_category: catName ? [{name: catName, qcode: '1'}] : [],
+    } as unknown as IEventOrPlanningItem;
+}
+
+function makePlanning(
+    slugline: string,
+    planningDate: string,
+    catName?: string,
+    priority?: number,
+): IEventOrPlanningItem {
+    return {
+        _id: slugline,
+        type: 'planning',
+        slugline: slugline,
+        planning_date: planningDate,
+        anpa_category: catName ? [{name: catName, qcode: '1'}] : [],
+        priority: priority,
+    } as unknown as IEventOrPlanningItem;
+}
+
+describe('utils.sort', () => {
+    describe('defaultSort', () => {
+        it('sorts events chronologically by dates.start ascending', () => {
+            const items = [
+                makeEvent('Maraton SM', '2026-07-14T08:00:00+0000', 'Urheilu'),
+                makeEvent('Talousfoorumi', '2026-07-14T14:00:00+0000', 'Talous'),
+                makeEvent('Keskustelua', '2026-07-14T09:00:00+0000', 'Uutiskooste'),
+            ];
+
+            const sorted = defaultSort([...items]);
+            const names = sorted.map((i) => (i as any).name);
+
+            expect(names).toEqual(['Maraton SM', 'Keskustelua', 'Talousfoorumi']);
+        });
+
+        it('does NOT sort events by anpa_category (department)', () => {
+            const items = [
+                makeEvent('Urheilu event', '2026-07-14T15:00:00+0000', 'Urheilu'),
+                makeEvent('Business event', '2026-07-14T08:00:00+0000', 'Business wire'),
+            ];
+
+            const sorted = defaultSort([...items]);
+            const names = sorted.map((i) => (i as any).name);
+
+            // 08:00 event first, even though "Business wire" sorts before "Urheilu" alphabetically
+            expect(names).toEqual(['Business event', 'Urheilu event']);
+        });
+
+        it('falls back to planning_date for planning items', () => {
+            const items = [
+                makePlanning('Late plan', '2026-07-14T12:00:00+0000'),
+                makePlanning('Early plan', '2026-07-14T00:00:00+0000'),
+            ];
+
+            const sorted = defaultSort([...items]);
+            const slugs = sorted.map((i) => (i as any).slugline);
+
+            expect(slugs).toEqual(['Early plan', 'Late plan']);
+        });
+
+        it('sorts mixed events and planning items chronologically', () => {
+            const items: Array<IEventOrPlanningItem> = [
+                makePlanning('Plan at noon', '2026-07-14T12:00:00+0000'),
+                makeEvent('Event at 8', '2026-07-14T08:00:00+0000'),
+                makeEvent('Event at 15', '2026-07-14T15:00:00+0000'),
+            ];
+
+            const sorted = defaultSort([...items]);
+            const labels = sorted.map((i) => (i as any).name ?? (i as any).slugline);
+
+            expect(labels).toEqual(['Event at 8', 'Plan at noon', 'Event at 15']);
+        });
+
+        it('handles missing dates gracefully', () => {
+            const items = [
+                makePlanning('No date', undefined as unknown as string),
+                makeEvent('With date', '2026-07-14T08:00:00+0000'),
+            ];
+
+            // Should not throw; undefined.toString() === 'undefined', sorts after a date string
+            expect(() => defaultSort([...items])).not.toThrow();
+        });
+    });
+
+    describe('sortItems', () => {
+        // A custom comparator that sorts by department (alpha) then priority (asc)
+        const customComparator = (a: any, b: any): number => {
+            const aDept = (a.anpa_category?.[0]?.name ?? '').toLowerCase();
+            const bDept = (b.anpa_category?.[0]?.name ?? '').toLowerCase();
+            const deptResult = aDept.localeCompare(bDept);
+
+            if (deptResult !== 0) return deptResult;
+
+            const aPrio = a.priority ?? 5;
+            const bPrio = b.priority ?? 5;
+
+            return aPrio - bPrio;
+        };
+
+        it('uses custom comparator for PLANNING view', () => {
+            const items = [
+                makePlanning('Urheilu prio 1', '2026-07-14T00:00:00+0000', 'Urheilu', 1),
+                makePlanning('Business prio 5', '2026-07-14T00:00:00+0000', 'Business wire', 5),
+            ];
+
+            const sorted = sortItems([...items], PLANNING, customComparator);
+            const slugs = sorted.map((i) => (i as any).slugline);
+
+            // Business wire sorts before Urheilu alphabetically, despite higher priority
+            expect(slugs).toEqual(['Business prio 5', 'Urheilu prio 1']);
+        });
+
+        it('falls back to defaultSort for PLANNING view when no comparator is provided', () => {
+            const items = [
+                makePlanning('Late', '2026-07-14T12:00:00+0000', 'Business wire'),
+                makePlanning('Early', '2026-07-14T00:00:00+0000', 'Urheilu'),
+            ];
+
+            const sorted = sortItems([...items], PLANNING, undefined);
+            const slugs = sorted.map((i) => (i as any).slugline);
+
+            // Chronological by planning_date, not by department
+            expect(slugs).toEqual(['Early', 'Late']);
+        });
+
+        it('custom comparator overrides chronological order for PLANNING view', () => {
+            // Planning items whose dept alpha order differs from date order
+            const items = [
+                makePlanning('Urheilu early', '2026-07-14T06:00:00+0000', 'Urheilu', 1),
+                makePlanning('Business late', '2026-07-14T14:00:00+0000', 'Business wire', 5),
+            ];
+
+            // Custom comparator sorts by dept (Business wire before Urheilu),
+            // ignoring the chronological order (06:00 before 14:00)
+            const sorted = sortItems([...items], PLANNING, customComparator);
+            const slugs = sorted.map((i) => (i as any).slugline);
+
+            expect(slugs).toEqual(['Business late', 'Urheilu early']);
+        });
+
+        it('uses defaultSort for EVENTS view even when custom comparator is provided', () => {
+            const items = [
+                makeEvent('Urheilu 15:00', '2026-07-14T15:00:00+0000', 'Urheilu'),
+                makeEvent('Business 08:00', '2026-07-14T08:00:00+0000', 'Business wire'),
+            ];
+
+            const sorted = sortItems([...items], EVENTS, customComparator);
+            const names = sorted.map((i) => (i as any).name);
+
+            // Chronological (08:00 first), NOT alphabetical by department
+            expect(names).toEqual(['Business 08:00', 'Urheilu 15:00']);
+        });
+
+        it('uses defaultSort for COMBINED view even when custom comparator is provided', () => {
+            const items: Array<IEventOrPlanningItem> = [
+                makeEvent('Event 14:00', '2026-07-14T14:00:00+0000', 'Talous'),
+                makePlanning('Plan 00:00', '2026-07-14T00:00:00+0000', 'Business wire', 1),
+            ];
+
+            const sorted = sortItems([...items], COMBINED, customComparator);
+            const labels = sorted.map((i) => (i as any).name ?? (i as any).slugline);
+
+            // Chronological: plan at 00:00 before event at 14:00
+            expect(labels).toEqual(['Plan 00:00', 'Event 14:00']);
+        });
+
+        it('custom comparator does not affect EVENTS view order', () => {
+            // Events with categories whose alphabetical order differs from chronological order
+            const items = [
+                makeEvent('Maraton SM', '2026-07-14T08:00:00+0000', 'Urheilu'),
+                makeEvent('Q2 Tulostiedote', '2026-07-14T12:00:00+0000', 'Business wire'),
+            ];
+
+            // Should be chronological (08:00 first), not alphabetical by department
+            const sorted = sortItems([...items], EVENTS, customComparator);
+            const names = sorted.map((i) => (i as any).name);
+
+            expect(names).toEqual(['Maraton SM', 'Q2 Tulostiedote']);
+        });
+
+        it('custom comparator does not affect COMBINED view order', () => {
+            // Mixed items whose dept alpha order differs from chronological order
+            const items: Array<IEventOrPlanningItem> = [
+                makeEvent('Urheilu event', '2026-07-14T15:00:00+0000', 'Urheilu'),
+                makePlanning('Business plan', '2026-07-14T00:00:00+0000', 'Business wire', 1),
+            ];
+
+            // Should be chronological (plan at 00:00 before event at 15:00),
+            // not alphabetical by department
+            const sorted = sortItems([...items], COMBINED, customComparator);
+            const labels = sorted.map((i) => (i as any).name ?? (i as any).slugline);
+
+            expect(labels).toEqual(['Business plan', 'Urheilu event']);
+        });
+    });
+});


### PR DESCRIPTION
### Purpose
The custom `comparePlanningItems` comparator introduced in [STT-90](https://sofab.atlassian.net/browse/STT-90?xpis=eyJicmlkZ2UiOiJzbWFydExpbmtzIiwiaWQiOiIxNzg0MDIyNzEzMjkxIiwic291cmNlIjoiamlyYS1KU1cifQ%3D%3D) and [STT-1306](https://sofab.atlassian.net/browse/STT-1306?xpis=eyJicmlkZ2UiOiJzbWFydExpbmtzIiwiaWQiOiIxNzg0MDIyNzEzMjkxIiwic291cmNlIjoiamlyYS1KU1cifQ%3D%3D) was applied to all list views, but events lack the metadata it keys on and should be sorted chronologically. It should only apply to the "Planning only" view.

### What has changed
- Sort now branches on `activeFilter` with custom comparator for PLANNING only; EVENTS and COMBINED use default chronological sort
- Extracted `defaultSort` and `sortItems` as testable pure functions
- Unit tests for both extracted functions

### Steps to test
1. Create a few events with different categories and start times throughout the day.
2. Create a few planning items with different departments, coverage statuses, and priorities.
3. Open the Planning module "Events Only" view and verify events are sorted chronologically by start time and not by department.
4. Switch to "Planning only" and verify the custom sort is still applied (department alphabetical → coverage tier → priority → date).
5. Switch to "Events & Planning" and verify items are sorted chronologically, not by department.

NOTE: Use an instance registered with a custom `comparePlanningItems` comparator like on [STT](https://github.com/superdesk/superdesk-stt/blob/ea4bf9b9aee7ba1102c85d437aa8c1ba1dc7884a/client/compare-planning-items.ts#L40).

Resolves: #[STT-1681](https://sofab.atlassian.net/browse/STT-1681)


[STT-90]: https://sofab.atlassian.net/browse/STT-90?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[STT-1306]: https://sofab.atlassian.net/browse/STT-1306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[STT-1681]: https://sofab.atlassian.net/browse/STT-1681?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ