### PR TITLE
keep first page items visible while loading more items

### DIFF
--- a/client/actions/planning/api.ts
+++ b/client/actions/planning/api.ts
@@ -154,14 +154,14 @@ const handleItemsForLastFetchedDay = (
     const itemsGrouped = planningUtils.getPlanningByDate(
         [...items, ...lastDayGroupItems],
         {},
-        params.advancedSearch.dates.start,
-        params.advancedSearch.dates.end,
+        params.advancedSearch?.dates?.start ?? moment(),
+        params.advancedSearch?.dates?.end,
         params.timezoneOffset,
     );
 
-    // on initial page load we need to make sure items for all groups are loaded
-    // otherwise if the first group has 1 item, a second has 50 items, user
-    // can end up in an invalid state where he can't trigger loadMore by scrolling
+    // On initial page load we still trigger loadMore to avoid dead-end scrolling
+    // states, but keep currently fetched items visible instead of returning an
+    // empty list while waiting for subsequent pages.
     if (itemsGrouped.length === 1 || params.page === 1) {
         const lastPage = Math.ceil(total / params.maxResults);
 
@@ -170,10 +170,21 @@ const handleItemsForLastFetchedDay = (
             return Promise.resolve(itemsGrouped.flatMap((x) => x.events));
         }
 
+        if (itemsGrouped.length > 1) {
+            const lastGroup = itemsGrouped[itemsGrouped.length - 1];
+
+            dispatch(storeLastDayGroup(lastGroup.events));
+            dispatch(planningUi.loadMore());
+
+            return Promise.resolve(
+                itemsGrouped.slice(0, itemsGrouped.length - 1).flatMap((x) => x.events),
+            );
+        }
+
         dispatch(storeLastDayGroup([...items, ...lastDayGroupItems]));
         dispatch(planningUi.loadMore());
 
-        return Promise.resolve([]);
+        return Promise.resolve(itemsGrouped.flatMap((x) => x.events));
     } else if (Object.keys(itemsGrouped).length > 1) {
         const lastGroup = itemsGrouped[itemsGrouped.length - 1];
 
@@ -183,6 +194,8 @@ const handleItemsForLastFetchedDay = (
             itemsGrouped.slice(0, itemsGrouped.length - 1).flatMap((x) => x.events),
         );
     }
+
+    return Promise.resolve(itemsGrouped.flatMap((x) => x.events));
 };
 
 /**
@@ -209,8 +222,10 @@ const fetch = (params: IPlanningSearchParams = {}) => ((dispatch, getState) => (
                     advancedSearch: {
                         ...params.advancedSearch,
                         dates: {
-                            ...params.advancedSearch.dates,
-                            start: params.advancedSearch?.dates?.start ? params.advancedSearch.dates.start : moment(),
+                            ...(params.advancedSearch?.dates ?? {}),
+                            start: params.advancedSearch?.dates?.start
+                                ? params.advancedSearch.dates.start
+                                : moment(),
                             end: params.advancedSearch?.dates?.end,
                         },
                     },

--- a/client/actions/planning/api.ts
+++ b/client/actions/planning/api.ts
@@ -185,7 +185,7 @@ const handleItemsForLastFetchedDay = (
         dispatch(planningUi.loadMore());
 
         return Promise.resolve(itemsGrouped.flatMap((x) => x.events));
-    } else if (Object.keys(itemsGrouped).length > 1) {
+    } else if (itemsGrouped.length > 1) {
         const lastGroup = itemsGrouped[itemsGrouped.length - 1];
 
         dispatch(storeLastDayGroup(lastGroup.events));

--- a/client/actions/planning/api.ts
+++ b/client/actions/planning/api.ts
@@ -164,9 +164,12 @@ const handleItemsForLastFetchedDay = (
     // empty list while waiting for subsequent pages.
     if (itemsGrouped.length === 1 || params.page === 1) {
         const lastPage = Math.ceil(total / params.maxResults);
+        const hasMorePages = params.page < lastPage;
 
         // No pages left to fetch
-        if (params.page > lastPage + 1) {
+        if (!hasMorePages) {
+            dispatch(storeLastDayGroup([]));
+
             return Promise.resolve(itemsGrouped.flatMap((x) => x.events));
         }
 

--- a/client/actions/planning/tests/api_test.ts
+++ b/client/actions/planning/tests/api_test.ts
@@ -10,6 +10,8 @@ import {PLANNING, SPIKED_STATE} from '../../../constants';
 import {MAIN} from '../../../constants';
 import contactsApi from '../../contacts';
 import {planningApis} from '../../../api';
+import planningUi from '../ui';
+import {planningUtils} from '../../../utils';
 
 describe('actions.planning.api', () => {
     let errorMessage;
@@ -189,6 +191,42 @@ describe('actions.planning.api', () => {
                     done();
                 })
                 .catch(done.fail);
+        });
+
+        it('keeps complete groups visible on first page while queueing loadMore', (done) => {
+            const p1 = {...data.plannings[0], _id: 'p1'};
+            const p2 = {...data.plannings[1], _id: 'p2'};
+
+            restoreSinonStub(planningApi.query);
+            restoreSinonStub(planningUi.loadMore);
+            sinon.stub(planningApi, 'query').callsFake(() => Promise.resolve({
+                _meta: {total: 100, max_results: 50, page: 1},
+                _items: [p1, p2],
+            }));
+            sinon.stub(planningUi, 'loadMore').callsFake(() => (() => Promise.resolve([])));
+
+            const groupedItems = [
+                {date: '2026-07-30', events: [p1]},
+                {date: '2026-07-31', events: [p2]},
+            ];
+
+            sinon.stub(planningUtils, 'getPlanningByDate').returns(groupedItems as any);
+
+            return store.test(done, planningApi.fetch({agendas: ['a1']} as any))
+                .then((items) => {
+                    expect(planningUi.loadMore.callCount).toBe(1);
+
+                    expect(planningApi.receivePlannings.callCount).toBe(1);
+                    expect(planningApi.receivePlannings.args[0]).toEqual([[p1]]);
+                    expect(items).toEqual([p1]);
+
+                    done();
+                })
+                .catch(done.fail)
+                .finally(() => {
+                    restoreSinonStub(planningUtils.getPlanningByDate);
+                    restoreSinonStub(planningUi.loadMore);
+                });
         });
     });
 


### PR DESCRIPTION
SDCP-1160

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

### Front-end checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)

Resolves: #[issue-number]

