### PR TITLE
Add slot support to the e2e stack for parallel instances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ test-server/__pycache__
 e2e-test-results
 templates-cache.generated.js
 .env
+# generated per-checkout by e2e/scripts/e2e-up.sh --slot
+e2e/.e2e-slot.env
 .python-version
 .idea
 npm-debug.log

--- a/e2e/RUNNING_LOCALLY.md
+++ b/e2e/RUNNING_LOCALLY.md
@@ -5,3 +5,28 @@ To run e2e tests locally:
 3. start mongo, redis, elastic services
 4. create a virtual environment in e2e/server, install dependencies and start honcho
 5. run `E2E="true" TZ="Australia/Sydney" npm run playwright-interactive` in `e2e` folder. Notice we set a timezone environment variable before launching Playwright. Some tests depend on a timezone and would fail if the timezone was not set. The E2E environment variable needs to be set so a dedicated database for e2e is used instead of overwriting your local database.
+
+Alternatively, `./e2e/scripts/e2e-up.sh` (from the repo root) brings up the whole dockerized stack with health checks and is idempotent; `./e2e/scripts/e2e-down.sh` tears it down.
+
+## Parallel instances (slots)
+
+Several e2e instances can run on one machine at the same time, for example when multiple agents author specs concurrently, each from its own git worktree. A slot shares the heavy docker services (mongo, elasticsearch, redis) with every other slot but gets its own backend container, mongo databases, elastic index prefix, redis DB, client build and ports.
+
+```
+./e2e/scripts/e2e-up.sh --slot auto    # claim the first free slot (1-5) and bring it up
+./e2e/scripts/e2e-up.sh --slot 3       # bring up slot 3 specifically
+./e2e/scripts/e2e-down.sh --slot 3     # tear down slot 3 and release it
+./e2e/scripts/e2e-down.sh --all        # tear down all slots, the default stack and shared services
+```
+
+Slot N uses api `:502N`, websocket `:512N`, client `:902N`, and mongo databases / elastic indices named `sd_e2e_s<N>*`, all disjoint from the default stack (`:5002` / `:9000` / `e2e_superdesk`), so a normally started stack keeps working alongside slots. Claims are lock directories under `/tmp/superdesk-planning-e2e`, and re-running `e2e-up.sh --slot auto` from the same checkout re-enters its slot.
+
+On success the slot's environment (including `TZ`) is written to `e2e/.e2e-slot.env` (gitignored). `playwright.config.ts` auto-loads it, so `npx playwright test` from that checkout targets the slot without further setup.
+
+Notes for running several slots:
+
+* One slot per checkout/worktree. The client build bakes the slot's backend URLs into `dist/`, and the slot env file lives in the checkout, so sharing a checkout between slots would clobber both.
+* To seed a fresh worktree's dependencies quickly, clone them from the main checkout with a copy-on-write copy: `cp -Rc` on macOS (APFS), `cp -a --reflink=auto` on Linux (btrfs/XFS; falls back to a regular copy elsewhere). `npm ci`/`npm install` work everywhere but are much slower.
+* The port ranges are disjoint from superdesk-client-core's slots (`:501N`), but the two repos' e2e stacks cannot run at the same time regardless: both bind 27017/6379/9200 on the host.
+* Docker Desktop needs enough VM memory for the shared services plus one backend container per active slot; for 4-5 slots ~8 GB is recommended.
+* Concurrent Chromium runs compete for CPU; parallel spec writing is free, but keep simultaneous test runs to 2-3 or expect timeout flakiness.

--- a/e2e/docker-compose.slot.yml
+++ b/e2e/docker-compose.slot.yml
@@ -1,0 +1,48 @@
+# One superdesk backend for a numbered e2e slot (see e2e/scripts/e2e-up.sh
+# --slot). Runs only the server; mongo, elastic and redis come from the shared
+# default project (docker-compose.yml), whose bridge network this service
+# joins. Every value that differs between slots arrives via environment, and
+# the project name is set with `docker compose -p sd-planning-e2e-s<N>` so
+# slots never collide with each other or with the default project.
+#
+# Not meant to be run by hand. e2e-up.sh exports the required variables; the
+# `:?` markers make a bare `docker compose up` fail loudly instead of
+# starting a server on the default ports.
+
+services:
+    server:
+        image: superdesk-planning-e2e-server:latest
+        networks:
+            - e2e
+        ports:
+            - "${PORT:?run via e2e-up.sh --slot}:5000"
+            - "${WSPORT:?}:5100"
+        environment:
+            - WEB_CONCURRENCY=2
+            - WEBPACK_MANIFEST_PATH=/opt/client-dist/manifest.json
+            - MONGO_URI=mongodb://mongo/${E2E_DB:?}
+            - ARCHIVED_MONGO_URI=mongodb://mongo/${E2E_DB}_archived
+            - ARCHIVED_URI=mongodb://mongo/${E2E_DB}_archived
+            - LEGAL_ARCHIVE_URI=mongodb://mongo/${E2E_DB}_legal
+            # Separate name family (sd_e2e_capi_s<N>, not <E2E_DB>_capi): the
+            # elastic flush on reset deletes indices matching <prefix>_*, so
+            # the contentapi index must not extend the main index prefix.
+            - CONTENTAPI_MONGO_URI=mongodb://mongo/${E2E_CAPI_DB:?}
+            - PUBLICAPI_MONGO_URI=mongodb://mongo/${E2E_PAPI_DB:?}
+            - ELASTICSEARCH_URL=http://elastic:9200
+            - ELASTICSEARCH_INDEX=${E2E_DB}
+            - CONTENTAPI_ELASTICSEARCH_INDEX=${E2E_CAPI_DB}
+            - CELERY_BROKER_URL=${REDIS_URL:?}
+            - REDIS_URL=${REDIS_URL:?}
+            - DEFAULT_TIMEZONE=Australia/Sydney
+            - SECRET_KEY=e2e
+            # CORS: some endpoints (e.g. /api/subscribers) echo CLIENT_URL as
+            # Access-Control-Allow-Origin instead of a wildcard, so it must
+            # name this slot's client origin or the planning UI bootstrap
+            # blocks on a CORS-failed request and never renders.
+            - SUPERDESK_CLIENT_URL=${CLIENT_URL:?}
+
+networks:
+    e2e:
+        external: true
+        name: superdesk-planning-e2e_e2e

--- a/e2e/docker-compose.slot.yml
+++ b/e2e/docker-compose.slot.yml
@@ -12,6 +12,9 @@
 services:
     server:
         image: superdesk-planning-e2e-server:latest
+        # Built locally by the default compose project; the name has no
+        # registry namespace, so any pull attempt is guaranteed to fail.
+        pull_policy: never
         networks:
             - e2e
         ports:

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -25,7 +25,7 @@
         "check-types": "tsc --noEmit --resolveJsonModule",
         "playwright": "playwright test --workers 1",
         "playwright-interactive": "playwright test --ui",
-        "start-client-server": "http-server dist -p 9000 -s &"
+        "start-client-server": "http-server dist -p ${CLIENT_PORT:-9000} -s &"
     },
     "volta": {
         "node": "22.22.0"

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,4 +1,25 @@
 import {defineConfig, devices} from '@playwright/test';
+import fs from 'fs';
+import path from 'path';
+
+/**
+ * e2e-up.sh --slot writes the slot's environment (backend URL, client URL,
+ * timezone) to .e2e-slot.env so tests run from this checkout target that slot
+ * without any manual setup. Real environment variables win over the file.
+ * Workers inherit process.env from this process, so setting values here also
+ * covers playwright/utils (SUPERDESK_URL).
+ */
+const slotEnvPath = path.join(__dirname, '.e2e-slot.env');
+
+if (fs.existsSync(slotEnvPath)) {
+    for (const line of fs.readFileSync(slotEnvPath, 'utf-8').split('\n')) {
+        const match = line.match(/^([A-Z_]+)=(.*)$/);
+
+        if (match != null && process.env[match[1]] == null) {
+            process.env[match[1]] = match[2];
+        }
+    }
+}
 
 /**
  * See https://playwright.dev/docs/test-configuration.
@@ -22,7 +43,7 @@ export default defineConfig({
     /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
     use: {
         /* Base URL to use in actions like `await page.goto('/')`. */
-        baseURL: 'http://localhost:9000',
+        baseURL: process.env.CLIENT_URL || 'http://localhost:9000',
 
         viewport: {width: 1280, height: 800},
 

--- a/e2e/scripts/e2e-down.sh
+++ b/e2e/scripts/e2e-down.sh
@@ -1,12 +1,17 @@
 #!/usr/bin/env bash
 #
-# Tear down the local end-to-end stack started by e2e-up.sh: stop the docker
-# compose server stack (e2e/docker-compose.yml) and kill the http-server
-# serving the client on :9000.
+# Tear down the local end-to-end stack started by e2e-up.sh.
 #
 # Usage (from repo root):
-#   ./e2e/scripts/e2e-down.sh                # stop server + client
+#   ./e2e/scripts/e2e-down.sh                # stop the default stack (api :5002, client :9000)
 #   ./e2e/scripts/e2e-down.sh --volumes      # also remove docker volumes (drops DB state)
+#   ./e2e/scripts/e2e-down.sh --slot N       # tear down slot N and release its lock
+#   ./e2e/scripts/e2e-down.sh --all          # tear down every slot, the default stack and shared services
+#
+# While any slot is active, the no-argument form stops only the default
+# backend and client and leaves the shared docker services (mongo, elastic,
+# redis) running, because slots depend on them. Use --all to take everything
+# down.
 #
 # Always exits 0 even if some pieces were already stopped — the script is
 # idempotent.
@@ -14,35 +19,78 @@
 set -euo pipefail
 
 VOLUMES=false
+ALL=false
+SLOT=""
 
-for arg in "$@"; do
-    case "$arg" in
+while [ $# -gt 0 ]; do
+    case "$1" in
         --volumes) VOLUMES=true ;;
-        *) echo "unknown argument: $arg" >&2; exit 2 ;;
+        --all) ALL=true ;;
+        --slot)
+            shift
+            [ $# -gt 0 ] || { echo "--slot needs a value (1-5)" >&2; exit 2; }
+            SLOT="$1"
+            ;;
+        *) echo "unknown argument: $1" >&2; exit 2 ;;
     esac
+    shift
 done
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 E2E_DIR="$REPO_ROOT/e2e"
 
+MAX_SLOTS=5
+SLOT_LOCK_ROOT="${E2E_SLOT_LOCK_ROOT:-/tmp/superdesk-planning-e2e}"
+
 log() { printf '\n[e2e-down] %s\n' "$*"; }
 
-# Kill anything listening on the client port. `lsof -ti` works on macOS and
+# Kill anything listening on the given port. `lsof -ti` works on macOS and
 # Linux. Suppress errors when nothing is listening.
-if command -v lsof > /dev/null; then
-    if pids=$(lsof -ti:9000 2>/dev/null); then
-        log "stopping client server (PIDs: $pids)"
-        kill $pids 2>/dev/null || true
-    else
-        log "no client server running on :9000"
+kill_port() {
+    local port="$1"
+    local name="$2"
+    if command -v lsof > /dev/null; then
+        if pids=$(lsof -ti:"$port" 2>/dev/null); then
+            log "stopping $name (PIDs: $pids)"
+            kill $pids 2>/dev/null || true
+        fi
     fi
-else
-    log "lsof not found; skipping client server stop"
-fi
+}
 
-# Stop the dockerized server stack.
-if [ -f "$E2E_DIR/docker-compose.yml" ]; then
+active_slots() {
+    ls "$SLOT_LOCK_ROOT" 2>/dev/null | sed -n 's/^slot-\([0-9][0-9]*\)\.lock$/\1/p' | sort -n
+}
+
+down_slot() {
+    local n="$1"
+    local project="sd-planning-e2e-s$n"
+    log "tearing down slot $n (project $project)"
+    kill_port $((9020 + n)) "slot $n client server"
+    # Project-only down: no -f, so compose finds the containers by project
+    # label without interpolating docker-compose.slot.yml (whose required
+    # variables are not set here). cd to / so no local compose file is
+    # picked up implicitly.
+    if ! (cd / && docker compose -p "$project" down --remove-orphans > /dev/null 2>&1); then
+        docker ps -aq --filter "label=com.docker.compose.project=$project" \
+            | xargs docker rm -f 2>/dev/null || true
+    fi
+    # Remove the slot env file from the checkout that claimed the slot (which
+    # is not necessarily the one this script runs from).
+    local owner
+    owner="$(head -n 1 "$SLOT_LOCK_ROOT/slot-$n.lock/owner" 2>/dev/null || true)"
+    if [ -n "$owner" ]; then
+        rm -f "$owner/e2e/.e2e-slot.env"
+    fi
+    rm -rf "${SLOT_LOCK_ROOT:?}/slot-$n.lock"
+}
+
+down_default_stack() {
+    kill_port 9000 "client server"
+    if [ ! -f "$E2E_DIR/docker-compose.yml" ]; then
+        log "no $E2E_DIR/docker-compose.yml; nothing to tear down"
+        return
+    fi
     if [ "$VOLUMES" = true ]; then
         log "docker compose down -v (volumes removed; DB state dropped)"
         (cd "$E2E_DIR" && docker compose down -v)
@@ -50,8 +98,39 @@ if [ -f "$E2E_DIR/docker-compose.yml" ]; then
         log "docker compose down"
         (cd "$E2E_DIR" && docker compose down)
     fi
+}
+
+if [ -n "$SLOT" ]; then
+    case "$SLOT" in
+        ''|*[!0-9]*) echo "--slot must be 1-$MAX_SLOTS, got: $SLOT" >&2; exit 2 ;;
+    esac
+    down_slot "$SLOT"
+    log "done"
+    exit 0
+fi
+
+if [ "$ALL" = true ]; then
+    for n in $(seq 1 "$MAX_SLOTS"); do
+        if [ -d "$SLOT_LOCK_ROOT/slot-$n.lock" ] \
+            || docker ps -aq --filter "label=com.docker.compose.project=sd-planning-e2e-s$n" 2>/dev/null | grep -q .; then
+            down_slot "$n"
+        fi
+    done
+    down_default_stack
+    log "done"
+    exit 0
+fi
+
+slots="$(active_slots)"
+if [ -n "$slots" ]; then
+    # Slots share mongo/elastic/redis with the default stack, so taking the
+    # whole compose project down would pull the rug out from under them.
+    log "active slots ($(echo $slots | tr '\n' ' ')) depend on the shared docker services; stopping only the default server and client"
+    log "use --all to tear down everything including slots"
+    kill_port 9000 "client server"
+    (cd "$E2E_DIR" && docker compose rm -sf server > /dev/null 2>&1) || true
 else
-    log "no $E2E_DIR/docker-compose.yml; nothing to tear down"
+    down_default_stack
 fi
 
 log "done"

--- a/e2e/scripts/e2e-down.sh
+++ b/e2e/scripts/e2e-down.sh
@@ -59,7 +59,9 @@ kill_port() {
 }
 
 active_slots() {
-    ls "$SLOT_LOCK_ROOT" 2>/dev/null | sed -n 's/^slot-\([0-9][0-9]*\)\.lock$/\1/p' | sort -n
+    # || true: under pipefail a missing lock root would fail the ls and, via
+    # set -e at the call site, abort the whole teardown before it does anything.
+    ls "$SLOT_LOCK_ROOT" 2>/dev/null | sed -n 's/^slot-\([0-9][0-9]*\)\.lock$/\1/p' | sort -n || true
 }
 
 down_slot() {

--- a/e2e/scripts/e2e-down.sh
+++ b/e2e/scripts/e2e-down.sh
@@ -79,7 +79,9 @@ down_slot() {
     # is not necessarily the one this script runs from).
     local owner
     owner="$(head -n 1 "$SLOT_LOCK_ROOT/slot-$n.lock/owner" 2>/dev/null || true)"
-    if [ -n "$owner" ]; then
+    # The lock lives under world-writable /tmp, so only trust the recorded
+    # path if it actually looks like a checkout of this repo.
+    if [ -n "$owner" ] && [ -f "$owner/e2e/scripts/e2e-up.sh" ]; then
         rm -f "$owner/e2e/.e2e-slot.env"
     fi
     rm -rf "${SLOT_LOCK_ROOT:?}/slot-$n.lock"
@@ -104,6 +106,7 @@ if [ -n "$SLOT" ]; then
     case "$SLOT" in
         ''|*[!0-9]*) echo "--slot must be 1-$MAX_SLOTS, got: $SLOT" >&2; exit 2 ;;
     esac
+    { [ "$SLOT" -ge 1 ] && [ "$SLOT" -le "$MAX_SLOTS" ]; } || { echo "--slot must be 1-$MAX_SLOTS, got: $SLOT" >&2; exit 2; }
     down_slot "$SLOT"
     log "done"
     exit 0

--- a/e2e/scripts/e2e-up.sh
+++ b/e2e/scripts/e2e-up.sh
@@ -11,25 +11,52 @@
 # without wasted work.
 #
 # Usage (from repo root):
-#   ./e2e/scripts/e2e-up.sh                  # bring up the stack
+#   ./e2e/scripts/e2e-up.sh                  # bring up the default stack (api :5002, client :9000)
 #   ./e2e/scripts/e2e-up.sh --reinstall      # force dependency reinstall (repo root + e2e/)
 #   ./e2e/scripts/e2e-up.sh --rebuild        # force docker compose build + client rebuild
+#   ./e2e/scripts/e2e-up.sh --slot auto      # claim a numbered slot for a parallel instance
+#   ./e2e/scripts/e2e-up.sh --slot 3         # bring up slot 3 specifically
 #
-# Exits 0 only when both the server (e.g. http://localhost:5002/api/) and the
-# client (http://localhost:9000/) respond. Otherwise exits non-zero with a
-# clear error message.
+# Slots (parallel instances):
+#   A slot is an isolated e2e instance that shares the heavy docker services
+#   (mongo, elastic, redis) with every other slot but gets its own backend
+#   container, mongo databases, elastic index prefix, redis DB, client build
+#   and ports. Slot N uses api :502N, websocket :512N, client :902N and
+#   databases named sd_e2e_s<N>*. Slots exist so several agents can author
+#   specs concurrently, one slot per git checkout/worktree. (The port ranges
+#   are disjoint from superdesk-client-core's slots, but the two repos' e2e
+#   stacks still cannot run at the same time: both bind 27017/6379/9200.)
+#
+#   Slots are claimed via lock directories under /tmp/superdesk-planning-e2e.
+#   `--slot auto` re-enters a slot already claimed by this checkout, else
+#   picks the first free one. Release with ./e2e/scripts/e2e-down.sh --slot N.
+#
+#   On success the slot environment is written to e2e/.e2e-slot.env.
+#   playwright.config.ts auto-loads that file, so `npx playwright test` run
+#   from this checkout targets the slot with no extra setup.
+#
+# Exits 0 only when both the server (SUPERDESK_URL, default
+# http://localhost:5002/api/) and the client (default http://localhost:9000/)
+# respond. Otherwise exits non-zero with a clear error message.
 
 set -euo pipefail
 
 REINSTALL=false
 REBUILD=false
+SLOT="${E2E_SLOT:-}"
 
-for arg in "$@"; do
-    case "$arg" in
+while [ $# -gt 0 ]; do
+    case "$1" in
         --reinstall) REINSTALL=true ;;
         --rebuild) REBUILD=true ;;
-        *) echo "unknown argument: $arg" >&2; exit 2 ;;
+        --slot)
+            shift
+            [ $# -gt 0 ] || { echo "--slot needs a value: 1-5 or auto" >&2; exit 2; }
+            SLOT="$1"
+            ;;
+        *) echo "unknown argument: $1" >&2; exit 2 ;;
     esac
+    shift
 done
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -37,26 +64,102 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 E2E_DIR="$REPO_ROOT/e2e"
 COMPOSE_PROJECT="superdesk-planning-e2e"
 
-# SUPERDESK_URL is the single knob: point it at the e2e backend's /api root.
-# PORT (the docker host bind for the server) is derived from it so that
-# port-overriding (e.g. macOS AirPlay grabs 5000, 5050 is used elsewhere) needs
-# only one export:
-#   export SUPERDESK_URL=http://localhost:5002/api
-SUPERDESK_URL="${SUPERDESK_URL:-http://localhost:5002/api}"
-SERVER_URL="${SUPERDESK_URL%/}/"
-CLIENT_URL="http://localhost:9000/"
-SUPERDESK_HOST_PORT="$(printf '%s\n' "$SUPERDESK_URL" | sed -E 's#^https?://##; s#/.*$##')"
-PORT="${PORT:-${SUPERDESK_HOST_PORT##*:}}"
-case "$PORT" in
-    ''|*[!0-9]*)
-        printf '\n[e2e-up] ERROR: could not derive a numeric backend port from SUPERDESK_URL="%s". Include an explicit port, e.g. http://localhost:5002/api.\n' "$SUPERDESK_URL" >&2
-        exit 1
-        ;;
-esac
-export SUPERDESK_URL PORT
+MAX_SLOTS=5
+SLOT_LOCK_ROOT="${E2E_SLOT_LOCK_ROOT:-/tmp/superdesk-planning-e2e}"
+SERVER_IMAGE="superdesk-planning-e2e-server:latest"
+INFRA_SERVICES="elastic redis mongo"
 
 log() { printf '\n[e2e-up] %s\n' "$*"; }
 fail() { printf '\n[e2e-up] ERROR: %s\n' "$*" >&2; exit 1; }
+
+# --- slot claiming -----------------------------------------------------------
+
+slot_lock_dir() { echo "$SLOT_LOCK_ROOT/slot-$1.lock"; }
+slot_owner() { head -n 1 "$(slot_lock_dir "$1")/owner" 2>/dev/null || true; }
+
+# mkdir is atomic, so two concurrent claims of the same slot cannot both
+# succeed. Re-entrant for the checkout that already owns the slot, so
+# re-running e2e-up.sh is safe.
+claim_slot() {
+    local n="$1"
+    local lock
+    lock="$(slot_lock_dir "$n")"
+    mkdir -p "$SLOT_LOCK_ROOT"
+    if mkdir "$lock" 2>/dev/null; then
+        printf '%s\n' "$REPO_ROOT" > "$lock/owner"
+        printf 'claimed %s pid=%s\n' "$(date '+%Y-%m-%dT%H:%M:%S')" "$$" >> "$lock/owner"
+        return 0
+    fi
+    [ "$(slot_owner "$n")" = "$REPO_ROOT" ]
+}
+
+if [ "$SLOT" = "auto" ]; then
+    SLOT=""
+    # prefer a slot this checkout already owns, so re-runs do not leak claims
+    for n in $(seq 1 "$MAX_SLOTS"); do
+        if [ "$(slot_owner "$n")" = "$REPO_ROOT" ]; then SLOT="$n"; break; fi
+    done
+    if [ -z "$SLOT" ]; then
+        for n in $(seq 1 "$MAX_SLOTS"); do
+            if claim_slot "$n"; then SLOT="$n"; break; fi
+        done
+    fi
+    [ -n "$SLOT" ] || fail "no free slot (1-$MAX_SLOTS). Inspect $SLOT_LOCK_ROOT for holders; release a stale one with ./e2e/scripts/e2e-down.sh --slot <N>."
+    log "using slot $SLOT"
+elif [ -n "$SLOT" ]; then
+    case "$SLOT" in
+        ''|*[!0-9]*) fail "--slot must be 1-$MAX_SLOTS or auto, got: $SLOT" ;;
+    esac
+    { [ "$SLOT" -ge 1 ] && [ "$SLOT" -le "$MAX_SLOTS" ]; } || fail "--slot must be 1-$MAX_SLOTS, got: $SLOT"
+    claim_slot "$SLOT" || fail "slot $SLOT is claimed by $(slot_owner "$SLOT"). If that checkout is done with it, release it: ./e2e/scripts/e2e-down.sh --slot $SLOT"
+fi
+
+# --- URL and name derivation -------------------------------------------------
+
+if [ -n "$SLOT" ]; then
+    if [ -n "${SUPERDESK_URL:-}" ]; then
+        log "note: --slot overrides the ambient SUPERDESK_URL (${SUPERDESK_URL})"
+    fi
+    PORT=$((5020 + SLOT))
+    WSPORT=$((5120 + SLOT))
+    CLIENT_PORT=$((9020 + SLOT))
+    SUPERDESK_URL="http://localhost:$PORT/api"
+    SUPERDESK_WS_URL="ws://localhost:$WSPORT"
+    CLIENT_URL="http://localhost:$CLIENT_PORT"
+    # sd_e2e_s<N> (not e2e_superdesk_s<N>): the elastic flush that runs on
+    # reset deletes indices matching <prefix>_*, so slot names must form
+    # their own family and the capi name must not extend the main prefix.
+    E2E_DB="sd_e2e_s$SLOT"
+    E2E_CAPI_DB="sd_e2e_capi_s$SLOT"
+    E2E_PAPI_DB="sd_e2e_papi_s$SLOT"
+    # DBs 11-15: the default stack uses redis DB 1, and kombu prefixes fanout
+    # channels with the DB number, so distinct DBs isolate notifications too.
+    # The hostname is the compose service name; slots join the same network.
+    REDIS_URL="redis://redis:6379/$((10 + SLOT))"
+    SLOT_PROJECT="sd-planning-e2e-s$SLOT"
+    export SUPERDESK_URL SUPERDESK_WS_URL PORT WSPORT CLIENT_URL REDIS_URL
+    export E2E_DB E2E_CAPI_DB E2E_PAPI_DB
+else
+    # SUPERDESK_URL is the single knob: point it at the e2e backend's /api root.
+    # PORT (the docker host bind for the server) is derived from it so that
+    # port-overriding (e.g. macOS AirPlay grabs 5000, 5050 is used elsewhere) needs
+    # only one export:
+    #   export SUPERDESK_URL=http://localhost:5002/api
+    SUPERDESK_URL="${SUPERDESK_URL:-http://localhost:5002/api}"
+    SUPERDESK_WS_URL="${SUPERDESK_WS_URL:-}"
+    CLIENT_URL="http://localhost:9000"
+    CLIENT_PORT=9000
+    SUPERDESK_HOST_PORT="$(printf '%s\n' "$SUPERDESK_URL" | sed -E 's#^https?://##; s#/.*$##')"
+    PORT="${PORT:-${SUPERDESK_HOST_PORT##*:}}"
+    case "$PORT" in
+        ''|*[!0-9]*)
+            fail "could not derive a numeric backend port from SUPERDESK_URL=\"$SUPERDESK_URL\". Include an explicit port, e.g. http://localhost:5002/api."
+            ;;
+    esac
+    export SUPERDESK_URL PORT
+fi
+
+SERVER_URL="${SUPERDESK_URL%/}/"
 
 # Strict HTTP status (echoes the code, or 000 on connection failure). Unlike
 # reachable(), this lets callers require a specific code, e.g. a real 200 on a
@@ -96,19 +199,29 @@ ensure_deps() {
     fi
 }
 
+# The slot compose file references the image by name only; the default
+# project owns the build config. Build it there when it is missing.
+ensure_server_image() {
+    if ! docker image inspect "$SERVER_IMAGE" > /dev/null 2>&1; then
+        log "server image $SERVER_IMAGE not found; building it (one-time, slow)"
+        (cd "$E2E_DIR" && docker compose build server)
+    fi
+}
+
 # Pre-flight: warn about host port conflicts.
 # The e2e docker-compose maps mongo (27017), redis (6379), elasticsearch
-# (9200), and the server ($PORT, 5100) to host ports. If the user has local
-# instances of these running, docker compose will fail with port-in-use. We
-# only warn and name the holding PIDs; we do not kill anything.
+# (9200), and the server ($PORT, websocket) to host ports. If the user has
+# local instances of these running, docker compose will fail with port-in-use.
+# We only warn and name the holding PIDs; we do not kill anything.
 preflight_check_port() {
     local port="$1"
     local name="$2"
+    local project="${3:-$COMPOSE_PROJECT}"
     if command -v lsof > /dev/null && lsof -ti:"$port" > /dev/null 2>&1; then
         local pids
         pids=$(lsof -ti:"$port" 2>/dev/null)
         # If our own stack already owns the port, that is fine.
-        if docker compose -p "$COMPOSE_PROJECT" ps -q 2>/dev/null | grep -q .; then
+        if docker compose -p "$project" ps -q 2>/dev/null | grep -q .; then
             return 0
         fi
         cat >&2 <<EOF
@@ -125,20 +238,48 @@ EOF
 }
 
 # 1. Server (docker compose at e2e/docker-compose.yml)
-if reachable "$SERVER_URL"; then
-    log "server already reachable; skipping docker bring-up"
-else
-    preflight_check_port 27017 mongo || true
-    preflight_check_port 6379 redis || true
-    preflight_check_port 9200 elasticsearch || true
-    preflight_check_port "$PORT" "superdesk server" || true
+if [ -n "$SLOT" ]; then
+    ensure_server_image
 
-    log "bringing up server via docker compose (host port $PORT)"
-    if [ "$REBUILD" = true ]; then
-        (cd "$E2E_DIR" && docker compose build)
+    # Shared infra services live in the default compose project, so a slot
+    # coexists with the default stack and with other slots. `up -d` on
+    # already-running services is a no-op, and it creates the bridge network
+    # the slot server joins.
+    if ! docker compose -p "$COMPOSE_PROJECT" ps -q 2>/dev/null | grep -q .; then
+        preflight_check_port 27017 mongo || true
+        preflight_check_port 6379 redis || true
+        preflight_check_port 9200 elasticsearch || true
     fi
-    (cd "$E2E_DIR" && docker compose up -d)
-    wait_until_reachable "$SERVER_URL" "server" 240
+    log "ensuring shared docker services are up ($INFRA_SERVICES)"
+    # --no-recreate: never let a worktree's compose invocation recreate (and,
+    # with tmpfs data, wipe) an infra service another slot is using.
+    (cd "$E2E_DIR" && docker compose up -d --no-recreate $INFRA_SERVICES)
+
+    if reachable "$SERVER_URL"; then
+        log "slot $SLOT server already reachable; skipping docker bring-up"
+    else
+        preflight_check_port "$PORT" "superdesk server (slot $SLOT)" "$SLOT_PROJECT" || true
+        preflight_check_port "$WSPORT" "websocket server (slot $SLOT)" "$SLOT_PROJECT" || true
+        log "bringing up slot $SLOT server via docker compose (project $SLOT_PROJECT, host port $PORT)"
+        (cd "$E2E_DIR" && docker compose -f docker-compose.slot.yml -p "$SLOT_PROJECT" up -d)
+        wait_until_reachable "$SERVER_URL" "server (slot $SLOT)" 240
+    fi
+else
+    if reachable "$SERVER_URL"; then
+        log "server already reachable; skipping docker bring-up"
+    else
+        preflight_check_port 27017 mongo || true
+        preflight_check_port 6379 redis || true
+        preflight_check_port 9200 elasticsearch || true
+        preflight_check_port "$PORT" "superdesk server" || true
+
+        log "bringing up server via docker compose (host port $PORT)"
+        if [ "$REBUILD" = true ]; then
+            (cd "$E2E_DIR" && docker compose build)
+        fi
+        (cd "$E2E_DIR" && docker compose up -d)
+        wait_until_reachable "$SERVER_URL" "server" 240
+    fi
 fi
 
 # 2. Dependencies
@@ -152,11 +293,12 @@ ensure_deps "$E2E_DIR" "npm install"
 
 # 3. Client build (build-tools -> e2e/dist; http-server serves that dir).
 # Rebuild when forced, deps reinstalled, the app bundles are missing, OR the
-# dist was built against a different SUPERDESK_URL. The last two matter because:
+# dist was built against different backend URLs. The last two matter because:
 #   - a failed/partial build leaves a non-empty dist/ WITHOUT the bundles, so
 #     "is dist empty?" is not a sufficient staleness test;
-#   - the backend URL is baked into the bundle at build time (webpack
-#     DefinePlugin), so a dist built for one port silently breaks on another.
+#   - the backend api and websocket URLs are baked into the bundle at build
+#     time (webpack DefinePlugin), so a dist built for one slot silently
+#     breaks on another.
 REQUIRED_BUNDLES="app.bundle.js init.bundle.js app.bundle.css"
 BUILD_META="$E2E_DIR/dist/.e2e-built-with"
 
@@ -166,46 +308,74 @@ client_build_complete() {
     done
     return 0
 }
+build_meta_current() { printf '%s\n%s\n' "$SUPERDESK_URL" "${SUPERDESK_WS_URL:-}"; }
 build_url_matches() {
-    [ -f "$BUILD_META" ] && [ "$(cat "$BUILD_META" 2>/dev/null)" = "$SUPERDESK_URL" ]
+    [ -f "$BUILD_META" ] && [ "$(cat "$BUILD_META" 2>/dev/null)" = "$(build_meta_current)" ]
 }
 
 if [ "$REBUILD" = true ] || [ "$REINSTALL" = true ] || ! client_build_complete || ! build_url_matches; then
     if ! client_build_complete; then
         log "client bundles missing or incomplete; (re)building client"
     elif ! build_url_matches; then
-        log "dist was built for a different backend URL; rebuilding for $SUPERDESK_URL"
+        log "dist was built for different backend URLs; rebuilding for $SUPERDESK_URL"
     else
         log "building client (this is the slow step on a cold cache)"
     fi
-    (cd "$E2E_DIR" && SUPERDESK_URL="$SUPERDESK_URL" npm run build)
+    (cd "$E2E_DIR" && SUPERDESK_URL="$SUPERDESK_URL" SUPERDESK_WS_URL="${SUPERDESK_WS_URL:-}" npm run build)
     # A build can exit non-zero on warnings yet still leave a partial dist, and
     # build-tools can swallow webpack failures. Never serve a build we cannot
     # confirm produced the app bundles.
     client_build_complete || fail "client build finished but the app bundles are missing from dist/ ($REQUIRED_BUNDLES). The build failed; re-read the build output above and re-run with --rebuild."
-    printf '%s\n' "$SUPERDESK_URL" > "$BUILD_META"
+    build_meta_current > "$BUILD_META"
     log "client build complete (backend baked as $SUPERDESK_URL)"
 fi
 
-# 4. Client static server (http-server serving dist on :9000)
-if reachable "$CLIENT_URL"; then
+# 4. Client static server (http-server serving dist on $CLIENT_PORT)
+if reachable "$CLIENT_URL/"; then
     log "client already reachable; skipping client server start"
 else
-    log "starting client server on $CLIENT_URL"
-    (cd "$E2E_DIR" && npm run start-client-server)
-    wait_until_reachable "$CLIENT_URL" "client" 60
+    if [ -n "$SLOT" ]; then
+        preflight_check_port "$CLIENT_PORT" "client server (slot $SLOT)" "$SLOT_PROJECT" || true
+    fi
+    log "starting client server on $CLIENT_URL/"
+    (cd "$E2E_DIR" && CLIENT_PORT="$CLIENT_PORT" npm run start-client-server)
+    wait_until_reachable "$CLIENT_URL/" "client" 60
 fi
 
 # Final health gate: the app entry bundle must actually be served with a 200.
 # A 200 on / (index.html) is returned even when the bundles 404, which renders
 # a blank page. This is the difference between "the port answers" and "the app
 # works", and it is exactly the failure a non-technical user cannot diagnose.
-bundle_status="$(http_status "${CLIENT_URL}app.bundle.js")"
+bundle_status="$(http_status "$CLIENT_URL/app.bundle.js")"
 if [ "$bundle_status" != "200" ]; then
     fail "client is up but app.bundle.js returns HTTP $bundle_status, the app would render blank. The build is incomplete; re-run: ./e2e/scripts/e2e-up.sh --rebuild"
 fi
 
+# 5. Slot hand-off: environment file for playwright.
+if [ -n "$SLOT" ]; then
+    # TZ matches what RUNNING_LOCALLY.md prescribes for test runs; some specs
+    # assert on dates and fail in other timezones. The config's env loader
+    # only applies values that are not already set in the environment.
+    cat > "$E2E_DIR/.e2e-slot.env" <<EOF
+E2E_SLOT=$SLOT
+SUPERDESK_URL=$SUPERDESK_URL
+SUPERDESK_WS_URL=$SUPERDESK_WS_URL
+CLIENT_URL=$CLIENT_URL
+CLIENT_PORT=$CLIENT_PORT
+TZ=Australia/Sydney
+PLAYWRIGHT_HTML_OPEN=never
+EOF
+    log "slot environment written to e2e/.e2e-slot.env (auto-loaded by playwright.config.ts)"
+else
+    # A leftover slot env file would silently redirect playwright at a slot
+    # stack; the default stack must not inherit it.
+    rm -f "$E2E_DIR/.e2e-slot.env"
+fi
+
 log "ready"
+if [ -n "$SLOT" ]; then
+    log "  slot:   $SLOT (release with ./e2e/scripts/e2e-down.sh --slot $SLOT)"
+fi
 log "  server: $SERVER_URL"
-log "  client: $CLIENT_URL"
+log "  client: $CLIENT_URL/"
 log "Run e2e tests from $E2E_DIR, e.g. \`npm run playwright\`."

--- a/e2e/scripts/e2e-up.sh
+++ b/e2e/scripts/e2e-up.sh
@@ -221,7 +221,7 @@ preflight_check_port() {
         local pids
         pids=$(lsof -ti:"$port" 2>/dev/null)
         # If our own stack already owns the port, that is fine.
-        if docker compose -p "$project" ps -q 2>/dev/null | grep -q .; then
+        if docker ps -q --filter "label=com.docker.compose.project=$project" 2>/dev/null | grep -q .; then
             return 0
         fi
         cat >&2 <<EOF

--- a/e2e/scripts/e2e-up.sh
+++ b/e2e/scripts/e2e-up.sh
@@ -193,7 +193,20 @@ wait_until_reachable() {
 ensure_deps() {
     local dir="$1"
     local install_cmd="${2:-npm ci}"
-    if [ "$REINSTALL" = true ] || [ ! -d "$dir/node_modules" ]; then
+    local stale=false
+
+    # npm writes node_modules/.package-lock.json on every install. A repo
+    # lockfile newer than that marker means the installed tree predates it,
+    # which surfaces as misleading build failures rather than anything
+    # naming the real cause.
+    if [ ! -d "$dir/node_modules" ]; then
+        stale=true
+    elif [ "$dir/package-lock.json" -nt "$dir/node_modules/.package-lock.json" ]; then
+        log "dependencies in $dir are older than package-lock.json; reinstalling"
+        stale=true
+    fi
+
+    if [ "$REINSTALL" = true ] || [ "$stale" = true ]; then
         log "installing dependencies in $dir ($install_cmd)"
         (cd "$dir" && $install_cmd)
     fi


### PR DESCRIPTION
### Purpose

Planning counterpart of superdesk/superdesk-client-core#5295: parallel e2e instances (slots) so several agents can write and run specs concurrently, one slot per checkout/worktree.

### What has changed

- `e2e-up.sh --slot auto|N` claims slot N: api `:502N`, ws `:512N`, client `:902N`, per-slot databases and elastic prefix (`sd_e2e_s<N>*`), redis DB. Mongo, elasticsearch and redis stay shared; planning's prepopulate reset doesn't care about database names, so no per-slot mongod is needed here (unlike client-core, whose dump-based restore does).
- The slot env lands in `e2e/.e2e-slot.env` (including `TZ`) and `playwright.config.ts` auto-loads it, so `npx playwright test` just works from that checkout. No storageState handling needed since planning logs in per test.
- `SUPERDESK_CLIENT_URL` is set per slot: some endpoints (e.g. `/api/subscribers`) echo it as the CORS allow-origin instead of a wildcard, and without it the slot client gets blocked and the planning UI never renders its list.
- The default no-slot flow behaves exactly as before (verified).

### Steps to test

1. `./e2e/scripts/e2e-up.sh --slot auto` from two checkouts (e.g. main checkout plus a worktree); they claim slots 1 and 2.
2. Run `npx playwright test playwright/modals.spec.ts` from both `e2e` dirs at the same time; both pass, and mongo/elastic show cleanly separated `sd_e2e_s1*`/`sd_e2e_s2*` data.
3. `./e2e/scripts/e2e-down.sh --all` cleans everything up.

I tested this locally with two concurrent slots plus the unchanged default flow.

### Checklist
- [x] I reviewed my code
- [x] I tested all affected functionality and made sure it works