### PR TITLE
[SDBELGA-1104] fix: Reload Events in list using single Redux action

### DIFF
--- a/client/actions/events/notifications.ts
+++ b/client/actions/events/notifications.ts
@@ -1,7 +1,7 @@
 import {get} from 'lodash';
 
 import {planningApi} from '../../superdeskApi';
-import {IWebsocketMessageData, ITEM_TYPE} from '../../interfaces';
+import {IWebsocketMessageData, ITEM_TYPE, PLANNING_VIEW} from '../../interfaces';
 import * as selectors from '../../selectors';
 import {WORKFLOW_STATE, EVENTS, LOCKS} from '../../constants';
 import {gettext, dispatchUtils, getErrorMessage, lockUtils} from '../../utils';
@@ -20,9 +20,9 @@ import eventsPlanning from '../eventsPlanning';
 const onEventCreated = (_e, data) => (
     (dispatch) => {
         if (data && data.item) {
-            return dispatch(eventsUi.scheduleRefetch())
-                .then(() => dispatch(eventsPlanning.ui.scheduleRefetch()));
+            return planningApi.ui.list.reloadListPages(PLANNING_VIEW.EVENTS);
         }
+        return Promise.resolve();
     }
 );
 
@@ -254,8 +254,8 @@ const onRecurringEventCreated = (_e, data) => (
             // Once we know our Recurring Events can be received from Elasticsearch,
             // go ahead and refresh the current list of events
                 .then((items) => {
-                    dispatch(eventsUi.scheduleRefetch());
-                    dispatch(eventsPlanning.ui.scheduleRefetch());
+                    planningApi.ui.list.reloadListPages(PLANNING_VIEW.EVENTS);
+
                     // Fetch the event if it is 'planning only' view
                     if (selectors.main.isPlanningView(getState())) {
                         dispatch(eventsApi.fetchById(data.item, {force: true}));
@@ -277,13 +277,9 @@ const onRecurringEventCreated = (_e, data) => (
  * @param {object} data - Event and User IDs
  */
 const onEventUpdated = (_e, data) => (
-    (dispatch, getState) => {
+    (dispatch) => {
         if (data && data.item) {
-            dispatch(main.setUnsetLoadingIndicator(true));
-            dispatch(eventsUi.scheduleRefetch(get(data, 'recurrence_id') ? [data.item] : []))
-                .then(() => dispatch(eventsPlanning.ui.scheduleRefetch()))
-                .finally(() => dispatch(main.setUnsetLoadingIndicator(false)));
-
+            planningApi.ui.list.reloadListPages(PLANNING_VIEW.EVENTS);
             dispatch(fetchItemHistoryOnRecurringNotitication(data));
         }
 

--- a/client/actions/events/tests/notifications_test.ts
+++ b/client/actions/events/tests/notifications_test.ts
@@ -730,16 +730,12 @@ describe('actions.events.notifications', () => {
         beforeEach(() => {
             restoreSinonStub(eventsNotifications.onEventUpdated);
             sinon.stub(main, 'closePreviewAndEditorForItems').callsFake(() => (Promise.resolve()));
-            sinon.stub(main, 'setUnsetLoadingIndicator').callsFake(() => (Promise.resolve()));
-            sinon.stub(eventsUi, 'scheduleRefetch').callsFake(() => (Promise.resolve()));
-            sinon.stub(eventsPlanningUi, 'scheduleRefetch').callsFake(() => (Promise.resolve()));
+            sinon.stub(planningApi.ui.list, 'reloadListPages').callsFake(() => (Promise.resolve({})));
         });
 
         afterEach(() => {
             restoreSinonStub(main.closePreviewAndEditorForItems);
-            restoreSinonStub(main.setUnsetLoadingIndicator);
-            restoreSinonStub(eventsUi.scheduleRefetch);
-            restoreSinonStub(eventsPlanningUi.scheduleRefetch);
+            restoreSinonStub(planningApi.ui.list.reloadListPages);
         });
 
         it('onEventUpdated does call scheduleRefetch if item is being edited', (done) => {
@@ -761,8 +757,7 @@ describe('actions.events.notifications', () => {
 
             return store.test(done, eventsNotifications.onEventUpdated({}, {item: data.events[0]._id}))
                 .then(() => {
-                    expect(eventsUi.scheduleRefetch.callCount).toBe(1);
-                    expect(eventsPlanningUi.scheduleRefetch.callCount).toBe(1);
+                    expect(planningApi.ui.list.reloadListPages.callCount).toBe(1);
                     done();
                 })
                 .catch(done.fail);
@@ -771,8 +766,7 @@ describe('actions.events.notifications', () => {
         it('onEventUpdated does calls scheduleRefetch if item is not being edited', (done) => (
             store.test(done, eventsNotifications.onEventUpdated({}, {item: data.events[0]._id}))
                 .then(() => {
-                    expect(eventsUi.scheduleRefetch.callCount).toBe(1);
-                    expect(eventsPlanningUi.scheduleRefetch.callCount).toBe(1);
+                    expect(planningApi.ui.list.reloadListPages.callCount).toBe(1);
                     done();
                 })
                 .catch(done.fail)
@@ -794,29 +788,33 @@ describe('actions.events.notifications', () => {
                 recurrence_id: 'rec1',
             }))
                 .then(() => {
-                    expect(eventsUi.scheduleRefetch.callCount).toBe(1);
-                    expect(eventsPlanningUi.scheduleRefetch.callCount).toBe(1);
-                    expect(eventsUi.scheduleRefetch.args[0]).toEqual([[data.events[0]._id]]);
+                    expect(planningApi.ui.list.reloadListPages.callCount).toBe(1);
                     done();
                 })
                 .catch(done.fail);
         });
     });
 
-    it('calls scheduleRefetch for events.ui and eventsPlanning.ui', (done) => {
-        sinon.stub(eventsUi, 'scheduleRefetch').returns(Promise.resolve());
-        sinon.stub(eventsPlanningUi, 'scheduleRefetch').returns(Promise.resolve());
+    describe('onEventCreated', () => {
+        beforeEach(() => {
+            restoreSinonStub(eventsNotifications.onEventCreated);
+            sinon.stub(main, 'closePreviewAndEditorForItems').callsFake(() => (Promise.resolve()));
+            sinon.stub(planningApi.ui.list, 'reloadListPages').callsFake(() => (Promise.resolve({})));
+        });
 
-        store.test(done, eventsNotifications.onEventCreated({}, {item: 'e1'}))
-            .then(() => {
-                expect(eventsUi.scheduleRefetch.callCount).toBe(1);
-                expect(eventsPlanningUi.scheduleRefetch.callCount).toBe(1);
+        afterEach(() => {
+            restoreSinonStub(main.closePreviewAndEditorForItems);
+            restoreSinonStub(planningApi.ui.list.reloadListPages);
+        });
 
-                restoreSinonStub(eventsUi.scheduleRefetch);
-                restoreSinonStub(eventsPlanningUi.scheduleRefetch);
+        it('calls scheduleRefetch for events.ui and eventsPlanning.ui', (done) => {
+            store.test(done, eventsNotifications.onEventCreated({}, {item: 'e1'}))
+                .then(() => {
+                    expect(planningApi.ui.list.reloadListPages.callCount).toBe(1);
 
-                done();
-            })
-            .catch(done.fail);
+                    done();
+                })
+                .catch(done.fail);
+        });
     });
 });

--- a/client/actions/planning/notifications.ts
+++ b/client/actions/planning/notifications.ts
@@ -1,10 +1,10 @@
 import {get} from 'lodash';
 
-import {IWebsocketMessageData, ITEM_TYPE} from '../../interfaces';
-import {planningApi, superdeskApi} from '../../superdeskApi';
+import {IWebsocketMessageData, ITEM_TYPE, PLANNING_VIEW} from '../../interfaces';
+import {planningApi} from '../../superdeskApi';
 
-import {gettext, lockUtils, getErrorMessage} from '../../utils';
-import {PLANNING, MODALS, WORKFLOW_STATE, WORKSPACE} from '../../constants';
+import {gettext, lockUtils} from '../../utils';
+import {PLANNING, MODALS, WORKFLOW_STATE, WORKSPACE, MAIN} from '../../constants';
 
 import planning from './index';
 import assignments from '../assignments/index';
@@ -42,7 +42,7 @@ const onPlanningCreated = (_e, data) => (
                 dispatch(main.fetchItemHistory({_id: data.event_item, type: ITEM_TYPE.EVENT}));
             }
 
-            return planningApi.ui.list.reloadListPages();
+            return planningApi.ui.list.reloadListPages(PLANNING_VIEW.PLANNING);
         }
 
         return Promise.resolve();
@@ -67,7 +67,7 @@ const onPlanningUpdated = (_e, data) => (
         }
 
         if (get(data, 'item')) {
-            planningApi.ui.list.reloadListPages()
+            planningApi.ui.list.reloadListPages(PLANNING_VIEW.PLANNING)
                 .then((results) => {
                     if (selectors.general.currentWorkspace(getState()) === WORKSPACE.ASSIGNMENTS) {
                         const selectedItems = selectors.multiSelect.selectedPlannings(getState());
@@ -83,11 +83,6 @@ const onPlanningUpdated = (_e, data) => (
                             dispatch(planning.api.fetchById(data.item, {force: true}));
                         }
                     }
-                })
-                .catch((error) => {
-                    superdeskApi.ui.notify.error(
-                        getErrorMessage(error, gettext('Failed to reload item list'))
-                    );
                 });
 
             if (get(data, 'added_agendas.length', 0) > 0 || get(data, 'removed_agendas.length', 0) > 0) {

--- a/client/actions/planning/notifications.ts
+++ b/client/actions/planning/notifications.ts
@@ -69,6 +69,11 @@ const onPlanningUpdated = (_e, data) => (
         if (get(data, 'item')) {
             planningApi.ui.list.reloadListPages(PLANNING_VIEW.PLANNING)
                 .then((results) => {
+                    // the list was not reloaded
+                    if (results == null) {
+                        return;
+                    }
+
                     if (selectors.general.currentWorkspace(getState()) === WORKSPACE.ASSIGNMENTS) {
                         const selectedItems = selectors.multiSelect.selectedPlannings(getState());
                         const currentPreviewId = selectors.main.previewId(getState());

--- a/client/api/planning.ts
+++ b/client/api/planning.ts
@@ -137,6 +137,36 @@ export function getPlanningByIds(
         .then((response) => response._items);
 }
 
+export function getPlanningByEventIds(eventIds: Array<IEventItem['_id']>): Promise<Array<IPlanningItem>> {
+    if (eventIds.length === 0) {
+        return Promise.resolve([]);
+    } else if (eventIds.length > PLANNING.FETCH_IDS_CHUNK_SIZE) {
+        // chunk the requests (otherwise URL may become too long)
+        const requests: Array<Promise<Array<IPlanningItem>>> = [];
+
+        for (let i = 0; i < Math.ceil(eventIds.length / PLANNING.FETCH_IDS_CHUNK_SIZE); i++) {
+            requests.push(
+                searchPlanningGetAll({
+                    event_item: eventIds.slice(
+                        i * PLANNING.FETCH_IDS_CHUNK_SIZE,
+                        (i + 1) * PLANNING.FETCH_IDS_CHUNK_SIZE
+                    ),
+                    only_future: false,
+                    include_killed: true,
+                }),
+            );
+        }
+
+        return Promise
+            .all(requests)
+            .then((responses) => (
+                Array.prototype.concat.apply([], responses)
+            ));
+    }
+
+    return searchPlanningGetAll({event_item: eventIds, only_future: false, include_killed: true});
+}
+
 function getPlanningEditorProfile() {
     return planningProfile(planningApi.redux.store.getState());
 }
@@ -273,6 +303,7 @@ export const planning: IPlanningAPI['planning'] = {
     searchGetAll: searchPlanningGetAll,
     getById: getPlanningById,
     getByIds: getPlanningByIds,
+    getByEventIds: getPlanningByEventIds,
     getEditorProfile: getPlanningEditorProfile,
     getSearchProfile: getPlanningSearchProfile,
     featured: featured,

--- a/client/api/ui/list.ts
+++ b/client/api/ui/list.ts
@@ -27,6 +27,7 @@ import {getEventFilterParams} from '../../selectors/events';
 import {getPlanningFilterParams} from '../../selectors/planning';
 import {getEventsPlanningViewParams} from '../../selectors/eventsplanning';
 import {getErrorMessage, gettext} from '../../utils';
+import {throttlePromise} from '../../utils/throttle';
 import {
     searchParamsToOld,
     removeUndefinedParams,
@@ -73,16 +74,28 @@ function _refetchListItemPages(): Promise<{items: Array<IEventOrPlanningItem>, t
     return getPages().then(() => ({items, total}));
 }
 
+const RELOAD_LIST_PAGES_COOLDOWN_MS = 1000;
+
+// Collapse bursts of websocket notifications: the first call reloads immediately, while
+// calls received during a reload or its cooldown share a single follow-up reload.
+const reloadListPagesThrottled = throttlePromise(_reloadListPages, RELOAD_LIST_PAGES_COOLDOWN_MS);
+
 function reloadListPages(forViewType: PLANNING_VIEW): Promise<IReloadPagePayload | null> {
-    const {getState, dispatch} = planningApi.redux.store;
-    const state = getState();
-    const currentView = activeFilter(state);
-    const currentListViewType = getCurrentListViewType(state);
+    const currentView = activeFilter(planningApi.redux.store.getState());
 
     if (![forViewType, PLANNING_VIEW.COMBINED].includes(currentView)) {
         // No need to reload the current page, as it won't include the changes required
         return Promise.resolve(null);
     }
+
+    return reloadListPagesThrottled();
+}
+
+function _reloadListPages(): Promise<IReloadPagePayload | null> {
+    const {getState, dispatch} = planningApi.redux.store;
+    const state = getState();
+    const currentView = activeFilter(state);
+    const currentListViewType = getCurrentListViewType(state);
 
     dispatch(actions.main.setUnsetLoadingIndicator(true));
     return _refetchListItemPages()

--- a/client/api/ui/list.ts
+++ b/client/api/ui/list.ts
@@ -73,7 +73,7 @@ function _refetchListItemPages(): Promise<{items: Array<IEventOrPlanningItem>, t
     return getPages().then(() => ({items, total}));
 }
 
-function reloadListPages(forViewType: PLANNING_VIEW) {
+function reloadListPages(forViewType: PLANNING_VIEW): Promise<IReloadPagePayload | null> {
     const {getState, dispatch} = planningApi.redux.store;
     const state = getState();
     const currentView = activeFilter(state);
@@ -81,7 +81,7 @@ function reloadListPages(forViewType: PLANNING_VIEW) {
 
     if (![forViewType, PLANNING_VIEW.COMBINED].includes(currentView)) {
         // No need to reload the current page, as it won't include the changes required
-        return Promise.resolve();
+        return Promise.resolve(null);
     }
 
     dispatch(actions.main.setUnsetLoadingIndicator(true));
@@ -147,6 +147,8 @@ function reloadListPages(forViewType: PLANNING_VIEW) {
             superdeskApi.ui.notify.error(
                 getErrorMessage(error, gettext('Failed to reload item list'))
             );
+
+            return null;
         })
         .finally(() => {
             dispatch(actions.main.setUnsetLoadingIndicator(false));

--- a/client/api/ui/list.ts
+++ b/client/api/ui/list.ts
@@ -26,6 +26,7 @@ import {activeFilter, getCurrentListViewType, lastRequestParams} from '../../sel
 import {getEventFilterParams} from '../../selectors/events';
 import {getPlanningFilterParams} from '../../selectors/planning';
 import {getEventsPlanningViewParams} from '../../selectors/eventsplanning';
+import {getErrorMessage, gettext} from '../../utils';
 import {
     searchParamsToOld,
     removeUndefinedParams,
@@ -72,11 +73,16 @@ function _refetchListItemPages(): Promise<{items: Array<IEventOrPlanningItem>, t
     return getPages().then(() => ({items, total}));
 }
 
-function reloadListPages() {
+function reloadListPages(forViewType: PLANNING_VIEW) {
     const {getState, dispatch} = planningApi.redux.store;
     const state = getState();
     const currentView = activeFilter(state);
     const currentListViewType = getCurrentListViewType(state);
+
+    if (![forViewType, PLANNING_VIEW.COMBINED].includes(currentView)) {
+        // No need to reload the current page, as it won't include the changes required
+        return Promise.resolve();
+    }
 
     dispatch(actions.main.setUnsetLoadingIndicator(true));
     return _refetchListItemPages()
@@ -110,23 +116,21 @@ function reloadListPages() {
 
                 const eventIds = eventsWithPlannings.map((event) => event._id);
 
-                return planningApi.planning.searchGetAll({
-                    event_item: eventIds,
-                    only_future: false,
-                    include_killed: true,
-                }).then((plannings) => {
-                    payload.plannings = payload.plannings.concat(plannings);
+                return planningApi.planning
+                    .getByEventIds(eventIds)
+                    .then((plannings) => {
+                        payload.plannings = payload.plannings.concat(plannings);
 
-                    payload.relatedPlannings = eventsWithPlannings.reduce(
-                        (acc, curr) => {
-                            acc[curr._id] = curr.planning_ids;
-                            return acc;
-                        },
-                        {},
-                    );
+                        payload.relatedPlannings = eventsWithPlannings.reduce(
+                            (acc, curr) => {
+                                acc[curr._id] = curr.planning_ids;
+                                return acc;
+                            },
+                            {},
+                        );
 
-                    return payload;
-                });
+                        return payload;
+                    });
             }
 
             return payload;
@@ -138,6 +142,11 @@ function reloadListPages() {
             dispatch({type: MAIN.ACTIONS.RELOAD_LIST_PAGES, payload: payload});
 
             return payload;
+        })
+        .catch((error) => {
+            superdeskApi.ui.notify.error(
+                getErrorMessage(error, gettext('Failed to reload item list'))
+            );
         })
         .finally(() => {
             dispatch(actions.main.setUnsetLoadingIndicator(false));

--- a/client/interfaces.ts
+++ b/client/interfaces.ts
@@ -2272,7 +2272,7 @@ export interface IPlanningAPI {
             clearList(): void;
             setViewType(viewType: LIST_VIEW_TYPE): Promise<any>;
             changeCurrentView(view: PLANNING_VIEW): Promise<any>;
-            reloadListPages(forViewType: PLANNING_VIEW): Promise<IReloadPagePayload>;
+            reloadListPages(forViewType: PLANNING_VIEW): Promise<IReloadPagePayload | null>;
         };
     };
     locations: {

--- a/client/interfaces.ts
+++ b/client/interfaces.ts
@@ -2209,6 +2209,7 @@ export interface IPlanningAPI {
             spikeState?: ISearchSpikeState,
             params?: ISearchParams
         ): Promise<Array<IPlanningItem>>;
+        getByEventIds(eventIds: Array<IEventItem['_id']>): Promise<Array<IPlanningItem>>;
         getEditorProfile(): IPlanningFormProfile;
         getSearchProfile(): IPlanningSearchProfile;
         featured: {
@@ -2271,7 +2272,7 @@ export interface IPlanningAPI {
             clearList(): void;
             setViewType(viewType: LIST_VIEW_TYPE): Promise<any>;
             changeCurrentView(view: PLANNING_VIEW): Promise<any>;
-            reloadListPages(): Promise<IReloadPagePayload>;
+            reloadListPages(forViewType: PLANNING_VIEW): Promise<IReloadPagePayload>;
         };
     };
     locations: {

--- a/client/utils/tests/throttle_test.ts
+++ b/client/utils/tests/throttle_test.ts
@@ -44,7 +44,7 @@ describe('utils.throttlePromise', () => {
     });
 
     it('executes the first call immediately', (done) => {
-        (async () => {
+        (async() => {
             const result = throttled();
 
             expect(callCount).toBe(1);
@@ -55,7 +55,7 @@ describe('utils.throttlePromise', () => {
     });
 
     it('collapses calls received during an execution into a single follow-up', (done) => {
-        (async () => {
+        (async() => {
             const first = throttled();
             const second = throttled();
             const third = throttled();
@@ -78,7 +78,7 @@ describe('utils.throttlePromise', () => {
     });
 
     it('waits for a slow execution to finish before starting the follow-up', (done) => {
-        (async () => {
+        (async() => {
             const first = throttled();
             const second = throttled();
 
@@ -97,7 +97,7 @@ describe('utils.throttlePromise', () => {
     });
 
     it('executes immediately again when idle and cooled down', (done) => {
-        (async () => {
+        (async() => {
             const first = throttled();
 
             deferreds[0].resolve('one');
@@ -114,7 +114,7 @@ describe('utils.throttlePromise', () => {
     });
 
     it('propagates a rejection to that cycle and recovers afterwards', (done) => {
-        (async () => {
+        (async() => {
             const first = throttled();
             const second = throttled();
             let caught;

--- a/client/utils/tests/throttle_test.ts
+++ b/client/utils/tests/throttle_test.ts
@@ -1,0 +1,137 @@
+import {throttlePromise} from '../throttle';
+
+const COOLDOWN_MS = 50;
+
+interface IDeferred {
+    promise: Promise<any>;
+    resolve(value?: any): void;
+    reject(reason?: any): void;
+}
+
+function createDeferred(): IDeferred {
+    const deferred: Partial<IDeferred> = {};
+
+    deferred.promise = new Promise((resolve, reject) => {
+        deferred.resolve = resolve;
+        deferred.reject = reject;
+    });
+
+    return deferred as IDeferred;
+}
+
+function delay(ms: number): Promise<void> {
+    return new Promise((resolve) => {
+        setTimeout(resolve, ms);
+    });
+}
+
+describe('utils.throttlePromise', () => {
+    let deferreds: Array<IDeferred>;
+    let callCount: number;
+    let throttled: () => Promise<any>;
+
+    beforeEach(() => {
+        deferreds = [];
+        callCount = 0;
+        throttled = throttlePromise(() => {
+            callCount++;
+            const deferred = createDeferred();
+
+            deferreds.push(deferred);
+
+            return deferred.promise;
+        }, COOLDOWN_MS);
+    });
+
+    it('executes the first call immediately', (done) => {
+        (async () => {
+            const result = throttled();
+
+            expect(callCount).toBe(1);
+
+            deferreds[0].resolve('one');
+            expect(await result).toBe('one');
+        })().then(done, done.fail);
+    });
+
+    it('collapses calls received during an execution into a single follow-up', (done) => {
+        (async () => {
+            const first = throttled();
+            const second = throttled();
+            const third = throttled();
+
+            expect(callCount).toBe(1);
+            expect(second).toBe(third);
+
+            deferreds[0].resolve('one');
+            expect(await first).toBe('one');
+
+            // The follow-up does not start until the cooldown has elapsed
+            expect(callCount).toBe(1);
+            await delay(COOLDOWN_MS * 2);
+            expect(callCount).toBe(2);
+
+            deferreds[1].resolve('two');
+            expect(await second).toBe('two');
+            expect(await third).toBe('two');
+        })().then(done, done.fail);
+    });
+
+    it('waits for a slow execution to finish before starting the follow-up', (done) => {
+        (async () => {
+            const first = throttled();
+            const second = throttled();
+
+            // Cooldown elapses while the first execution is still running
+            await delay(COOLDOWN_MS * 2);
+            expect(callCount).toBe(1);
+
+            deferreds[0].resolve('one');
+            await first;
+            await delay(0);
+            expect(callCount).toBe(2);
+
+            deferreds[1].resolve('two');
+            expect(await second).toBe('two');
+        })().then(done, done.fail);
+    });
+
+    it('executes immediately again when idle and cooled down', (done) => {
+        (async () => {
+            const first = throttled();
+
+            deferreds[0].resolve('one');
+            await first;
+            await delay(COOLDOWN_MS * 2);
+
+            const second = throttled();
+
+            expect(callCount).toBe(2);
+
+            deferreds[1].resolve('two');
+            expect(await second).toBe('two');
+        })().then(done, done.fail);
+    });
+
+    it('propagates a rejection to that cycle and recovers afterwards', (done) => {
+        (async () => {
+            const first = throttled();
+            const second = throttled();
+            let caught;
+
+            deferreds[0].reject('oops');
+            try {
+                await first;
+            } catch (error) {
+                caught = error;
+            }
+            expect(caught).toBe('oops');
+
+            await delay(COOLDOWN_MS * 2);
+            expect(callCount).toBe(2);
+
+            deferreds[1].resolve('two');
+            expect(await second).toBe('two');
+        })().then(done, done.fail);
+    });
+});

--- a/client/utils/throttle.ts
+++ b/client/utils/throttle.ts
@@ -1,0 +1,51 @@
+/**
+ * Wraps a promise returning function so bursts of calls are collapsed.
+ *
+ * The first call executes `fn` immediately. Calls received while an execution
+ * is in progress, or before `cooldownMs` has elapsed since that execution
+ * started, share a single follow-up execution and all receive its result.
+ * Executions never overlap.
+ *
+ * Not replaceable with `lodash.throttle`: that one measures its window in wall
+ * clock time only, so it fires the trailing call even if the previous async
+ * execution is still running (executions would overlap), and callers inside
+ * the window get the result of the execution that started before their call
+ * rather than one that reflects it.
+ */
+export function throttlePromise<T>(fn: () => Promise<T>, cooldownMs: number): () => Promise<T> {
+    let pending: Promise<T> | null = null;
+
+    // Resolves once the current execution has finished and its cooldown has elapsed
+    let gate: Promise<void> | null = null;
+
+    function execute(): Promise<T> {
+        const result = fn();
+        const cooldown = new Promise<void>((resolve) => {
+            setTimeout(resolve, cooldownMs);
+        });
+
+        gate = Promise.all([result.catch(() => null), cooldown]).then(() => {
+            gate = null;
+        });
+
+        return result;
+    }
+
+    return () => {
+        if (pending != null) {
+            return pending;
+        }
+
+        if (gate == null) {
+            return execute();
+        }
+
+        pending = gate.then(() => {
+            pending = null;
+
+            return execute();
+        });
+
+        return pending;
+    };
+}


### PR DESCRIPTION
### Purpose
The previous fix seemed to work for Planning items, but the same bug occurred when creating or updating Events.

### What has changed
* Use the newer `reloadListPages` functionality when reacting to websocket messages for Event create and update
* Show user error message when reloading the list fails
* Add new param to `reloadListPages` that allows to reload only the list if it's in the Event or Planning view, or the combined view
* Fixes as error when there are too many Events with associated Planning items, leading to the `Request Line is too large` error (uses EventID request chunking instead)._

Resolves: [SDBELGA-1104]

Related PR https://github.com/superdesk/superdesk-planning/pull/2899



[SDBELGA-1104]: https://sofab.atlassian.net/browse/SDBELGA-1104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ