### PR TITLE
[SDESK-8005] Decouple editor fields registry from import evaluation order

### DIFF
--- a/client/components/fields/editor/index.tsx
+++ b/client/components/fields/editor/index.tsx
@@ -59,7 +59,7 @@ import {FIELD_TO_EDITOR_COMPONENT} from '../resources/registerEditorFields';
  * This is the single source of truth for field definitions, allows for registering
  * other fields from a different place through `registerEditorField`
 */
-Object.assign(FIELD_TO_EDITOR_COMPONENT, {
+const DEFAULT_EDITOR_FIELDS: typeof FIELD_TO_EDITOR_COMPONENT = {
     featured: EditorFieldFeatured,
     source: EditorFieldIngestSource,
     location: EditorFieldLocation,
@@ -148,11 +148,18 @@ Object.assign(FIELD_TO_EDITOR_COMPONENT, {
     scheduled_updates: EditorFieldScheduledUpdates,
     coverage_assignment_status: EditorFieldAssignedCoverageComponent,
     assignment_priority: EditorFieldAssignmentPriority,
-});
+};
+
+// The registrations from ../resources can run before or after this module,
+// depending on whether the compiler hoists the import below. Fill only fields
+// that are not registered yet, so registrations always win over these defaults,
+// as they did under statement-order evaluation.
+for (const field of Object.keys(DEFAULT_EDITOR_FIELDS)) {
+    if (FIELD_TO_EDITOR_COMPONENT[field] == null) {
+        FIELD_TO_EDITOR_COMPONENT[field] = DEFAULT_EDITOR_FIELDS[field];
+    }
+}
 
 export {FIELD_TO_EDITOR_COMPONENT};
 
-// Loads the registrations from ../resources; works regardless of whether the
-// compiler hoists this import, since the registry object lives in a module
-// with no circular dependencies.
 import '../resources/index';

--- a/client/components/fields/editor/index.tsx
+++ b/client/components/fields/editor/index.tsx
@@ -53,11 +53,13 @@ import {EditorFieldAddCoverageToWorkflow} from './AddCoverageToWorkflow';
 import {EditorFieldAssignmentPriority} from './AssignmentPriority';
 import {EditorFieldCreationDate} from './CreationDate';
 
+import {FIELD_TO_EDITOR_COMPONENT} from '../resources/registerEditorFields';
+
 /**
  * This is the single source of truth for field definitions, allows for registering
  * other fields from a different place through `registerEditorField`
 */
-export const FIELD_TO_EDITOR_COMPONENT = {
+Object.assign(FIELD_TO_EDITOR_COMPONENT, {
     featured: EditorFieldFeatured,
     source: EditorFieldIngestSource,
     location: EditorFieldLocation,
@@ -146,7 +148,11 @@ export const FIELD_TO_EDITOR_COMPONENT = {
     scheduled_updates: EditorFieldScheduledUpdates,
     coverage_assignment_status: EditorFieldAssignedCoverageComponent,
     assignment_priority: EditorFieldAssignmentPriority,
-};
+});
 
-// Import resource fields so that registration happens after the above
+export {FIELD_TO_EDITOR_COMPONENT};
+
+// Loads the registrations from ../resources; works regardless of whether the
+// compiler hoists this import, since the registry object lives in a module
+// with no circular dependencies.
 import '../resources/index';

--- a/client/components/fields/resources/registerEditorFields.tsx
+++ b/client/components/fields/resources/registerEditorFields.tsx
@@ -2,7 +2,13 @@ import * as React from 'react';
 import {connect} from 'react-redux';
 
 import {IEditorFieldProps, IPlanningAppState} from '../../../interfaces';
-import {FIELD_TO_EDITOR_COMPONENT} from '../editor';
+
+/**
+ * Owned here rather than in ../editor so registration does not depend on module
+ * evaluation order in the circular import between the two files; ../editor adds
+ * its initial entries and re-exports it.
+ */
+export const FIELD_TO_EDITOR_COMPONENT: {[field: string]: React.ComponentType<any>} = {};
 
 interface IEditorHocOptions<S extends IEditorFieldProps> {
     Component: React.ComponentType<S>;


### PR DESCRIPTION
### Purpose

superdesk-client-core is moving from ts-loader to swc (superdesk/superdesk-client-core#5293), and the editor fields registry breaks under it. `editor/index.tsx` fills `FIELD_TO_EDITOR_COMPONENT` and then imports `../resources` at the bottom of the file so registration happens after; that only works because tsc's CommonJS emit runs statements in source order. swc hoists imports like the ES spec says, so the registrations run first, write into an uninitialized object, and the app crashes at boot with `Cannot set properties of undefined (setting 'ednote')`. Any other spec-compliant toolchain (esbuild, native ESM) would trip on it the same way.

### What has changed

The registry object now lives in `registerEditorFields.tsx`, which has no circular imports, so it exists before any registration runs. `editor/index.tsx` adds its initial entries with `Object.assign` and re-exports it, so consumers don't change. Works under both evaluation orders.

### Steps to test

Build the client with this branch and client-core develop (or #5293): the app boots and planning editor fields render. Without this, combined with #5293, it crashes on load.

Part of [SDESK-8005] (the client-core build speedup); needed before superdesk/superdesk-client-core#5293 ships to planning users.


[SDESK-8005]: https://sofab.atlassian.net/browse/SDESK-8005?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ