### PR TITLE
[SDESK-7989] - Cannot save coverage priority

### DIFF
--- a/client/components/fields/resources/common.tsx
+++ b/client/components/fields/resources/common.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable react/no-multi-comp */
 import React from 'react';
+import {get} from 'lodash';
 
 import {IVocabularyItem} from 'superdesk-api';
 
@@ -86,7 +87,7 @@ registerEditorField(
         getOptions: () => [],
         valueAdapter: {
             getValue: (item: any, field: string) => {
-                const value = item[field];
+                const value = get(item, field);
 
                 return (value !== null && value !== undefined && value !== '') ? [value] : [];
             },
@@ -130,7 +131,7 @@ registerEditorField(
         getOptions: () => [],
         valueAdapter: {
             getValue: (item, field) => {
-                const value = item[field];
+                const value = get(item, field);
 
                 return (value !== null && value !== undefined && value !== '') ? [value] : [];
             },

--- a/e2e/playwright/page-object-models/planning/planning/coverageEditor.ts
+++ b/e2e/playwright/page-object-models/planning/planning/coverageEditor.ts
@@ -1,7 +1,7 @@
-import type {Locator} from '@playwright/test';
+import {expect, Locator} from '@playwright/test';
 
 import {Editor} from '../../../utils/common/editor';
-import {Input, SelectInput, ActionMenu, ToggleInput} from '../../../utils/common';
+import {Input, SelectInput, ActionMenu, ToggleInput, UrgencyTreeSelectInput} from '../../../utils/common';
 import {PlanningEditor} from './planningEditor';
 
 /**
@@ -38,6 +38,8 @@ export class CoverageEditor extends Editor {
                 '[data-test-id="field-g2_content_type"] select',
             ),
             genre: new SelectInput(parentEditor.page, getParent, '[data-test-id="field-genre"] select'),
+            headline: new Input(parentEditor.page, getParent, '[data-test-id="field-headline"] input'),
+            priority: new UrgencyTreeSelectInput(parentEditor.page, getParent, '[data-test-id="field-priority"]'),
             slugline: new Input(parentEditor.page, getParent, '[data-test-id="field-slugline"] input'),
             ednote: new Input(parentEditor.page, getParent, '[data-test-id="field-ednote"] textarea'),
             internal_note: new Input(parentEditor.page, getParent, '[data-test-id="field-internal_note"] textarea'),
@@ -115,6 +117,23 @@ export class CoverageEditor extends Editor {
 
         await menu.open();
         await menu.getAction(label).click();
+    }
+
+    // Selecting a value on a fresh coverage races the autosave-driven remount,
+    // which can drop the selection. Retry until it sticks in the field.
+    async setPriority(value: string): Promise<void> {
+        await expect(async () => {
+            await this.getField('priority').type(value);
+            await expect(this.element.getByTestId('field-priority')).toContainText(value, {timeout: 3000});
+        }).toPass({timeout: 20000});
+    }
+
+    async collapse(): Promise<void> {
+        await this.element.getByRole('button', {name: 'Collapse', exact: true}).click();
+    }
+
+    async expand(): Promise<void> {
+        await this.element.locator('.sd-collapse-box__header').click();
     }
 
     async toggleAddToWorkflow(): Promise<void> {

--- a/e2e/playwright/planning/edit_planning.spec.ts
+++ b/e2e/playwright/planning/edit_planning.spec.ts
@@ -4,6 +4,7 @@ import moment from 'moment/moment';
 import {setup, login, waitForPageLoad, SubNavBar, Workqueue, CLIENT_FORMAT} from '../utils/common';
 import {PlanningList, PlanningEditor, AssignmentEditor} from '../page-object-models/planning';
 import {setupPlanningPublishing} from '../utils/fixtures/publish_config';
+import {enableCoverageExtraFields} from '../utils/fixtures/coverage_profile';
 
 test.describe('Planning.Planning: edit metadata', () => {
     let editor: PlanningEditor;
@@ -173,5 +174,61 @@ test.describe('Planning.Planning: edit metadata', () => {
         await editor.waitForAutosave();
         await expect(editor.postButton).not.toBeVisible();
         await expect(editor.unpostButton).toBeVisible();
+    });
+});
+
+test.describe('Planning.Coverage: field persistence on collapse/expand', () => {
+    let editor: PlanningEditor;
+    let subnav: SubNavBar;
+
+    test.beforeEach(async ({page}) => {
+        editor = new PlanningEditor(page);
+        subnav = new SubNavBar(page);
+
+        await setup(page, 'planning_prepopulate_data', '/#/planning');
+        await enableCoverageExtraFields(page.request);
+        await login(page);
+        await waitForPageLoad.planning(page);
+        await subnav.createPlanning();
+        await editor.waitTillOpen();
+    });
+
+    test('coverage field values persist after collapsing and expanding', async () => {
+        const coverage = {
+            content_type: 'Text',
+            genre: 'Factbox',
+            slugline: 'coverage slugline',
+            headline: 'coverage headline',
+            ednote: 'something to write about',
+            internal_note: 'internal to us',
+            news_coverage_status: 'On merit',
+            'scheduled.date': moment().format(CLIENT_FORMAT),
+            'scheduled.time': '13:15',
+            priority: '2',
+        };
+
+        await editor.type({
+            slugline: 'Plan with coverage',
+            'planning_date.date': moment().format(CLIENT_FORMAT),
+            'planning_date.time': '12:13',
+        });
+
+        await editor.addCoverage('Text');
+        const coverageEditor = editor.getCoverageEditor(0);
+
+        // content_type is already set by addCoverage; re-selecting it resets the coverage.
+        const {content_type, priority, ...textFields} = coverage;
+
+        await coverageEditor.type(textFields);
+        await editor.waitForAutosave();
+        await coverageEditor.setPriority(priority);
+
+        await coverageEditor.expect(coverage);
+
+        await coverageEditor.collapse();
+        await coverageEditor.expand();
+
+        // SDESK-7989: priority rendered empty here before the fix
+        await coverageEditor.expect(coverage);
     });
 });

--- a/e2e/playwright/utils/fixtures/coverage_profile.ts
+++ b/e2e/playwright/utils/fixtures/coverage_profile.ts
@@ -1,0 +1,14 @@
+import type {APIRequestContext} from '@playwright/test';
+import {addItems} from '../common';
+
+// The coverage editor reads field config from the `planning_types` "coverage"
+// profile merged over the defaults, so a partial editor override is enough.
+export async function enableCoverageExtraFields(request: APIRequestContext) {
+    await addItems(request, 'planning_types', [{
+        name: 'coverage',
+        editor: {
+            priority: {enabled: true, index: 10},
+            headline: {enabled: true, index: 11},
+        },
+    }]);
+}


### PR DESCRIPTION
### Purpose
This PR fixes an issue where setting a coverage priority and saving looked like it didn't persist. The value was actually saved but it just rendered empty after collapsing and re-expanding the coverage panel, making it appear unsaved.

### What has changed
- The priority/urgency field's `valueAdapter.getValue` used a flat `item[field]` lookup, which fails for the nested planning.priority` path. On remount (expand) the tree-select re-seeded empty. Switched to lodash `get(item, field)` so nested paths resolve.
- Added tests

### How to test
1. Enable the Priority field on a coverage profile.
2. Create a Planning item, add a Text coverage, set a priority, and save.
3. Collapse the coverage panel, then re-expand it.
4. The priority still shows its value (previously it went empty).

Resolves : [SDESK-7989](https://sofab.atlassian.net/browse/SDESK-7989)


[SDESK-7989]: https://sofab.atlassian.net/browse/SDESK-7989?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ