### PR TITLE
[SDBELGA-1129] - Update Autocomplete to use the unified resource

### DIFF
--- a/server/planning/search/planning_autocomplete.py
+++ b/server/planning/search/planning_autocomplete.py
@@ -1,7 +1,7 @@
 from typing import Dict, Any
 from datetime import timedelta
 
-from superdesk.core import get_app_config, get_current_async_app
+from superdesk.core import get_app_config
 from superdesk.utc import utcnow
 from apps.archive.autocomplete import (
     SETTING_LIMIT as AUTOCOMPLETE_LIMIT,
@@ -12,8 +12,6 @@ from apps.archive.autocomplete import (
 
 from planning.common import WORKFLOW_STATE, POST_STATE
 from planning.types.unified import PlanningItemType, UnifiedPlanningResource
-
-UNIFIED_RESOURCE = "unified_planning"
 
 
 async def get_planning_suggestions(field: str, language: str) -> Dict[str, int]:
@@ -61,11 +59,8 @@ async def get_event_suggestions(field: str, language: str) -> Dict[str, int]:
 
 
 async def _run_suggestions_query(query: Dict[str, Any]) -> Dict[str, int]:
-    async_app = get_current_async_app()
-    index = async_app.elastic.get_elastic_index_name(UNIFIED_RESOURCE)
-    elastic = UnifiedPlanningResource.get_service().elastic
-    res = await elastic.search(query, [index])
-    return _get_aggregation_values(res["aggregations"])
+    res = await UnifiedPlanningResource.get_service().search(query)
+    return _get_aggregation_values(res.hits["aggregations"])
 
 
 def _get_aggregation_values(aggregations) -> Dict[str, int]:

--- a/server/planning/search/planning_autocomplete.py
+++ b/server/planning/search/planning_autocomplete.py
@@ -1,7 +1,7 @@
 from typing import Dict, Any
 from datetime import timedelta
 
-from superdesk.core import get_app_config, get_current_app
+from superdesk.core import get_app_config, get_current_async_app
 from superdesk.utc import utcnow
 from apps.archive.autocomplete import (
     SETTING_LIMIT as AUTOCOMPLETE_LIMIT,
@@ -11,10 +11,13 @@ from apps.archive.autocomplete import (
 )
 
 from planning.common import WORKFLOW_STATE, POST_STATE
+from planning.types.unified import PlanningItemType, UnifiedPlanningResource
+
+UNIFIED_RESOURCE = "unified_planning"
 
 
-def get_planning_suggestions(field: str, language: str) -> Dict[str, int]:
-    bool_query = _construct_bool_query(language)
+async def get_planning_suggestions(field: str, language: str) -> Dict[str, int]:
+    bool_query = _construct_bool_query(language, PlanningItemType.PLANNING)
     bool_query["should"].append(
         {
             "nested": {
@@ -41,22 +44,28 @@ def get_planning_suggestions(field: str, language: str) -> Dict[str, int]:
     query = {
         "query": {"bool": bool_query},
         "aggs": aggs_query,
+        "size": 0,
     }
 
-    app = get_current_app()
-    res = app.data.elastic.search(query, "planning", params={"size": 0})
-    return _get_aggregation_values(res.hits["aggregations"])
+    return await _run_suggestions_query(query)
 
 
-def get_event_suggestions(field: str, language: str) -> Dict[str, int]:
+async def get_event_suggestions(field: str, language: str) -> Dict[str, int]:
     query = {
-        "query": {"bool": _construct_bool_query(language)},
+        "query": {"bool": _construct_bool_query(language, PlanningItemType.EVENT)},
         "aggs": _construct_aggs_query(field, language),
+        "size": 0,
     }
 
-    app = get_current_app()
-    res = app.data.elastic.search(query, "events", params={"size": 0})
-    return _get_aggregation_values(res.hits["aggregations"])
+    return await _run_suggestions_query(query)
+
+
+async def _run_suggestions_query(query: Dict[str, Any]) -> Dict[str, int]:
+    async_app = get_current_async_app()
+    index = async_app.elastic.get_elastic_index_name(UNIFIED_RESOURCE)
+    elastic = UnifiedPlanningResource.get_service().elastic
+    res = await elastic.search(query, [index])
+    return _get_aggregation_values(res["aggregations"])
 
 
 def _get_aggregation_values(aggregations) -> Dict[str, int]:
@@ -97,7 +106,7 @@ def agg_field_suggestion(field):
     }
 
 
-def _construct_bool_query(language: str) -> Dict[str, Any]:
+def _construct_bool_query(language: str, item_type: PlanningItemType) -> Dict[str, Any]:
     versioncreated_min = (
         utcnow() - timedelta(days=get_app_config(AUTOCOMPLETE_DAYS), hours=get_app_config(AUTOCOMPLETE_HOURS))
     ).replace(
@@ -106,6 +115,7 @@ def _construct_bool_query(language: str) -> Dict[str, Any]:
 
     return {
         "must": [
+            {"term": {"type": item_type.value}},
             {"term": {"pubstatus": POST_STATE.USABLE}},
             {"terms": {"state": [WORKFLOW_STATE.SCHEDULED, WORKFLOW_STATE.POSTPONED, WORKFLOW_STATE.RESCHEDULED]}},
             {"range": {"versioncreated": {"gte": versioncreated_min}}},

--- a/server/planning/tests/unified_resource/autocomplete_test.py
+++ b/server/planning/tests/unified_resource/autocomplete_test.py
@@ -1,0 +1,136 @@
+from superdesk.flask import g
+from superdesk.tests import utils as test_utils, fixtures
+from superdesk.utc import utcnow
+
+from planning.types.unified import UnifiedPlanningResource, PlanningItemType
+from planning.tests import TestCase, fixtures as planning_fixtures
+from planning.search.planning_autocomplete import get_event_suggestions, get_planning_suggestions
+
+
+class UnifiedResourceAutocompleteTestCase(TestCase):
+    app_config = {
+        **TestCase.app_config.copy(),
+        "ELASTICSEARCH_FORCE_REFRESH": True,
+        "ARCHIVE_AUTOCOMPLETE_DAYS": 30,
+        "ARCHIVE_AUTOCOMPLETE_HOURS": 0,
+        "ARCHIVE_AUTOCOMPLETE_LIMIT": 100,
+    }
+
+    async def asyncSetUp(self):
+        await super().asyncSetUp()
+        self.planning_service = UnifiedPlanningResource.get_service()
+
+        await test_utils.post_items("users", fixtures.users.all_users())
+        g.user = fixtures.users.admin().to_dict()
+        await test_utils.post_items("vocabularies", planning_fixtures.cvs.all_cvs())
+        await test_utils.post_items("desks", fixtures.desks.all_desks())
+        await test_utils.post_items("stages", fixtures.stages.all_stages())
+
+    def _event(self, guid, slugline, state="scheduled", pubstatus="usable", language="en"):
+        now = utcnow()
+        return dict(
+            guid=guid,
+            type=PlanningItemType.EVENT,
+            name=slugline,
+            slugline=slugline,
+            language=language,
+            languages=[language],
+            state=state,
+            pubstatus=pubstatus,
+            dates={"start": now, "end": now},
+        )
+
+    def _planning(self, guid, slugline, state="scheduled", pubstatus="usable", language="en", coverages=None):
+        item = dict(
+            guid=guid,
+            type=PlanningItemType.PLANNING,
+            name=slugline,
+            slugline=slugline,
+            language=language,
+            languages=[language],
+            state=state,
+            pubstatus=pubstatus,
+            dates={"start": utcnow()},
+        )
+        if coverages is not None:
+            item["coverages"] = coverages
+        return item
+
+    def _coverage(self, slugline, language="en"):
+        return {
+            "planning": {
+                "scheduled": "2026-06-30T16:30:55+0000",
+                "slugline": slugline,
+                "language": language,
+                "g2_content_type": "text",
+            },
+            "workflow_status": "draft",
+            "news_coverage_status": {
+                "qcode": "ncostat:int",
+                "name": "Intended",
+                "label": "Coverage Intended",
+            },
+            "assigned_to": {
+                "desk": fixtures.desks.SPORTS_DESK_ID,
+                "user": fixtures.users.ADMIN_USER_ID,
+            },
+        }
+
+    async def _seed(self, items):
+        await self.planning_service.create([UnifiedPlanningResource.from_dict(item) for item in items])
+
+    async def test_event_suggestions_read_from_unified_resource(self):
+        await self._seed(
+            [
+                self._event("ev-alpha", "event-alpha"),
+                self._event("ev-beta", "event-beta", state="postponed"),
+                # excluded: not posted / wrong state / wrong language
+                self._event("ev-draft", "event-draft", state="draft", pubstatus=None),
+                self._event("ev-cancelled", "event-cancelled", state="cancelled"),
+                self._event("ev-de", "event-de", language="de"),
+                # a planning item must not leak into event suggestions (shared index, type filter)
+                self._planning("pl-alpha", "planning-alpha"),
+            ]
+        )
+
+        suggestions = await get_event_suggestions("slugline", "en")
+
+        self.assertEqual(suggestions.get("event-alpha"), 1)
+        self.assertEqual(suggestions.get("event-beta"), 1)
+        self.assertNotIn("event-draft", suggestions)
+        self.assertNotIn("event-cancelled", suggestions)
+        self.assertNotIn("event-de", suggestions)
+        self.assertNotIn("planning-alpha", suggestions)
+
+    async def test_planning_suggestions_read_from_unified_resource(self):
+        await self._seed(
+            [
+                self._planning("pl-alpha", "planning-alpha", coverages=[self._coverage("coverage-slug")]),
+                self._planning("pl-beta", "planning-beta", state="rescheduled"),
+                self._planning("pl-draft", "planning-draft", state="draft", pubstatus=None),
+                # an event must not leak into planning suggestions
+                self._event("ev-alpha", "event-alpha"),
+            ]
+        )
+
+        suggestions = await get_planning_suggestions("slugline", "en")
+
+        self.assertEqual(suggestions.get("planning-alpha"), 1)
+        self.assertEqual(suggestions.get("planning-beta"), 1)
+        # coverage sluglines are aggregated in as well
+        self.assertEqual(suggestions.get("coverage-slug"), 1)
+        self.assertNotIn("planning-draft", suggestions)
+        self.assertNotIn("event-alpha", suggestions)
+
+    async def test_coverage_language_filter(self):
+        # coverage in a different language than requested is excluded
+        await self._seed(
+            [
+                self._planning("pl-alpha", "planning-alpha", coverages=[self._coverage("coverage-de", language="de")]),
+            ]
+        )
+
+        suggestions = await get_planning_suggestions("slugline", "en")
+
+        self.assertEqual(suggestions.get("planning-alpha"), 1)
+        self.assertNotIn("coverage-de", suggestions)


### PR DESCRIPTION
### Purpose
Migrate the planning autocomplete providers off the legacy Eve-backed `events` / `planning` elastic indexes and onto the async unified resource (`unified_planning`).

### What has changed
`server/planning/search/planning_autocomplete.py`:
- Both providers (`get_planning_suggestions`, `get_event_suggestions`) are now async and query the single `unified_planning` index via the async elastic client instead of the sync Eve datalayer.
- Added an `item_type` filter (`{"term": {"type": "event"|"planning"}}`) so event and planning suggestions stay separate on the shared index.
- Added tests 

Resolves: [SDBELGA-1129](https://sofab.atlassian.net/browse/SDBELGA-1129)


[SDBELGA-1129]: https://sofab.atlassian.net/browse/SDBELGA-1129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ