### PR TITLE
Annotate e2e specs with Confluence QA case coverage

### DIFF
--- a/e2e/playwright/assignments/edit_priority.spec.ts
+++ b/e2e/playwright/assignments/edit_priority.spec.ts
@@ -23,7 +23,11 @@ test.describe('Planning.Assignment: edit assignment priority', () => {
         await editor.waitTillOpen();
     });
 
-    test('can edit Assignment priority', async ({page}) => {
+    test('can edit Assignment priority', {
+        annotation: [
+            {type: 'confluence', description: '1344443378 partial'}, // Assignments - regression observed STT-1378
+        ],
+    }, async ({page}) => {
         await editor.type({slugline: 'Slugline'});
         await editor.addCoverage('Text');
 

--- a/e2e/playwright/events/edit_event.spec.ts
+++ b/e2e/playwright/events/edit_event.spec.ts
@@ -7,7 +7,11 @@ import {EventEditor, PlanningList} from '../page-object-models/planning';
 import {createEventFor, TEST_EVENTS} from '../utils/fixtures/events';
 import {setupPlanningPublishing} from '../utils/fixtures/publish_config';
 
-test.describe('Planning.Events: edit metadata', () => {
+test.describe('Planning.Events: edit metadata', {
+    annotation: [
+        {type: 'confluence', description: '1311835122 complete'}, // Assign event to calendar
+    ],
+}, () => {
     let editor: EventEditor;
     let list: PlanningList;
     let subnav: SubNavBar;
@@ -52,7 +56,11 @@ test.describe('Planning.Events: edit metadata', () => {
         await editor.waitTillOpen();
     });
 
-    test('can create an Event', async () => {
+    test('can create an Event', {
+        annotation: [
+            {type: 'confluence', description: '1311835116 complete'}, // Create new event
+        ],
+    }, async () => {
         await list.expectEmpty();
         await editor.expectItemType();
         await workqueue.expectTitle(0, 'Untitled*');
@@ -129,7 +137,11 @@ test.describe('Planning.Events: edit metadata', () => {
         ).toContainText('Scheduled');
     });
 
-    test('Post updates the initial values', async ({page}) => {
+    test('Post updates the initial values', {
+        annotation: [
+            {type: 'confluence', description: '1311835145 complete'}, // Post event
+        ],
+    }, async ({page}) => {
         await setupPlanningPublishing(page.request);
         // Enter minimum Event metadata
         await editor.expectItemType();
@@ -164,7 +176,11 @@ test.describe('Planning.Events: edit metadata', () => {
     });
 });
 
-test.describe('Planing.Events: edit existing events', () => {
+test.describe('Planing.Events: edit existing events', {
+    annotation: [
+        {type: 'confluence', description: '1311835118 complete'}, // Edit event
+    ],
+}, () => {
     let list: PlanningList;
     let editor: EventEditor;
 

--- a/e2e/playwright/events/event_action_cancel.spec.ts
+++ b/e2e/playwright/events/event_action_cancel.spec.ts
@@ -80,7 +80,11 @@ test.describe('Planning.Events: event cancel action', () => {
         await expect(editor.element.getByTestId('internal-note-label')).toContainText(reason);
     }
 
-    test('can cancel from the list', async({page}) => {
+    test('can cancel from the list', {
+        annotation: [
+            {type: 'confluence', description: '1311835124 complete'}, // Cancel event
+        ],
+    }, async({page}) => {
         // 1. Cancel Event from list
         // 1.a Create the Event
         reason = 'Cancelled due to some reason';
@@ -108,7 +112,11 @@ test.describe('Planning.Events: event cancel action', () => {
         await editor.closeButton.click();
     });
 
-    test('can cancel from the preview', async() => {
+    test('can cancel from the preview', {
+        annotation: [
+            {type: 'confluence', description: '1311835147 complete'}, // Event preview
+        ],
+    }, async() => {
         // 2. Cancel Event from preview
         // 2.a Create the Event
         reason = 'Cancelling2 something else';

--- a/e2e/playwright/events/event_action_create_planning.spec.ts
+++ b/e2e/playwright/events/event_action_create_planning.spec.ts
@@ -130,7 +130,11 @@ test.describe('Planning.Events: create planning action', () => {
             .click();
     }
 
-    test('can create from the list', async () => {
+    test('can create from the list', {
+        annotation: [
+            {type: 'confluence', description: '1311835139 complete'}, // Create planning item from event
+        ],
+    }, async () => {
         await list.clickAction(0, 'Create Planning Item');
         await expectListItemText();
         await doubleClickPlanningItem();
@@ -138,7 +142,11 @@ test.describe('Planning.Events: create planning action', () => {
         await canEditPlanningAfterwards();
     });
 
-    test('can create and open from the list', async () => {
+    test('can create and open from the list', {
+        annotation: [
+            {type: 'confluence', description: '1311835141 complete'}, // Create and open planning item from event
+        ],
+    }, async () => {
         await list.clickAction(0, 'Create and Open Planning Item');
         await expectEditorValues();
         await expectListItemText();

--- a/e2e/playwright/events/event_action_duplicate.spec.ts
+++ b/e2e/playwright/events/event_action_duplicate.spec.ts
@@ -49,7 +49,11 @@ test.describe('Planning.Events: duplicate event', () => {
         await waitForPageLoad.planning(page);
     });
 
-    test('can duplicate an event', async() => {
+    test('can duplicate an event', {
+        annotation: [
+            {type: 'confluence', description: '1311835120 complete'}, // Duplicate event
+        ],
+    }, async() => {
         // 1. Duplicate from the list
         await subnav.createEvent();
         await editor.createAndClose(event);

--- a/e2e/playwright/events/event_embedded_coverage.spec.ts
+++ b/e2e/playwright/events/event_embedded_coverage.spec.ts
@@ -23,7 +23,11 @@ test.describe('Planning.Events: embedded coverage', () => {
         await waitForPageLoad.planning(page);
     });
 
-    test('can add a planning item to a new Event', async () => {
+    test('can add a planning item to a new Event', {
+        annotation: [
+            {type: 'confluence', description: '1311835165 complete'}, // Add planning item as event
+        ],
+    }, async () => {
         await subnav.createEvent();
         await editor.waitTillOpen();
 

--- a/e2e/playwright/item_locks.spec.ts
+++ b/e2e/playwright/item_locks.spec.ts
@@ -141,35 +141,55 @@ test.describe('Planning: item locks', () => {
             await testUnlockedFromEditPanel(page, 'Cancel', 'events', 'event1');
         });
 
-        test('spike action', async ({page}) => {
+        test('spike action', {
+            annotation: [
+                {type: 'confluence', description: '1311835127 complete'}, // Spike event
+            ],
+        }, async ({page}) => {
             await testCancelActionFromModal(page, 'Spike');
             await testUnlockedFromModal(page, 'Spike', 'events', 'event1');
             await testCancelActionFromEditPanel('Cancel');
             await testUnlockedFromEditPanel(page, 'Cancel', 'events', 'event1');
         });
 
-        test('update time action', async ({page}) => {
+        test('update time action', {
+            annotation: [
+                {type: 'confluence', description: '1311835131 complete'}, // Update event time
+            ],
+        }, async ({page}) => {
             await testCancelActionFromModal(page, 'Update time');
             await testUnlockedFromModal(page, 'Update time', 'events', 'event1');
             await testCancelActionFromEditPanel('Update time');
             await testUnlockedFromEditPanel(page, 'Update time', 'events', 'event1');
         });
 
-        test('mark as postponed action', async ({page}) => {
+        test('mark as postponed action', {
+            annotation: [
+                {type: 'confluence', description: '1311835133 complete'}, // Mark event as postponed
+            ],
+        }, async ({page}) => {
             await testCancelActionFromModal(page, 'Mark as Postponed');
             await testUnlockedFromModal(page, 'Mark as Postponed', 'events', 'event1');
             await testCancelActionFromEditPanel('Mark as Postponed');
             await testUnlockedFromEditPanel(page, 'Mark as Postponed', 'events', 'event1');
         });
 
-        test('reschedule action', async ({page}) => {
+        test('reschedule action', {
+            annotation: [
+                {type: 'confluence', description: '1311835135 complete'}, // Reschedule event
+            ],
+        }, async ({page}) => {
             await testCancelActionFromModal(page, 'Reschedule');
             await testUnlockedFromModal(page, 'Reschedule', 'events', 'event1');
             await testCancelActionFromEditPanel('Reschedule');
             await testUnlockedFromEditPanel(page, 'Reschedule', 'events', 'event1');
         });
 
-        test('convert to recurring action', async ({page}) => {
+        test('convert to recurring action', {
+            annotation: [
+                {type: 'confluence', description: '1311835137 complete'}, // Convert to recurring event
+            ],
+        }, async ({page}) => {
             await testCancelActionFromModal(page, 'Convert to Recurring Event');
             await testUnlockedFromModal(page, 'Convert to Recurring Event', 'events', 'event1');
             // No need to test editor actions, as this is not available in the Editor
@@ -289,7 +309,11 @@ test.describe('Planning: item locks', () => {
             await waitForPageLoad.planning(page);
         });
 
-        test('spike action', async ({page}) => {
+        test('spike action', {
+            annotation: [
+                {type: 'confluence', description: '1311835167 complete'}, // Spike planning
+            ],
+        }, async ({page}) => {
             await testCancelActionFromModal(page, 'Spike');
             await testUnlockedFromModal(page, 'Spike', 'planning', 'plan1');
             await testCancelActionFromEditPanel('Spike');

--- a/e2e/playwright/planning/accessibility.spec.ts
+++ b/e2e/playwright/planning/accessibility.spec.ts
@@ -70,7 +70,11 @@ test.describe('Planning.Planning: list view accessibility', () => {
         await expect(group).toHaveAttribute('aria-activedescendant', 'list-panel-0--0');
     });
 
-    test('can open an item for editing using a keyboard', async ({page}) => {
+    test('can open an item for editing using a keyboard', {
+        annotation: [
+            {type: 'confluence', description: '1311835157 complete'}, // Edit planning item in popup
+        ],
+    }, async ({page}) => {
         const group = page.locator('.sd-list-item-group').first();
 
         await group.focus();

--- a/e2e/playwright/planning/edit_planning.spec.ts
+++ b/e2e/playwright/planning/edit_planning.spec.ts
@@ -5,7 +5,11 @@ import {setup, login, waitForPageLoad, SubNavBar, Workqueue, CLIENT_FORMAT} from
 import {PlanningList, PlanningEditor, AssignmentEditor} from '../page-object-models/planning';
 import {setupPlanningPublishing} from '../utils/fixtures/publish_config';
 
-test.describe('Planning.Planning: edit metadata', () => {
+test.describe('Planning.Planning: edit metadata', {
+    annotation: [
+        {type: 'confluence', description: '1311835155 complete'}, // Edit planning item
+    ],
+}, () => {
     let editor: PlanningEditor;
     let list: PlanningList;
     let subnav: SubNavBar;
@@ -25,7 +29,11 @@ test.describe('Planning.Planning: edit metadata', () => {
         await editor.waitTillOpen();
     });
 
-    test('can create a Planning item', async () => {
+    test('can create a Planning item', {
+        annotation: [
+            {type: 'confluence', description: '1311835114 complete'}, // Create new planning item
+        ],
+    }, async () => {
         const plan = {
             slugline: 'slugline of the planning',
             'planning_date.date': moment().format(CLIENT_FORMAT),
@@ -69,7 +77,11 @@ test.describe('Planning.Planning: edit metadata', () => {
         await workqueue.expectTitle(0, 'slugline of the planning');
     });
 
-    test('can add coverage to workflow', async ({page}) => {
+    test('can add coverage to workflow', {
+        annotation: [
+            {type: 'confluence', description: '1311835171 complete'}, // Add coverage
+        ],
+    }, async ({page}) => {
         await editor.type({
             slugline: 'Plan',
             'planning_date.date': moment().format(CLIENT_FORMAT),
@@ -142,7 +154,11 @@ test.describe('Planning.Planning: edit metadata', () => {
         await expect(editor.postButton).toBeVisible();
     });
 
-    test('Post updates the initial values', async () => {
+    test('Post updates the initial values', {
+        annotation: [
+            {type: 'confluence', description: '1311835143 complete'}, // Post planning item
+        ],
+    }, async () => {
         // Enter minimum Planning metadata
         await editor.expectItemType();
         await editor.type({

--- a/e2e/playwright/planning/featured_planning.spec.ts
+++ b/e2e/playwright/planning/featured_planning.spec.ts
@@ -5,7 +5,11 @@ import {PlanningList, PlanningEditor, PlanningPreview, FeaturedModal} from '../p
 import {createPlanningFor} from '../utils/fixtures/planning';
 import {setupPlanningPublishing} from '../utils/fixtures/publish_config';
 
-test.describe('Planning.Featured', () => {
+test.describe('Planning.Featured', {
+    annotation: [
+        {type: 'confluence', description: '1311835163 complete'}, // Featured stories
+    ],
+}, () => {
     let subnav: SubNavBar;
     let modal: FeaturedModal;
     let uiFrameworkModal: UiFrameworkModal;

--- a/e2e/playwright/planning/planning_action_cancel.spec.ts
+++ b/e2e/playwright/planning/planning_action_cancel.spec.ts
@@ -33,7 +33,11 @@ test.describe('Planning.Planning: cancel planning item', () => {
         await waitForPageLoad.planning(page);
     });
 
-    test('can cancel a Planning item', async ({page}) => {
+    test('can cancel a Planning item', {
+        annotation: [
+            {type: 'confluence', description: '1311835153 complete'}, // Planning item preview
+        ],
+    }, async ({page}) => {
         const reason = 'Not covering anymore';
         await list.item(0).click();
 

--- a/e2e/playwright/search/search_filters.spec.ts
+++ b/e2e/playwright/search/search_filters.spec.ts
@@ -66,7 +66,12 @@ test.describe('Search.Filters: creating search filters', () => {
         await searchFilters.expectItemText(0, 'Test Empties');
     });
 
-    test('can create event filter', async ({page}) => {
+    test('can create event filter', {
+        annotation: [
+            // Planning filters and scheduled exports - basic cases (Mikayel) - PASS 02.11.22
+            {type: 'confluence', description: '1311835173 complete'},
+        ],
+    }, async ({page}) => {
         await addItems(page.request, 'locations', [LOCATIONS.sydney_opera_house]);
 
         await searchFilters.open();

--- a/e2e/playwright/search/search_planning.spec.ts
+++ b/e2e/playwright/search/search_planning.spec.ts
@@ -22,7 +22,11 @@ test.describe('Search.Planning: searching planning items', () => {
         await waitForPageLoad.planning(page);
     });
 
-    test('can search planning metadata', async ({page}) => {
+    test('can search planning metadata', {
+        annotation: [
+            {type: 'confluence', description: '1311835175 partial'}, // Search planning (Mikayel)
+        ],
+    }, async ({page}) => {
         await addItems(
             page.request,
             'planning',

--- a/e2e/playwright/workqueue.spec.ts
+++ b/e2e/playwright/workqueue.spec.ts
@@ -24,7 +24,11 @@ test.describe('Planning.Workqueue', () => {
         await waitForPageLoad.planning(page);
     });
 
-    test('Events', async({page}) => {
+    test('Events', {
+        annotation: [
+            {type: 'confluence', description: '1311835149 complete'}, // Minimise event
+        ],
+    }, async({page}) => {
         // Add the 3 Events we'll use for testing against
         await addItems(
             page.request,


### PR DESCRIPTION
### Purpose
Baseline that links our existing Playwright e2e tests to their Confluence QA cases, so the QA coverage dashboard can track what's automated vs the backlog and show progress over time. Planning half of the pair (client-core: superdesk/superdesk-client-core#5298).

### What has changed
Adds `confluence` annotations to existing e2e tests, tagging each with the QA case id and whether coverage is complete or partial. Purely additive: no test logic changed, none added or removed. Format on the test's details object:
`{type: 'confluence', description: '<confluencePageId> complete|partial'}`

### Steps to test
Lint and type-check pass. Annotations render in the Playwright HTML report as `confluence: <id> ...`. No behavioural change to any test.