### PR TITLE
fix event user metrics counting

### DIFF
--- a/server/features/events.feature
+++ b/server/features/events.feature
@@ -287,6 +287,22 @@ Feature: Events
             ]
         }
         """
+
+        When we patch "/events/#events._id#"
+        """
+        {"slugline": "test"}
+        """
+        Then we get OK response
+        When we get "user_metrics"
+        Then we get list with 1 items
+        """
+        {
+            "_items": [
+                {"name": "published_events", "value": 1}
+            ]
+        }
+        """
+
         When we post to "/events/post"
         """
         {"event": "#events._id#", "etag": "#events._etag#", "pubstatus": "cancelled"}
@@ -304,7 +320,7 @@ Feature: Events
         }]
         """
         When we get "/events_history"
-        Then we get a list with 3 items
+        Then we get a list with 5 items
         """
             {"_items": [{
                 "event_id": "#events._id#",
@@ -312,6 +328,14 @@ Feature: Events
                 },
                 {
                 "event_id": "#events._id#",
+                "operation": "post",
+                "update": {"state": "scheduled"}
+                },
+                {
+                "event_id": "#events._id#",
+                "operation": "edited"
+                },
+                {
                 "operation": "post",
                 "update": {"state": "scheduled"}
                 },

--- a/server/planning/events/events_post.py
+++ b/server/planning/events/events_post.py
@@ -66,7 +66,7 @@ class EventsPostService(EventsBaseService):
             update_method = self.get_update_method(event, doc)
 
             if (
-                not doc.get("firstpublished")
+                not event.get("firstpublished")
                 and doc.get("pubstatus") == POST_STATE.USABLE
                 and event.get("original_creator")
             ):


### PR DESCRIPTION
it was counting event multiple times on updates
after posting.

SDBELGA-1141

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

### Front-end checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)

Resolves: #[issue-number]

