### PR TITLE
[STT-1738] Add a `card_view` list config for entity cards in previews (backport of #2925)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ It allows to ingest and manage events, to create planning within agenda, and to 
     * [Assignments](#assignments-config)
     * [Authoring](#authoring-config)
     * [Search Filters](#search-filters-config)
+* [Client Config](#client-config)
+    * [List item config](#list-item-config)
 * [Slack Integration](#slack-integration)
 * [Celery Tasks](#celery-tasks)
     * [Expire Items](#celery-tasks-expire-items)
@@ -412,6 +414,81 @@ Example: Add a custom text field with `_id` of `sttregistrationinfo` to Assignme
 To enable, create a local storage entry called "devtools" with a value `'["redux-logger"]'`. It can be done by running the following command in the console:
 
     localStorage.setItem('devtools', '["redux-logger"]')
+
+
+## Client Config
+Unlike the sections above, these options are defined in `superdesk.config.js`, not in `settings.py`.
+
+### List item config
+Controls which fields are rendered on Event, Planning and Assignment list rows, and on the entity cards that represent linked items inside item previews. Everything lives under the `planning` key:
+
+```js
+planning: {
+    event_list_item: {firstLine: [...], secondLine: [...]},
+    planning_list_item: {firstLine: [...], secondLine: [...]},
+    assignment_list_item: {firstLine: [...], secondLine: [...]},
+}
+```
+
+`firstLine` and `secondLine` are arrays of field configs:
+
+```js
+{fieldId: 'slugline'}
+{fieldId: 'event_datetime', position: 'end'}
+{fieldId: 'anpa_category', fieldOptions: {hideLabel: true}}
+{fieldId: 'vocabulary', fieldOptions: {vocabularyId: 'event_type', hideVocabularyName: true}}
+```
+
+* `fieldId` is required.
+* `position` is either `start` (the default) or `end`. Fields marked `end` are pushed to the opposite side of the line.
+* `fieldOptions` is field specific. `anpa_category` and `priority` accept `hideLabel`, `vocabulary` requires `vocabularyId` and accepts `hideVocabularyName`.
+
+Omitting a block falls back to the built-in defaults in `client/config.ts`.
+
+`assignmentsList` is a deprecated older format for the assignments list, superseded by `planning.assignment_list_item`.
+
+#### View variants
+`event_list_item` and `planning_list_item` accept two optional blocks alongside `firstLine` and `secondLine`:
+
+* `compact_view` is used by the "Compact list" view option, which only appears in the view menu when this block is configured. Only its `firstLine` is rendered, the second line is always empty.
+* `card_view` is used by the cards that represent linked items inside Event, Planning and Assignment previews, for example the related Event shown on a Planning item and vice versa. A configured `card_view` fully describes the card, so an omitted `firstLine` or `secondLine` renders nothing rather than falling back to the list config. Cards never render the item type icon, and `related_events` / `related_plannings` are ignored inside a card so that cards cannot nest.
+
+`assignment_list_item` has no view variants.
+
+```js
+planning_list_item: {
+    firstLine: [
+        {fieldId: 'anpa_category', fieldOptions: {hideLabel: true}},
+        {fieldId: 'slugline'},
+        {fieldId: 'coverages', position: 'end'},
+    ],
+    secondLine: [
+        {fieldId: 'state'},
+        {fieldId: 'internalnote'},
+        {fieldId: 'related_events', position: 'end'},
+    ],
+    card_view: {
+        firstLine: [
+            {fieldId: 'slugline'},
+            {fieldId: 'coverages', position: 'end'},
+        ],
+        secondLine: [
+            {fieldId: 'state'},
+        ],
+    },
+},
+```
+
+#### Available field ids
+Events and Planning items, registered in `client/components/fields/index.tsx`:
+
+`name`, `slugline`, `headline`, `description`, `definition_short`, `internalnote`, `state`, `event_datetime`, `related_events`, `related_plannings`, `urgency`, `priority`, `calendars`, `location`, `files`, `featured`, `agendas`, `coverages`, `reference`, `vocabulary`, `anpa_category`
+
+Not every field is meaningful for both item types. `calendars` and `related_plannings` apply to Events, while `agendas`, `coverages` and `related_events` apply to Planning items. An id that is not registered is skipped silently.
+
+Assignments use a separate set, defined in `client/components/Assignments/AssignmentItem/fields/index.ts`:
+
+`accepted`, `content`, `description_text`, `desk`, `due_date`, `genre`, `headline`, `internal`, `name`, `priority`, `slugline`, `state`, `language`, `anpa_category`, `vocabulary`
 
 
 ## Slack Integration

--- a/client/components/Assignments/AssignmentPreviewContainer/index.tsx
+++ b/client/components/Assignments/AssignmentPreviewContainer/index.tsx
@@ -220,6 +220,7 @@ class AssignmentPreviewContainerComponent extends React.Component<IProps> {
                                             createUploadLink={getFileDownloadURL}
                                             files={files}
                                             hideEditIcon={true}
+                                            cardView={true}
                                         />
 
                                         <PreviewFieldRelatedArticles
@@ -253,7 +254,7 @@ class AssignmentPreviewContainerComponent extends React.Component<IProps> {
                         desks={desks}
                         allowEditPlanning={false}
                         currentCoverageId={assignment.coverage_item}
-
+                        cardView={true}
                     />
                 </ContentBlock>
             </div>

--- a/client/components/Events/EventMetadata/EventMetadata_test.tsx
+++ b/client/components/Events/EventMetadata/EventMetadata_test.tsx
@@ -1,9 +1,14 @@
 import React from 'react';
 import {mount} from 'enzyme';
+import '../../../utils/testUtils';
 import {EventMetadata} from '../index';
 import moment from 'moment';
 import {createTestStore, eventUtils} from '../../../utils';
 import {Provider} from 'react-redux';
+import {appConfig} from 'appConfig';
+import {ItemIcon} from '../../ItemIcon';
+import {LineItems} from '../../UI/List/LineItems';
+import {RelatedEventListItem} from './RelatedEventListItem';
 
 describe('<EventMetadata />', () => {
     it('renders metadata of an event', () => {
@@ -47,5 +52,113 @@ describe('<EventMetadata />', () => {
         expect(content.find('[data-test-id="field-definition_short"] p').text()).toBe('definition_short 1');
         expect(content.find('[data-test-id="field-event_contact_info"] > p').text()).toBe('-');
         expect(content.find('[data-test-id="field-location"] a').text()).toBe('location1address1');
+    });
+});
+
+describe('<EventMetadata /> card view', () => {
+    const event = {
+        _id: 'event1',
+        type: 'event',
+        slugline: 'event slugline',
+        name: 'event name',
+        dates: {
+            start: moment('2016-10-15T13:01:11+0000'),
+            end: moment('2016-10-15T13:02:11+0000'),
+            tz: moment.tz.guess(),
+        },
+    };
+
+    const renderEvent = (props = {}) => mount(
+        <Provider store={createTestStore()}>
+            <EventMetadata event={event} {...props} />
+        </Provider>
+    );
+
+    afterEach(() => {
+        delete appConfig.planning.event_list_item;
+    });
+
+    it('renders the configured card_view fields and drops the ones card_view omits', () => {
+        appConfig.planning.event_list_item = {
+            firstLine: [{fieldId: 'slugline'}, {fieldId: 'name'}],
+            card_view: {
+                firstLine: [{fieldId: 'name'}],
+                secondLine: [{fieldId: 'state'}],
+            },
+        };
+
+        const listItem = renderEvent({cardView: true}).find(RelatedEventListItem);
+
+        expect(listItem.find('span.sd-list-item__name').text()).toBe('event name');
+        expect(listItem.find('span.sd-list-item__slugline').length).toBe(0);
+    });
+
+    it('falls back to the configured list config when card_view is not configured', () => {
+        appConfig.planning.event_list_item = {
+            firstLine: [{fieldId: 'slugline'}],
+        };
+
+        const listItem = renderEvent({cardView: true}).find(RelatedEventListItem);
+
+        expect(listItem.find('span.sd-list-item__slugline').text()).toBe('event slugline');
+        expect(listItem.find('span.sd-list-item__name').length).toBe(0);
+    });
+
+    it('renders the same lines as the list view when nothing is configured', () => {
+        const cardLines = renderEvent({cardView: true}).find(LineItems)
+            .html();
+        const listLines = renderEvent().find(LineItems)
+            .html();
+
+        expect(cardLines).toBe(listLines);
+    });
+
+    it('does not render the item icon in card view even when showIcon is true', () => {
+        const cardItem = renderEvent({cardView: true, showIcon: true}).find(RelatedEventListItem);
+        const listItem = renderEvent({showIcon: true}).find(RelatedEventListItem);
+
+        expect(cardItem.find(ItemIcon).length).toBe(0);
+        expect(listItem.find(ItemIcon).length).toBe(1);
+    });
+
+    it('renders no second line when card_view omits it', () => {
+        appConfig.planning.event_list_item = {
+            firstLine: [{fieldId: 'slugline'}],
+            secondLine: [{fieldId: 'state'}],
+            card_view: {
+                firstLine: [{fieldId: 'name'}],
+            },
+        };
+
+        const listItem = renderEvent({cardView: true}).find(RelatedEventListItem);
+
+        expect(listItem.find(LineItems).prop('secondLine')).toEqual([]);
+    });
+
+    it('renders no first line when card_view omits it', () => {
+        appConfig.planning.event_list_item = {
+            firstLine: [{fieldId: 'slugline'}],
+            card_view: {
+                secondLine: [{fieldId: 'state'}],
+            },
+        };
+
+        const listItem = renderEvent({cardView: true}).find(RelatedEventListItem);
+
+        expect(listItem.find(LineItems).prop('firstLine')).toEqual([]);
+    });
+
+    it('never nests event cards, even when card_view configures related_plannings', () => {
+        appConfig.planning.event_list_item = {
+            firstLine: [{fieldId: 'name'}],
+            card_view: {
+                firstLine: [{fieldId: 'name'}, {fieldId: 'related_plannings'}],
+            },
+        };
+
+        const listItem = renderEvent({cardView: true}).find(RelatedEventListItem);
+
+        expect(listItem.find(LineItems).prop('firstLine'))
+            .toEqual([{fieldId: 'name'}]);
     });
 });

--- a/client/components/Events/EventMetadata/RelatedEventListItem.tsx
+++ b/client/components/Events/EventMetadata/RelatedEventListItem.tsx
@@ -11,7 +11,12 @@ import * as selectors from '../../../selectors';
 import * as List from '../../UI/List';
 import {ItemIcon} from '../../ItemIcon';
 import {LineItems} from '../../../components/UI/List/LineItems';
-import {eventFirstLineConfig, eventSecondLineConfig} from '../../../config';
+import {
+    eventFirstLineConfig,
+    eventSecondLineConfig,
+    getEventCardFirstLineConfig,
+    getEventCardSecondLineConfig,
+} from '../../../config';
 import {renderFields} from '../../../components/fields';
 import {getUserInterfaceLanguageFromCV} from '../../../utils/users';
 import {ILineConfig} from 'globals';
@@ -23,6 +28,9 @@ interface IBaseProps {
     noBg?: boolean;
     showBorder?: boolean;
     showIcon?: boolean;
+
+    // Preview card variant: card_view config, no item type icon
+    cardView?: boolean;
     shadow?: number;
     dateOnly?: boolean;
     eventActions?: React.ReactNode;
@@ -73,8 +81,12 @@ class RelatedEventListItemComponent extends React.PureComponent<IProps> {
             language,
         );
 
+        const firstLineConfig = this.props.cardView ? getEventCardFirstLineConfig() : eventFirstLineConfig;
+        const secondLineConfig = this.props.cardView ? getEventCardSecondLineConfig() : eventSecondLineConfig;
+
         return (
             <List.Item
+                testId="related-event-item"
                 noBg={this.props.noBg}
                 activated={this.props.active}
                 shadow={this.props.shadow}
@@ -99,8 +111,8 @@ class RelatedEventListItemComponent extends React.PureComponent<IProps> {
                     </List.Column>
                 )}
 
-                {!this.props.showIcon ? null : (
-                    <List.Column>
+                {(this.props.cardView || !this.props.showIcon) ? null : (
+                    <List.Column testId="item-type-icon">
                         <ItemIcon
                             item={this.props.item}
                             color={ICON_COLORS.DARK_BLUE_GREY}
@@ -114,8 +126,8 @@ class RelatedEventListItemComponent extends React.PureComponent<IProps> {
                     style={this.props.noColumnPadding ? undefined : {paddingBlock: 'var(--space--1)'}}
                 >
                     <LineItems
-                        firstLine={eventFirstLineConfig.filter(({fieldId}) => fieldId !== 'related_plannings')}
-                        secondLine={eventSecondLineConfig.filter(({fieldId}) => fieldId !== 'related_plannings')}
+                        firstLine={firstLineConfig.filter(({fieldId}) => fieldId !== 'related_plannings')}
+                        secondLine={secondLineConfig.filter(({fieldId}) => fieldId !== 'related_plannings')}
                         renderFieldsWithProps={renderFieldsWithProps}
                     />
                 </List.Column>

--- a/client/components/Events/EventMetadata/index.tsx
+++ b/client/components/Events/EventMetadata/index.tsx
@@ -48,6 +48,7 @@ interface IProps {
     showIcon?: boolean; // defaults to true
     showBorder?: boolean; // defaults to true
     hideEditIcon?: boolean;
+    cardView?: boolean;
 }
 
 const mapStateToProps = (state) => ({
@@ -145,6 +146,7 @@ class EventMetadataComponent extends React.PureComponent<IProps> {
                 noBg={!active}
                 showBorder={showBorder}
                 showIcon={showIcon}
+                cardView={this.props.cardView}
                 dateOnly={dateOnly}
                 eventActions={eventActions}
             />

--- a/client/components/Events/EventPreviewContent.tsx
+++ b/client/components/Events/EventPreviewContent.tsx
@@ -80,6 +80,7 @@ export class EventPreviewContentComponent extends React.PureComponent<IProps> {
                         users={users}
                         desks={desks}
                         allowEditPlanning={true}
+                        cardView={true}
                     />
                 ) :
                     <span className="sd-text__info">{gettext('No related planning items.')}</span>

--- a/client/components/Planning/PlanningPreviewContent.tsx
+++ b/client/components/Planning/PlanningPreviewContent.tsx
@@ -221,6 +221,7 @@ export class PlanningPreviewContentComponent extends React.PureComponent<IProps>
                                 createUploadLink={getFileDownloadURL}
                                 files={files}
                                 hideEditIcon={hideEditIcon}
+                                cardView={true}
                             />
                         ))}
                     </>

--- a/client/components/RelatedPlannings/PlanningMetaData/RelatedPlanningListItem.tsx
+++ b/client/components/RelatedPlannings/PlanningMetaData/RelatedPlanningListItem.tsx
@@ -12,7 +12,12 @@ import * as List from '../../UI/List';
 import {ICON_COLORS} from '../../../constants';
 import {ItemIcon} from '../../../components/ItemIcon';
 import {LineItems} from '../../../components/UI/List/LineItems';
-import {getPlanningSecondLineConfig, planningFirstLineConfig} from '../../../config';
+import {
+    getPlanningCardFirstLineConfig,
+    getPlanningCardSecondLineConfig,
+    getPlanningSecondLineConfig,
+    planningFirstLineConfig,
+} from '../../../config';
 import {getUserInterfaceLanguageFromCV} from '../../../utils/users';
 import {renderFields} from '../../../components/fields';
 import {ILineConfig} from 'globals';
@@ -24,6 +29,9 @@ interface IBaseProps {
     noBg?: boolean;
     showBorder?: boolean;
     showIcon?: boolean;
+
+    // Preview card variant: card_view config, no item type icon
+    cardView?: boolean;
     shadow?: number;
     editPlanningComponent?: React.ReactNode;
     isAgendaEnabled: boolean;
@@ -83,8 +91,15 @@ class RelatedPlanningListItemComponent extends React.PureComponent<IProps> {
             language,
         );
 
+        const {isAgendaEnabled} = this.props;
+        const firstLineConfig = this.props.cardView ? getPlanningCardFirstLineConfig() : planningFirstLineConfig;
+        const secondLineConfig = this.props.cardView ?
+            getPlanningCardSecondLineConfig({isAgendaEnabled}) :
+            getPlanningSecondLineConfig({isAgendaEnabled});
+
         return (
             <List.Item
+                testId="related-planning-item"
                 noBg={this.props.noBg}
                 activated={this.props.active}
                 shadow={this.props.shadow}
@@ -107,8 +122,8 @@ class RelatedPlanningListItemComponent extends React.PureComponent<IProps> {
                     </List.Column>
                 )}
 
-                {!this.props.showIcon ? null : (
-                    <List.Column>
+                {(this.props.cardView || !this.props.showIcon) ? null : (
+                    <List.Column testId="item-type-icon">
                         <ItemIcon
                             item={this.props.item}
                             color={ICON_COLORS.DARK_BLUE_GREY}
@@ -122,11 +137,8 @@ class RelatedPlanningListItemComponent extends React.PureComponent<IProps> {
                     style={this.props.noColumnPadding ? undefined : {paddingBlock: 'var(--space--1)'}}
                 >
                     <LineItems
-                        firstLine={planningFirstLineConfig.filter(({fieldId}) => fieldId !== 'related_events')}
-                        secondLine={
-                            getPlanningSecondLineConfig({isAgendaEnabled: this.props.isAgendaEnabled})
-                                .filter(({fieldId}) => fieldId !== 'related_events')
-                        }
+                        firstLine={firstLineConfig.filter(({fieldId}) => fieldId !== 'related_events')}
+                        secondLine={secondLineConfig.filter(({fieldId}) => fieldId !== 'related_events')}
                         renderFieldsWithProps={renderFieldsWithProps}
                     />
                 </List.Column>

--- a/client/components/RelatedPlannings/PlanningMetaData/index.tsx
+++ b/client/components/RelatedPlannings/PlanningMetaData/index.tsx
@@ -19,6 +19,7 @@ interface IProps {
     active?: boolean;
     showIcon?: boolean; // defaults to true
     showBorder?: boolean; // defaults to true
+    cardView?: boolean;
     noBg?: boolean;
     navigation?: any;
     onEditPlanning?(): void;
@@ -65,6 +66,7 @@ export class PlanningMetaData extends React.PureComponent<IProps> {
                 noBg={this.props.noBg}
                 showBorder={this.props.showBorder ?? true}
                 showIcon={this.props.showIcon ?? true}
+                cardView={this.props.cardView}
                 editPlanningComponent={editPlanningComponent}
             />
         );

--- a/client/components/RelatedPlannings/RelatedPlannings_test.tsx
+++ b/client/components/RelatedPlannings/RelatedPlannings_test.tsx
@@ -1,9 +1,14 @@
 import React from 'react';
 import {mount} from 'enzyme';
+import '../../utils/testUtils';
 import {RelatedPlannings} from '../RelatedPlannings';
 import * as selectors from '../../selectors';
 import {createTestStore} from '../../utils';
 import {Provider} from 'react-redux';
+import {appConfig} from 'appConfig';
+import {ItemIcon} from '../ItemIcon';
+import {LineItems} from '../UI/List/LineItems';
+import {RelatedPlanningListItem} from './PlanningMetaData/RelatedPlanningListItem';
 
 describe('<RelatedPlannings />', () => {
     it('fetches agenda for the planning item from store', () => {
@@ -76,5 +81,114 @@ describe('<RelatedPlannings />', () => {
         const relPlanningNode = wrapper.find('.simple-list').childAt(0);
 
         expect(relPlanningNode.text()).toBe(' planning 3 created by ABC in agenda agenda1, agenda2');
+    });
+});
+
+describe('<RelatedPlannings /> card view', () => {
+    const plan = {
+        _id: '3',
+        type: 'planning',
+        slugline: 'planning 3',
+        description_text: 'planning description',
+    };
+
+    const renderPlannings = (props = {}) => mount(
+        <Provider store={createTestStore()}>
+            <RelatedPlannings
+                plannings={[plan]}
+                openPlanningItem={true}
+                expandable={true}
+                allowEditPlanning={false}
+                {...props}
+            />
+        </Provider>
+    );
+
+    afterEach(() => {
+        delete appConfig.planning.planning_list_item;
+    });
+
+    it('renders the configured card_view fields and drops the ones card_view omits', () => {
+        appConfig.planning.planning_list_item = {
+            firstLine: [{fieldId: 'slugline'}, {fieldId: 'description'}],
+            card_view: {
+                firstLine: [{fieldId: 'description'}],
+                secondLine: [{fieldId: 'state'}],
+            },
+        };
+
+        const listItem = renderPlannings({cardView: true}).find(RelatedPlanningListItem);
+
+        expect(listItem.find('span.sd-list-item__description').text()).toBe('planning description');
+        expect(listItem.find('span.sd-list-item__slugline').length).toBe(0);
+    });
+
+    it('falls back to the configured list config when card_view is not configured', () => {
+        appConfig.planning.planning_list_item = {
+            firstLine: [{fieldId: 'slugline'}],
+        };
+
+        const listItem = renderPlannings({cardView: true}).find(RelatedPlanningListItem);
+
+        expect(listItem.find('span.sd-list-item__slugline').text()).toBe('planning 3');
+        expect(listItem.find('span.sd-list-item__description').length).toBe(0);
+    });
+
+    it('renders the same lines as the list view when nothing is configured', () => {
+        const cardLines = renderPlannings({cardView: true}).find(LineItems)
+            .html();
+        const listLines = renderPlannings().find(LineItems)
+            .html();
+
+        expect(cardLines).toBe(listLines);
+    });
+
+    it('does not render the item icon in card view even when showIcon is true', () => {
+        const cardItem = renderPlannings({cardView: true}).find(RelatedPlanningListItem);
+        const listItem = renderPlannings().find(RelatedPlanningListItem);
+
+        expect(cardItem.find(ItemIcon).length).toBe(0);
+        expect(listItem.find(ItemIcon).length).toBe(1);
+    });
+
+    it('renders no second line when card_view omits it', () => {
+        appConfig.planning.planning_list_item = {
+            firstLine: [{fieldId: 'slugline'}],
+            secondLine: [{fieldId: 'state'}],
+            card_view: {
+                firstLine: [{fieldId: 'description'}],
+            },
+        };
+
+        const listItem = renderPlannings({cardView: true}).find(RelatedPlanningListItem);
+
+        expect(listItem.find(LineItems).prop('secondLine')).toEqual([]);
+    });
+
+    it('renders no first line when card_view omits it', () => {
+        appConfig.planning.planning_list_item = {
+            firstLine: [{fieldId: 'slugline'}],
+            card_view: {
+                secondLine: [{fieldId: 'state'}],
+            },
+        };
+
+        const listItem = renderPlannings({cardView: true}).find(RelatedPlanningListItem);
+
+        expect(listItem.find(LineItems).prop('firstLine')).toEqual([]);
+    });
+
+    it('never nests planning cards, even when card_view configures related_events', () => {
+        appConfig.planning.planning_list_item = {
+            firstLine: [{fieldId: 'slugline'}],
+            card_view: {
+                firstLine: [{fieldId: 'slugline'}, {fieldId: 'related_events'}],
+            },
+        };
+
+        const listItem = renderPlannings({cardView: true}).find(RelatedPlanningListItem);
+
+        expect(listItem.find(LineItems).prop('firstLine'))
+            .toEqual([{fieldId: 'slugline'}]);
     });
 });

--- a/client/components/RelatedPlannings/index.tsx
+++ b/client/components/RelatedPlannings/index.tsx
@@ -24,6 +24,7 @@ export const RelatedPlanningsComponent = ({
     allowEditPlanning,
     contentTypes,
     currentCoverageId,
+    cardView,
 }) => (
     (
         <div>
@@ -42,6 +43,7 @@ export const RelatedPlanningsComponent = ({
                         contentTypes={contentTypes}
                         tabEnabled={true}
                         currentCoverageId={currentCoverageId}
+                        cardView={cardView}
                     />
                 ))
                 :
@@ -131,6 +133,7 @@ RelatedPlanningsComponent.propTypes = {
     allowEditPlanning: PropTypes.bool,
     contentTypes: PropTypes.array,
     currentCoverageId: PropTypes.string,
+    cardView: PropTypes.bool,
 };
 
 RelatedPlanningsComponent.defaultProps = {short: false};

--- a/client/components/UI/List/Column.tsx
+++ b/client/components/UI/List/Column.tsx
@@ -17,6 +17,7 @@ interface IProps {
     checked?: boolean;
     className?: string;
     style?: React.CSSProperties;
+    testId?: string;
 }
 
 export const Column = ({
@@ -28,8 +29,10 @@ export const Column = ({
     checked,
     className,
     style,
+    testId,
 }: IProps) => (
     <div
+        data-test-id={testId}
         className={classNames(
             'sd-list-item__column',
             {

--- a/client/config.ts
+++ b/client/config.ts
@@ -125,6 +125,34 @@ export const eventFirstLineConfig: Array<ILineConfig> =
 export const eventSecondLineConfig: Array<ILineConfig> =
     appConfig.planning?.event_list_item?.secondLine ?? eventSecondLineConfigDefaults;
 
+type ICardViewConfig = {firstLine?: Array<ILineConfig>; secondLine?: Array<ILineConfig>};
+
+// A configured `card_view` fully describes the card: an omitted line renders nothing
+const getCardLine = (
+    cardView: ICardViewConfig | undefined,
+    line: keyof ICardViewConfig,
+    listLine: Array<ILineConfig> | undefined,
+    defaults: Array<ILineConfig>,
+): Array<ILineConfig> => cardView != null ?
+    cardView[line] ?? [] :
+    listLine ?? defaults;
+
+export const getEventCardFirstLineConfig = (): Array<ILineConfig> =>
+    getCardLine(
+        appConfig.planning?.event_list_item?.card_view,
+        'firstLine',
+        appConfig.planning?.event_list_item?.firstLine,
+        eventFirstLineConfigDefaults,
+    );
+
+export const getEventCardSecondLineConfig = (): Array<ILineConfig> =>
+    getCardLine(
+        appConfig.planning?.event_list_item?.card_view,
+        'secondLine',
+        appConfig.planning?.event_list_item?.secondLine,
+        eventSecondLineConfigDefaults,
+    );
+
 const planningFirstLineDefaults: Array<ILineConfig> = [
     {fieldId: 'slugline'},
     {fieldId: 'internalnote'},
@@ -142,6 +170,30 @@ const planningSecondLineDefaults: Array<ILineConfig> = [
 export const planningFirstLineConfig: Array<ILineConfig> =
     appConfig.planning?.planning_list_item?.firstLine ?? planningFirstLineDefaults;
 
+const filterAgendas = (config: Array<ILineConfig>, isAgendaEnabled: boolean): Array<ILineConfig> =>
+    config.filter(({fieldId}: ILineConfig) => isAgendaEnabled ? true : fieldId !== 'agendas');
+
 export const getPlanningSecondLineConfig = ({isAgendaEnabled}: {isAgendaEnabled: boolean}): Array<ILineConfig> =>
-    (appConfig.planning?.planning_list_item?.secondLine ?? planningSecondLineDefaults)
-        .filter(({fieldId}: ILineConfig) => isAgendaEnabled ? true : fieldId !== 'agendas');
+    filterAgendas(
+        appConfig.planning?.planning_list_item?.secondLine ?? planningSecondLineDefaults,
+        isAgendaEnabled,
+    );
+
+export const getPlanningCardFirstLineConfig = (): Array<ILineConfig> =>
+    getCardLine(
+        appConfig.planning?.planning_list_item?.card_view,
+        'firstLine',
+        appConfig.planning?.planning_list_item?.firstLine,
+        planningFirstLineDefaults,
+    );
+
+export const getPlanningCardSecondLineConfig = ({isAgendaEnabled}: {isAgendaEnabled: boolean}): Array<ILineConfig> =>
+    filterAgendas(
+        getCardLine(
+            appConfig.planning?.planning_list_item?.card_view,
+            'secondLine',
+            appConfig.planning?.planning_list_item?.secondLine,
+            planningSecondLineDefaults,
+        ),
+        isAgendaEnabled,
+    );

--- a/client/globals.d.ts
+++ b/client/globals.d.ts
@@ -240,6 +240,13 @@ declare module 'superdesk-api' {
                     firstLine: Array<ILineConfig>;
                     secondLine?: Array<ILineConfig>;
                 };
+
+                // Cards for linked items shown inside item previews. A configured
+                // card_view fully describes the card: an omitted line renders nothing
+                card_view?: {
+                    firstLine?: Array<ILineConfig>;
+                    secondLine?: Array<ILineConfig>;
+                };
             };
 
             event_list_item?: {
@@ -248,6 +255,13 @@ declare module 'superdesk-api' {
 
                 compact_view?: {
                     firstLine: Array<ILineConfig>;
+                    secondLine?: Array<ILineConfig>;
+                };
+
+                // Cards for linked items shown inside item previews. A configured
+                // card_view fully describes the card: an omitted line renders nothing
+                card_view?: {
+                    firstLine?: Array<ILineConfig>;
                     secondLine?: Array<ILineConfig>;
                 };
             };

--- a/client/planning-extension/src/globals.d.ts
+++ b/client/planning-extension/src/globals.d.ts
@@ -59,6 +59,13 @@ declare module 'superdesk-api' {
                     firstLine: Array<ILineConfig>;
                     secondLine?: Array<ILineConfig>;
                 };
+
+                // Cards for linked items shown inside item previews. A configured
+                // card_view fully describes the card: an omitted line renders nothing
+                card_view?: {
+                    firstLine?: Array<ILineConfig>;
+                    secondLine?: Array<ILineConfig>;
+                };
             };
 
             event_list_item?: {
@@ -67,6 +74,13 @@ declare module 'superdesk-api' {
 
                 compact_view?: {
                     firstLine: Array<ILineConfig>;
+                    secondLine?: Array<ILineConfig>;
+                };
+
+                // Cards for linked items shown inside item previews. A configured
+                // card_view fully describes the card: an omitted line renders nothing
+                card_view?: {
+                    firstLine?: Array<ILineConfig>;
                     secondLine?: Array<ILineConfig>;
                 };
             };

--- a/e2e/playwright/preview_card_view.spec.ts
+++ b/e2e/playwright/preview_card_view.spec.ts
@@ -1,0 +1,201 @@
+import {test, expect} from '@playwright/test';
+
+import {setup, login, waitForPageLoad, addItems, changeWorkspace} from './utils/common';
+import {
+    AdvancedSearch,
+    AssignmentEditor,
+    PlanningEditor,
+    PlanningList,
+    PlanningPreview,
+} from './page-object-models/planning';
+import {createEventFor} from './utils/fixtures/events';
+import {createPlanningFor} from './utils/fixtures/planning';
+
+const EVENT_ID = 'e2e-card-view-event';
+
+const EVENT = {
+    guid: EVENT_ID,
+    name: 'Card View Event',
+    // list config only
+    slugline: 'EVENT-LIST-ONLY-SLUGLINE',
+    // card_view only
+    reference: 'EVENT-CARD-ONLY-REF',
+    calendars: [{qcode: 'sport', name: 'Sport'}],
+};
+
+const PLANNING = {
+    slugline: 'PLANNING-CARD-SLUGLINE',
+    // card_view only
+    headline: 'PLANNING-CARD-ONLY-HEADLINE',
+    // list config only
+    description_text: 'PLANNING-LIST-ONLY-DESCRIPTION',
+    // card_view second line only
+    urgency: 3,
+    related_events: [{_id: EVENT_ID, link_type: 'primary'}],
+};
+
+test.describe('Planning: entity cards inside item previews', () => {
+    let list: PlanningList;
+    let preview: PlanningPreview;
+    let search: AdvancedSearch;
+
+    test.beforeEach(async ({page}) => {
+        list = new PlanningList(page);
+        preview = new PlanningPreview(page);
+        search = new AdvancedSearch(page);
+
+        await setup(page, 'planning_prepopulate_data', '/#/planning');
+        await addItems(page.request, 'events', [createEventFor.today(EVENT)]);
+        await addItems(page.request, 'planning', [createPlanningFor.today(PLANNING)]);
+
+        await login(page);
+        await waitForPageLoad.planning(page);
+    });
+
+    const openPlanningPreview = async () => {
+        await search.viewPlanningOnly();
+        await list.expectItemCount(1);
+        await list.item(0).click();
+        await preview.waitTillOpen();
+        await expect(preview.entityCards).toHaveCount(1);
+    };
+
+    const openEventPreview = async () => {
+        await search.viewEventsOnly();
+        await list.expectItemCount(1);
+        await list.item(0).click();
+        await preview.waitTillOpen();
+        await expect(preview.entityCards).toHaveCount(1);
+    };
+
+    test('related event card in a planning preview uses event_list_item.card_view', async () => {
+        await openPlanningPreview();
+
+        const card = preview.entityCard(0);
+
+        await expect(card).toContainText(EVENT.name);
+        await expect(card).toContainText(EVENT.reference);
+
+        await expect(card).not.toContainText('Calendar:');
+        await expect(card).not.toContainText(EVENT.slugline);
+    });
+
+    test('related planning card in an event preview uses planning_list_item.card_view', async () => {
+        await openEventPreview();
+
+        const card = preview.entityCard(0);
+
+        await expect(card).toContainText(PLANNING.slugline);
+        await expect(card).toContainText(PLANNING.headline);
+
+        // Asserted by class rather than the "Urgency:" label, which is translatable
+        await expect(card.locator(`.urgency-label--${PLANNING.urgency}`)).toBeVisible();
+
+        await expect(card).not.toContainText(PLANNING.description_text);
+    });
+
+    test('related event card in a planning preview has no content type icon', async () => {
+        await openPlanningPreview();
+
+        await expect(preview.entityCard(0)).toContainText(EVENT.reference);
+
+        // The last test proves this id is live on the same component outside a card
+        await expect(preview.itemTypeIcons(preview.entityCard(0))).toHaveCount(0);
+    });
+
+    test('related planning card in an event preview has no content type icon', async () => {
+        await openEventPreview();
+
+        await expect(preview.entityCard(0)).toContainText(PLANNING.headline);
+        await expect(preview.itemTypeIcons(preview.entityCard(0))).toHaveCount(0);
+    });
+
+    // The third `cardView` call site. It cannot be seeded: an assignment only exists once a
+    // coverage is put into workflow.
+    test('assignment preview cards use card_view and omit the type icon', async ({page}) => {
+        const editor = new PlanningEditor(page);
+        const assignmentEditor = new AssignmentEditor(page);
+
+        await search.viewPlanningOnly();
+        await list.expectItemCount(1);
+        await list.item(0).dblclick();
+        await editor.waitTillOpen();
+        await editor.addCoverage('Text');
+
+        const coverageEditor = editor.getCoverageEditor(0);
+        // `editor.waitLoadingComplete()` is unusable here: with a coverage collapse box open its
+        // close-button locator matches two elements. Wait on the state label, as other specs do.
+        const coverageState = coverageEditor.element
+            .locator('.sd-collapse-box__content-block--top')
+            .locator('.label');
+
+        await coverageEditor.editAssignmentButton.click();
+        await assignmentEditor.waitTillOpen();
+        await assignmentEditor.type({desk: 'Politic Desk'});
+        await assignmentEditor.okButton.click();
+        await assignmentEditor.waitTillClosed();
+
+        await editor.waitForAutosave();
+        await editor.saveButton.click();
+
+        // Saving re-mounts the coverage collapsed and the reopening click can land on the
+        // pre-save render, so retry until the saved state shows
+        await expect(async () => {
+            await coverageEditor.element.click();
+            await expect(coverageState).toContainText('Draft', {timeout: 2_000});
+        }).toPass({timeout: 30_000});
+
+        await coverageEditor.toggleAddToWorkflow();
+        await editor.saveButton.click();
+        await expect(coverageState).toContainText('Assigned');
+
+        await changeWorkspace(page, 'Assignments');
+        await list.expectItemCount(1);
+        await list.item(0).click();
+        await preview.waitTillOpen();
+
+        await expect(preview.entityCards).toHaveCount(2);
+
+        const eventCard = preview.entityCard(0);
+        const planningCard = preview.entityCard(1);
+
+        await expect(eventCard).toContainText(EVENT.reference);
+        await expect(eventCard).not.toContainText('Calendar:');
+        await expect(preview.itemTypeIcons(eventCard)).toHaveCount(0);
+
+        await expect(planningCard).toContainText(PLANNING.headline);
+        await expect(planningCard).not.toContainText(PLANNING.description_text);
+        await expect(preview.itemTypeIcons(planningCard)).toHaveCount(0);
+    });
+
+    // Control for the assertions above: the editor renders the same `RelatedEventListItem` without
+    // `cardView`, so it must keep the list config and the icon
+    test('the same event item outside a card keeps the list config and the type icon', async ({page}) => {
+        const editor = new PlanningEditor(page);
+
+        await search.viewPlanningOnly();
+        await list.expectItemCount(1);
+        await list.item(0).dblclick();
+        await editor.waitTillOpen();
+
+        const associatedEvent = editor.element.getByTestId('editor--event-item__0');
+
+        await expect(associatedEvent).toContainText(EVENT.slugline);
+        await expect(associatedEvent).toContainText('Calendar:');
+        await expect(associatedEvent).not.toContainText(EVENT.reference);
+        await expect(preview.itemTypeIcons(associatedEvent)).toHaveCount(1);
+    });
+
+    test('list rows still use the full list config, not card_view', async () => {
+        await search.viewEventsOnly();
+        await list.expectItemCount(1);
+        await expect(list.item(0)).toContainText(EVENT.slugline);
+        await expect(list.item(0)).toContainText('Calendar:');
+        await expect(list.item(0)).not.toContainText(EVENT.reference);
+
+        await search.viewPlanningOnly();
+        await list.expectItemCount(1);
+        await expect(list.item(0)).toContainText(PLANNING.description_text);
+        await expect(list.item(0)).not.toContainText(PLANNING.headline);
+    });
+});

--- a/e2e/playwright/preview_card_view.spec.ts
+++ b/e2e/playwright/preview_card_view.spec.ts
@@ -7,7 +7,7 @@ import {
     PlanningEditor,
     PlanningList,
     PlanningPreview,
-} from './page-object-models/planning';
+} from './utils/planning';
 import {createEventFor} from './utils/fixtures/events';
 import {createPlanningFor} from './utils/fixtures/planning';
 

--- a/e2e/playwright/utils/planning/planningPreview.ts
+++ b/e2e/playwright/utils/planning/planningPreview.ts
@@ -17,6 +17,25 @@ export class PlanningPreview {
         return this.element.locator('.icon-close-small');
     }
 
+    /**
+     * Entity cards (related event / related planning) inside a preview. A CollapseBox only renders
+     * its collapsed item while closed, so these match the cards and not an expanded card's content.
+     */
+    get entityCards(): Locator {
+        return this.element.locator(
+            '[data-test-id="related-event-item"], [data-test-id="related-planning-item"]'
+        );
+    }
+
+    entityCard(index: number): Locator {
+        return this.entityCards.nth(index);
+    }
+
+    // The column wrapping `ItemIcon` on a related event / planning item
+    itemTypeIcons(scope?: Locator): Locator {
+        return (scope ?? this.element).locator('[data-test-id="item-type-icon"]');
+    }
+
     get actionMenu(): ActionMenu {
         return new ActionMenu(this.page, () => this.element);
     }

--- a/e2e/superdesk.config.js
+++ b/e2e/superdesk.config.js
@@ -76,6 +76,60 @@ module.exports = function() {
             keywords: true
         },
 
+        planning: {
+            // `firstLine`/`secondLine` mirror the product defaults so the rest of the suite sees an
+            // unchanged list. Only `card_view` differs; preview_card_view.spec.ts asserts on that.
+            event_list_item: {
+                firstLine: [
+                    {fieldId: 'slugline'},
+                    {fieldId: 'internalnote'},
+                    {fieldId: 'name'},
+                    {fieldId: 'calendars'},
+                    {fieldId: 'location'},
+                    {fieldId: 'event_datetime', position: 'end'},
+                ],
+                secondLine: [
+                    {fieldId: 'state'},
+                    {fieldId: 'related_plannings'},
+                    {fieldId: 'location'},
+                ],
+                card_view: {
+                    firstLine: [
+                        {fieldId: 'name'},
+                        {fieldId: 'reference'},
+                    ],
+                    secondLine: [
+                        {fieldId: 'state'},
+                    ],
+                },
+            },
+
+            planning_list_item: {
+                firstLine: [
+                    {fieldId: 'slugline'},
+                    {fieldId: 'internalnote'},
+                    {fieldId: 'description'},
+                ],
+                secondLine: [
+                    {fieldId: 'state'},
+                    {fieldId: 'featured'},
+                    {fieldId: 'agendas'},
+                    {fieldId: 'related_events'},
+                    {fieldId: 'coverages', position: 'end'},
+                ],
+                card_view: {
+                    firstLine: [
+                        {fieldId: 'slugline'},
+                        {fieldId: 'headline'},
+                    ],
+                    secondLine: [
+                        {fieldId: 'state'},
+                        {fieldId: 'urgency'},
+                    ],
+                },
+            },
+        },
+
         default_timezone: 'Australia/Sydney',
         shortDateFormat: 'DD/MM',
         ArchivedDateFormat: 'D/MM/YYYY',


### PR DESCRIPTION
Backport of #2925 to `release/3.5`, which is the branch STT installs from.

Cherry-picked `ca5a1e4dc` cleanly (no conflicts), plus one commit adapting the new e2e spec to this branch: page objects live under `e2e/playwright/utils/planning` here rather than `page-object-models/planning`. Same adjustment the STT-1699 backport needed.

See #2925 for the full description of the change.

### Steps to test

Same as #2925. Nothing is visible until `card_view` is configured, so the quickest check is the e2e spec.

