### PR TITLE
[SDESK-8001] Fix planning editor turning read-only after assigning a coverage

### DIFF
--- a/client/components/Main/ItemEditor/EditorHeader.tsx
+++ b/client/components/Main/ItemEditor/EditorHeader.tsx
@@ -134,6 +134,7 @@ export class EditorHeader extends React.Component<IProps> {
 
         states.showEdit = states.existingItem &&
             !states.isLockedInContext &&
+            !lockUtils.isItemLockedByAssociatedItem(initialValues as IEventItem, lockedItems) &&
             eventUtils.canEditEvent(initialValues as IEventItem, session, privileges, lockedItems);
 
         if (states.readOnly) {
@@ -170,6 +171,7 @@ export class EditorHeader extends React.Component<IProps> {
 
         states.showEdit = states.existingItem &&
             !states.isLockedInContext &&
+            !lockUtils.isItemLockedByAssociatedItem(initialVals, lockedItems) &&
             planningUtils.canEditPlanning(initialVals, null, session, privileges, lockedItems) &&
             !addNewsItemToPlanning;
 

--- a/client/utils/index.ts
+++ b/client/utils/index.ts
@@ -260,6 +260,8 @@ export const createStore = (params = {}, app = planningApp) => {
 export const getErrorMessage = (error, defaultMessage) => {
     if (get(error, 'data._message')) {
         return get(error, 'data._message');
+    } else if (get(error, '_message')) {
+        return get(error, '_message');
     } else if (get(error, 'data._issues.validator exception')) {
         return get(error, 'data._issues.validator exception');
     } else if (get(error, 'data._error.message')) {

--- a/client/utils/locks.ts
+++ b/client/utils/locks.ts
@@ -59,6 +59,22 @@ function getPlanningLock(item: IPlanningItem | null, lockedItems: ILockedItems):
         return lockedItems.recurring[item.recurrence_id];
     }
 
+    // The server stores the lock of a planning with a primary related event under
+    // the event bucket only (see `planning_locks.py`), keyed by the event id with
+    // `item_id` pointing back at the planning item.
+    // Not using `getRelatedEventIdsForPlanning` here to avoid a circular import.
+    const primaryEventIds = (item.related_events ?? [])
+        .filter((link) => link.link_type === 'primary')
+        .map((link) => link._id);
+
+    for (const eventId of primaryEventIds) {
+        const eventLock = lockedItems.event[eventId];
+
+        if (eventLock != null && eventLock.item_id === item._id) {
+            return eventLock;
+        }
+    }
+
     return null;
 }
 
@@ -102,6 +118,36 @@ function isItemLocked(item: IEventOrPlanningItem | IAssignmentItem, lockedItems:
     return self.getLock(item, lockedItems) != null;
 }
 
+/**
+ * An event and its primary linked plannings share a single lock slot, so an item
+ * cannot be locked while an associated item in the chain holds the lock, not even
+ * by the same session. The chain lock lives in the event bucket, keyed by the
+ * event id, with `item_id` telling which item actually holds it.
+ */
+function isItemLockedByAssociatedItem(item: IEventOrPlanningItem, lockedItems: ILockedItems): boolean {
+    if (item?._id == null) {
+        return false;
+    }
+
+    if (item.type === 'event') {
+        const lock = lockedItems.event[item._id];
+
+        return lock != null && lock.item_id !== item._id;
+    }
+
+    if (item.type === 'planning') {
+        return (item.related_events ?? [])
+            .filter((link) => link.link_type === 'primary')
+            .some((link) => {
+                const lock = lockedItems.event[link._id];
+
+                return lock != null && lock.item_id !== item._id;
+            });
+    }
+
+    return false;
+}
+
 function isLockedForAddToPlanning(item: IEventOrPlanningItem, lockedItems: ILockedItems): boolean {
     return self.getLockAction(item, lockedItems) === PLANNING.ITEM_ACTIONS.ADD_TO_PLANNING.lock_action;
 }
@@ -135,6 +181,7 @@ const self = {
     isLockRestricted,
     isItemLockedInThisSession,
     isItemLocked,
+    isItemLockedByAssociatedItem,
     isLockedForAddToPlanning,
     getLockedItemIds,
     getLockFromItem,

--- a/client/utils/tests/index_test.ts
+++ b/client/utils/tests/index_test.ts
@@ -29,6 +29,10 @@ describe('Utils', () => {
         error = utils.getErrorMessage(response, 'Nothing here');
         expect(error).toBe('Something else happened');
 
+        // Rejections carrying the parsed response body directly
+        error = utils.getErrorMessage({_message: 'An associated event is already locked.'}, 'Nothing');
+        expect(error).toBe('An associated event is already locked.');
+
         response = {data: {}};
         error = utils.getErrorMessage(response, 'Something unexpected');
         expect(error).toBe('Something unexpected');

--- a/client/utils/tests/locks_test.ts
+++ b/client/utils/tests/locks_test.ts
@@ -56,6 +56,48 @@ describe('utils.locks', () => {
             expect(lockUtils.getLock(item, lockedItems)).toEqual(item);
         });
 
+        it('returns planning locks stored under the primary related event', () => {
+            // The `planning_locks` endpoint stores the lock of an event linked
+            // planning under the event bucket only, with `item_id` pointing
+            // back at the planning item
+            const item = cloneDeep(testData.plannings[1]);
+            const lock = {
+                item_id: item._id,
+                item_type: 'planning',
+                action: 'edit',
+                user: 'ident1',
+                session: 'session1',
+            };
+
+            lockedItems.event[testData.events[0]._id] = lock;
+            expect(lockUtils.getLock(item, lockedItems)).toEqual(lock);
+
+            // A lock on the event itself does not count as this planning's lock
+            lockedItems.event[testData.events[0]._id] = {...lock, item_id: testData.events[0]._id};
+            expect(lockUtils.getLock(item, lockedItems)).toBe(null);
+        });
+
+        it('detects chain locks held by an associated item', () => {
+            const planning = cloneDeep(testData.plannings[1]);
+            const event = cloneDeep(testData.events[0]);
+            const lockByEvent = {item_id: event._id, item_type: 'event', action: 'edit'};
+            const lockByPlanning = {item_id: planning._id, item_type: 'planning', action: 'edit'};
+
+            // Nothing locked
+            expect(lockUtils.isItemLockedByAssociatedItem(planning, lockedItems)).toBe(false);
+            expect(lockUtils.isItemLockedByAssociatedItem(event, lockedItems)).toBe(false);
+
+            // The event holds the chain lock: the planning is blocked, the event is not
+            lockedItems.event[event._id] = lockByEvent;
+            expect(lockUtils.isItemLockedByAssociatedItem(planning, lockedItems)).toBe(true);
+            expect(lockUtils.isItemLockedByAssociatedItem(event, lockedItems)).toBe(false);
+
+            // The planning holds the chain lock: the event is blocked, the planning is not
+            lockedItems.event[event._id] = lockByPlanning;
+            expect(lockUtils.isItemLockedByAssociatedItem(planning, lockedItems)).toBe(false);
+            expect(lockUtils.isItemLockedByAssociatedItem(event, lockedItems)).toBe(true);
+        });
+
         it('returns assignment locks', () => {
             let item = cloneDeep(testData.assignments[0]);
 

--- a/e2e/playwright/item_locks.spec.ts
+++ b/e2e/playwright/item_locks.spec.ts
@@ -1,10 +1,10 @@
 import {Page, test, expect} from '@playwright/test';
 
 import {setup, login, waitForPageLoad, addItems, forceUnlockItem, Modal, getMenuItem} from './utils/common';
-import {EventEditor, PlanningList} from './page-object-models/planning';
+import {EventEditor, PlanningEditor, PlanningList, AssignmentEditor} from './page-object-models/planning';
 
-import {TEST_PLANNINGS} from './utils/fixtures/planning';
-import {TEST_EVENTS} from './utils/fixtures/events';
+import {TEST_PLANNINGS, createPlanningFor} from './utils/fixtures/planning';
+import {TEST_EVENTS, createEventFor} from './utils/fixtures/events';
 
 test.describe('Planning: item locks', () => {
     let list: PlanningList;
@@ -173,6 +173,105 @@ test.describe('Planning: item locks', () => {
             await testCancelActionFromModal(page, 'Convert to Recurring Event');
             await testUnlockedFromModal(page, 'Convert to Recurring Event', 'events', 'event1');
             // No need to test editor actions, as this is not available in the Editor
+        });
+    });
+
+    // An event and its primary-linked planning items share one "chain" lock,
+    // stored server-side under the event id even when held by the planning
+    test.describe('chain locks with event-linked planning items', () => {
+        const EVENT_ID = 'chain_event_1';
+        const PLAN_ID = 'chain_plan_1';
+        let planningEditor: PlanningEditor;
+
+        test.beforeEach(async ({page}) => {
+            planningEditor = new PlanningEditor(page);
+
+            await addItems(page.request, 'events', [createEventFor.today({
+                guid: EVENT_ID,
+                name: 'Chain Event',
+                slugline: 'Chain Event',
+            })]);
+            await addItems(page.request, 'planning', [createPlanningFor.today({
+                guid: PLAN_ID,
+                slugline: 'Chain Planning',
+                related_events: [{_id: EVENT_ID, link_type: 'primary'}],
+            })]);
+            await login(page);
+            await waitForPageLoad.planning(page);
+        });
+
+        async function openLinkedPlanningForEdit(): Promise<void> {
+            if (!(await list.nestedPlanningItem(0, 0).isVisible())) {
+                await list.toggleAssociatedPlanning(0);
+            }
+            await list.nestedPlanningItem(0, 0).dblclick();
+            await planningEditor.waitTillOpen();
+        }
+
+        test('editor stays editable after assigning a coverage to a desk and saving', async ({page}) => {
+            await openLinkedPlanningForEdit();
+            await expect(planningEditor.fields.slugline.element).toBeEnabled();
+
+            await planningEditor.addCoverage('Text');
+
+            const coverageEditor = planningEditor.getCoverageEditor(0);
+            const assignmentEditor = new AssignmentEditor(page);
+
+            await coverageEditor.editAssignmentButton.click();
+            await assignmentEditor.waitTillOpen();
+            await assignmentEditor.type({desk: 'Politic Desk'});
+            await assignmentEditor.okButton.click();
+            await assignmentEditor.waitTillClosed();
+
+            const saveRequest = page.waitForResponse(
+                (response) => response.url().includes('/api/planning/') && response.request().method() === 'PATCH',
+            );
+
+            await planningEditor.saveButton.click();
+            await saveRequest;
+
+            // Save disabling marks the save as processed; the regression
+            // swapped the toolbar to Close/Edit at this point
+            await expect(planningEditor.saveButton).toBeDisabled();
+            await expect(coverageEditor.element).toContainText('Politic Desk');
+            await expect(planningEditor.editButton).not.toBeAttached();
+            await expect(planningEditor.fields.slugline.element).toBeEnabled();
+
+            // The session still holds the lock, so a reload must reopen
+            // straight into edit mode
+            await page.reload();
+            await waitForPageLoad.planning(page);
+            await openLinkedPlanningForEdit();
+
+            await expect(planningEditor.editButton).not.toBeAttached();
+            await expect(planningEditor.fields.slugline.element).toBeEnabled();
+        });
+
+        test('read-only planning item hides Edit while the linked event is being edited', async ({page}) => {
+            await list.item(0).dblclick();
+            await editor.waitTillOpen();
+            await expect(editor.fields.slugline.element).toBeEnabled();
+
+            await list.toggleAssociatedPlanning(0);
+            await list.nestedPlanningItem(0, 0).dblclick();
+            await planningEditor.waitTillOpen();
+
+            await expect(planningEditor.fields.slugline.element).toHaveValue('Chain Planning');
+            await expect(planningEditor.fields.slugline.element).toBeDisabled();
+            await expect(planningEditor.editButton).not.toBeAttached();
+
+            // Edit appearing after the unlock proves its absence was lock-driven.
+            // The "Item Unlocked" modal backdrop aria-hides the editor, so
+            // dismiss it before asserting
+            await forceUnlockItem(page.request, 'events', EVENT_ID);
+            await modal.waitTillOpen();
+            await modal.shouldContainTitle('Item Unlocked');
+            await modal.getFooterButton('OK').click();
+            await modal.waitTillClosed();
+
+            await expect(planningEditor.editButton).toBeVisible();
+            await planningEditor.editButton.click();
+            await expect(planningEditor.fields.slugline.element).toBeEnabled();
         });
     });
 


### PR DESCRIPTION
### Purpose
A user is editing a planning item that is linked to an event. They assign one of its coverages to a desk and save. The editor switches to read-only as if another user had taken over the item, Edit does nothing, and reloading the page does not help. The lock that appears to block the user is in fact their own: for event-linked planning items the backend registers the lock under the related event, and the client lock store never looked there.

There is a related rough edge: while the linked event is open in the editor, the planning item opens read-only (correct, since an event and its linked planning items share a single lock) but shows an Edit button that always fails with the generic "Failed to lock item".

### What has changed
- `getPlanningLock` also checks the event bucket for the planning's primary related events, matching how the `planning_locks` endpoint stores these locks
- The read-only editor hides the Edit button while an associated item in the chain holds the lock, instead of offering an Edit that always fails
- Lock errors now show the server's reason (for example "An associated event is already locked.") instead of the generic message
- Unit tests for all three behaviours
- E2e tests covering both scenarios (editor stays editable after assigning a coverage and saving; read-only view hides Edit while the linked event is being edited)

### Steps to test
Setup: a planning item linked to an event (for example create an event, then create a planning item from it).

Scenario 1, editor turns read-only after saving:
1. Open the planning item in the editor, add a coverage, assign it to a desk/user, and save
2. Before the fix the editor flips to read-only and stays that way even after a page reload. After the fix it stays editable, and after a reload the item opens straight back into edit mode

Scenario 2, editing while the related event is open:
1. Open the related event in the editor, then double click the linked planning item: it opens read-only, which is correct
2. Before the fix an Edit button shows and clicking it fails with "Failed to lock item". After the fix the button is not shown; close the event editor and the planning item becomes editable again

Resolves: [SDESK-7987] and [SDESK-8001]


[SDESK-7987]: https://sofab.atlassian.net/browse/SDESK-7987?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[SDESK-8001]: https://sofab.atlassian.net/browse/SDESK-8001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ