### PR TITLE
fix ci after superdesk-core changes

### DIFF
--- a/e2e/server/core-requirements.in
+++ b/e2e/server/core-requirements.in
@@ -1,2 +1,3 @@
 honcho
+aiomoto[sqs]
 git+https://github.com/superdesk/superdesk-core.git@develop#egg=superdesk-core

--- a/e2e/server/core-requirements.txt
+++ b/e2e/server/core-requirements.txt
@@ -7,21 +7,32 @@
 aioboto3==15.5.0
     # via superdesk-core
 aiobotocore[boto3]==2.25.1
-    # via aioboto3
+    # via
+    #   aioboto3
+    #   aiomoto
 aiofiles==25.1.0
     # via
     #   aioboto3
     #   quart
+aioftp==0.27.2
+    # via superdesk-core
 aiohappyeyeballs==2.6.1
     # via aiohttp
 aiohttp==3.13.5
     # via
     #   aiobotocore
     #   elasticsearch
+    #   superdesk-core
+aioimaplib==2.0.1
+    # via superdesk-core
 aioitertools==0.13.0
     # via aiobotocore
+aiomoto[sqs]==0.5.3
+    # via -r core-requirements.in
 aiosignal==1.4.0
     # via aiohttp
+aiosmtplib==5.1.2
+    # via superdesk-core
 amqp==5.3.1
     # via kombu
 annotated-types==0.7.0
@@ -45,18 +56,19 @@ billiard==4.2.4
 blinker==1.9.0
     # via
     #   flask
-    #   flask-mail
     #   quart
     #   sentry-sdk
     #   superdesk-core
 boto3==1.40.61
     # via
     #   aiobotocore
+    #   moto
     #   superdesk-core
 botocore==1.40.61
     # via
     #   aiobotocore
     #   boto3
+    #   moto
     #   s3transfer
 cachetools==7.1.1
     # via flask-oidc-ex
@@ -101,6 +113,7 @@ cryptography==48.0.0
     # via
     #   authlib
     #   jwcrypto
+    #   moto
 dnspython==2.8.0
     # via pymongo
 draftjs-exporter[lxml]==5.2.0
@@ -117,19 +130,14 @@ feedparser==6.0.12
     # via superdesk-core
 flask==3.1.3
     # via
-    #   flask-mail
     #   flask-oidc-ex
     #   quart
-flask-mail==0.10.0
-    # via superdesk-core
 flask-oidc-ex==0.6.2
     # via superdesk-core
 frozenlist==1.8.0
     # via
     #   aiohttp
     #   aiosignal
-future==1.0.0
-    # via python-twitter
 h11==0.16.0
     # via
     #   hypercorn
@@ -191,6 +199,8 @@ markupsafe==3.0.3
     #   quart
     #   superdesk-core
     #   werkzeug
+moto[sqs]==5.2.1
+    # via aiomoto
 motor==3.7.1
     # via superdesk-core
 multidict==6.7.1
@@ -200,14 +210,14 @@ multidict==6.7.1
     #   yarl
 oauth2client==4.1.3
     # via flask-oidc-ex
-oauthlib==3.3.1
-    # via requests-oauthlib
 packaging==26.2
     # via kombu
 pillow==12.0.0
     # via
     #   reportlab
     #   superdesk-core
+platformdirs==4.10.0
+    # via aiomoto
 priority==2.0.0
     # via hypercorn
 prompt-toolkit==3.0.52
@@ -253,8 +263,6 @@ python-jwt==4.1.0
     # via flask-oidc-ex
 python-magic==0.4.27
     # via superdesk-core
-python-twitter==3.5
-    # via superdesk-core
 pytz==2026.2
     # via
     #   croniter
@@ -262,7 +270,9 @@ pytz==2026.2
     #   quart-babel
     #   superdesk-core
 pyyaml==6.0.3
-    # via superdesk-core
+    # via
+    #   responses
+    #   superdesk-core
 quart @ git+https://github.com/MarkLark86/quart@fix-test-client-with-utf8-url
     # via
     #   eve
@@ -282,11 +292,11 @@ reportlab==4.5.0
     # via superdesk-core
 requests==2.33.1
     # via
-    #   python-twitter
-    #   requests-oauthlib
+    #   moto
+    #   responses
     #   superdesk-core
-requests-oauthlib==2.0.0
-    # via python-twitter
+responses==0.26.2
+    # via moto
 rsa==4.9.1
     # via oauth2client
 s3transfer==0.14.0
@@ -330,6 +340,7 @@ urllib3==2.6.3
     #   botocore
     #   elasticsearch
     #   requests
+    #   responses
     #   sentry-sdk
     #   superdesk-core
 vine==5.1.0
@@ -344,6 +355,7 @@ websockets==16.0
 werkzeug==3.1.8
     # via
     #   flask
+    #   moto
     #   quart
 wrapt==1.17.3
     # via aiobotocore
@@ -351,5 +363,7 @@ wsproto==1.3.2
     # via hypercorn
 xmlsec==1.3.14
     # via superdesk-core
+xmltodict==1.0.4
+    # via moto
 yarl==1.23.0
     # via aiohttp

--- a/server/planning/feeding_services/event_file_service.py
+++ b/server/planning/feeding_services/event_file_service.py
@@ -77,7 +77,8 @@ class EventFileFeedingService(FileFeedingService):
             )
             return
 
-        for filename in get_sorted_files(self.path, sort_by=FileSortAttributes.created):
+        sorted_files = await get_sorted_files(self.path, sort_by=FileSortAttributes.created)
+        for filename in sorted_files:
             try:
                 last_updated = None
                 file_path = os.path.join(self.path, filename)

--- a/server/planning/feeding_services/event_http_service.py
+++ b/server/planning/feeding_services/event_http_service.py
@@ -55,16 +55,17 @@ class EventHTTPFeedingService(HTTPFeedingServiceBase):
         :return: a list of events which can be saved.
         """
 
-        response = await self.get_url(self.config["url"])
-        parser = await self.get_feed_parser(provider)
+        async with self.get_url(self.config["url"]) as response:
+            response_content = await response.read()
+            parser = await self.get_feed_parser(provider)
 
-        logger.info("Ingesting events with {} parser".format(parser.__class__.__name__))
-        logger.info("Ingesting content: {} ...".format(str(response.content)[:4000]))
+            logger.info("Ingesting events with {} parser".format(parser.__class__.__name__))
+            logger.info("Ingesting content: {} ...".format(str(response_content)[:4000]))
 
-        if hasattr(parser, "parse_http"):
-            items = await parser.parse_http(response.content, provider)
-        else:
-            items = await parser.parse(response.content)
+            if hasattr(parser, "parse_http"):
+                items = await parser.parse_http(response_content, provider)
+            else:
+                items = await parser.parse(response_content)
 
         if isinstance(items, list):
             yield items

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -17,6 +17,7 @@ pytest-env==1.2.0
 black~=25.11
 behave==1.2.6
 aioresponses==0.7.8
+aiomoto[sqs]==0.3.0
 
 -r mypy-requirements.txt
 

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -17,7 +17,7 @@ pytest-env==1.2.0
 black~=25.11
 behave==1.2.6
 aioresponses==0.7.8
-aiomoto[sqs]==0.3.0
+aiomoto[sqs]==0.5.3
 
 -r mypy-requirements.txt
 


### PR DESCRIPTION
### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

### Front-end checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)

Resolves: #[issue-number]

