### PR TITLE
[STT-1722] - Assignments view goes blank after clicking on the history tab in preview panel

### DIFF
--- a/client/components/Assignments/AssignmentHistory.tsx
+++ b/client/components/Assignments/AssignmentHistory.tsx
@@ -52,11 +52,11 @@ class AssignmentHistoryComponent extends React.Component {
 
             if (user) {
                 return (
-                    <span>{prefix}<strong>{desk.name}</strong>
+                    <span>{prefix}<strong>{desk?.name ?? '-'}</strong>
                         {gettext(' and ')}<strong>{user.display_name}</strong>{suffix}</span>
                 );
             } else {
-                return (<span>{prefix}<strong>{desk.name}</strong>{suffix}</span>);
+                return (<span>{prefix}<strong>{desk?.name ?? '-'}</strong>{suffix}</span>);
             }
 
         case ASSIGNMENTS.HISTORY_OPERATIONS.EDIT_PRIORITY:
@@ -81,7 +81,7 @@ class AssignmentHistoryComponent extends React.Component {
             desk = getItemInArrayById(this.props.desks, get(update, 'assigned_to.desk'));
             return (
                 <span>{gettext('Assignment ')}<strong>{gettext('submitted')}</strong>
-                    {gettext(' to ')}<strong>{desk.name}</strong>{suffix}</span>
+                    {gettext(' to ')}<strong>{desk?.name ?? '-'}</strong>{suffix}</span>
             );
 
         case ASSIGNMENTS.HISTORY_OPERATIONS.CANCELLED:

--- a/client/components/Assignments/AssignmentHistory.tsx
+++ b/client/components/Assignments/AssignmentHistory.tsx
@@ -11,7 +11,7 @@ import {ASSIGNMENTS} from '../../constants';
 import {AbsoluteDate} from '../';
 import {ContentBlock} from '../UI/SidePanel';
 
-class AssignmentHistoryComponent extends React.Component {
+export class AssignmentHistoryComponent extends React.Component {
     componentWillMount() {
         const {assignment, fetchAssignmentHistory} = this.props;
 

--- a/client/components/Assignments/AssignmentHistory_test.tsx
+++ b/client/components/Assignments/AssignmentHistory_test.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import {mount} from 'enzyme';
+import sinon from 'sinon';
+
+import '../../utils/testUtils';
+import {users, desks} from '../../utils/testData';
+import {AssignmentHistoryComponent} from './AssignmentHistory';
+
+describe('<AssignmentHistory />', () => {
+    let fetchAssignmentHistory;
+    const assignment = {_id: 'as1'};
+
+    beforeEach(() => {
+        fetchAssignmentHistory = sinon.spy();
+    });
+
+    const getWrapper = (props) => mount(
+        <AssignmentHistoryComponent
+            assignment={assignment}
+            fetchAssignmentHistory={fetchAssignmentHistory}
+            users={users}
+            {...props}
+        />
+    );
+
+    it('renders create history when desk is not found (with user)', () => {
+        const wrapper = getWrapper({
+            desks: [],
+            assignmentHistoryItems: [{
+                _id: 'ah1',
+                operation: 'create',
+                _created: '2026-07-16T09:39:57+0000',
+                user_id: 'ident1',
+                update: {assigned_to: {desk: 'nonexistent_desk', user: 'ident1'}},
+            }],
+        });
+
+        expect(wrapper.find('.history-list .item').length).toBe(1);
+        expect(wrapper.find('.history-list .item').text()).toContain('-');
+    });
+
+    it('renders create history when desk is not found (without user)', () => {
+        const wrapper = getWrapper({
+            desks: [],
+            assignmentHistoryItems: [{
+                _id: 'ah2',
+                operation: 'create',
+                _created: '2026-07-16T09:39:57+0000',
+                user_id: 'ident1',
+                update: {assigned_to: {desk: 'nonexistent_desk'}},
+            }],
+        });
+
+        expect(wrapper.find('.history-list .item').length).toBe(1);
+        expect(wrapper.find('.history-list .item').text()).toContain('-');
+    });
+
+    it('renders submitted history when desk is not found', () => {
+        const wrapper = getWrapper({
+            desks: [],
+            assignmentHistoryItems: [{
+                _id: 'ah3',
+                operation: 'submitted',
+                _created: '2026-07-16T09:39:57+0000',
+                user_id: 'ident1',
+                update: {assigned_to: {desk: 'nonexistent_desk'}},
+            }],
+        });
+
+        expect(wrapper.find('.history-list .item').length).toBe(1);
+        expect(wrapper.find('.history-list .item').text()).toContain('-');
+    });
+
+    it('renders create history when desk is found', () => {
+        const wrapper = getWrapper({
+            desks: desks,
+            assignmentHistoryItems: [{
+                _id: 'ah4',
+                operation: 'create',
+                _created: '2026-07-16T09:39:57+0000',
+                user_id: 'ident1',
+                update: {assigned_to: {desk: 123, user: 'ident1'}},
+            }],
+        });
+
+        expect(wrapper.find('.history-list .item').length).toBe(1);
+        expect(wrapper.find('.history-list .item').text()).toContain('Politic Desk');
+    });
+});

--- a/client/components/Coverages/CoverageHistory.tsx
+++ b/client/components/Coverages/CoverageHistory.tsx
@@ -38,8 +38,8 @@ export class CoverageHistory extends React.Component {
 
                 assignment = ([ASSIGNMENTS.HISTORY_OPERATIONS.REASSIGNED,
                     COVERAGES.HISTORY_OPERATIONS.ASSIGNED].includes(historyItem.operation) ?
-                    gettext(' to \'{{ desk }}\'', {desk: desk.name}) :
-                    gettext(' for \'{{ desk }}\'', {desk: desk.name}));
+                    gettext(' to \'{{ desk }}\'', {desk: desk?.name ?? '-'}) :
+                    gettext(' for \'{{ desk }}\'', {desk: desk?.name ?? '-'}));
 
                 if (user) {
                     assignment += gettext(' and \'{{ user }}\'', {user: user.display_name});

--- a/client/components/Coverages/CoverageHistory_test.tsx
+++ b/client/components/Coverages/CoverageHistory_test.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import {mount} from 'enzyme';
+
+import '../../utils/testUtils';
+import {users, desks} from '../../utils/testData';
+import {CoverageHistory} from './CoverageHistory';
+
+describe('<CoverageHistory />', () => {
+    const getHistoryData = (items) => ({
+        items: items,
+        planning: {
+            g2_content_type: 'text',
+        },
+    });
+
+    const getWrapper = (props) => mount(
+        <CoverageHistory
+            users={users}
+            contentTypes={[]}
+            {...props}
+        />
+    );
+
+    const openCollapseBox = (wrapper) => {
+        wrapper.find('CollapseBox').setState({isOpen: true});
+        wrapper.update();
+    };
+
+    it('renders coverage_created history when desk is not found', () => {
+        const wrapper = getWrapper({
+            desks: [],
+            historyData: getHistoryData([{
+                _id: 'ch1',
+                operation: 'coverage_created',
+                _created: '2026-07-16T09:39:57+0000',
+                user_id: 'ident1',
+                update: {
+                    assigned_to: {desk: 'nonexistent_desk', user: 'ident1'},
+                    planning: {g2_content_type: 'text'},
+                },
+            }]),
+        });
+
+        openCollapseBox(wrapper);
+
+        expect(wrapper.find('.history-list .item').length).toBe(1);
+        expect(wrapper.find('.history-list .item').text()).toContain('-');
+    });
+
+    it('renders reassigned history when desk is not found', () => {
+        const wrapper = getWrapper({
+            desks: [],
+            historyData: getHistoryData([
+                {
+                    _id: 'ch1',
+                    operation: 'coverage_created',
+                    _created: '2026-07-16T09:39:57+0000',
+                    user_id: 'ident1',
+                    update: {
+                        assigned_to: {desk: 'nonexistent_desk', user: 'ident1'},
+                        planning: {g2_content_type: 'text'},
+                    },
+                },
+                {
+                    _id: 'ch2',
+                    operation: 'reassigned',
+                    _created: '2026-07-16T09:40:00+0000',
+                    user_id: 'ident1',
+                    update: {
+                        assigned_to: {desk: 'nonexistent_desk', user: 'ident1'},
+                    },
+                },
+            ]),
+        });
+
+        openCollapseBox(wrapper);
+
+        expect(wrapper.find('.history-list .item').length).toBe(2);
+        expect(wrapper.find('.history-list .item')
+            .at(1)
+            .text()).toContain('-');
+    });
+
+    it('renders coverage_created history when desk is found', () => {
+        const wrapper = getWrapper({
+            desks: desks,
+            historyData: getHistoryData([{
+                _id: 'ch1',
+                operation: 'coverage_created',
+                _created: '2026-07-16T09:39:57+0000',
+                user_id: 'ident1',
+                update: {
+                    assigned_to: {desk: 123, user: 'ident1'},
+                    planning: {g2_content_type: 'text'},
+                },
+            }]),
+        });
+
+        openCollapseBox(wrapper);
+
+        expect(wrapper.find('.history-list .item').length).toBe(1);
+        expect(wrapper.find('.history-list .item').text()).toContain('Politic Desk');
+    });
+});

--- a/client/components/Coverages/CoverageHistory_test.tsx
+++ b/client/components/Coverages/CoverageHistory_test.tsx
@@ -22,7 +22,7 @@ describe('<CoverageHistory />', () => {
     );
 
     const openCollapseBox = (wrapper) => {
-        wrapper.find('CollapseBox').setState({isOpen: true});
+        wrapper.find('.sd-collapse-box').simulate('click');
         wrapper.update();
     };
 


### PR DESCRIPTION
### Purpose
This PR fixes an issue where the assignments view goes blank with an uncaught `TypeError: Cannot read properties of null (reading 'name')` when clicking the History tab on an assignment whose history references a desk that can no longer be resolved. The same latent crash exists in the planning coverage history and has been patched in this PR too.

### What has changed
- Guarded `desk.name` dereferences in AssignmentHistory (3 sites) and CoverageHistory (2 sites) with `desk?.name ?? '-'`
- Added tests

### Steps to test
1. Open an assignment whose history references a desk that is not in the desks collection (e.g. the desk was deleted, or manually update the assignments_history doc's update.assigned_to.desk to a non-existent id in Mongo).
2. Click the History tab in the assignment preview panel.
3. Verify the view no longer goes blank. The history row renders with - in place of the missing desk name.
4. Open a planning item with a coverage whose history has the same unresolvable desk reference
5. Click the History tab in the planning preview and expand the coverage history card. Verify it renders with - instead of crashing.
6. Verify it renders with - instead of crashing.

Resolves: #[STT-1722](https://sofab.atlassian.net/browse/STT-1722)



[STT-1722]: https://sofab.atlassian.net/browse/STT-1722?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ