### PR TITLE
[SDESK-7986]- Clear button does not work for 'topic' in assignments filter section

### DIFF
--- a/client/components/fields/editor/base/text.tsx
+++ b/client/components/fields/editor/base/text.tsx
@@ -76,6 +76,14 @@ export class EditorFieldText extends React.Component<IEditorFieldTextProps, ISta
         if (prevProps?.item?._id !== this.props.item?._id) {
             this.setState({userHasModified: false});
         }
+
+        // Honor an external clear (e.g. the "Clear" button) when the prop transitions to empty
+        const prevValue = get(prevProps.item, prevProps.field, prevProps.defaultValue || '');
+        const nextValue = get(this.props.item, this.props.field, this.props.defaultValue || '');
+
+        if (prevValue !== nextValue && !nextValue && this.state.value !== '') {
+            this.setState({value: '', userHasModified: false});
+        }
     }
 
     onChange(value: string) {

--- a/e2e/playwright/search/clear_filters.spec.ts
+++ b/e2e/playwright/search/clear_filters.spec.ts
@@ -1,0 +1,42 @@
+import {test, expect} from '@playwright/test';
+
+import {setup, login, waitForPageLoad} from '../utils/common';
+import {AdvancedSearch} from '../page-object-models/planning';
+
+test.describe('Search.Clear: advanced filter panel Clear button', () => {
+    let search: AdvancedSearch;
+
+    test.beforeEach(async ({page}) => {
+        search = new AdvancedSearch(page);
+
+        await setup(page, 'planning_prepopulate_data', '/#/planning');
+        await login(page);
+        await waitForPageLoad.planning(page);
+
+        await search.viewEventsAndPlanning();
+        await search.toggleSearchPanel();
+        await search.openAllToggleBoxes();
+    });
+
+    test('Clear resets every filled field, including text inputs', async () => {
+        await search.searchFor({
+            slugline: 'Original',
+            name: 'Testing',
+            subject: ['archaeology', 'music'],
+        });
+
+        await search.clickClear();
+
+        // SDESK-7986: text inputs kept their typed value after Clear
+        await search.fields.slugline.expect('');
+        await search.fields.name.expect('');
+        await search.fields.subject.expectEmpty();
+    });
+
+    test('Search keeps typed text and does not wipe the input', async () => {
+        await search.enterSearchParams({slugline: 'Original'});
+        await search.clickSearch();
+
+        await search.fields.slugline.expect('Original');
+    });
+});

--- a/e2e/playwright/utils/common/inputs/selectMetaTerms.ts
+++ b/e2e/playwright/utils/common/inputs/selectMetaTerms.ts
@@ -25,6 +25,10 @@ export class SelectMetaTerms extends Input {
         }
     }
 
+    async expectEmpty(): Promise<void> {
+        await expect(this.parent.locator(`${this.selector} .sd-line-input__input li`)).toHaveCount(0);
+    }
+
     async clear(): Promise<void> {
         await clickAll(this.parent, `${this.selector} .sd-line-input__input li`);
     }


### PR DESCRIPTION
### Purpose
This PR fixes the `Clear` button in the Assignments advanced filter panel not clearing text fields like in the case where pressing `Clear` left the **Topic** field still showing the typed value, even though the search itself was reset.

### What has changed
- The advanced-filter text field (`EditorFieldText`) kept its value in internal state and, since debouncing was added, stopped re-syncing from props — so once you typed, pressing `Clear` no longer emptied it. It now detects an external clear (the value being reset from outside) and clears the input, while still preserving what you type during normal use.
- Added an end-to-end test 

### Steps to test
1. Go to the **Assignments** section and open the left-side advanced filter panel.
2. Fill in several fields, including a text field like **Topic** (slugline).
3. Press `Clear`
4. All fields, including **Topic**, should now be empty.

Resolves : https://sofab.atlassian.net/browse/SDESK-7986
