### PR TITLE
[STT-1699] Render item previews from the content profile

### DIFF
--- a/client/components/Assignments/AssignmentPreviewContainer/AssignmentPreview.tsx
+++ b/client/components/Assignments/AssignmentPreviewContainer/AssignmentPreview.tsx
@@ -10,7 +10,6 @@ import {
     IFile,
     IPlanningFormProfile,
     IPlanningItem,
-    PREVIEW_PANEL,
 } from '../../../interfaces';
 
 import {assignmentUtils, planningUtils} from '../../../utils';
@@ -18,7 +17,7 @@ import {assignmentUtils, planningUtils} from '../../../utils';
 import {ContactsPreviewList} from '../../Contacts/ContactsPreviewList';
 import {Row} from '../../UI/Preview';
 import {FileReadOnlyList} from '../../UI';
-import {previewGroupToProfile, renderFieldsForPanel} from '../../fields';
+import {getCustomFieldSourcePaths, renderProfileFieldsFlat} from '../../fields';
 
 interface IProps {
     assignment: IAssignmentItem;
@@ -35,6 +34,43 @@ interface IProps {
 }
 
 export class AssignmentPreview extends React.PureComponent<IProps> {
+    /**
+     * Coverage profile fields read from the coverage (`assignment.planning`),
+     * except a few sourced from the planning item.
+     */
+    getFieldProps(profile: ICoverageContentProfile | ICoverageFormProfile): {[key: string]: {[key: string]: any}} {
+        const planningItemFields = ['anpa_category', 'subject', 'location'];
+        const fieldProps: {[key: string]: {[key: string]: any}} = {
+            ...getCustomFieldSourcePaths(profile, 'coverage'),
+        };
+
+        Object.keys(profile?.editor ?? {}).forEach((fieldName) => {
+            if (fieldProps[fieldName] == null) {
+                fieldProps[fieldName] = {
+                    field: planningItemFields.includes(fieldName) ?
+                        `planning.${fieldName}` :
+                        `coverage.${fieldName}`,
+                };
+            }
+        });
+
+        return fieldProps;
+    }
+
+    /**
+     * Fields the coverage profile does not cover but the planning profile enables
+     * (place, category, subject) keep rendering from the planning item, as before
+     * the previews became profile driven.
+     */
+    getPlanningOnlyExcludes(coverageProfile, planningProfile): Array<string> {
+        const planningItemFields = ['place', 'anpa_category', 'subject'];
+
+        return Object.keys(planningProfile?.editor ?? {}).filter((fieldName) => (
+            !planningItemFields.includes(fieldName) ||
+            coverageProfile?.editor?.[fieldName]?.enabled
+        ));
+    }
+
     render() {
         const {gettext} = superdeskApi.localization;
         const {
@@ -47,6 +83,7 @@ export class AssignmentPreview extends React.PureComponent<IProps> {
             createLink,
         } = this.props;
 
+        const profile = assignmentCoverageProfile ?? coverageFormProfile;
         const planning: Partial<ICoveragePlanningDetails> = assignment?.planning ?? {};
         const contactId = assignment?.assigned_to?.contact ?? planning?.contact_info;
         const showXMPFiles = planningUtils.showXMPFileUIControl(assignment);
@@ -61,33 +98,49 @@ export class AssignmentPreview extends React.PureComponent<IProps> {
                     </Row>
                 )}
 
-                {renderFieldsForPanel(
+                {renderProfileFieldsFlat(
                     'form-preview',
-                    {
-                        ...previewGroupToProfile(PREVIEW_PANEL.ASSIGNMENT, coverageFormProfile, false, true),
-                        ...previewGroupToProfile(PREVIEW_PANEL.ASSIGNMENT, planningFormProfile, false, true),
-                    },
+                    profile,
                     {
                         item: {
                             coverage: planning,
                             planning: planningItem,
                         },
                         language: planning.language,
-                        schema: assignmentCoverageProfile?.schema,
+                        renderEmpty: true,
+                        schema: profile?.schema,
+                    },
+                    this.getFieldProps(profile),
+                    [
+                        'contact_info',
+                        'files',
+                        'xmp_file',
+                        'scheduled',
+                        'scheduled_updates',
+                        'g2_content_type',
+                        'news_coverage_status',
+                        'add_coverage_to_workflow',
+                        'multiple_content',
+                        'no_content_linking',
+                        'flags',
+                    ],
+                )}
+
+                {renderProfileFieldsFlat(
+                    'form-preview',
+                    planningFormProfile,
+                    {
+                        item: {planning: planningItem},
+                        language: planning.language,
+                        renderEmpty: true,
+                        schema: planningFormProfile?.schema,
                     },
                     {
-                        contact_info: {field: 'coverage'},
-                        language: {field: 'coverage.language'},
-                        slugline: {field: 'coverage.slugline'},
                         place: {field: 'planning.place'},
                         anpa_category: {field: 'planning.anpa_category'},
                         subject: {field: 'planning.subject'},
-                        genre: {field: 'coverage.genre'},
-                        keyword: {field: 'coverage.keyword'},
-                        ednote: {field: 'coverage.ednote', renderEmpty: true},
-                        internal_note: {field: 'coverage.internal_note', renderEmpty: true},
-                        location: {field: 'planning.location'},
-                    }
+                    },
+                    this.getPlanningOnlyExcludes(profile, planningFormProfile),
                 )}
 
                 <Row

--- a/client/components/Assignments/AssignmentPreviewContainer/AssignmentPreview.tsx
+++ b/client/components/Assignments/AssignmentPreviewContainer/AssignmentPreview.tsx
@@ -24,7 +24,7 @@ interface IProps {
     coverageFormProfile: ICoverageFormProfile;
     planningFormProfile: IPlanningFormProfile;
     planningItem: IPlanningItem;
-    files: Array<IFile>;
+    files: {[key: string]: IFile};
     createLink(file: IFile): string;
 
     /**

--- a/client/components/Assignments/AssignmentPreviewContainer/AssignmentPreviewContainer_test.tsx
+++ b/client/components/Assignments/AssignmentPreviewContainer/AssignmentPreviewContainer_test.tsx
@@ -174,4 +174,13 @@ describe('<AssignmentPreviewContainer />', () => {
         expect(wrapper.find(AssignmentPreview).length).toBe(1);
         expect(wrapper.find(LockContainer).length).toBe(0);
     });
+
+    it('renders planning profile only fields sourced from the planning item', () => {
+        // subject and anpa_category are enabled in the planning profile but not in the coverage profile
+        const wrapper = getWrapper();
+        const html = wrapper.find(AssignmentPreview).html();
+
+        expect(html).toContain('Subjects:');
+        expect(html).toContain('ANPA Category:');
+    });
 });

--- a/client/components/Assignments/AssignmentPreviewContainer/index.tsx
+++ b/client/components/Assignments/AssignmentPreviewContainer/index.tsx
@@ -53,7 +53,7 @@ interface IStateProps {
     lockedItems: ILockedItems;
     currentWorkspace: 'ASSIGNMENTS' | 'AUTHORING' | 'AUTHORING_WIDGET';
     contentTypes: Array<IG2ContentType>;
-    files: Array<IFile>;
+    files: {[key: string]: IFile};
     archiveItems: {[itemId: string]: IArticle};
 
     assignmentCoverageProfile: ICoverageContentProfile;

--- a/client/components/Assignments/AssignmentPreviewContainer/index.tsx
+++ b/client/components/Assignments/AssignmentPreviewContainer/index.tsx
@@ -207,7 +207,7 @@ class AssignmentPreviewContainerComponent extends React.Component<IProps> {
                 {this.props.relatedEvents.length > 0 && (
                     <ContentBlock className="AssignmentPreview__event" padSmall={true}>
                         <h3 className="side-panel__heading side-panel__heading--big">
-                            {gettext('Associated Events')}
+                            {gettext('Related Events')}
                         </h3>
 
                         <Spacer v gap="8">

--- a/client/components/Coverages/CoveragePreview/index.tsx
+++ b/client/components/Coverages/CoveragePreview/index.tsx
@@ -9,7 +9,6 @@ import {
     IPlanningCoverageItem,
     IPlanningItem,
     IPlanningNewsCoverageStatus,
-    PREVIEW_PANEL,
 } from '../../../interfaces';
 
 import {Row as PreviewRow} from '../../UI/Preview';
@@ -22,7 +21,7 @@ import {CoverageItem} from '../';
 import {CoveragePreviewTopBar} from './CoveragePreviewTopBar';
 import {ScheduledUpdate} from '../ScheduledUpdate';
 
-import {previewGroupToProfile, renderFieldsForPanel} from '../../fields';
+import {getCustomFieldSourcePaths, renderProfileFieldsFlat} from '../../fields';
 
 import {InternalNoteLabel} from '../../index';
 import '../style.scss';
@@ -123,9 +122,9 @@ export class CoveragePreview extends React.PureComponent<IProps> {
                     />
                 </PreviewRow>
 
-                {renderFieldsForPanel(
+                {renderProfileFieldsFlat(
                     'form-preview',
-                    previewGroupToProfile(PREVIEW_PANEL.COVERAGE, formProfile),
+                    formProfile,
                     {
                         item: coverage,
                         language: coverage.planning.language ?? getUserInterfaceLanguageFromCV(),
@@ -133,6 +132,7 @@ export class CoveragePreview extends React.PureComponent<IProps> {
                         schema: formProfile?.schema,
                     },
                     {
+                        ...getCustomFieldSourcePaths(formProfile, 'planning'),
                         language: {field: 'planning.language', enabled: false},
                         slugline: {field: 'planning.slugline'},
                         ednote: {field: 'planning.ednote'},
@@ -143,7 +143,18 @@ export class CoveragePreview extends React.PureComponent<IProps> {
                         flags: {field: 'planning.flags'},
                         location: {field: 'planning.location'},
                         anpa_category: {field: 'planning.anpa_category'},
-                    }
+                        subject: {field: 'planning.subject'},
+                        headline: {field: 'planning.headline'},
+                        priority: {field: 'planning.priority'},
+                    },
+                    [
+                        'contact_info',
+                        'files',
+                        'xmp_file',
+                        'scheduled_updates',
+                        'add_coverage_to_workflow',
+                        'multiple_content',
+                    ],
                 )}
 
                 {planningUtils.showXMPFileUIControl(coverage) && (

--- a/client/components/Coverages/CoveragePreview/index.tsx
+++ b/client/components/Coverages/CoveragePreview/index.tsx
@@ -41,7 +41,7 @@ interface IProps {
     item: IPlanningItem;
     canScheduleUpdates: boolean;
     createLink(file: IFile): string;
-    files: Array<IFile>;
+    files: {[key: string]: IFile};
 }
 
 export class CoveragePreview extends React.PureComponent<IProps> {

--- a/client/components/Events/EventMetadata/EventMetadata_test.tsx
+++ b/client/components/Events/EventMetadata/EventMetadata_test.tsx
@@ -43,7 +43,8 @@ describe('<EventMetadata />', () => {
         expect(content.find('[data-test-id="field-name"] > p').text()).toBe('name1');
         expect(content.find('[data-test-id="field-dates"] > p').text()).toBe(eventDateText);
         expect(content.find('[data-test-id="field-occur_status"] > p').text()).toBe('Planned, occurs certainly');
-        expect(content.find('[data-test-id="field-definition_short"] > p').text()).toBe('definition_short 1');
+        // `definition_short` is truncatable, so its text renders inside <ExpandableText>
+        expect(content.find('[data-test-id="field-definition_short"] p').text()).toBe('definition_short 1');
         expect(content.find('[data-test-id="field-event_contact_info"] > p').text()).toBe('-');
         expect(content.find('[data-test-id="field-location"] a').text()).toBe('location1address1');
     });

--- a/client/components/Events/EventPreviewContent.tsx
+++ b/client/components/Events/EventPreviewContent.tsx
@@ -63,6 +63,30 @@ export class EventPreviewContentComponent extends React.PureComponent<IProps> {
         const versionCreator = get(updatedBy, 'display_name') ? updatedBy :
             users.find((user) => user._id === updatedBy);
 
+        // Rendered at the profile position of the `related_plannings` group
+        const relatedPlanningsNode = hideRelatedItems ? null : (
+            <>
+                {item._plannings && (
+                    <h3 className="side-panel__heading side-panel__heading--big">
+                        {gettext('Related Plannings')}
+                    </h3>
+                )}
+                {get(item, '_plannings.length') > 0 ? (
+                    <RelatedPlannings
+                        className="related-plannings"
+                        plannings={item._plannings}
+                        openPlanningItem={true}
+                        expandable={true}
+                        users={users}
+                        desks={desks}
+                        allowEditPlanning={true}
+                    />
+                ) :
+                    <span className="sd-text__info">{gettext('No related planning items.')}</span>
+                }
+            </>
+        );
+
         return (
             <ContentBlock>
                 <div className="side-panel__content-block--flex">
@@ -98,28 +122,8 @@ export class EventPreviewContentComponent extends React.PureComponent<IProps> {
                     },
                     {},
                     ['recurring_rules', 'related_plannings'],
+                    {related_plannings: relatedPlanningsNode},
                 )}
-
-                {!hideRelatedItems && item._plannings && (
-                    <h3 className="side-panel__heading side-panel__heading--big">
-                        {gettext('Related Planning Items')}
-                    </h3>
-                )}
-                {!hideRelatedItems && get(item, '_plannings.length') > 0 ? (
-                    <RelatedPlannings
-                        className="related-plannings"
-                        plannings={item._plannings}
-                        openPlanningItem={true}
-                        expandable={true}
-                        users={users}
-                        desks={desks}
-                        allowEditPlanning={true}
-                    />
-                ) :
-                    !hideRelatedItems &&
-                    <span className="sd-text__info">{gettext('No related planning items.')}</span>
-                }
-
             </ContentBlock>
         );
     }

--- a/client/components/Events/EventPreviewContent.tsx
+++ b/client/components/Events/EventPreviewContent.tsx
@@ -4,9 +4,9 @@ import {get} from 'lodash';
 
 import {IDesk, IUser} from 'superdesk-api';
 import {superdeskApi} from '../../superdeskApi';
-import {IEventFormProfile, IEventItem, IFile, PREVIEW_PANEL} from '../../interfaces';
+import {IEventFormProfile, IEventItem} from '../../interfaces';
 
-import {getCreator, getFileDownloadURL} from '../../utils';
+import {getCreator} from '../../utils';
 import {getUserInterfaceLanguageFromCV} from '../../utils/users';
 import * as selectors from '../../selectors';
 
@@ -15,12 +15,10 @@ import {
     RelatedPlannings,
     StateLabel,
 } from '../index';
-import {ToggleBox, FileReadOnlyList} from '../UI';
 import {ContentBlock} from '../UI/SidePanel';
-import {LinkInput} from '../UI/Form';
 import * as actions from '../../actions';
 
-import {renderGroupedFieldsForPanel, previewGroupToProfile} from '../fields';
+import {renderProfileGroupedFields} from '../fields';
 
 interface IProps {
     item: IEventItem;
@@ -29,7 +27,6 @@ interface IProps {
     formProfile: IEventFormProfile;
     fetchEventFiles(event: IEventItem): Promise<void>;
     hideRelatedItems?: boolean;
-    files: {[key: string]: IFile};
 }
 
 const mapStateToProps = (state, ownProps) => ({
@@ -38,7 +35,6 @@ const mapStateToProps = (state, ownProps) => ({
     users: selectors.general.users(state),
     desks: selectors.general.desks(state),
     formProfile: selectors.forms.eventProfile(state),
-    files: selectors.general.files(state),
     contacts: selectors.general.contacts(state),
 });
 
@@ -59,7 +55,6 @@ export class EventPreviewContentComponent extends React.PureComponent<IProps> {
             desks,
             formProfile,
             hideRelatedItems,
-            files,
         } = this.props;
         const createdBy = getCreator(item, 'original_creator', users);
         const updatedBy = getCreator(item, 'version_creator', users);
@@ -91,9 +86,9 @@ export class EventPreviewContentComponent extends React.PureComponent<IProps> {
                     </div>
                 </div>
 
-                {renderGroupedFieldsForPanel(
+                {renderProfileGroupedFields(
                     'form-preview',
-                    previewGroupToProfile(PREVIEW_PANEL.EVENT, formProfile),
+                    formProfile,
                     {
                         item: item,
                         language: item.language ?? getUserInterfaceLanguageFromCV(),
@@ -102,33 +97,9 @@ export class EventPreviewContentComponent extends React.PureComponent<IProps> {
                         profile: formProfile,
                     },
                     {},
+                    ['recurring_rules', 'related_plannings'],
                 )}
 
-                <FileReadOnlyList
-                    formProfile={formProfile}
-                    files={files}
-                    item={item}
-                    createLink={getFileDownloadURL}
-                />
-
-                {get(formProfile, 'editor.links.enabled') && (
-                    <ToggleBox
-                        title={gettext('External Links')}
-                        isOpen={false}
-                        badgeValue={get(item, 'links.length', 0) > 0 ? item.links.length : null}
-                    >
-                        {get(item, 'links.length') > 0 ? (
-                            <ul>
-                                {get(item, 'links', []).map((link, index) => (
-                                    <li key={index}>
-                                        <LinkInput value={link} readOnly={true} />
-                                    </li>
-                                ))}
-                            </ul>
-                        ) :
-                            <span className="sd-text__info">{gettext('No external links added.')}</span>}
-                    </ToggleBox>
-                )}
                 {!hideRelatedItems && item._plannings && (
                     <h3 className="side-panel__heading side-panel__heading--big">
                         {gettext('Related Planning Items')}

--- a/client/components/Events/tests/EventPreviewContent_test.tsx
+++ b/client/components/Events/tests/EventPreviewContent_test.tsx
@@ -75,11 +75,13 @@ describe('<EventPreviewContent />', () => {
             subject: {enabled: true, group: 'details', index: 1},
             definition_long: {enabled: true, group: 'details', index: 2},
             internal_note: {enabled: true, group: 'details', index: 3},
+            related_plannings: {enabled: true, group: 'related_plannings', index: 0},
             ednote: {enabled: false},
         },
         groups: {
             main: {_id: 'main', name: 'Main', index: 0},
             details: {_id: 'details', name: 'Details', index: 1, useToggleBox: true},
+            related_plannings: {_id: 'related_plannings', name: 'Related Plannings', index: 2},
         },
     };
 
@@ -189,6 +191,11 @@ describe('<EventPreviewContent />', () => {
 
         expect(linkLabel.text()).toBe('www.google.com');
         expect(linkValue.text()).toBe('https://www.google.com');
+
+        // The related plannings section renders at its profile group position, after the toggle groups
+        const html = wrapper.html();
+
+        expect(html.indexOf('Related Plannings')).toBeGreaterThan(html.indexOf('toggle-details'));
 
         let relatedPlannings = wrapper.find('.related-plannings');
 

--- a/client/components/Events/tests/EventPreviewContent_test.tsx
+++ b/client/components/Events/tests/EventPreviewContent_test.tsx
@@ -56,6 +56,33 @@ describe('<EventPreviewContent />', () => {
         event_contact_info: [storeContact._id],
     };
 
+    // The preview follows the profile's field order and groups
+    astore.initialState.forms.profiles.event = {
+        ...astore.initialState.forms.profiles.event,
+        editor: {
+            slugline: {enabled: true, group: 'main', index: 0},
+            name: {enabled: true, group: 'main', index: 1},
+            definition_short: {enabled: true, group: 'main', index: 2},
+            occur_status: {enabled: true, group: 'main', index: 3},
+            dates: {enabled: true, group: 'main', index: 4},
+            calendars: {enabled: true, group: 'main', index: 5},
+            place: {enabled: true, group: 'main', index: 6},
+            location: {enabled: true, group: 'main', index: 7},
+            event_contact_info: {enabled: true, group: 'main', index: 8},
+            files: {enabled: true, group: 'main', index: 9},
+            links: {enabled: true, group: 'main', index: 10},
+            anpa_category: {enabled: true, group: 'details', index: 0},
+            subject: {enabled: true, group: 'details', index: 1},
+            definition_long: {enabled: true, group: 'details', index: 2},
+            internal_note: {enabled: true, group: 'details', index: 3},
+            ednote: {enabled: false},
+        },
+        groups: {
+            main: {_id: 'main', name: 'Main', index: 0},
+            details: {_id: 'details', name: 'Details', index: 1, useToggleBox: true},
+        },
+    };
+
     astore.initialState.planning.plannings.p2.original_creator =
         astore.initialState.users[0];
     astore.initialState.main.previewId = 'e1';
@@ -121,11 +148,11 @@ describe('<EventPreviewContent />', () => {
         verifyDataRow(dataRows.at(5), 'Calendars:', 'Sport');
         verifyDataRow(dataRows.at(6), 'Places:', 'ACT');
 
-        let eventDetails = wrapper.find('.toggle-box').first();
+        const eventDetails = wrapper.find('[data-test-id="toggle-details"]').first();
 
         eventDetails.find('.toggle-box__header').simulate('click');
 
-        const eventDetailRows = wrapper.find('.toggle-box').first()
+        const eventDetailRows = wrapper.find('[data-test-id="toggle-details"]').first()
             .find('.toggle-box__content')
             .find('.form__row');
 
@@ -141,20 +168,20 @@ describe('<EventPreviewContent />', () => {
                 .trim()
         ).toBe(`${storeContact.first_name} ${storeContact.last_name}`);
 
-        let files = wrapper.find('.toggle-box').at(1);
+        let files = wrapper.find('[data-test-id="field-files"]').first();
 
         files.find('.toggle-box__header').simulate('click');
-        files = wrapper.find('.toggle-box').at(1);
+        files = wrapper.find('[data-test-id="field-files"]').first();
 
         const file = files.find(FileInput).first();
         const fileValue = file.find('a').first();
 
         expect(fileValue.text()).toContain('file1.jpg  (1kB)');
 
-        let links = wrapper.find('.toggle-box').at(2);
+        let links = wrapper.find('[data-test-id="field-links"]').first();
 
         links.find('.toggle-box__header').simulate('click');
-        links = wrapper.find('.toggle-box').at(2);
+        links = wrapper.find('[data-test-id="field-links"]').first();
 
         const link = links.find(LinkInput).first();
         const linkLabel = link.find('label').first();

--- a/client/components/Planning/PlanningPreviewContent.tsx
+++ b/client/components/Planning/PlanningPreviewContent.tsx
@@ -14,7 +14,6 @@ import {
     IPlanningItem,
     IPlanningNewsCoverageStatus,
     ISession,
-    PREVIEW_PANEL,
 } from '../../interfaces';
 
 import {eventUtils, getCreator, getFileDownloadURL} from '../../utils';
@@ -28,13 +27,12 @@ import {
     StateLabel,
     Label,
 } from '../index';
-import {ToggleBox} from '../UI';
-import {FileInput} from '../UI/Form';
 import {CoveragePreview} from '../Coverages';
 import {ContentBlock} from '../UI/SidePanel';
 import {EventMetadata} from '../Events';
 import {FeatureLabel} from './FeaturedPlanning';
-import {previewGroupToProfile, renderGroupedFieldsForPanel} from '../fields';
+import {renderProfileGroupedFields} from '../fields';
+import {PreviewFieldFiles} from '../fields/preview/Files';
 import {getRelatedEventIdsForPlanning} from '../../utils/planning';
 import {coverageProfiles} from '../../selectors/coverageProfiles';
 import {getCoverageFields} from '../../api/editor/item_planning';
@@ -161,6 +159,75 @@ export class PlanningPreviewContentComponent extends React.PureComponent<IProps>
         const primaryEventId = getRelatedEventIdsForPlanning(this.props.item, 'primary')[0];
         const primaryRelatedEvent = (relatedEvents ?? []).find((relatedEvent) => relatedEvent._id === primaryEventId);
 
+        // These sections follow the profile's group order, same as the editor
+        const fallbackSectionOrder = {attachments: 0, coverages: 1, associated_event: 2};
+        const profileGroups = formProfile?.planning?.groups ?? {};
+        const sectionOrder = (groupId: keyof typeof fallbackSectionOrder): number => (
+            profileGroups[groupId]?.index ?? (fallbackSectionOrder[groupId] + 1000)
+        );
+        const bottomSections = [
+            {
+                id: 'attachments' as const,
+                node: (
+                    <PreviewFieldFiles
+                        item={item}
+                        profile={formProfile?.planning}
+                        testId="field-files"
+                    />
+                ),
+            },
+            {
+                id: 'coverages' as const,
+                node: !hasCoverage ? null : (
+                    <>
+                        {currentCoverage == null ? (
+                            <>
+                                <h3 className="side-panel__heading--big">{gettext('Coverages')}</h3>
+                                {otherCoverages.map((coverage, i) => (
+                                    <CoveragesPreview key={i} coverage={coverage} index={i} />
+                                ))}
+                            </>
+                        ) : (
+                            <>
+                                <h3 className="side-panel__heading--big">{gettext('This Coverage')}</h3>
+                                <CoveragesPreview coverage={currentCoverage} index={0} />
+
+                                {(otherCoverages ?? []).length > 0 && (
+                                    <>
+                                        <h3 className="side-panel__heading--big">{gettext('Other Coverages')}</h3>
+                                        {otherCoverages.map((coverage, i) => (
+                                            <CoveragesPreview key={i} coverage={coverage} index={i} />
+                                        ))}
+                                    </>
+                                )}
+                            </>
+                        )}
+                    </>
+                ),
+            },
+            {
+                id: 'associated_event' as const,
+                node: (hideRelatedItems || (relatedEvents?.length ?? 0) < 1) ? null : (
+                    <>
+                        <h3 className="side-panel__heading--big">
+                            {gettext('Related Events')}
+                        </h3>
+                        {relatedEvents.map((relatedEvent) => (
+                            <EventMetadata
+                                key={`related_event--${relatedEvent._id}`}
+                                event={relatedEvent}
+                                dateOnly={true}
+                                onEditEvent={onEditEvent.bind(null, relatedEvent)}
+                                createUploadLink={getFileDownloadURL}
+                                files={files}
+                                hideEditIcon={hideEditIcon}
+                            />
+                        ))}
+                    </>
+                ),
+            },
+        ].sort((a, b) => sectionOrder(a.id) - sectionOrder(b.id));
+
         return (
             <ContentBlock noPadding={noPadding}>
                 <div className="side-panel__content-block--flex">
@@ -192,85 +259,31 @@ export class PlanningPreviewContentComponent extends React.PureComponent<IProps>
                         <FeatureLabel item={item} />
                     </div>
                 </div>
-                {renderGroupedFieldsForPanel(
+                {renderProfileGroupedFields(
                     'form-preview',
-                    previewGroupToProfile(PREVIEW_PANEL.PLANNING, formProfile?.planning),
+                    formProfile?.planning,
                     {
                         item: item,
                         language: item.language ?? getUserInterfaceLanguageFromCV(),
                         renderEmpty: true,
-                        schema: formProfile?.planning.schema,
+                        schema: formProfile?.planning?.schema,
                         profile: formProfile?.planning,
                     },
                     {},
+                    [
+                        'coverages',
+                        'associated_event',
+                        'related_plannings',
+                        'overide_auto_assign_to_workflow',
+                        'add_coverage_to_workflow',
+                        'files',
+                    ],
                 )}
-                {get(formProfile, 'planning.editor.files.enabled') && (
-                    <ToggleBox
-                        title={gettext('Attached Files')}
-                        isOpen={false}
-                        badgeValue={get(item, 'files.length', 0) > 0 ? item.files.length : null}
-                    >
-                        {get(item, 'files.length') > 0 ? (
-                            <ul>
-                                {get(item, 'files', []).map((file, index) => (
-                                    <li key={index}>
-                                        <FileInput
-                                            value={file}
-                                            createLink={getFileDownloadURL}
-                                            readOnly={true}
-                                            files={files}
-                                        />
-                                    </li>
-                                ))}
-                            </ul>
-                        ) :
-                            <span className="sd-text__info">{gettext('No attached files added.')}</span>}
-                    </ToggleBox>
-                )}
-                {!hideRelatedItems && (relatedEvents?.length ?? 0) > 0 && (
-                    <>
-                        <h3 className="side-panel__heading--big">
-                            {gettext('Associated Events')}
-                        </h3>
-                        {relatedEvents.map((relatedEvent) => (
-                            <EventMetadata
-                                key={`related_event--${relatedEvent._id}`}
-                                event={relatedEvent}
-                                dateOnly={true}
-                                onEditEvent={onEditEvent.bind(null, relatedEvent)}
-                                createUploadLink={getFileDownloadURL}
-                                files={files}
-                                hideEditIcon={hideEditIcon}
-                            />
-                        ))}
-                    </>
-                )}
-                {hasCoverage && (
-                    <>
-                        {currentCoverage == null ? (
-                            <>
-                                <h3 className="side-panel__heading--big">{gettext('Coverages')}</h3>
-                                {otherCoverages.map((coverage, i) => (
-                                    <CoveragesPreview key={i} coverage={coverage} index={i} />
-                                ))}
-                            </>
-                        ) : (
-                            <>
-                                <h3 className="side-panel__heading--big">{gettext('This Coverage')}</h3>
-                                <CoveragesPreview coverage={currentCoverage} index={0} />
-
-                                {(otherCoverages ?? []).length > 0 && (
-                                    <>
-                                        <h3 className="side-panel__heading--big">{gettext('Other Coverages')}</h3>
-                                        {otherCoverages.map((coverage, i) => (
-                                            <CoveragesPreview key={i} coverage={coverage} index={i} />
-                                        ))}
-                                    </>
-                                )}
-                            </>
-                        )}
-                    </>
-                )}
+                {bottomSections.map((section) => (
+                    <React.Fragment key={section.id}>
+                        {section.node}
+                    </React.Fragment>
+                ))}
             </ContentBlock>
         );
     }

--- a/client/components/Planning/PlanningPreviewContent.tsx
+++ b/client/components/Planning/PlanningPreviewContent.tsx
@@ -56,7 +56,7 @@ interface IReduxProps {
     lockedItems: ILockedItems;
     formProfile: IFormProfiles;
     newsCoverageStatus: Array<IPlanningNewsCoverageStatus>;
-    files: Array<IFile>;
+    files: {[key: string]: IFile};
     coverageProfiles: Array<ICoverageContentProfile>;
 }
 

--- a/client/components/Planning/tests/PlanningPreviewContent_test.tsx
+++ b/client/components/Planning/tests/PlanningPreviewContent_test.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import {mount} from 'enzyme';
+import {Provider} from 'react-redux';
+
+import {PlanningPreviewContent} from '../PlanningPreviewContent';
+import {getTestActionStore} from '../../../utils/testUtils';
+import {createTestStore} from '../../../utils';
+
+describe('<PlanningPreviewContent />', () => {
+    // p2 has both a coverage and a related event
+    const getWrapper = (profileOverrides = {}) => {
+        const astore = getTestActionStore();
+
+        astore.init();
+        astore.initialState.main.previewId = 'p2';
+        astore.initialState.main.previewType = 'planning';
+        astore.initialState.forms.profiles.planning = {
+            ...astore.initialState.forms.profiles.planning,
+            editor: {
+                ...astore.initialState.forms.profiles.planning.editor,
+                files: {enabled: true},
+            },
+            ...profileOverrides,
+        };
+
+        const store = createTestStore({initialState: astore.initialState});
+
+        return mount(
+            <Provider store={store}>
+                <PlanningPreviewContent item={astore.initialState.planning.plannings.p2} />
+            </Provider>
+        );
+    };
+
+    const getSectionPositions = (wrapper) => {
+        const html = wrapper.html();
+
+        return {
+            files: html.indexOf('data-test-id="field-files"'),
+            coverages: html.indexOf('Coverages'),
+            relatedEvents: html.indexOf('Related Events'),
+        };
+    };
+
+    it('renders bottom sections in default order: attached files, coverages, related events', () => {
+        const positions = getSectionPositions(getWrapper());
+
+        expect(positions.files).toBeGreaterThan(-1);
+        expect(positions.coverages).toBeGreaterThan(positions.files);
+        expect(positions.relatedEvents).toBeGreaterThan(positions.coverages);
+    });
+
+    it('orders bottom sections by the profile group indexes when configured', () => {
+        const positions = getSectionPositions(getWrapper({
+            groups: {
+                coverages: {_id: 'coverages', name: 'Coverages', index: 1},
+                associated_event: {_id: 'associated_event', name: 'Associated Event', index: 2},
+                attachments: {_id: 'attachments', name: 'Attachments', index: 3},
+            },
+        }));
+
+        expect(positions.coverages).toBeGreaterThan(-1);
+        expect(positions.relatedEvents).toBeGreaterThan(positions.coverages);
+        expect(positions.files).toBeGreaterThan(positions.relatedEvents);
+    });
+});

--- a/client/components/Planning/tests/PlanningPreviewContent_test.tsx
+++ b/client/components/Planning/tests/PlanningPreviewContent_test.tsx
@@ -54,7 +54,7 @@ describe('<PlanningPreviewContent />', () => {
         const positions = getSectionPositions(getWrapper({
             groups: {
                 coverages: {_id: 'coverages', name: 'Coverages', index: 1},
-                associated_event: {_id: 'associated_event', name: 'Associated Event', index: 2},
+                associated_event: {_id: 'associated_event', name: 'Related Events', index: 2},
                 attachments: {_id: 'attachments', name: 'Attachments', index: 3},
             },
         }));

--- a/client/components/UI/FileReadOnlyList.tsx
+++ b/client/components/UI/FileReadOnlyList.tsx
@@ -22,6 +22,7 @@ interface IProps {
     files: Array<IFile>;
     field?: string;
     noToggle: boolean;
+    testId?: string;
 }
 
 export default class FileReadOnlyList extends React.PureComponent<IProps> {
@@ -70,6 +71,7 @@ export default class FileReadOnlyList extends React.PureComponent<IProps> {
 
         return (
             <ToggleBox
+                testId={this.props.testId}
                 title={gettext('Attached Files')}
                 isOpen={false}
                 badgeValue={get(item, `${field}.length`, 0) > 0 ? item[field].length : null}

--- a/client/components/UI/FileReadOnlyList.tsx
+++ b/client/components/UI/FileReadOnlyList.tsx
@@ -19,7 +19,9 @@ interface IProps {
     formProfile?: IEventFormProfile | IPlanningFormProfile | ICoverageFormProfile;
     item: IEventItem | IPlanningItem | IPlanningCoverageItem;
     createLink(file: IFile): string;
-    files: Array<IFile>;
+
+    // The files store keeps an object keyed by file id
+    files: {[key: string]: IFile};
     field?: string;
     noToggle: boolean;
     testId?: string;

--- a/client/components/UI/Form/InputArray/index.tsx
+++ b/client/components/UI/Form/InputArray/index.tsx
@@ -149,7 +149,7 @@ export class InputArray extends React.PureComponent<IProps> {
         const hasLabel = (label ?? '').length > 0;
         const addButtonElement = showAddButton && addButton;
         const labelElement = !hasLabel ? null : (
-            <Spacer h gap="0" justifyContent="space-between" alignItems="center" noWrap style={{paddingBlockStart: 8}}>
+            <Spacer h gap="0" justifyContent="space-between" alignItems="center" noWrap>
                 <div className={classNames('InputArray__label', labelClassName)}>{label}</div>
                 <div>
                     {buttonWithLabel && addButtonElement}

--- a/client/components/UI/Preview/ExpandableText.tsx
+++ b/client/components/UI/Preview/ExpandableText.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {get} from 'lodash';
 
 import {gettext} from '../../../utils';
 
@@ -26,31 +25,56 @@ export class ExpandableText extends React.Component {
         this.dom.parent = ref;
     }
 
+    truncate(lines) {
+        const {expandAt, expandAtChars} = this.props;
+        const truncated = [];
+        let charsUsed = 0;
+
+        for (const line of lines) {
+            if (truncated.length >= expandAt || charsUsed >= expandAtChars) {
+                break;
+            }
+
+            const charsRemaining = expandAtChars - charsUsed;
+
+            truncated.push(line.length > charsRemaining ? line.slice(0, charsRemaining) : line);
+            charsUsed += Math.min(line.length, charsRemaining);
+        }
+
+        return truncated;
+    }
+
     render() {
-        const {value, className, expandAt} = this.props;
+        const {value, className, expandAt, expandAtChars} = this.props;
         const {expanded} = this.state;
 
         if (!value) {
             return null;
         }
 
-        let text = value.replace(/\r/g, '')
+        const lines = value.replace(/\r/g, '')
             .split('\n');
 
-        if (get(text, 'length', 0) > expandAt) {
-            if (!expanded) {
-                text = text.slice(0, expandAt);
-            }
+        // Count visible characters like truncate() does, so the link never appears when nothing is hidden
+        const contentLength = lines.reduce((total, line) => total + line.length, 0);
+        const needsTruncation = lines.length > expandAt || contentLength > expandAtChars;
+        let text = lines;
 
+        if (needsTruncation) {
             const linkText = expanded ?
                 gettext('Show less') :
                 gettext('Show all');
 
-            text.push(
-                <a className="sd-text__expandable-link" onClick={this.toggleExpanded}>
+            text = [
+                ...(expanded ? lines : this.truncate(lines)),
+                <a
+                    key="expandable-link"
+                    className="sd-text__expandable-link"
+                    onClick={this.toggleExpanded}
+                >
                     ... {linkText}
-                </a>
-            );
+                </a>,
+            ];
         }
 
         return (
@@ -67,8 +91,10 @@ ExpandableText.propTypes = {
     value: PropTypes.string,
     className: PropTypes.string,
     expandAt: PropTypes.number,
+    expandAtChars: PropTypes.number,
 };
 
 ExpandableText.defaultProps = {
     expandAt: 3,
+    expandAtChars: 500,
 };

--- a/client/components/UI/Preview/ExpandableText.tsx
+++ b/client/components/UI/Preview/ExpandableText.tsx
@@ -70,7 +70,16 @@ export class ExpandableText extends React.Component {
                 <a
                     key="expandable-link"
                     className="sd-text__expandable-link"
+                    role="button"
+                    tabIndex={0}
+                    aria-expanded={expanded}
                     onClick={this.toggleExpanded}
+                    onKeyDown={(event) => {
+                        if (event.key === 'Enter' || event.key === ' ') {
+                            event.preventDefault();
+                            this.toggleExpanded();
+                        }
+                    }}
                 >
                     ... {linkText}
                 </a>,

--- a/client/components/UI/Preview/ExpandableText_test.tsx
+++ b/client/components/UI/Preview/ExpandableText_test.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import {mount} from 'enzyme';
+
+// Configures the enzyme adapter as an import side effect
+import '../../../utils/testUtils';
+
+import {ExpandableText} from './ExpandableText';
+
+describe('<ExpandableText />', () => {
+    const getLink = (wrapper) => wrapper.find('.sd-text__expandable-link');
+
+    it('does not truncate short values', () => {
+        const wrapper = mount(<ExpandableText value={'short text'} />);
+
+        expect(wrapper.text()).toContain('short text');
+        expect(getLink(wrapper).length).toBe(0);
+    });
+
+    it('truncates values with more lines than expandAt', () => {
+        const wrapper = mount(<ExpandableText value={'one\ntwo\nthree\nfour'} />);
+
+        expect(wrapper.text()).toContain('one');
+        expect(wrapper.text()).toContain('three');
+        expect(wrapper.text()).not.toContain('four');
+        expect(getLink(wrapper).text()).toContain('Show all');
+    });
+
+    it('truncates a single long paragraph by character count', () => {
+        const wrapper = mount(<ExpandableText value={'a'.repeat(600)} />);
+        const text = wrapper.find('p').text();
+
+        expect(text).toContain('a'.repeat(500));
+        expect(text).not.toContain('a'.repeat(501));
+        expect(getLink(wrapper).text()).toContain('Show all');
+    });
+
+    it('does not offer expanding when newlines push the raw length over the limit but no content is hidden', () => {
+        // 500 visible characters over 2 lines: raw length is 501 due to the newline
+        const wrapper = mount(<ExpandableText value={'a'.repeat(250) + '\n' + 'b'.repeat(250)} />);
+
+        expect(getLink(wrapper).length).toBe(0);
+        expect(wrapper.text()).toContain('b'.repeat(250));
+    });
+
+    it('expands and collapses on link click', () => {
+        const wrapper = mount(<ExpandableText value={'b'.repeat(600)} />);
+
+        getLink(wrapper).simulate('click');
+        expect(wrapper.find('p').text()).toContain('b'.repeat(600));
+        expect(getLink(wrapper).text()).toContain('Show less');
+
+        getLink(wrapper).simulate('click');
+        expect(wrapper.find('p').text()).not.toContain('b'.repeat(600));
+        expect(getLink(wrapper).text()).toContain('Show all');
+    });
+});

--- a/client/components/UI/Preview/ExpandableText_test.tsx
+++ b/client/components/UI/Preview/ExpandableText_test.tsx
@@ -42,6 +42,16 @@ describe('<ExpandableText />', () => {
         expect(wrapper.text()).toContain('b'.repeat(250));
     });
 
+    it('expands via keyboard', () => {
+        const wrapper = mount(<ExpandableText value={'c'.repeat(600)} />);
+
+        expect(getLink(wrapper).prop('role')).toBe('button');
+        expect(getLink(wrapper).prop('tabIndex')).toBe(0);
+
+        getLink(wrapper).simulate('keydown', {key: 'Enter'});
+        expect(wrapper.find('p').text()).toContain('c'.repeat(600));
+    });
+
     it('expands and collapses on link click', () => {
         const wrapper = mount(<ExpandableText value={'b'.repeat(600)} />);
 

--- a/client/components/UI/Preview/style.scss
+++ b/client/components/UI/Preview/style.scss
@@ -1,4 +1,10 @@
 .sd-text__expandable-link {
     cursor: pointer;
     user-select: none;
+    color: var(--sd-colour-interactive);
+    text-decoration: underline;
+
+    &:hover {
+        text-decoration: none;
+    }
 }

--- a/client/components/editor-standalone/field-definitions/priority-field.ts
+++ b/client/components/editor-standalone/field-definitions/priority-field.ts
@@ -10,7 +10,7 @@ export const PRIORITY_CONFIG: Omit<IDropdownConfigManualSource, 'options'> = {
     multiple: false,
 };
 
-export const DEFAULT_PRIORITY_COLORS = {
+export const DEFAULT_PRIORITY_COLORS: {[qcode: number]: string} = {
     1: '#d33c44',
     2: '#ff6900',
     3: '#f5a623',

--- a/client/components/fields/PriorityBadge.tsx
+++ b/client/components/fields/PriorityBadge.tsx
@@ -13,7 +13,7 @@ export const PriorityBadge: FunctionComponent<{priority: number | string}> = ({p
     const label = vocabularyItem == null
         ? priority.toString()
         : superdeskApi.entities.vocabulary.getVocabularyItemNameTranslated(vocabularyItem);
-    const backgroundColor = vocabularyItem?.color ?? DEFAULT_PRIORITY_COLORS[priority];
+    const backgroundColor = vocabularyItem?.color ?? DEFAULT_PRIORITY_COLORS[Number(priority)];
 
     if (backgroundColor == null) {
         return <span data-test-id="priority-badge">{label}</span>;

--- a/client/components/fields/PriorityBadge.tsx
+++ b/client/components/fields/PriorityBadge.tsx
@@ -1,0 +1,42 @@
+import React, {FunctionComponent} from 'react';
+import {superdeskApi} from '../../superdeskApi';
+import {DEFAULT_PRIORITY_COLORS} from '../../components/editor-standalone/field-definitions/priority-field';
+import {getTextColor} from 'superdesk-ui-framework/react';
+
+/**
+ * The priority value as a coloured badge, shared by list views and previews.
+ * Falls back to plain text when no colour is configured for the value.
+ */
+export const PriorityBadge: FunctionComponent<{priority: number | string}> = ({priority}) => {
+    const vocabulary = superdeskApi.entities.vocabulary?.getAll()?.get('priority');
+    const vocabularyItem = vocabulary?.items.find(({qcode}) => qcode.toString() === priority.toString());
+    const label = vocabularyItem == null
+        ? priority.toString()
+        : superdeskApi.entities.vocabulary.getVocabularyItemNameTranslated(vocabularyItem);
+    const backgroundColor = vocabularyItem?.color ?? DEFAULT_PRIORITY_COLORS[priority];
+
+    if (backgroundColor == null) {
+        return <span data-test-id="priority-badge">{label}</span>;
+    }
+
+    return (
+        <div style={{display: 'flex', alignItems: 'center'}}>
+            <div
+                data-test-id="priority-badge"
+                style={{
+                    display: 'inline-flex',
+                    justifyContent: 'center',
+                    alignItems: 'center',
+                    height: '1.2em',
+                    minWidth: '1.2em',
+                    paddingInline: 'var(--space--0-5)',
+                    background: backgroundColor,
+                    color: getTextColor(backgroundColor),
+                    borderRadius: 'var(--b-radius--x-small)',
+                }}
+            >
+                {label}
+            </div>
+        </div>
+    );
+};

--- a/client/components/fields/editor/AssociatedEvent.tsx
+++ b/client/components/fields/editor/AssociatedEvent.tsx
@@ -127,8 +127,10 @@ export class EditorFieldAssociatedEventComponent extends React.PureComponent<IAs
                         {events.map((event, i) => (
                             <AssociatedEventItem
                                 index={i}
-                                // Newly added events have a temporary `_id` but no `_etag` yet
-                                key={event._id}
+                                // The `_etag` part forces a remount when the event changes;
+                                // the `_id` part keeps the key defined and unique for newly
+                                // added events, which have no `_etag` yet
+                                key={`${event._id}-${event._etag}`}
                                 event={event}
                                 planningItem={this.props.item}
                                 updateEventItem={(item, updates, scrollOnChange) =>

--- a/client/components/fields/editor/AssociatedEvent.tsx
+++ b/client/components/fields/editor/AssociatedEvent.tsx
@@ -127,7 +127,8 @@ export class EditorFieldAssociatedEventComponent extends React.PureComponent<IAs
                         {events.map((event, i) => (
                             <AssociatedEventItem
                                 index={i}
-                                key={event._etag}
+                                // Newly added events have a temporary `_id` but no `_etag` yet
+                                key={event._id}
                                 event={event}
                                 planningItem={this.props.item}
                                 updateEventItem={(item, updates, scrollOnChange) =>

--- a/client/components/fields/editor/Coverages.tsx
+++ b/client/components/fields/editor/Coverages.tsx
@@ -12,6 +12,7 @@ import {
 } from '../../../interfaces';
 
 import {CoverageArrayInput} from '../../Coverages';
+import {Row} from '../../UI/Form';
 import {getFileDownloadURL} from '../../../utils';
 import {IPropsEditorFieldCoverages} from './coverages.interface';
 
@@ -157,15 +158,18 @@ export class EditorFieldCoverages extends React.PureComponent<IPropsEditorFieldC
         const {gettext} = superdeskApi.localization;
 
         return (
-            <CoverageArrayInput
-                {...this.props}
-                testId="field-coverages"
-                field={this.props.field ?? 'coverages'}
-                value={this.getCoverages()}
-                disabled={this.props.disabled}
-                addButtonText={this.props.addButtonText ?? gettext('Add a coverage')}
-                createUploadLink={getFileDownloadURL}
-            />
+            // Standard bottom field spacing; the inner InputArray row is unpadded when there are no errors
+            <Row>
+                <CoverageArrayInput
+                    {...this.props}
+                    testId="field-coverages"
+                    field={this.props.field ?? 'coverages'}
+                    value={this.getCoverages()}
+                    disabled={this.props.disabled}
+                    addButtonText={this.props.addButtonText ?? gettext('Add a coverage')}
+                    createUploadLink={getFileDownloadURL}
+                />
+            </Row>
         );
     }
 }

--- a/client/components/fields/index.tsx
+++ b/client/components/fields/index.tsx
@@ -378,6 +378,9 @@ export function renderProfileFieldsFlat(
 /**
  * Renders panel fields with the profile's field order, groups and toggle boxes,
  * same as the editor. Falls back to flat rendering when the profile has no groups.
+ * `groupNodeOverrides` replaces a whole group with a custom node at the group's
+ * profile position (a null value skips the group); used for bespoke sections
+ * like related plannings.
  */
 export function renderProfileGroupedFields(
     panelType: IRenderPanelType,
@@ -385,6 +388,7 @@ export function renderProfileGroupedFields(
     globalProps: {[key: string]: any},
     fieldProps: {[key: string]: any},
     excludeFields: Array<string> = [],
+    groupNodeOverrides: {[groupId: string]: React.ReactNode} = {},
 ) {
     if (profile?.editor == null) {
         return null;
@@ -394,11 +398,23 @@ export function renderProfileGroupedFields(
     const groupIds = Object.keys(formGroups).sort((a, b) => formGroups[a].index - formGroups[b].index);
 
     if (groupIds.length === 0) {
-        return renderProfileFieldsFlat(panelType, profile, globalProps, fieldProps, excludeFields);
+        const flatFields = renderProfileFieldsFlat(panelType, profile, globalProps, fieldProps, excludeFields);
+        const overrideNodes = Object.entries(groupNodeOverrides)
+            .filter(([, node]) => node != null)
+            .map(([groupId, node]) => <React.Fragment key={groupId}>{node}</React.Fragment>);
+
+        // No groups to derive positions from: bespoke sections go after the fields
+        return overrideNodes.length === 0 ? flatFields : [flatFields, ...overrideNodes];
     }
 
     return groupIds
         .map((groupId) => {
+            if (Object.prototype.hasOwnProperty.call(groupNodeOverrides, groupId)) {
+                const node = groupNodeOverrides[groupId];
+
+                return node == null ? null : <React.Fragment key={groupId}>{node}</React.Fragment>;
+            }
+
             const group = formGroups[groupId];
 
             // Fields that render their own toggle box (files, links) must not

--- a/client/components/fields/index.tsx
+++ b/client/components/fields/index.tsx
@@ -9,6 +9,7 @@ import {
     PREVIEW_PANEL,
 } from '../../interfaces';
 import {superdeskApi} from '../../superdeskApi';
+import {getEditorFormGroupsFromProfile, getEnabledProfileFields} from '../../utils/contentProfiles';
 
 import {name} from './name';
 import {slugline} from './slugline';
@@ -28,6 +29,8 @@ import {FIELD_TO_EDITOR_COMPONENT} from './editor';
 import {FIELD_TO_LIST_COMPONENT} from './list';
 
 import {FIELD_TO_FORM_PREVIEW_COMPONENT, FIELD_TO_PREVIEW_COMPONENT} from './preview';
+import {PreviewFieldCustomVocabulary} from './preview/CustomVocabulary';
+import {PreviewFieldCustomTextField} from './preview/CustomTextField';
 
 import {ToggleBox} from '../UI/ToggleBox';
 import './style.scss';
@@ -133,12 +136,13 @@ export function renderFieldsForPanel(
     refs: {[key: string]: React.RefObject<any>} = {},
     schema?: {[key: string]: IProfileSchemaType},
     coverageProfile?: ISearchProfile,
+    addCustomVocabulariesField: boolean = true,
 ) {
     const fieldComponents = getFieldsForPanel(panelType);
     const fields: {[key: string]: IRenderFieldItem} = {};
 
     // Only render custom_vocabularies for preview. Otherwise rendering in editor is done differently
-    if ((panelType === 'simple-preview' || panelType === 'form-preview')) {
+    if ((panelType === 'simple-preview' || panelType === 'form-preview') && addCustomVocabulariesField) {
         const schemes = new Set<string>((globalProps.item?.subject ?? []).map((x) => x.scheme));
 
         if ((schemes.size > 0 || !schemes.has('subject'))) {
@@ -169,6 +173,20 @@ export function renderFieldsForPanel(
 
         if (schema?.[fieldName] != null) {
             newField.props.schema = schema[fieldName];
+        }
+
+        // Custom vocabulary/text fields have no static preview component
+        // (the vocabulary id is the field name), resolve them by schema type
+        if (newField.component == null && (panelType === 'simple-preview' || panelType === 'form-preview')) {
+            const schemaType = schema?.[fieldName]?.type ?? globalProps?.schema?.[fieldName]?.type;
+
+            if (schemaType === 'custom_vocabulary') {
+                newField.component = PreviewFieldCustomVocabulary;
+                newField.props.fieldName = fieldName;
+            } else if (schemaType === 'custom_text') {
+                newField.component = PreviewFieldCustomTextField;
+                newField.props.fieldName = fieldName;
+            }
         }
 
         if (newField.component == null) {
@@ -268,6 +286,159 @@ export function renderGroupedFieldsForPanel(
 
         return null;
     })
+        .filter((group) => group != null);
+}
+
+/**
+ * Returns `fieldProps` pointing custom vocabulary/text fields at their
+ * value arrays (`subject` / `fields`) under `basePath`.
+ */
+export function getCustomFieldSourcePaths(
+    profile,
+    basePath: string,
+): {[key: string]: {field: string}} {
+    const fieldProps: {[key: string]: {field: string}} = {};
+
+    Object.keys(profile?.schema ?? {}).forEach((fieldName) => {
+        const fieldType = profile.schema[fieldName]?.type;
+
+        if (fieldType === 'custom_vocabulary') {
+            fieldProps[fieldName] = {field: `${basePath}.subject`};
+        } else if (fieldType === 'custom_text') {
+            fieldProps[fieldName] = {field: `${basePath}.fields`};
+        }
+    });
+
+    return fieldProps;
+}
+
+function renderProfileFieldsInOrder(
+    panelType: IRenderPanelType,
+    fieldNames: Array<string>,
+    globalProps: {[key: string]: any},
+    fieldProps: {[key: string]: any},
+    excludeFields: Array<string>,
+) {
+    const orderedProfile: ISearchProfile = {};
+
+    fieldNames
+        .filter((fieldName) => !excludeFields.includes(fieldName))
+        .forEach((fieldName, index) => {
+            orderedProfile[fieldName] = {enabled: true, index: index};
+        });
+
+    if (Object.keys(orderedProfile).length === 0) {
+        return null;
+    }
+
+    return renderFieldsForPanel(
+        panelType,
+        orderedProfile,
+        globalProps,
+        fieldProps,
+        undefined,
+        undefined,
+        'enabled',
+        {},
+        undefined,
+        undefined,
+        false, // CVs render as individual fields, not the combined block
+    );
+}
+
+/**
+ * Renders panel fields flat, in profile field order, without group containers.
+ * Matches the coverage editor (which ignores groups), for coverage based previews.
+ */
+export function renderProfileFieldsFlat(
+    panelType: IRenderPanelType,
+    profile,
+    globalProps: {[key: string]: any},
+    fieldProps: {[key: string]: any},
+    excludeFields: Array<string> = [],
+) {
+    if (profile?.editor == null) {
+        return null;
+    }
+
+    // Sorted copy: getGroupFieldsSorted() would re-index the store profile in place
+    const fieldNames = getEnabledProfileFields(profile)
+        .sort((a, b) => a.field.index - b.field.index)
+        .map((entry) => entry.name);
+
+    return renderProfileFieldsInOrder(
+        panelType,
+        fieldNames,
+        globalProps,
+        fieldProps,
+        excludeFields,
+    );
+}
+
+/**
+ * Renders panel fields with the profile's field order, groups and toggle boxes,
+ * same as the editor. Falls back to flat rendering when the profile has no groups.
+ */
+export function renderProfileGroupedFields(
+    panelType: IRenderPanelType,
+    profile,
+    globalProps: {[key: string]: any},
+    fieldProps: {[key: string]: any},
+    excludeFields: Array<string> = [],
+) {
+    if (profile?.editor == null) {
+        return null;
+    }
+
+    const formGroups = getEditorFormGroupsFromProfile(profile);
+    const groupIds = Object.keys(formGroups).sort((a, b) => formGroups[a].index - formGroups[b].index);
+
+    if (groupIds.length === 0) {
+        return renderProfileFieldsFlat(panelType, profile, globalProps, fieldProps, excludeFields);
+    }
+
+    return groupIds
+        .map((groupId) => {
+            const group = formGroups[groupId];
+
+            // Fields that render their own toggle box (files, links) must not
+            // nest it inside the group's toggle box
+            const fieldPropsForGroup = !group.useToggleBox ? fieldProps : group.fields.reduce(
+                (acc, fieldName) => {
+                    acc[fieldName] = {...fieldProps[fieldName], noToggle: true};
+
+                    return acc;
+                },
+                {...fieldProps},
+            );
+
+            const renderedFields = renderProfileFieldsInOrder(
+                panelType,
+                group.fields,
+                globalProps,
+                fieldPropsForGroup,
+                excludeFields,
+            );
+
+            if (renderedFields == null) {
+                return null;
+            }
+
+            return group.useToggleBox ? (
+                <ToggleBox
+                    key={groupId}
+                    isOpen={false}
+                    title={group.title}
+                    testId={`toggle-${groupId}`}
+                >
+                    {renderedFields}
+                </ToggleBox>
+            ) : (
+                <div key={groupId} data-test-id={`preview-group__${groupId}`}>
+                    {renderedFields}
+                </div>
+            );
+        })
         .filter((group) => group != null);
 }
 

--- a/client/components/fields/index_test.tsx
+++ b/client/components/fields/index_test.tsx
@@ -1,0 +1,124 @@
+import {renderProfileGroupedFields, renderProfileFieldsFlat} from './index';
+import {ToggleBox} from '../UI/ToggleBox';
+
+describe('profile driven field rendering', () => {
+    // A fresh profile per test: rendering sorts and re-indexes fields in place
+    const getProfile = () => ({
+        editor: {
+            name: {enabled: true, group: 'main', index: 0},
+            slugline: {enabled: true, group: 'main', index: 1},
+            ednote: {enabled: true, group: 'details', index: 2},
+            internal_note: {enabled: false, group: 'details', index: 3},
+            headline: {enabled: true, index: 4}, // enabled, but not part of any group
+        },
+        schema: {},
+        groups: {
+            main: {_id: 'main', name: 'Main', index: 0},
+            details: {_id: 'details', name: 'Details', index: 1, useToggleBox: true},
+        },
+    });
+
+    const globalProps = {item: {}, language: 'en', renderEmpty: true};
+    const getFieldKeys = (children) => children.map((child) => child.key);
+
+    describe('renderProfileGroupedFields', () => {
+        it('renders groups in profile order, with fields in editor order', () => {
+            const groups: any = renderProfileGroupedFields('form-preview', getProfile(), globalProps, {});
+
+            expect(groups.length).toBe(2);
+
+            expect(groups[0].type).toBe('div');
+            expect(groups[0].key).toBe('main');
+            expect(getFieldKeys(groups[0].props.children)).toEqual(['name-0', 'slugline-1']);
+
+            expect(groups[1].type).toBe(ToggleBox);
+            expect(groups[1].key).toBe('details');
+            expect(groups[1].props.title).toBe('Details');
+            expect(groups[1].props.isOpen).toBe(false);
+            expect(getFieldKeys(groups[1].props.children)).toEqual(['ednote-0']);
+        });
+
+        it('skips excluded fields, dropping groups left empty', () => {
+            const groups: any = renderProfileGroupedFields(
+                'form-preview', getProfile(), globalProps, {}, ['ednote'],
+            );
+
+            expect(groups.length).toBe(1);
+            expect(groups[0].key).toBe('main');
+        });
+
+        it('falls back to flat rendering when the profile defines no groups', () => {
+            const profile = {...getProfile(), groups: {}};
+            const fields: any = renderProfileGroupedFields('form-preview', profile, globalProps, {});
+
+            expect(getFieldKeys(fields)).toEqual(['name-0', 'slugline-1', 'ednote-2', 'headline-3']);
+        });
+
+        it('marks fields inside toggle box groups with noToggle to prevent nested toggles', () => {
+            const profile = {
+                editor: {
+                    files: {enabled: true, group: 'attachments', index: 0},
+                    slugline: {enabled: true, group: 'main', index: 0},
+                },
+                schema: {},
+                groups: {
+                    main: {_id: 'main', name: 'Main', index: 0},
+                    attachments: {_id: 'attachments', name: 'Attachments', index: 1, useToggleBox: true},
+                },
+            };
+            const groups: any = renderProfileGroupedFields('form-preview', profile, globalProps, {});
+
+            expect(groups[0].props.children[0].props.noToggle).toBeUndefined();
+            expect(groups[1].type).toBe(ToggleBox);
+            expect(groups[1].props.children[0].props.noToggle).toBe(true);
+        });
+
+        it('renders the priority field at its profile position in a non-toggle group', () => {
+            // Priority as an integer field inside a plain group, like real planning profiles
+            const profile = {
+                editor: {
+                    description_text: {enabled: true, group: 'description', index: 0},
+                    priority: {enabled: true, group: 'description', index: 1},
+                    internal_note: {enabled: true, group: 'description', index: 2},
+                },
+                schema: {priority: {type: 'integer', required: false}},
+                groups: {
+                    description: {_id: 'description', name: 'Description', index: 0, useToggleBox: false},
+                },
+            };
+            const groups: any = renderProfileGroupedFields(
+                'form-preview', profile, {item: {priority: 2}, language: 'en', renderEmpty: true}, {},
+            );
+
+            expect(groups.length).toBe(1);
+            expect(getFieldKeys(groups[0].props.children))
+                .toEqual(['description_text-0', 'priority-1', 'internal_note-2']);
+        });
+
+        it('returns null for a profile without an editor config', () => {
+            expect(renderProfileGroupedFields('form-preview', null, globalProps, {})).toBe(null);
+            expect(renderProfileGroupedFields('form-preview', {}, globalProps, {})).toBe(null);
+        });
+    });
+
+    describe('renderProfileFieldsFlat', () => {
+        it('renders enabled fields flat in profile order, ignoring groups', () => {
+            const fields: any = renderProfileFieldsFlat('form-preview', getProfile(), globalProps, {});
+
+            expect(getFieldKeys(fields)).toEqual(['name-0', 'slugline-1', 'ednote-2', 'headline-3']);
+        });
+
+        it('skips excluded fields', () => {
+            const fields: any = renderProfileFieldsFlat(
+                'form-preview', getProfile(), globalProps, {}, ['ednote', 'headline'],
+            );
+
+            expect(getFieldKeys(fields)).toEqual(['name-0', 'slugline-1']);
+        });
+
+        it('returns null when the profile has no editor config', () => {
+            expect(renderProfileFieldsFlat('form-preview', null, globalProps, {})).toBe(null);
+            expect(renderProfileFieldsFlat('form-preview', {}, globalProps, {})).toBe(null);
+        });
+    });
+});

--- a/client/components/fields/index_test.tsx
+++ b/client/components/fields/index_test.tsx
@@ -99,6 +99,48 @@ describe('profile driven field rendering', () => {
             expect(renderProfileGroupedFields('form-preview', null, globalProps, {})).toBe(null);
             expect(renderProfileGroupedFields('form-preview', {}, globalProps, {})).toBe(null);
         });
+
+        it('renders group node overrides at the group profile position', () => {
+            const profile = {
+                ...getProfile(),
+                editor: {
+                    ...getProfile().editor,
+                    related_plannings: {enabled: true, group: 'related', index: 0},
+                },
+                groups: {
+                    related: {_id: 'related', name: 'Related', index: 0},
+                    main: {_id: 'main', name: 'Main', index: 1},
+                    details: {_id: 'details', name: 'Details', index: 2, useToggleBox: true},
+                },
+            };
+            const overrideNode = 'override-content';
+            const groups: any = renderProfileGroupedFields(
+                'form-preview', profile, globalProps, {}, [], {related: overrideNode},
+            );
+
+            expect(groups.length).toBe(3);
+            expect(groups[0].key).toBe('related');
+            expect(groups[0].props.children).toBe(overrideNode);
+            expect(groups[1].key).toBe('main');
+
+            // A null override skips the group entirely
+            const withoutSection: any = renderProfileGroupedFields(
+                'form-preview', profile, globalProps, {}, [], {related: null},
+            );
+
+            expect(withoutSection.map((group) => group.key)).toEqual(['main', 'details']);
+        });
+
+        it('appends group node overrides after the fields when the profile has no groups', () => {
+            const profile = {...getProfile(), groups: {}};
+            const rendered: any = renderProfileGroupedFields(
+                'form-preview', profile, globalProps, {}, [], {related: 'override-content'},
+            );
+
+            expect(rendered.length).toBe(2);
+            expect(rendered[1].key).toBe('related');
+            expect(rendered[1].props.children).toBe('override-content');
+        });
     });
 
     describe('renderProfileFieldsFlat', () => {

--- a/client/components/fields/preview/CustomTextField.tsx
+++ b/client/components/fields/preview/CustomTextField.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react';
+import {get} from 'lodash';
+
+import {IListFieldProps} from '../../../interfaces';
+import {superdeskApi} from '../../../superdeskApi';
+
+import {PreviewFormItem} from './base/PreviewFormItem';
+
+interface IProps extends IListFieldProps {
+    fieldName: string;
+    testId?: string;
+    renderEmpty?: boolean;
+}
+
+/**
+ * Generic preview for a custom text field (field name == vocabulary id).
+ * `field`, when provided, points to a coverage style `fields` array
+ * (`[{field, value}]`); otherwise the value is read from `item[fieldName]`.
+ */
+export const PreviewFieldCustomTextField: React.FunctionComponent<IProps> = (props) => {
+    const {item, language, fieldName} = props;
+    const vocabulary = superdeskApi.entities.vocabulary.getVocabulary(fieldName);
+
+    if (vocabulary == null) {
+        return null;
+    }
+
+    let value: string | undefined;
+
+    if (props.field != null) {
+        const fieldsArray = get(item, props.field);
+
+        value = Array.isArray(fieldsArray) ?
+            fieldsArray.find((entry) => entry.field === fieldName)?.value :
+            undefined;
+    } else {
+        value = get(item, fieldName);
+    }
+
+    return (
+        <PreviewFormItem
+            testId={props.testId}
+            label={vocabulary.translations?.display_name?.[language] ?? vocabulary.display_name}
+            light={true}
+            value={value}
+            renderEmpty={props.renderEmpty}
+            convertNewlineToBreak={true}
+        />
+    );
+};

--- a/client/components/fields/preview/CustomVocabulary.tsx
+++ b/client/components/fields/preview/CustomVocabulary.tsx
@@ -1,0 +1,76 @@
+import * as React from 'react';
+import {get} from 'lodash';
+
+import {IListFieldProps} from '../../../interfaces';
+import {superdeskApi} from '../../../superdeskApi';
+
+import {Tag} from 'superdesk-ui-framework/react';
+import {PreviewFormItem} from './base/PreviewFormItem';
+import {getVocabularyItemFieldTranslated} from '../../../utils/vocabularies';
+
+interface IProps extends IListFieldProps {
+    fieldName: string;
+    testId?: string;
+    renderEmpty?: boolean;
+}
+
+/**
+ * Generic preview for a custom vocabulary field (field name == vocabulary id).
+ * `field` is the path to the subject array within the item, defaults to `subject`.
+ */
+export const PreviewFieldCustomVocabulary: React.FunctionComponent<IProps> = (props) => {
+    const {item, language, fieldName} = props;
+    const vocabulary = superdeskApi.entities.vocabulary.getVocabulary(fieldName);
+
+    if (vocabulary == null) {
+        return null;
+    }
+
+    const values = (get(item, props.field ?? 'subject') ?? [])
+        .filter((entry) => entry.scheme === fieldName);
+    const label = vocabulary.translations?.display_name?.[language] ?? vocabulary.display_name;
+
+    if (values.length === 0) {
+        return (
+            <PreviewFormItem
+                testId={props.testId}
+                label={label}
+                light={true}
+                renderEmpty={props.renderEmpty}
+            />
+        );
+    }
+
+    const names: Array<string> = values
+        .map((entry) => getVocabularyItemFieldTranslated(entry, 'name', language) || entry.name);
+
+    if (vocabulary.selection_type !== 'multi selection') {
+        return (
+            <PreviewFormItem
+                testId={props.testId}
+                label={label}
+                light={true}
+                value={names.join(', ')}
+            />
+        );
+    }
+
+    return (
+        <PreviewFormItem
+            testId={props.testId}
+            label={label}
+            light={true}
+            renderEmpty={true}
+        >
+            <div style={{display: 'flex', flexWrap: 'wrap', gap: 'var(--space--0-5)'}}>
+                {names.map((name, index) => (
+                    <Tag
+                        key={index}
+                        text={name}
+                        readOnly={true}
+                    />
+                ))}
+            </div>
+        </PreviewFormItem>
+    );
+};

--- a/client/components/fields/preview/CustomVocabulary_test.tsx
+++ b/client/components/fields/preview/CustomVocabulary_test.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import {mount} from 'enzyme';
+
+// Configures the enzyme adapter as an import side effect
+import '../../../utils/testUtils';
+
+import {superdeskApi} from '../../../superdeskApi';
+import {PreviewFieldCustomVocabulary} from './CustomVocabulary';
+
+describe('<PreviewFieldCustomVocabulary />', () => {
+    const item = {
+        subject: [
+            {qcode: '01000000', name: 'arts and entertainment', scheme: 'topics'},
+            {qcode: '02000000', name: 'crime and justice', scheme: 'topics'},
+            {qcode: 'other', name: 'other value', scheme: 'another_cv'},
+        ],
+    };
+
+    let originalVocabulary;
+
+    beforeEach(() => {
+        originalVocabulary = superdeskApi.entities.vocabulary;
+    });
+
+    afterEach(() => {
+        Object.assign(superdeskApi.entities, {vocabulary: originalVocabulary});
+    });
+
+    const setVocabulary = (selectionType) => {
+        Object.assign(superdeskApi.entities, {
+            vocabulary: {
+                getVocabulary: (id) => (id !== 'topics' ? null : {
+                    _id: 'topics',
+                    display_name: 'IPTC',
+                    selection_type: selectionType,
+                }),
+            },
+        });
+    };
+
+    it('renders multi selection values as read-only pills', () => {
+        setVocabulary('multi selection');
+        const wrapper = mount(<PreviewFieldCustomVocabulary item={item} fieldName="topics" language="en" />);
+        const pills = wrapper.find('.tag-label');
+
+        expect(pills.length).toBe(2);
+        expect(pills.at(0).text()).toBe('arts and entertainment');
+        expect(pills.at(1).text()).toBe('crime and justice');
+
+        // Read-only: no remove buttons
+        expect(wrapper.find('.tag-label__remove').length).toBe(0);
+    });
+
+    it('renders single selection values as plain text', () => {
+        setVocabulary('single selection');
+        const wrapper = mount(<PreviewFieldCustomVocabulary item={item} fieldName="topics" language="en" />);
+
+        expect(wrapper.find('.tag-label').length).toBe(0);
+        expect(wrapper.text()).toContain('arts and entertainment, crime and justice');
+    });
+
+    it('renders a labelled dash when empty and renderEmpty is set', () => {
+        setVocabulary('multi selection');
+        const wrapper = mount(
+            <PreviewFieldCustomVocabulary
+                item={{subject: []}}
+                fieldName="topics"
+                language="en"
+                renderEmpty={true}
+            />
+        );
+
+        expect(wrapper.text()).toContain('IPTC');
+        expect(wrapper.text()).toContain('-');
+    });
+
+    it('renders nothing when empty without renderEmpty', () => {
+        setVocabulary('multi selection');
+        const wrapper = mount(
+            <PreviewFieldCustomVocabulary item={{subject: []}} fieldName="topics" language="en" />
+        );
+
+        expect(wrapper.isEmptyRender()).toBe(true);
+    });
+});

--- a/client/components/fields/preview/Files.tsx
+++ b/client/components/fields/preview/Files.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import {connect} from 'react-redux';
+
+import {IFile, IListFieldProps} from '../../../interfaces';
+
+import {FileReadOnlyList} from '../../UI';
+import {getFileDownloadURL} from '../../../utils';
+import * as selectors from '../../../selectors';
+
+interface IProps extends IListFieldProps {
+    files: {[key: string]: IFile};
+    testId?: string;
+    noToggle?: boolean; // set when rendered inside a toggle box group
+}
+
+const mapStateToProps = (state) => ({
+    files: selectors.general.files(state),
+});
+
+const PreviewFieldFilesComponent: React.FunctionComponent<IProps> = (props) => (
+    <FileReadOnlyList
+        testId={props.testId}
+        formProfile={props.profile}
+        files={props.files}
+        item={props.item}
+        createLink={getFileDownloadURL}
+        noToggle={props.noToggle ?? false}
+    />
+);
+
+export const PreviewFieldFiles = connect(mapStateToProps)(PreviewFieldFilesComponent);

--- a/client/components/fields/preview/Links.tsx
+++ b/client/components/fields/preview/Links.tsx
@@ -1,0 +1,44 @@
+import * as React from 'react';
+import {get} from 'lodash';
+
+import {IListFieldProps} from '../../../interfaces';
+import {superdeskApi} from '../../../superdeskApi';
+
+import {ToggleBox} from '../../UI';
+import {LinkInput} from '../../UI/Form';
+
+interface IProps extends IListFieldProps {
+    testId?: string;
+    noToggle?: boolean; // set when rendered inside a toggle box group
+}
+
+export const PreviewFieldLinks: React.FunctionComponent<IProps> = (props) => {
+    const {gettext} = superdeskApi.localization;
+    const links: Array<string> = get(props.item, props.field ?? 'links') ?? [];
+
+    const linkList = links.length > 0 ? (
+        <ul>
+            {links.map((link, index) => (
+                <li key={index}>
+                    <LinkInput value={link} readOnly={true} />
+                </li>
+            ))}
+        </ul>
+    ) :
+        <span className="sd-text__info">{gettext('No external links added.')}</span>;
+
+    if (props.noToggle) {
+        return <div data-test-id={props.testId}>{linkList}</div>;
+    }
+
+    return (
+        <ToggleBox
+            testId={props.testId}
+            title={gettext('External Links')}
+            isOpen={false}
+            badgeValue={links.length > 0 ? links.length : null}
+        >
+            {linkList}
+        </ToggleBox>
+    );
+};

--- a/client/components/fields/preview/Location.tsx
+++ b/client/components/fields/preview/Location.tsx
@@ -21,7 +21,8 @@ export class PreviewFieldLocation extends React.PureComponent<IListFieldProps> {
                     value={locations.length ? '' : undefined} // otherwise it won't render in preview
                     {...this.props}
                 >
-                    {locations.map((location) => (
+                    {/* An empty array is truthy, which would suppress the "-" fallback */}
+                    {locations.length === 0 ? null : locations.map((location) => (
                         <div key={location.qcode}>
                             <Location
                                 name={location.name}

--- a/client/components/fields/preview/Location_test.tsx
+++ b/client/components/fields/preview/Location_test.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import {mount} from 'enzyme';
+
+// Configures the enzyme adapter as an import side effect
+import '../../../utils/testUtils';
+
+import {PreviewFieldLocation} from './Location';
+
+describe('<PreviewFieldLocation />', () => {
+    it('renders a dash when empty and renderEmpty is set', () => {
+        const wrapper = mount(<PreviewFieldLocation item={{location: []}} renderEmpty={true} />);
+
+        expect(wrapper.text()).toContain('Location');
+        expect(wrapper.text()).toContain('-');
+    });
+
+    it('renders nothing when empty without renderEmpty', () => {
+        const wrapper = mount(<PreviewFieldLocation item={{location: []}} />);
+
+        expect(wrapper.find('.form__row').length).toBe(0);
+    });
+
+    it('renders the location when set', () => {
+        const wrapper = mount(
+            <PreviewFieldLocation
+                item={{location: [{qcode: 'loc1', name: 'City Hall', formatted_address: 'Main St 1'}]}}
+            />
+        );
+
+        expect(wrapper.text()).toContain('City Hall');
+    });
+});

--- a/client/components/fields/preview/Place.tsx
+++ b/client/components/fields/preview/Place.tsx
@@ -1,0 +1,82 @@
+import * as React from 'react';
+import {connect} from 'react-redux';
+import {get} from 'lodash';
+
+import {IPlace, IListFieldProps} from '../../../interfaces';
+import {superdeskApi} from '../../../superdeskApi';
+
+import {Tag} from 'superdesk-ui-framework/react';
+import {PreviewFormItem} from './base/PreviewFormItem';
+import {getVocabularyItemNames} from '../../../utils/vocabularies';
+import * as selectors from '../../../selectors';
+
+interface IProps extends IListFieldProps {
+    places: Array<IPlace>;
+    testId?: string;
+    renderEmpty?: boolean;
+}
+
+const mapStateToProps = (state) => ({
+    places: selectors.vocabs.locators(state),
+});
+
+/**
+ * Place values render as read-only pills when the `locators` vocabulary
+ * is multi selection (like the editor field), as plain text otherwise.
+ */
+export const PreviewFieldPlaceComponent: React.FunctionComponent<IProps> = (props) => {
+    const {gettext} = superdeskApi.localization;
+    const label = gettext('Places');
+    const names = getVocabularyItemNames(
+        get(props.item, props.field ?? 'place') ?? [],
+        props.places,
+        'qcode',
+        'name',
+        props.language,
+    );
+
+    if (names.length === 0) {
+        return (
+            <PreviewFormItem
+                testId={props.testId}
+                label={label}
+                light={true}
+                renderEmpty={props.renderEmpty}
+            />
+        );
+    }
+
+    const vocabulary = superdeskApi.entities.vocabulary?.getVocabulary('locators');
+
+    if (vocabulary?.selection_type !== 'multi selection') {
+        return (
+            <PreviewFormItem
+                testId={props.testId}
+                label={label}
+                light={true}
+                value={names.join(', ')}
+            />
+        );
+    }
+
+    return (
+        <PreviewFormItem
+            testId={props.testId}
+            label={label}
+            light={true}
+            renderEmpty={true}
+        >
+            <div style={{display: 'flex', flexWrap: 'wrap', gap: 'var(--space--0-5)'}}>
+                {names.map((name, index) => (
+                    <Tag
+                        key={index}
+                        text={name}
+                        readOnly={true}
+                    />
+                ))}
+            </div>
+        </PreviewFormItem>
+    );
+};
+
+export const PreviewFieldPlace = connect(mapStateToProps)(PreviewFieldPlaceComponent);

--- a/client/components/fields/preview/Place_test.tsx
+++ b/client/components/fields/preview/Place_test.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import {mount} from 'enzyme';
+
+// Configures the enzyme adapter as an import side effect
+import '../../../utils/testUtils';
+
+import {superdeskApi} from '../../../superdeskApi';
+import {PreviewFieldPlaceComponent} from './Place';
+
+describe('<PreviewFieldPlace />', () => {
+    const places = [
+        {qcode: 'ACT', name: 'ACT'},
+        {qcode: 'NSW', name: 'New South Wales'},
+    ];
+    const item = {place: [{qcode: 'ACT', name: 'ACT'}, {qcode: 'NSW', name: 'New South Wales'}]};
+
+    let originalVocabulary;
+
+    beforeEach(() => {
+        originalVocabulary = superdeskApi.entities.vocabulary;
+    });
+
+    afterEach(() => {
+        Object.assign(superdeskApi.entities, {vocabulary: originalVocabulary});
+    });
+
+    const setLocatorsVocabulary = (selectionType) => {
+        Object.assign(superdeskApi.entities, {
+            vocabulary: {
+                getVocabulary: (id) => (id !== 'locators' ? null : {
+                    _id: 'locators',
+                    selection_type: selectionType,
+                }),
+            },
+        });
+    };
+
+    it('renders places as read-only pills when locators is multi selection', () => {
+        setLocatorsVocabulary('multi selection');
+        const wrapper = mount(<PreviewFieldPlaceComponent item={item} places={places} language="en" />);
+        const pills = wrapper.find('.tag-label');
+
+        expect(pills.length).toBe(2);
+        expect(pills.at(0).text()).toBe('ACT');
+        expect(pills.at(1).text()).toBe('New South Wales');
+        expect(wrapper.find('.tag-label__remove').length).toBe(0);
+    });
+
+    it('renders places as plain text when locators is single selection', () => {
+        setLocatorsVocabulary('single selection');
+        const wrapper = mount(<PreviewFieldPlaceComponent item={item} places={places} language="en" />);
+
+        expect(wrapper.find('.tag-label').length).toBe(0);
+        expect(wrapper.text()).toContain('ACT, New South Wales');
+    });
+
+    it('renders a dash when empty and renderEmpty is set', () => {
+        setLocatorsVocabulary('multi selection');
+        const wrapper = mount(
+            <PreviewFieldPlaceComponent item={{}} places={places} language="en" renderEmpty={true} />
+        );
+
+        expect(wrapper.text()).toContain('Places');
+        expect(wrapper.text()).toContain('-');
+    });
+});

--- a/client/components/fields/preview/Priority.tsx
+++ b/client/components/fields/preview/Priority.tsx
@@ -1,0 +1,44 @@
+import * as React from 'react';
+import {get} from 'lodash';
+
+import {IListFieldProps} from '../../../interfaces';
+import {superdeskApi} from '../../../superdeskApi';
+
+import {PreviewFormItem} from './base/PreviewFormItem';
+import {PriorityBadge} from '../PriorityBadge';
+
+interface IProps extends IListFieldProps {
+    testId?: string;
+    renderEmpty?: boolean;
+}
+
+/**
+ * Priority as a coloured badge, same as in list views.
+ */
+export const PreviewFieldPriority: React.FunctionComponent<IProps> = (props) => {
+    const {gettext} = superdeskApi.localization;
+    const priority = get(props.item, props.field ?? 'priority');
+    const label = gettext('Priority');
+
+    if (priority == null) {
+        return (
+            <PreviewFormItem
+                testId={props.testId}
+                label={label}
+                light={true}
+                renderEmpty={props.renderEmpty}
+            />
+        );
+    }
+
+    return (
+        <PreviewFormItem
+            testId={props.testId}
+            label={label}
+            light={true}
+            renderEmpty={true}
+        >
+            <PriorityBadge priority={priority} />
+        </PreviewFormItem>
+    );
+};

--- a/client/components/fields/preview/Priority_test.tsx
+++ b/client/components/fields/preview/Priority_test.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import {mount} from 'enzyme';
+
+// Configures the enzyme adapter as an import side effect
+import '../../../utils/testUtils';
+
+import {superdeskApi} from '../../../superdeskApi';
+import {PreviewFieldPriority} from './Priority';
+
+describe('<PreviewFieldPriority />', () => {
+    let originalVocabulary;
+
+    beforeEach(() => {
+        originalVocabulary = superdeskApi.entities.vocabulary;
+        Object.assign(superdeskApi.entities, {
+            vocabulary: {
+                getAll: () => new Map([['priority', {
+                    _id: 'priority',
+                    display_name: 'Aiheen tärkeys',
+                    items: [
+                        {qcode: 1, name: 'Pääaihe (3 300)', color: '#ed021a'},
+                        {qcode: 2, name: 'Perus (2 000)', color: '#dfa37c'},
+                    ],
+                }]]),
+                getVocabularyItemNameTranslated: (item) => item.name,
+            },
+        });
+    });
+
+    afterEach(() => {
+        Object.assign(superdeskApi.entities, {vocabulary: originalVocabulary});
+    });
+
+    it('renders the value as a coloured badge', () => {
+        const wrapper = mount(<PreviewFieldPriority item={{priority: 2}} />);
+
+        expect(wrapper.text()).toContain('Priority');
+        expect(wrapper.text()).toContain('Perus (2 000)');
+    });
+
+    it('renders plain text when the value has no colour configured', () => {
+        const wrapper = mount(<PreviewFieldPriority item={{priority: 9}} />);
+
+        expect(wrapper.text()).toContain('9');
+        expect(wrapper.find('div[data-test-id="priority-badge"]').length).toBe(0);
+        expect(wrapper.find('span[data-test-id="priority-badge"]').length).toBe(1);
+    });
+
+    it('renders a dash when empty and renderEmpty is set', () => {
+        const wrapper = mount(<PreviewFieldPriority item={{}} renderEmpty={true} />);
+
+        expect(wrapper.text()).toContain('Priority');
+        expect(wrapper.text()).toContain('-');
+    });
+
+    it('renders nothing when empty without renderEmpty', () => {
+        const wrapper = mount(<PreviewFieldPriority item={{}} />);
+
+        expect(wrapper.isEmptyRender()).toBe(true);
+    });
+});

--- a/client/components/fields/preview/base/PreviewFormItem.tsx
+++ b/client/components/fields/preview/base/PreviewFormItem.tsx
@@ -32,6 +32,14 @@ export class PreviewFormItem extends React.PureComponent<IBasePreviewProps> {
                         dangerouslySetInnerHTML={{__html: value}}
                     />
                 );
+            } else if (this.props.expandable) {
+                // ExpandableText handles newlines itself, so it always gets the raw string
+                children = (
+                    <ExpandableText
+                        value={this.props.value || this.props.defaultString || '-'}
+                        className={textClass}
+                    />
+                );
             } else {
                 const value = (
                     this.props.value?.length && this.props.convertNewlineToBreak ?
@@ -39,14 +47,10 @@ export class PreviewFormItem extends React.PureComponent<IBasePreviewProps> {
                         this.props.value
                 ) || this.props.defaultString || '-';
 
-                children = !this.props.expandable ? (
+                children = (
                     <p className={textClass}>
                         {value}
                     </p>
-                ) : (
-                    <ExpandableText
-                        value={value}
-                    />
                 );
             }
         }

--- a/client/components/fields/preview/index.ts
+++ b/client/components/fields/preview/index.ts
@@ -14,6 +14,10 @@ import {PreviewFieldCustomVocabularies} from './CustomVocabularies';
 import {PreviewFieldUrgency} from './Urgency';
 import {PreviewFieldFlags} from './Flags';
 import {PreviewFieldRelatedArticles} from './RelatedArticles';
+import {PreviewFieldPriority} from './Priority';
+import {PreviewFieldFiles} from './Files';
+import {PreviewFieldLinks} from './Links';
+import {PreviewFieldPlace} from './Place';
 
 import * as selectors from '../../../selectors';
 import {planningUtils} from '../../../utils';
@@ -231,6 +235,7 @@ const multilingualFieldOptions: {[key: string]: IPreviewHocOptions} = {
         props: () => ({
             label: superdeskApi.localization.gettext('Description'),
             convertNewlineToBreak: true,
+            expandable: true,
         }),
         getValue: getPreviewString,
     },
@@ -238,6 +243,7 @@ const multilingualFieldOptions: {[key: string]: IPreviewHocOptions} = {
         props: () => ({
             label: superdeskApi.localization.gettext('Long Description'),
             convertNewlineToBreak: true,
+            expandable: true,
         }),
         getValue: getPreviewString,
     },
@@ -252,6 +258,7 @@ const multilingualFieldOptions: {[key: string]: IPreviewHocOptions} = {
         props: () => ({
             label: superdeskApi.localization.gettext('Ednote'),
             convertNewlineToBreak: true,
+            expandable: true,
         }),
         getValue: getPreviewString,
     },
@@ -263,6 +270,7 @@ const multilingualFieldOptions: {[key: string]: IPreviewHocOptions} = {
         props: () => ({
             label: superdeskApi.localization.gettext('Description'),
             convertNewlineToBreak: true,
+            expandable: true,
         }),
         getValue: getPreviewString,
     },
@@ -270,6 +278,7 @@ const multilingualFieldOptions: {[key: string]: IPreviewHocOptions} = {
         props: () => ({
             label: superdeskApi.localization.gettext('Registration Details'),
             convertNewlineToBreak: true,
+            expandable: true,
         }),
         getValue: getPreviewString,
     },
@@ -277,11 +286,15 @@ const multilingualFieldOptions: {[key: string]: IPreviewHocOptions} = {
         props: () => ({
             label: superdeskApi.localization.gettext('Invitation Details'),
             convertNewlineToBreak: true,
+            expandable: true,
         }),
         getValue: getPreviewString,
     },
     accreditation_info: {
-        props: () => ({label: superdeskApi.localization.gettext('Accreditation Info')}),
+        props: () => ({
+            label: superdeskApi.localization.gettext('Accreditation Info'),
+            expandable: true,
+        }),
         getValue: getPreviewString,
     },
     priority: {
@@ -322,6 +335,15 @@ FIELD_TO_PREVIEW_COMPONENT.custom_vocabularies = PreviewFieldCustomVocabularies;
 
 FIELD_TO_FORM_PREVIEW_COMPONENT.urgency = PreviewFieldUrgency;
 FIELD_TO_FORM_PREVIEW_COMPONENT.flags = PreviewFieldFlags;
+
+// Both profile field names for flags; the values live in `item.flags`
+FIELD_TO_FORM_PREVIEW_COMPONENT.marked_for_not_publication = PreviewFieldFlags;
+FIELD_TO_FORM_PREVIEW_COMPONENT.no_content_linking = PreviewFieldFlags;
+
+FIELD_TO_FORM_PREVIEW_COMPONENT.priority = PreviewFieldPriority;
+FIELD_TO_FORM_PREVIEW_COMPONENT.files = PreviewFieldFiles;
+FIELD_TO_FORM_PREVIEW_COMPONENT.links = PreviewFieldLinks;
+FIELD_TO_FORM_PREVIEW_COMPONENT.place = PreviewFieldPlace;
 
 FIELD_TO_FORM_PREVIEW_COMPONENT.related_items = PreviewFieldRelatedArticles;
 FIELD_TO_PREVIEW_COMPONENT.related_items = PreviewFieldRelatedArticles;

--- a/client/components/fields/priority.tsx
+++ b/client/components/fields/priority.tsx
@@ -2,8 +2,7 @@ import React, {FunctionComponent} from 'react';
 import {Spacer} from '@sourcefabric/common';
 import {superdeskApi} from '../../superdeskApi';
 import {IFieldsProps} from '../../interfaces';
-import {DEFAULT_PRIORITY_COLORS} from '../../components/editor-standalone/field-definitions/priority-field';
-import {getTextColor} from 'superdesk-ui-framework/react';
+import {PriorityBadge} from './PriorityBadge';
 import {ILineConfigPriority} from 'globals';
 
 type IProps = Omit<IFieldsProps, 'fieldOptions'> & ILineConfigPriority;
@@ -16,36 +15,13 @@ export const priority: FunctionComponent<IProps> = (props) => {
         return null;
     }
 
-    const vocabulary = superdeskApi.entities.vocabulary.getAll().get('priority');
-    const vocabularyItem = vocabulary.items.find(({qcode}) => qcode.toString() === item.priority.toString());
-    const label = vocabularyItem == null
-        ? item.priority.toString()
-        : superdeskApi.entities.vocabulary.getVocabularyItemNameTranslated(vocabularyItem);
-
-    const backgroundColor = vocabularyItem?.color ?? DEFAULT_PRIORITY_COLORS[item.priority];
     const showFieldLabel = props.fieldOptions?.hideLabel !== true;
 
     return (
         <Spacer h gap="4" justifyContent="start" noWrap style={{whiteSpace: 'nowrap', width: 'auto'}}>
             {showFieldLabel && <span className="sd-list-item__text-label">{gettext('Priority:')}</span>}
 
-            <div style={{display: 'flex', alignItems: 'center'}}>
-                <div
-                    style={{
-                        display: 'inline-flex',
-                        justifyContent: 'center',
-                        alignItems: 'center',
-                        height: '1.2em',
-                        minWidth: '1.2em',
-                        paddingInline: 'var(--space--0-5)',
-                        background: backgroundColor,
-                        color: getTextColor(backgroundColor),
-                        borderRadius: 'var(--b-radius--x-small)',
-                    }}
-                >
-                    {label}
-                </div>
-            </div>
+            <PriorityBadge priority={item.priority} />
         </Spacer>
     );
 };

--- a/client/interfaces.ts
+++ b/client/interfaces.ts
@@ -1151,7 +1151,9 @@ export interface IEditorProfileGroup {
 export interface IProfileFieldEntry {
     name: string;
     field: IProfileEditorField;
-    schema: IProfileSchemaType;
+
+    // Not every profile field carries a schema entry
+    schema?: IProfileSchemaType;
 }
 
 export interface IEditorProfile {

--- a/client/utils/contentProfiles.ts
+++ b/client/utils/contentProfiles.ts
@@ -40,7 +40,7 @@ export function getProfileFields(profile: IEditorProfile): Array<IProfileFieldEn
         .map((fieldName) => ({
             name: fieldName,
             field: profile.editor[fieldName],
-            schema: profile.schema[fieldName],
+            schema: profile.schema?.[fieldName],
         }));
 }
 
@@ -312,7 +312,7 @@ export function getFieldNameTranslated(field: string): string {
     case 'overide_auto_assign_to_workflow':
         return gettext('Override Auto Assign to Workflow');
     case 'associated_event':
-        return gettext('Associated Event');
+        return gettext('Related Events');
     case 'coverages':
         return gettext('Coverages');
     case 'headline':

--- a/e2e/playwright/events/event_preview_profile.spec.ts
+++ b/e2e/playwright/events/event_preview_profile.spec.ts
@@ -1,0 +1,97 @@
+import {test, expect} from '@playwright/test';
+
+import {setup, addItems, login, waitForPageLoad} from '../utils/common';
+import {PlanningList, PlanningPreview} from '../page-object-models/planning';
+import {createEventFor} from '../utils/fixtures/events';
+import {createPlanningFor} from '../utils/fixtures/planning';
+import {EVENT_PROFILE_GROUPED_PREVIEW} from '../utils/fixtures/planning_types';
+
+const EVENT_ID = 'e2e-event-profile-preview';
+
+test.describe('Planning.Events: profile driven preview panel', () => {
+    let list: PlanningList;
+    let preview: PlanningPreview;
+
+    const openPreview = async () => {
+        await list.item(0).click();
+        await preview.waitTillOpen();
+    };
+
+    test.beforeEach(async ({page}) => {
+        list = new PlanningList(page);
+        preview = new PlanningPreview(page);
+
+        await setup(page, 'planning_prepopulate_data', '/#/planning');
+        await addItems(page.request, 'planning_types', [EVENT_PROFILE_GROUPED_PREVIEW]);
+        await addItems(page.request, 'events', [createEventFor.today({
+            guid: EVENT_ID,
+            slugline: 'Event Profile Preview',
+            definition_short: 'A short event description',
+            anpa_category: [{qcode: 'e', name: 'Entertainment'}],
+            // location deliberately left unset to cover empty-field rendering
+        })]);
+        await addItems(page.request, 'planning', [createPlanningFor.today({
+            slugline: 'Linked Planning',
+            related_events: [{_id: EVENT_ID, link_type: 'primary'}],
+        })]);
+
+        await login(page);
+        await waitForPageLoad.planning(page);
+    });
+
+    test('preview shows fields in profile order and profile groups', async () => {
+        await openPreview();
+
+        const mainGroup = preview.element.getByTestId('preview-group__main');
+
+        const fieldOrder = [
+            'field-slugline',
+            'field-dates',
+            'field-definition_short',
+            'field-location',
+        ];
+        const mainGroupRows = mainGroup.locator('[data-test-id^="field-"]');
+
+        await expect(mainGroupRows).toHaveCount(fieldOrder.length);
+        for (let index = 0; index < fieldOrder.length; index++) {
+            await expect(mainGroupRows.nth(index)).toHaveAttribute('data-test-id', fieldOrder[index]);
+        }
+
+        const location = preview.element.getByTestId('field-location');
+
+        await expect(location.locator('label')).toHaveText('Location:');
+        await expect(location.locator('p')).toHaveText('-');
+
+        const toggleGroup = preview.element.getByTestId('toggle-extra');
+
+        await expect(toggleGroup).toBeVisible();
+        await expect(toggleGroup.getByRole('button')).toHaveAttribute('aria-expanded', 'false');
+
+        await toggleGroup.getByRole('button').click();
+        await expect(toggleGroup.getByTestId('field-anpa_category')).toBeVisible();
+        await expect(toggleGroup.getByTestId('field-anpa_category')).toContainText('Entertainment');
+    });
+
+    test('attachments render before related plannings, without nested toggles', async () => {
+        await openPreview();
+
+        const attachments = preview.element.getByTestId('toggle-attachments');
+
+        await expect(attachments).toBeVisible();
+        await attachments.getByRole('button').click();
+
+        // The files field must not nest its own toggle box inside the group toggle
+        await expect(attachments).toContainText('No attached files added.');
+        await expect(attachments.locator('.toggle-box')).toHaveCount(0);
+
+        const heading = preview.element.locator('h3', {hasText: 'Related Plannings'});
+
+        await expect(heading).toBeVisible();
+        await expect(preview.element).toContainText('Linked Planning');
+
+        const html = await preview.element.innerHTML();
+
+        expect(html.indexOf('toggle-attachments')).toBeGreaterThan(-1);
+        expect(html.indexOf('toggle-attachments')).toBeLessThan(html.indexOf('Related Plannings'));
+    });
+});

--- a/e2e/playwright/planning/planning_preview_profile.spec.ts
+++ b/e2e/playwright/planning/planning_preview_profile.spec.ts
@@ -1,0 +1,125 @@
+import {test, expect, Locator} from '@playwright/test';
+
+import {setup, addItems, login, waitForPageLoad} from '../utils/common';
+import {PlanningList, PlanningPreview} from '../page-object-models/planning';
+import {createPlanningFor} from '../utils/fixtures/planning';
+import {PLANNING_PROFILE_GROUPED_PREVIEW} from '../utils/fixtures/planning_types';
+
+// Longer than the 500 character truncation threshold, no newlines,
+// with a marker at the end that is only visible once expanded.
+const LONG_TEXT_HEAD = 'Long description preview text. '.repeat(20);
+const LONG_TEXT_TAIL = 'END-OF-DESCRIPTION-MARKER';
+const LONG_TEXT = LONG_TEXT_HEAD + LONG_TEXT_TAIL;
+
+test.describe('Planning.Planning: profile driven preview panel', () => {
+    let list: PlanningList;
+    let preview: PlanningPreview;
+
+    const openPreview = async () => {
+        await list.item(0).click();
+        await preview.waitTillOpen();
+    };
+
+    const expandableLink = (row: Locator): Locator => row.locator('.sd-text__expandable-link');
+
+    test.beforeEach(async ({page}) => {
+        list = new PlanningList(page);
+        preview = new PlanningPreview(page);
+
+        await setup(page, 'planning_prepopulate_data', '/#/planning');
+        await addItems(page.request, 'planning_types', [PLANNING_PROFILE_GROUPED_PREVIEW]);
+        await addItems(
+            page.request,
+            'planning',
+            [createPlanningFor.today({
+                slugline: 'Profile Preview',
+                name: 'Field Without A Group',
+                description_text: LONG_TEXT,
+                anpa_category: [{qcode: 'e', name: 'Entertainment'}],
+                priority: 2,
+                // internal_note deliberately left unset to cover empty-field rendering
+            })],
+        );
+
+        await login(page);
+        await waitForPageLoad.planning(page);
+    });
+
+    test('preview shows fields in profile order and profile groups', async () => {
+        await openPreview();
+
+        const mainGroup = preview.element.getByTestId('preview-group__main');
+        const mainGroupRows = mainGroup.locator('[data-test-id^="field-"]');
+        const fieldOrder = [
+            'field-description_text',
+            'field-slugline',
+            'field-priority',
+            'field-planning_date',
+            'field-internal_note',
+        ];
+
+        await expect(mainGroupRows).toHaveCount(fieldOrder.length);
+        for (let index = 0; index < fieldOrder.length; index++) {
+            await expect(mainGroupRows.nth(index)).toHaveAttribute('data-test-id', fieldOrder[index]);
+        }
+
+        const toggleGroup = preview.element.getByTestId('toggle-extra');
+
+        await expect(toggleGroup).toBeVisible();
+        await expect(toggleGroup.getByRole('button')).toHaveAttribute('aria-expanded', 'false');
+        await expect(toggleGroup.getByTestId('field-anpa_category')).not.toBeVisible();
+
+        await toggleGroup.getByRole('button').click();
+        await expect(toggleGroup.getByTestId('field-anpa_category')).toBeVisible();
+        // The 'ANPA Category' label is translated to 'Category' in this build
+        await expect(toggleGroup.getByTestId('field-anpa_category')).toContainText('Category:');
+        await expect(toggleGroup.getByTestId('field-anpa_category')).toContainText('Entertainment');
+
+        // Enabled in the profile but assigned to no group, so it must not render
+        await expect(preview.element.getByTestId('field-name')).not.toBeAttached();
+    });
+
+    test('empty enabled text field renders with a dash', async () => {
+        await openPreview();
+
+        const internalNote = preview.element.getByTestId('field-internal_note');
+
+        await expect(internalNote).toBeVisible();
+        await expect(internalNote.locator('label')).toHaveText('Internal Note:');
+        await expect(internalNote.locator('p')).toHaveText('-');
+    });
+
+    test('priority renders as a coloured vocabulary badge', async () => {
+        await openPreview();
+
+        const priorityRow = preview.element.getByTestId('field-priority');
+
+        await expect(priorityRow.locator('label')).toHaveText('Priority:');
+
+        // The value renders as a badge showing the vocabulary item name,
+        // not as the legacy plain "Priority:: 2" text
+        const badge = priorityRow.getByTestId('priority-badge');
+
+        await expect(badge).toHaveText('2');
+        await expect(badge).toHaveCSS('background-color', 'rgb(255, 105, 0)');
+        await expect(priorityRow).not.toContainText('Priority::');
+    });
+
+    test('long text field truncates with a working "Show all"/"Show less" link', async () => {
+        await openPreview();
+
+        const description = preview.element.getByTestId('field-description_text');
+
+        await expect(description).toBeVisible();
+        await expect(description).not.toContainText(LONG_TEXT_TAIL);
+        await expect(expandableLink(description)).toContainText('Show all');
+
+        await expandableLink(description).click();
+        await expect(description).toContainText(LONG_TEXT_TAIL);
+        await expect(expandableLink(description)).toContainText('Show less');
+
+        await expandableLink(description).click();
+        await expect(description).not.toContainText(LONG_TEXT_TAIL);
+        await expect(expandableLink(description)).toContainText('Show all');
+    });
+});

--- a/e2e/playwright/utils/fixtures/planning_types.ts
+++ b/e2e/playwright/utils/fixtures/planning_types.ts
@@ -52,6 +52,62 @@ export const PLANNING_PROFILE_GROUPED_PREVIEW = {
     },
 };
 
+/**
+ * Event content profile used by the event preview panel spec.
+ * Same merge semantics as above: default enabled fields must be disabled
+ * explicitly, and the default groups (attachments at 5 with a toggle box,
+ * related_plannings at 7) survive the merge and provide the section order.
+ *
+ * Layout under test:
+ * - group "main" (plain container): slugline, dates, definition_short, location.
+ * - group "extra" (useToggleBox): anpa_category.
+ * - files stays in the default "attachments" group, related_plannings in its
+ *   default group, so attachments renders before the related plannings section.
+ */
+export const EVENT_PROFILE_GROUPED_PREVIEW = {
+    _id: 'event',
+    name: 'event',
+    editor: {
+        slugline: {enabled: true, group: 'main', index: 1},
+        dates: {enabled: true, group: 'main', index: 2},
+        definition_short: {enabled: true, group: 'main', index: 3},
+        location: {enabled: true, group: 'main', index: 4},
+        anpa_category: {enabled: true, group: 'extra', index: 1},
+        files: {enabled: true, group: 'attachments', index: 1},
+        related_plannings: {enabled: true, group: 'related_plannings', index: 1},
+        recurring_rules: {enabled: false},
+        name: {enabled: false},
+        calendars: {enabled: false},
+        occur_status: {enabled: false},
+        event_contact_info: {enabled: false},
+        subject: {enabled: false},
+        definition_long: {enabled: false},
+        internal_note: {enabled: false},
+        ednote: {enabled: false},
+        links: {enabled: false},
+    },
+    groups: {
+        main: {
+            _id: 'main',
+            name: 'Main',
+            index: 1,
+            showBookmark: true,
+            icon: 'align-left',
+            useToggleBox: false,
+            translations: {name: {}},
+        },
+        extra: {
+            _id: 'extra',
+            name: 'Extra',
+            index: 2,
+            showBookmark: true,
+            icon: 'info-sign',
+            useToggleBox: true,
+            translations: {name: {}},
+        },
+    },
+};
+
 export const ADVANCED_SEARCH = {
     "_id": "advanced_search",
     "name": "advanced_search",

--- a/e2e/playwright/utils/fixtures/planning_types.ts
+++ b/e2e/playwright/utils/fixtures/planning_types.ts
@@ -1,3 +1,57 @@
+/**
+ * Planning content profile used by the preview panel specs.
+ *
+ * The backend merges this record field-by-field into the default planning
+ * profile, so every field that is enabled in the default profile must be
+ * explicitly disabled (or re-grouped) here, otherwise it would still render.
+ * The merge semantics live in `merge_planning_type` in
+ * `server/planning/content_profiles/planning_types_async_service.py`.
+ *
+ * Layout under test:
+ * - group "main" (plain container): description_text, slugline, priority,
+ *   planning_date, internal_note; deliberately not the default field order.
+ * - group "extra" (useToggleBox): anpa_category.
+ * - "name" is enabled but assigned to no group, so it must not render.
+ */
+export const PLANNING_PROFILE_GROUPED_PREVIEW = {
+    _id: 'planning',
+    name: 'planning',
+    editor: {
+        description_text: {enabled: true, group: 'main', index: 1},
+        slugline: {enabled: true, group: 'main', index: 2},
+        priority: {enabled: true, group: 'main', index: 3},
+        planning_date: {enabled: true, group: 'main', index: 4},
+        internal_note: {enabled: true, group: 'main', index: 5},
+        anpa_category: {enabled: true, group: 'extra', index: 1},
+        name: {enabled: true, group: null, index: 6},
+        ednote: {enabled: false},
+        agendas: {enabled: false},
+        subject: {enabled: false},
+        urgency: {enabled: false},
+        marked_for_not_publication: {enabled: false},
+    },
+    groups: {
+        main: {
+            _id: 'main',
+            name: 'Main',
+            index: 10,
+            showBookmark: true,
+            icon: 'align-left',
+            useToggleBox: false,
+            translations: {name: {}},
+        },
+        extra: {
+            _id: 'extra',
+            name: 'Extra',
+            index: 11,
+            showBookmark: true,
+            icon: 'info-sign',
+            useToggleBox: true,
+            translations: {name: {}},
+        },
+    },
+};
+
 export const ADVANCED_SEARCH = {
     "_id": "advanced_search",
     "name": "advanced_search",

--- a/server/features/content_profiles_planning.feature
+++ b/server/features/content_profiles_planning.feature
@@ -224,7 +224,7 @@ Feature: Planning Content Profiles
             },
             "associated_event": {
                 "_id": "associated_event",
-                "name": "Associated Event",
+                "name": "Related Events",
                 "index": 6,
                 "showBookmark": true,
                 "icon": "calendar",

--- a/server/planning/content_profiles/profiles/planning.py
+++ b/server/planning/content_profiles/profiles/planning.py
@@ -125,7 +125,7 @@ DEFAULT_PLANNING_PROFILE = {
             "group": "attachments",
             "index": 1,
         },
-        # Associated Event group
+        # Related Events group
         "associated_event": {
             "enabled": True,
             "group": "associated_event",
@@ -202,7 +202,7 @@ DEFAULT_PLANNING_PROFILE = {
         },
         "associated_event": {
             "_id": "associated_event",
-            "name": "Associated Event",
+            "name": "Related Events",
             "index": 6,
             "showBookmark": True,
             "icon": "calendar",


### PR DESCRIPTION
### Purpose
Item previews (events, planning, coverages, assignments) rendered metadata from hardcoded field lists, so the field order never matched the editor, important fields like the category ended up in a collapsed Details box, and custom vocabulary fields were lumped together. This makes the previews profile driven so they mirror the editor, per STT-1699.

### What has changed
- Previews render fields with the order, groups and collapsible toggle boxes configured in the content profile (`renderProfileGroupedFields`), while coverage based previews render flat like the coverage editor does (`renderProfileFieldsFlat`)
- Custom vocabulary and custom text fields render individually at their profile position; multi selection vocabularies (and place) render as read-only pills
- Priority renders as the same coloured badge as list views (shared `PriorityBadge`)
- Long text fields truncate at 3 lines or 500 characters with a working Show all / Show less link, styled as a link
- The planning preview bottom sections (attachments, coverages, related events) follow the profile group order; remaining "Associated Event" labels are renamed to "Related Events" to match the editor
- The coverages editor field gets the standard bottom field spacing
- New unit tests plus a Playwright spec covering profile order, groups, empty fields, the priority badge and truncation

Note for existing instances: group order and labels live in the stored `planning_types` records, which override the shipped defaults, so existing profiles keep their configured order until adjusted in Content Profiles settings.

### Steps to test
1. In Planning, configure the planning or event profile with a custom field order, a group with the toggle box option, and a custom vocabulary field
2. Create an item with those fields set and open its preview from the list: fields should appear in editor order, toggle groups collapsed, empty text fields as a dash
3. Set a priority and check the preview shows the coloured badge, not plain text
4. Put 500+ characters in a description and check the Show all / Show less link
5. Open an assignment and check coverage fields plus subject, category and place from the planning item still render

### Front-end checklist
- [x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [x] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [x] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [x] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [x] This pull request is not adding redux based modals
- [x] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [x] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)

Resolves: [STT-1699](https://sofab.atlassian.net/browse/STT-1699)


[STT-1699]: https://sofab.atlassian.net/browse/STT-1699?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ