### PR TITLE
[SDBELGA-1104] Chunk id-based search requests to avoid too-long request lines

### DIFF
--- a/client/actions/eventsPlanning/tests/ui_test.ts
+++ b/client/actions/eventsPlanning/tests/ui_test.ts
@@ -421,7 +421,7 @@ describe('actions.eventsplanning.ui', () => {
         ];
 
         beforeEach(() => {
-            sinon.stub(planningApis.planning, 'searchGetAll').callsFake(
+            sinon.stub(planningApis.planning, 'getByEventIds').callsFake(
                 () => Promise.resolve(relatedPlannings)
             );
             sinon.stub(planningApi, 'receivePlannings').callsFake(
@@ -430,7 +430,7 @@ describe('actions.eventsplanning.ui', () => {
         });
 
         afterEach(() => {
-            restoreSinonStub(planningApis.planning.searchGetAll);
+            restoreSinonStub(planningApis.planning.getByEventIds);
             restoreSinonStub(planningApi.receivePlannings);
         });
 
@@ -443,12 +443,8 @@ describe('actions.eventsplanning.ui', () => {
 
             store.test(done, eventsPlanningUi.loadAllRelatedPlannings(items))
                 .then(() => {
-                    expect(planningApis.planning.searchGetAll.callCount).toBe(1);
-                    expect(planningApis.planning.searchGetAll.args[0][0]).toEqual({
-                        event_item: ['e1'],
-                        only_future: false,
-                        include_killed: true,
-                    });
+                    expect(planningApis.planning.getByEventIds.callCount).toBe(1);
+                    expect(planningApis.planning.getByEventIds.args[0][0]).toEqual(['e1']);
 
                     expect(planningApi.receivePlannings.callCount).toBe(1);
                     expect(planningApi.receivePlannings.args[0][0]).toEqual(relatedPlannings);
@@ -487,7 +483,7 @@ describe('actions.eventsplanning.ui', () => {
 
             store.test(done, eventsPlanningUi.loadAllRelatedPlannings(items))
                 .then(() => {
-                    expect(planningApis.planning.searchGetAll.callCount).toBe(0);
+                    expect(planningApis.planning.getByEventIds.callCount).toBe(0);
                     done();
                 })
                 .catch(done.fail);
@@ -501,7 +497,7 @@ describe('actions.eventsplanning.ui', () => {
 
             store.test(done, eventsPlanningUi.loadAllRelatedPlannings(items))
                 .then(() => {
-                    expect(planningApis.planning.searchGetAll.callCount).toBe(0);
+                    expect(planningApis.planning.getByEventIds.callCount).toBe(0);
                     done();
                 })
                 .catch(done.fail);
@@ -513,7 +509,7 @@ describe('actions.eventsplanning.ui', () => {
 
         beforeEach(() => {
             originalExpandSetting = appConfig.planning_expand_related_plannings;
-            sinon.stub(planningApis.planning, 'searchGetAll').callsFake(
+            sinon.stub(planningApis.planning, 'getByEventIds').callsFake(
                 () => Promise.resolve([])
             );
             sinon.stub(planningApi, 'receivePlannings').callsFake(
@@ -523,7 +519,7 @@ describe('actions.eventsplanning.ui', () => {
 
         afterEach(() => {
             appConfig.planning_expand_related_plannings = originalExpandSetting;
-            restoreSinonStub(planningApis.planning.searchGetAll);
+            restoreSinonStub(planningApis.planning.getByEventIds);
             restoreSinonStub(planningApi.receivePlannings);
         });
 
@@ -536,7 +532,7 @@ describe('actions.eventsplanning.ui', () => {
 
             store.test(done, eventsPlanningUi.receiveEventsPlanning(items))
                 .then(() => {
-                    expect(planningApis.planning.searchGetAll.callCount).toBe(1);
+                    expect(planningApis.planning.getByEventIds.callCount).toBe(1);
                     done();
                 })
                 .catch(done.fail);
@@ -551,7 +547,7 @@ describe('actions.eventsplanning.ui', () => {
 
             store.test(done, eventsPlanningUi.receiveEventsPlanning(items))
                 .then(() => {
-                    expect(planningApis.planning.searchGetAll.callCount).toBe(0);
+                    expect(planningApis.planning.getByEventIds.callCount).toBe(0);
                     done();
                 })
                 .catch(done.fail);

--- a/client/actions/eventsPlanning/ui.ts
+++ b/client/actions/eventsPlanning/ui.ts
@@ -193,11 +193,7 @@ const loadAllRelatedPlannings = (items) => (
 
         const eventIds = eventsWithPlannings.map((event) => event._id);
 
-        return planningApis.planning.searchGetAll({
-            event_item: eventIds,
-            only_future: false,
-            include_killed: true,
-        }).then((plannings) => {
+        return planningApis.planning.getByEventIds(eventIds).then((plannings) => {
             dispatch(planningApi.receivePlannings(plannings));
             eventsWithPlannings.forEach((event) => {
                 dispatch(self._showRelatedPlannings(event));

--- a/client/api/combined.ts
+++ b/client/api/combined.ts
@@ -9,6 +9,7 @@ import {
 } from '../interfaces';
 import {IRestApiResponse} from 'superdesk-api';
 import {searchRaw, searchRawGetAll, convertCommonParams, cvsToString, arrayToString, searchRawAndStore} from './search';
+import {searchInChunks} from '../utils/search';
 import {eventUtils, planningUtils} from '../utils';
 import {planningApi} from '../superdeskApi';
 import {combinedSearchProfile} from '../selectors/forms';
@@ -65,6 +66,18 @@ export function searchCombinedGetAll(params: ISearchParams): Promise<Array<IEven
 
             return items;
         });
+}
+
+export function getEventsAndPlanningByIds(
+    itemIds: Array<IEventOrPlanningItem['_id']>,
+    params: ISearchParams = {}
+): Promise<Array<IEventOrPlanningItem>> {
+    return searchInChunks(itemIds, (chunk) => (
+        searchCombinedGetAll({
+            ...params,
+            item_ids: chunk,
+        })
+    ));
 }
 
 export function searchAndStore(params: ISearchParams) {
@@ -154,6 +167,7 @@ function getCombinedSearchProfile() {
 export const combined: IPlanningAPI['combined'] = {
     search: searchCombined,
     searchGetAll: searchCombinedGetAll,
+    getByIds: getEventsAndPlanningByIds,
     getRecurringEventsAndPlanningItems: getRecurringEventsAndPlanningItems,
     getEventsAndPlanning: getEventsAndPlanning,
     getSearchProfile: getCombinedSearchProfile,

--- a/client/api/locks.ts
+++ b/client/api/locks.ts
@@ -49,8 +49,7 @@ function loadLockedItems(types?: Array<'events_and_planning' | 'featured_plannin
             }
 
             // Make sure that all items that are locked are loaded into the store
-            return planningApi.combined.searchGetAll({
-                item_ids: lockedItemIds,
+            return planningApi.combined.getByIds(lockedItemIds, {
                 only_future: false,
                 include_killed: true,
                 spike_state: 'draft',

--- a/client/api/planning.ts
+++ b/client/api/planning.ts
@@ -17,6 +17,7 @@ import {arrayToString, convertCommonParams, searchRaw, searchRawGetAll, cvsToStr
 import {planningApi, superdeskApi} from '../superdeskApi';
 import {IRestApiResponse} from 'superdesk-api';
 import {planningUtils, getErrorMessage} from '../utils';
+import {searchInChunks} from '../utils/search';
 import {planningProfile, planningSearchProfile} from '../selectors/forms';
 import {featured} from './featured';
 import {PLANNING} from '../constants';
@@ -138,33 +139,13 @@ export function getPlanningByIds(
 }
 
 export function getPlanningByEventIds(eventIds: Array<IEventItem['_id']>): Promise<Array<IPlanningItem>> {
-    if (eventIds.length === 0) {
-        return Promise.resolve([]);
-    } else if (eventIds.length > PLANNING.FETCH_IDS_CHUNK_SIZE) {
-        // chunk the requests (otherwise URL may become too long)
-        const requests: Array<Promise<Array<IPlanningItem>>> = [];
-
-        for (let i = 0; i < Math.ceil(eventIds.length / PLANNING.FETCH_IDS_CHUNK_SIZE); i++) {
-            requests.push(
-                searchPlanningGetAll({
-                    event_item: eventIds.slice(
-                        i * PLANNING.FETCH_IDS_CHUNK_SIZE,
-                        (i + 1) * PLANNING.FETCH_IDS_CHUNK_SIZE
-                    ),
-                    only_future: false,
-                    include_killed: true,
-                }),
-            );
-        }
-
-        return Promise
-            .all(requests)
-            .then((responses) => (
-                Array.prototype.concat.apply([], responses)
-            ));
-    }
-
-    return searchPlanningGetAll({event_item: eventIds, only_future: false, include_killed: true});
+    return searchInChunks(eventIds, (chunk) => (
+        searchPlanningGetAll({
+            event_item: chunk,
+            only_future: false,
+            include_killed: true,
+        })
+    ));
 }
 
 function getPlanningEditorProfile() {

--- a/client/interfaces.ts
+++ b/client/interfaces.ts
@@ -2244,6 +2244,10 @@ export interface IPlanningAPI {
         searchAndStore(params: ISearchParams): Promise<IRestApiResponse<IEventOrPlanningItem>>;
         search(params: ISearchParams): Promise<IRestApiResponse<IEventOrPlanningItem>>;
         searchGetAll(params: ISearchParams): Promise<Array<IEventOrPlanningItem>>;
+        getByIds(
+            itemIds: Array<IEventOrPlanningItem['_id']>,
+            params?: ISearchParams
+        ): Promise<Array<IEventOrPlanningItem>>;
         getRecurringEventsAndPlanningItems(
             event: IEventItem,
             loadPlannings?: boolean,

--- a/client/utils/search.ts
+++ b/client/utils/search.ts
@@ -29,16 +29,17 @@ export function searchInChunks<T>(
         return Promise.resolve([]);
     }
 
+    const safeChunkSize = Math.max(1, chunkSize);
     const requests: Array<Promise<Array<T>>> = [];
 
-    for (let i = 0; i < ids.length; i += chunkSize) {
-        requests.push(search(ids.slice(i, i + chunkSize)));
+    for (let i = 0; i < ids.length; i += safeChunkSize) {
+        requests.push(search(ids.slice(i, i + safeChunkSize)));
     }
 
     return Promise
         .all(requests)
         .then((responses) => (
-            Array.prototype.concat.apply([], responses)
+            responses.reduce<Array<T>>((all, chunkItems) => all.concat(chunkItems), [])
         ));
 }
 

--- a/client/utils/search.ts
+++ b/client/utils/search.ts
@@ -12,9 +12,35 @@ import {
     SORT_FIELD,
     SORT_ORDER,
 } from '../interfaces';
-import {MAIN} from '../constants';
+import {MAIN, PLANNING} from '../constants';
 import {getTimeZoneOffset, timeUtils} from './index';
 import {appConfig} from 'appConfig';
+
+/**
+ * Runs `search` over `ids` in chunks and concatenates the results, keeping each
+ * request's query string below the server's request line size limit.
+ */
+export function searchInChunks<T>(
+    ids: Array<string>,
+    search: (chunk: Array<string>) => Promise<Array<T>>,
+    chunkSize: number = PLANNING.FETCH_IDS_CHUNK_SIZE,
+): Promise<Array<T>> {
+    if (ids.length === 0) {
+        return Promise.resolve([]);
+    }
+
+    const requests: Array<Promise<Array<T>>> = [];
+
+    for (let i = 0; i < ids.length; i += chunkSize) {
+        requests.push(search(ids.slice(i, i + chunkSize)));
+    }
+
+    return Promise
+        .all(requests)
+        .then((responses) => (
+            Array.prototype.concat.apply([], responses)
+        ));
+}
 
 function commonParamsToSearchParams(params: ICommonSearchParams<IEventOrPlanningItem>): ISearchParams {
     return {

--- a/client/utils/tests/search_test.ts
+++ b/client/utils/tests/search_test.ts
@@ -53,6 +53,16 @@ describe('utils.search.searchInChunks', () => {
             .catch(done.fail);
     });
 
+    it('falls back to a chunk size of 1 when given an invalid chunk size', (done) => {
+        searchInChunks(['a', 'b'], search, 0)
+            .then((items) => {
+                expect(searchedChunks).toEqual([['a'], ['b']]);
+                expect(items).toEqual([{_id: 'a'}, {_id: 'b'}]);
+                done();
+            })
+            .catch(done.fail);
+    });
+
     it('rejects if any chunk fails', (done) => {
         const failingSearch = (chunk: Array<string>) => (
             chunk.includes('id-30') ?

--- a/client/utils/tests/search_test.ts
+++ b/client/utils/tests/search_test.ts
@@ -1,0 +1,77 @@
+import {searchInChunks} from '../search';
+
+describe('utils.search.searchInChunks', () => {
+    let searchedChunks: Array<Array<string>>;
+
+    const search = (chunk: Array<string>) => {
+        searchedChunks.push(chunk);
+
+        return Promise.resolve(chunk.map((id) => ({_id: id})));
+    };
+
+    beforeEach(() => {
+        searchedChunks = [];
+    });
+
+    it('resolves an empty list without searching', (done) => {
+        searchInChunks([], search)
+            .then((items) => {
+                expect(items).toEqual([]);
+                expect(searchedChunks).toEqual([]);
+                done();
+            })
+            .catch(done.fail);
+    });
+
+    it('searches small id lists in a single request', (done) => {
+        searchInChunks(['a', 'b', 'c'], search)
+            .then((items) => {
+                expect(searchedChunks).toEqual([['a', 'b', 'c']]);
+                expect(items).toEqual([{_id: 'a'}, {_id: 'b'}, {_id: 'c'}]);
+                done();
+            })
+            .catch(done.fail);
+    });
+
+    it('splits large id lists into chunks and concatenates the results in order', (done) => {
+        const ids = [];
+
+        for (let i = 0; i < 60; i++) {
+            ids.push(`id-${i}`);
+        }
+
+        searchInChunks(ids, search, 25)
+            .then((items) => {
+                expect(searchedChunks.length).toBe(3);
+                expect(searchedChunks[0].length).toBe(25);
+                expect(searchedChunks[1].length).toBe(25);
+                expect(searchedChunks[2].length).toBe(10);
+                expect(items.length).toBe(60);
+                expect(items.map((item) => item._id)).toEqual(ids);
+                done();
+            })
+            .catch(done.fail);
+    });
+
+    it('rejects if any chunk fails', (done) => {
+        const failingSearch = (chunk: Array<string>) => (
+            chunk.includes('id-30') ?
+                Promise.reject('search failed') :
+                search(chunk)
+        );
+        const ids = [];
+
+        for (let i = 0; i < 60; i++) {
+            ids.push(`id-${i}`);
+        }
+
+        searchInChunks(ids, failingSearch, 25)
+            .then(
+                () => done.fail('Expected the promise to reject'),
+                (error) => {
+                    expect(error).toBe('search failed');
+                    done();
+                }
+            );
+    });
+});


### PR DESCRIPTION
### Purpose
While testing #2900, loading the Planning workspace failed with a "Request Line is too large" error. The request came from `loadLockedItems` (`client/api/locks.ts`), which loads all currently locked items in a single `events_planning_search` request which exceeds the server's request line limit.

This is the same bug class #2900 fixed for `event_item` queries: chunking has been applied point-by-point since 2017 (`FETCH_IDS_CHUNK_SIZE`), while call sites written in between never got it.

### What has changed
* New `searchInChunks(ids, search, chunkSize)` helper in `client/utils/search.ts` that runs a search callback over IDs in chunks of 25 and concatenates the results, with unit tests.
* New `planningApi.combined.getByIds(itemIds, params)` that searches the combined repo in chunks.
* `loadLockedItems` now uses `combined.getByIds`, fixing the error above.
* `loadAllRelatedPlannings` now uses the chunked `planning.getByEventIds` (it had the same unchunked `event_item` query that #2900 fixed in `reloadListPages`).
* `getPlanningByEventIds` (added in #2900) is simplified to use `searchInChunks` instead of its hand-rolled chunk loop, same behavior.


Resolves: [SDBELGA-1104](https://sofab.atlassian.net/browse/SDBELGA-1104)

Related PRs: #2899, #2900


[SDBELGA-1104]: https://sofab.atlassian.net/browse/SDBELGA-1104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ