### PR TITLE
avoid reposting planning item

### DIFF
--- a/server/planning/common.py
+++ b/server/planning/common.py
@@ -394,7 +394,47 @@ async def update_post_item(updates, original):
         # From item actions
         pub_status = POST_STATE.USABLE
 
+    # Ignore technical/system-only updates (for example lock/unlock metadata updates)
+    # to avoid creating unexpected repost/history side effects.
+    repost_ignored_fields = {
+        LOCK_USER,
+        LOCK_SESSION,
+        LOCK_TIME,
+        LOCK_ACTION,
+        "_etag",
+        "_updated",
+        "version",
+        "versioncreated",
+        "versionposted",
+        "update_method",
+    }
+
+    changed_fields = sorted([field for field, value in updates.items() if value != original.get(field)])
+
+    def has_meaningful_changes() -> bool:
+        for field, value in updates.items():
+            if field in repost_ignored_fields:
+                continue
+
+            if value != original.get(field):
+                return True
+
+        return False
+
     if pub_status is not None:
+        # Respect explicit publish/unpublish requests even if there are no other
+        # editorial changes in the patch payload.
+        explicit_post_state_change = updates.get("pubstatus") is not None or updates.get("ingest_pubstatus") is not None
+
+        if not explicit_post_state_change and not has_meaningful_changes():
+            logger.debug(
+                "planning:repost_skipped item=%s type=%s reason=system_only_update changed_fields=%s",
+                original.get(ID_FIELD),
+                original.get(ITEM_TYPE),
+                changed_fields,
+            )
+            return None
+
         if original.get(ITEM_TYPE):
             resource_name = "events_post" if original.get(ITEM_TYPE) == "event" else "planning_post"
             item_post_service = get_resource_service(resource_name)
@@ -403,7 +443,23 @@ async def update_post_item(updates, original):
                 original.get(ITEM_TYPE): original.get(ID_FIELD),
                 "pubstatus": pub_status,
             }
+            logger.info(
+                "planning:repost_triggered item=%s type=%s resource=%s explicit_post_state_change=%s pubstatus=%s changed_fields=%s",
+                original.get(ID_FIELD),
+                original.get(ITEM_TYPE),
+                resource_name,
+                explicit_post_state_change,
+                pub_status,
+                changed_fields,
+            )
             return await item_post_service.post_async([doc])
+
+    logger.debug(
+        "planning:repost_not_required item=%s type=%s changed_fields=%s",
+        original.get(ID_FIELD),
+        original.get(ITEM_TYPE),
+        changed_fields,
+    )
 
 
 def get_coverage_type_name(qcode):

--- a/server/planning/item_lock.py
+++ b/server/planning/item_lock.py
@@ -71,6 +71,19 @@ class LockService(BaseComponent):
             raise SuperdeskApiError.forbiddenError(message="Item is locked by another user.")
 
         try:
+            request_id = request.headers.get("X-Request-Id") if request and getattr(request, "headers", None) else None
+            client_id = request.args.get("clientId") if request else None
+            logger.info(
+                "planning:item_lock: lock_requested resource=%s item=%s user=%s session=%s action=%s request_id=%s client_id=%s",
+                resource,
+                item_id,
+                user_id,
+                session_id,
+                action,
+                request_id,
+                client_id,
+            )
+
             can_user_lock, error_message = self.can_lock(item, user_id, session_id, resource)
 
             if can_user_lock:
@@ -101,6 +114,17 @@ class LockService(BaseComponent):
                     type=item.get("type"),
                     clientId=request.args.get("clientId") if request else None,
                 )
+
+                logger.info(
+                    "planning:item_lock: lock_applied resource=%s item=%s user=%s session=%s action=%s etag=%s request_id=%s",
+                    resource,
+                    item.get(ID_FIELD),
+                    user_id,
+                    session_id,
+                    updates.get(LOCK_ACTION),
+                    updates.get("_etag"),
+                    request_id,
+                )
             else:
                 raise SuperdeskApiError.forbiddenError(message=error_message)
 
@@ -128,6 +152,20 @@ class LockService(BaseComponent):
 
         item_service = get_resource_service(resource)
         item_id = item.get(ID_FIELD)
+        request_id = request.headers.get("X-Request-Id") if request and getattr(request, "headers", None) else None
+        client_id = request.args.get("clientId") if request else None
+        logger.info(
+            "planning:item_lock: unlock_requested resource=%s item=%s user=%s session=%s previous_lock_user=%s previous_lock_session=%s previous_lock_action=%s request_id=%s client_id=%s",
+            resource,
+            item_id,
+            user_id,
+            session_id,
+            item.get(LOCK_USER),
+            item.get(LOCK_SESSION),
+            item.get(LOCK_ACTION),
+            request_id,
+            client_id,
+        )
 
         can_user_unlock, error_message = self.can_unlock(item, user_id, resource)
 
@@ -160,6 +198,16 @@ class LockService(BaseComponent):
             clientId=request.args.get("clientId") if request else None,
         )
 
+        logger.info(
+            "planning:item_lock: unlock_applied resource=%s item=%s user=%s session=%s etag=%s request_id=%s",
+            resource,
+            item.get(ID_FIELD),
+            user_id,
+            session_id,
+            updates.get("_etag") or item.get("_etag"),
+            request_id,
+        )
+
         return item
 
     async def unlock_session(self, user_id, session_id, is_last_session):
@@ -181,8 +229,19 @@ class LockService(BaseComponent):
         logger.info(f"planning:item_lock: Unlocking {resource} resources")
         item_service = get_resource_service(resource)
         term_filter = {LOCK_USER: str(user_id)} if is_last_session else {LOCK_SESSION: str(session_id)}
+        unlocked_count = 0
         async for item in await item_service.search_async({"query": {"bool": {"filter": {"term": term_filter}}}}):
             await self.unlock(item, user_id, session_id, resource)
+            unlocked_count += 1
+
+        logger.info(
+            "planning:item_lock: unlock_session_complete resource=%s user=%s session=%s is_last_session=%s unlocked_count=%s",
+            resource,
+            user_id,
+            session_id,
+            is_last_session,
+            unlocked_count,
+        )
 
     def can_lock(self, item, user_id, session_id, resource):
         """

--- a/server/planning/planning/planning_autosave_service.py
+++ b/server/planning/planning/planning_autosave_service.py
@@ -17,6 +17,11 @@ class PlanningAutosaveAsyncService(AutosaveAsyncService):
 
         if not item:
             # Item is not currently being edited (No current autosave item)
+            logger.debug(
+                "planning:autosave_assignment_removed_skipped planning_id=%s coverage_id=%s reason=no_autosave_item",
+                planning_id,
+                coverage_id,
+            )
             return
 
         coverages = item.get("coverages") or []
@@ -35,6 +40,12 @@ class PlanningAutosaveAsyncService(AutosaveAsyncService):
             coverage_update.pop("assigned_to", None)
             coverage_update["workflow_status"] = WORKFLOW_STATE.DRAFT
 
+        logger.info(
+            "planning:autosave_assignment_removed planning_id=%s coverage_id=%s scheduled_updates=%s",
+            planning_id,
+            coverage_id,
+            len(coverage.get("scheduled_updates") or []),
+        )
         await self.system_update(planning_id, {"coverages": coverages})
 
     async def on_assignment_updated(self, updates: dict, original: dict) -> None:
@@ -48,14 +59,30 @@ class PlanningAutosaveAsyncService(AutosaveAsyncService):
 
         if "assigned_to" not in updates and "priority" not in updates:
             # Relevant Assignment data was not updated, no need to update the Planning autosave
+            logger.debug(
+                "planning:autosave_assignment_sync_skipped assignment_id=%s reason=no_relevant_fields",
+                original.get("_id"),
+            )
             return
 
         current_request = get_current_app().get_current_request()
         if current_request and "/planning" in current_request.path:
             # This request came from the Planning endpoint itself,
             # no need to respond to an Assignment update here
+            logger.debug(
+                "planning:autosave_assignment_sync_skipped assignment_id=%s reason=planning_request_path path=%s",
+                original.get("_id"),
+                current_request.path,
+            )
             return
 
         assignment = original.copy()
         assignment.update(updates)
+        logger.info(
+            "planning:autosave_assignment_sync assignment_id=%s planning_item=%s coverage_item=%s updated_fields=%s",
+            assignment.get("_id"),
+            assignment.get("planning_item"),
+            assignment.get("coverage_item"),
+            sorted(list(updates.keys())),
+        )
         await update_planning_from_assignment_changes(assignment, is_autosave=True)

--- a/server/planning/planning/planning_history.py
+++ b/server/planning/planning/planning_history.py
@@ -72,6 +72,14 @@ class PlanningHistoryService(HistoryService):
         if operation == "create" and update.get("state", "") == "ingested":
             history["operation"] = "ingested"
 
+        logger.debug(
+            "planning:history_save operation=%s planning_id=%s user_id=%s update_keys=%s",
+            history.get("operation"),
+            history.get("planning_id"),
+            history.get("user_id"),
+            sorted(list((history.get("update") or {}).keys())),
+        )
+
         self.post([history])
 
     def on_item_updated(self, updates, original, operation: str | None = None):
@@ -155,6 +163,12 @@ class PlanningHistoryService(HistoryService):
             original_coverage = original_coverages.get(cov.get("coverage_id"))
             diff = self._get_coverage_diff(cov, original_coverage)
             if len(diff.keys()) > 1:
+                logger.info(
+                    "planning:coverage_history_edited planning_id=%s coverage_id=%s diff_keys=%s",
+                    item.get(ID_FIELD),
+                    cov.get("coverage_id"),
+                    sorted(list(diff.keys())),
+                )
                 self._save_history(item, diff, "coverage_edited")
 
             if (

--- a/server/planning/planning/planning_history_async_service.py
+++ b/server/planning/planning/planning_history_async_service.py
@@ -48,6 +48,14 @@ class PlanningHistoryAsyncService(HistoryAsyncService[PlanningHistoryResourceMod
         if operation == "create" and update.get("state", "") == "ingested":
             history["operation"] = "ingested"
 
+        logger.debug(
+            "planning:history_save_async operation=%s planning_id=%s user_id=%s update_keys=%s",
+            history.get("operation"),
+            history.get("planning_id"),
+            history.get("user_id"),
+            sorted(list((history.get("update") or {}).keys())),
+        )
+
         await self.create([history])
 
     async def on_item_updated(self, updates: dict[str, Any], original: dict[str, Any], operation: str | None = None):
@@ -131,6 +139,12 @@ class PlanningHistoryAsyncService(HistoryAsyncService[PlanningHistoryResourceMod
             original_coverage = original_coverages.get(cov.get("coverage_id"), {})
             diff = await self._get_coverage_diff(cov, original_coverage)
             if len(diff.keys()) > 1:
+                logger.info(
+                    "planning:coverage_history_edited_async planning_id=%s coverage_id=%s diff_keys=%s",
+                    item.get(ID_FIELD),
+                    cov.get("coverage_id"),
+                    sorted(list(diff.keys())),
+                )
                 await self._save_history(item, diff, "coverage_edited")
 
             if original_coverage is not None:

--- a/server/planning/tests/planning_attribution_test.py
+++ b/server/planning/tests/planning_attribution_test.py
@@ -8,6 +8,7 @@ from planning.planning import planning as planning_module
 from planning.planning import planning_history as history_module
 from planning.planning.planning import PlanningService
 from planning.planning.planning_history import PlanningHistoryService
+from planning import common as common_module
 
 
 class DummyPlanningService(PlanningService):
@@ -262,3 +263,35 @@ async def test_ingest_patch_does_not_modify_version_creator(monkeypatch):
     assert "version_creator" not in captured_document, "Ingest should not modify version_creator"
     assert "versioncreated" not in captured_document, "Ingest should not modify versioncreated"
     assert "ingest_versioncreated" in captured_document, "Ingest should set ingest_versioncreated"
+
+
+@pytest.mark.asyncio
+async def test_async_service_lock_only_update_skips_repost(monkeypatch):
+    original = {
+        "_id": "planning-id",
+        "type": "planning",
+        "pubstatus": "usable",
+        "lock_user": "user-1",
+        "lock_session": "session-1",
+        "lock_time": "2026-07-23T09:44:47+0000",
+        "lock_action": "edit",
+        "coverages": [{"coverage_id": "cov-1", "planning": {"slugline": "Coverage"}}],
+    }
+
+    updates = {
+        "lock_user": None,
+        "lock_session": None,
+        "lock_time": None,
+        "lock_action": None,
+        "_etag": "etag-2",
+        "coverages": original["coverages"],
+    }
+
+    def should_not_repost(_resource_name):
+        raise AssertionError("Lock-only updates must not invoke repost resource lookup")
+
+    monkeypatch.setattr(common_module, "get_resource_service", should_not_repost)
+
+    result = await common_module.update_post_item(updates, original)
+
+    assert result is None, "Lock-only/system-only updates should not repost"

--- a/server/planning/tests/update_post_item_repost_guard_test.py
+++ b/server/planning/tests/update_post_item_repost_guard_test.py
@@ -1,0 +1,94 @@
+import pytest
+
+from planning import common as common_module
+
+
+class StubPostService:
+    def __init__(self):
+        self.calls = []
+
+    async def post_async(self, docs):
+        self.calls.append(docs)
+        return ["ok"]
+
+
+@pytest.mark.asyncio
+async def test_update_post_item_skips_repost_for_lock_only_updates(monkeypatch):
+    post_service = StubPostService()
+    monkeypatch.setattr(common_module, "get_resource_service", lambda _name: post_service)
+
+    original = {
+        "_id": "planning-id",
+        "type": "planning",
+        "pubstatus": "usable",
+        "lock_user": "user-1",
+        "lock_session": "session-1",
+        "lock_time": "2026-07-23T09:44:47+0000",
+        "lock_action": "edit",
+        "coverages": [{"coverage_id": "cov1", "planning": {"slugline": "A"}}],
+    }
+
+    updates = {
+        "lock_user": None,
+        "lock_session": None,
+        "lock_time": None,
+        "lock_action": None,
+        "_etag": "new-etag",
+        # Planning services populate coverages before calling update_post_item.
+        "coverages": original["coverages"],
+    }
+
+    result = await common_module.update_post_item(updates, original)
+
+    assert result is None
+    assert post_service.calls == []
+
+
+@pytest.mark.asyncio
+async def test_update_post_item_reposts_for_meaningful_changes(monkeypatch):
+    post_service = StubPostService()
+    monkeypatch.setattr(common_module, "get_resource_service", lambda _name: post_service)
+
+    original = {
+        "_id": "planning-id",
+        "type": "planning",
+        "pubstatus": "usable",
+        "name": "Old headline",
+    }
+
+    updates = {
+        "name": "New headline",
+        "_etag": "new-etag",
+    }
+
+    result = await common_module.update_post_item(updates, original)
+
+    assert result == ["ok"]
+    assert len(post_service.calls) == 1
+    assert post_service.calls[0][0]["planning"] == "planning-id"
+    assert post_service.calls[0][0]["pubstatus"] == "usable"
+
+
+@pytest.mark.asyncio
+async def test_update_post_item_honors_explicit_pubstatus(monkeypatch):
+    post_service = StubPostService()
+    monkeypatch.setattr(common_module, "get_resource_service", lambda _name: post_service)
+
+    original = {
+        "_id": "planning-id",
+        "type": "planning",
+        "pubstatus": "usable",
+        "lock_user": "user-1",
+    }
+
+    updates = {
+        "lock_user": None,
+        "pubstatus": "cancelled",
+        "_etag": "new-etag",
+    }
+
+    result = await common_module.update_post_item(updates, original)
+
+    assert result == ["ok"]
+    assert len(post_service.calls) == 1
+    assert post_service.calls[0][0]["pubstatus"] == "cancelled"


### PR DESCRIPTION
This pull request introduces improved logging and a more robust mechanism for handling reposts in the planning service, specifically to avoid unnecessary reposts when only system or lock-related fields are updated. It also adds comprehensive tests to ensure correct repost behavior and better traceability of item lock and history operations.

### Repost logic improvements

* Updated `update_post_item` in `common.py` to skip reposts when only system or lock-related fields are changed, unless there is an explicit publish/unpublish request. This prevents unnecessary history entries and side effects from technical updates.
* Added new tests in `update_post_item_repost_guard_test.py` and `planning_attribution_test.py` to verify that reposts are only triggered for meaningful changes or explicit pubstatus updates, and are skipped for lock-only/system-only updates. [[1]](diffhunk://#diff-c9d8135536a7b3a4fb94a4910e7e51770f15513ef0fb7dda15429b62a15e29d7R1-R94) [[2]](diffhunk://#diff-f90edce34447769cbb5c4daeacb9badefcb069cccd695c2fb90b128710e2bea6R266-R297)

### Logging enhancements

* Added detailed logging throughout the item lock, unlock, and unlock session methods in `item_lock.py` for better traceability of lock operations, including request and client IDs. [[1]](diffhunk://#diff-3b876103b9d4810f831a0bf9389dd5e8988a7dc4f60182e9168fe26f0b3b09d4R74-R86) [[2]](diffhunk://#diff-3b876103b9d4810f831a0bf9389dd5e8988a7dc4f60182e9168fe26f0b3b09d4R117-R127) [[3]](diffhunk://#diff-3b876103b9d4810f831a0bf9389dd5e8988a7dc4f60182e9168fe26f0b3b09d4R155-R168) [[4]](diffhunk://#diff-3b876103b9d4810f831a0bf9389dd5e8988a7dc4f60182e9168fe26f0b3b09d4R201-R210) [[5]](diffhunk://#diff-3b876103b9d4810f831a0bf9389dd5e8988a7dc4f60182e9168fe26f0b3b09d4R232-R244)
* Improved logging in the autosave and history services (`planning_autosave_service.py`, `planning_history.py`, `planning_history_async_service.py`) to record when autosave actions are skipped or performed, and when history entries are saved or coverages are edited. [[1]](diffhunk://#diff-4aaf90a8755f82428673c963234bf78a81f55a04b15fce5cfde92634235e0a4eR20-R24) [[2]](diffhunk://#diff-4aaf90a8755f82428673c963234bf78a81f55a04b15fce5cfde92634235e0a4eR43-R48) [[3]](diffhunk://#diff-4aaf90a8755f82428673c963234bf78a81f55a04b15fce5cfde92634235e0a4eR62-R87) [[4]](diffhunk://#diff-db31611ca42a58c486d546f33c4ef6bb07df36e34fac503a13bde9d4797489d9R75-R82) [[5]](diffhunk://#diff-db31611ca42a58c486d546f33c4ef6bb07df36e34fac503a13bde9d4797489d9R166-R171) [[6]](diffhunk://#diff-4e982de326be9b3dd82ddfbff3d42be59b61ac283e0d64cbbf75cad89cda7748R51-R58) [[7]](diffhunk://#diff-4e982de326be9b3dd82ddfbff3d42be59b61ac283e0d64cbbf75cad89cda7748R142-R147)

### Testing and code organization

* Added missing imports and improved test coverage to ensure that the new repost guard logic and logging do not break existing workflows.

These changes collectively improve the reliability, performance, and observability of the planning service's update and history mechanisms.

### Front-end checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)

Resolves: STT-1746
