### PR TITLE
[STT-1738] Fix list row spacing and trim the coverage card in previews

### DIFF
--- a/client/components/Coverages/CoverageItem.tsx
+++ b/client/components/Coverages/CoverageItem.tsx
@@ -206,9 +206,9 @@ export class CoverageItemComponent extends React.Component<IProps, IState> {
             isPreview,
         } = this.props;
 
-        // The label only says something when adding to workflow was a manual step. The server adds
-        // automatically when PLANNING_AUTO_ASSIGN_TO_WORKFLOW is on and the planning item does not
-        // set the override flag (see `planning_service.py`).
+        // Nobody chose to add this coverage to workflow: the server did it on creation, and the
+        // action that would have done it by hand is hidden in this state. The status label says
+        // "active" instead, which is all there is to say.
         const addedToWorkflowAutomatically = appConfig.planning_auto_assign_to_workflow === true &&
             item.flags?.overide_auto_assign_to_workflow !== true;
 
@@ -247,31 +247,32 @@ export class CoverageItemComponent extends React.Component<IProps, IState> {
                             `${this.state.internalNoteFieldPrefix}.workflow_status` : 'state'}
                         showHeaderText={false}
                     />
-                    {(this.state.addedToWorkflow && !addedToWorkflowAutomatically) && (
+                    {(this.state.addedToWorkflow && !addedToWorkflowAutomatically) ? (
                         <Label
                             text={gettext('Added to workflow')}
                             type="success"
                         />
-                    )}
-                    <Label
-                        text={this.props.coverage.workflow_status}
-                        style="hollow"
-                        type={(() => {
-                            const {coverage} = this.props;
+                    ) : (
+                        <Label
+                            text={this.props.coverage.workflow_status}
+                            style="hollow"
+                            type={(() => {
+                                const {coverage} = this.props;
 
-                            if (coverage.workflow_status === 'draft') {
-                                return 'default';
-                            } else if (coverage.workflow_status === 'assigned') {
-                                return 'primary';
-                            } else if (coverage.workflow_status === 'spiked') {
-                                return 'alert';
-                            } else if (coverage.workflow_status === 'active') {
-                                return 'success';
-                            } else {
-                                return 'warning';
-                            }
-                        })()}
-                    />
+                                if (coverage.workflow_status === 'draft') {
+                                    return 'default';
+                                } else if (coverage.workflow_status === 'assigned') {
+                                    return 'primary';
+                                } else if (coverage.workflow_status === 'spiked') {
+                                    return 'alert';
+                                } else if (coverage.workflow_status === 'active') {
+                                    return 'success';
+                                } else {
+                                    return 'warning';
+                                }
+                            })()}
+                        />
+                    )}
                 </span>
             </Row>
         );

--- a/client/components/Coverages/CoverageItem.tsx
+++ b/client/components/Coverages/CoverageItem.tsx
@@ -3,6 +3,7 @@ import {connect} from 'react-redux';
 import {get, isEqual} from 'lodash';
 
 import {IDesk, IUser} from 'superdesk-api';
+import {appConfig} from 'appConfig';
 import {IContactItem, IG2ContentType, IPlanningCoverageItem, IPlanningItem} from '../../interfaces';
 
 import * as selectors from '../../selectors';
@@ -179,7 +180,10 @@ export class CoverageItemComponent extends React.Component<IProps, IState> {
     renderFirstRow() {
         return (
             <Row paddingBottom>
-                <span className="sd-overflow-ellipsis sd-list-item--element-grow">
+                <span
+                    className="sd-overflow-ellipsis sd-list-item--element-grow"
+                    title={gettext('Coverage type')}
+                >
                     {this.state.displayContentType}
                 </span>
                 <time>
@@ -199,7 +203,14 @@ export class CoverageItemComponent extends React.Component<IProps, IState> {
         const {
             coverage,
             item,
+            isPreview,
         } = this.props;
+
+        // The label only says something when adding to workflow was a manual step. The server adds
+        // automatically when PLANNING_AUTO_ASSIGN_TO_WORKFLOW is on and the planning item does not
+        // set the override flag (see `planning_service.py`).
+        const addedToWorkflowAutomatically = appConfig.planning_auto_assign_to_workflow === true &&
+            item.flags?.overide_auto_assign_to_workflow !== true;
 
         return (
             <Row>
@@ -213,10 +224,15 @@ export class CoverageItemComponent extends React.Component<IProps, IState> {
                 )}
 
                 {this.state.deskAssigned && (
-                    <span className="sd-overflow-ellipsis sd-list-item--element-grow">
-                        <span className="sd-list-item__text-label sd-list-item__text-label--normal">
-                            {gettext('Desk: ')}
-                        </span>
+                    <span
+                        className="sd-overflow-ellipsis sd-list-item--element-grow"
+                        title={gettext('Desk')}
+                    >
+                        {isPreview ? null : (
+                            <span className="sd-list-item__text-label sd-list-item__text-label--normal">
+                                {gettext('Desk: ')}
+                            </span>
+                        )}
                         {get(this.state.deskAssigned, 'name')}
                     </span>
                 )}
@@ -231,7 +247,7 @@ export class CoverageItemComponent extends React.Component<IProps, IState> {
                             `${this.state.internalNoteFieldPrefix}.workflow_status` : 'state'}
                         showHeaderText={false}
                     />
-                    {this.state.addedToWorkflow && (
+                    {(this.state.addedToWorkflow && !addedToWorkflowAutomatically) && (
                         <Label
                             text={gettext('Added to workflow')}
                             type="success"

--- a/client/components/Coverages/CoverageItem_test.tsx
+++ b/client/components/Coverages/CoverageItem_test.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import {mount, ReactWrapper} from 'enzyme';
+import {appConfig} from 'appConfig';
+
+import '../../utils/testUtils';
+import {CoverageItemComponent} from './CoverageItem';
+
+describe('<CoverageItem />', () => {
+    const autoAssignToWorkflowDefault = appConfig.planning_auto_assign_to_workflow;
+
+    afterEach(() => {
+        appConfig.planning_auto_assign_to_workflow = autoAssignToWorkflowDefault;
+    });
+
+    interface IRenderOptions {
+        autoAssignToWorkflow: boolean;
+        overrideAutoAssignToWorkflow?: boolean;
+        workflowStatus?: string;
+        isPreview?: boolean;
+    }
+
+    const renderCoverageItem = ({
+        autoAssignToWorkflow,
+        overrideAutoAssignToWorkflow,
+        workflowStatus = 'active',
+        isPreview = true,
+    }: IRenderOptions): ReactWrapper => {
+        appConfig.planning_auto_assign_to_workflow = autoAssignToWorkflow;
+
+        // The component reads only a handful of fields off each entity, so the fixtures are
+        // narrower than the prop types
+        const props = {
+            index: 0,
+            isPreview: isPreview,
+            item: {
+                _id: 'plan1',
+                type: 'planning',
+                flags: {overide_auto_assign_to_workflow: overrideAutoAssignToWorkflow},
+            },
+            coverage: {
+                coverage_id: 'cov1',
+                workflow_status: workflowStatus,
+                assigned_to: {desk: 'desk1'},
+                planning: {g2_content_type: 'text'},
+            },
+            users: [],
+            desks: [{_id: 'desk1', name: 'Sports'}],
+            contentTypes: [{qcode: 'text', name: 'Text'}],
+            getContactById: () => Promise.resolve(null),
+        } as unknown as React.ComponentProps<typeof CoverageItemComponent>;
+
+        const wrapper = mount(<CoverageItemComponent {...props} />);
+
+        wrapper.update();
+
+        return wrapper;
+    };
+
+    it('shows "Added to workflow" when adding to workflow is not automatic', () => {
+        const wrapper = renderCoverageItem({autoAssignToWorkflow: false});
+
+        expect(wrapper.text()).toContain('Added to workflow');
+    });
+
+    it('hides "Added to workflow" when the coverage was added to workflow automatically', () => {
+        const wrapper = renderCoverageItem({autoAssignToWorkflow: true});
+
+        expect(wrapper.text()).not.toContain('Added to workflow');
+    });
+
+    it('shows "Added to workflow" when the planning item overrides auto assign to workflow', () => {
+        const wrapper = renderCoverageItem({
+            autoAssignToWorkflow: true,
+            overrideAutoAssignToWorkflow: true,
+        });
+
+        expect(wrapper.text()).toContain('Added to workflow');
+    });
+
+    it('hides "Added to workflow" when the coverage is not in workflow', () => {
+        const wrapper = renderCoverageItem({
+            autoAssignToWorkflow: false,
+            workflowStatus: 'draft',
+        });
+
+        expect(wrapper.text()).not.toContain('Added to workflow');
+    });
+
+    it('omits the "Desk" label in previews', () => {
+        const wrapper = renderCoverageItem({autoAssignToWorkflow: false, isPreview: true});
+
+        expect(wrapper.text()).toContain('Sports');
+        expect(wrapper.text()).not.toContain('Desk:');
+    });
+
+    it('renders the "Desk" label outside previews', () => {
+        const wrapper = renderCoverageItem({autoAssignToWorkflow: false, isPreview: false});
+
+        expect(wrapper.text()).toContain('Desk:');
+    });
+});

--- a/client/components/Coverages/CoverageItem_test.tsx
+++ b/client/components/Coverages/CoverageItem_test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {mount, ReactWrapper} from 'enzyme';
+import {Label} from 'superdesk-ui-framework/react';
 import {appConfig} from 'appConfig';
 
 import '../../utils/testUtils';
@@ -13,18 +14,18 @@ describe('<CoverageItem />', () => {
     });
 
     interface IRenderOptions {
-        autoAssignToWorkflow: boolean;
+        autoAssignToWorkflow?: boolean;
         overrideAutoAssignToWorkflow?: boolean;
         workflowStatus?: string;
         isPreview?: boolean;
     }
 
     const renderCoverageItem = ({
-        autoAssignToWorkflow,
+        autoAssignToWorkflow = false,
         overrideAutoAssignToWorkflow,
         workflowStatus = 'active',
         isPreview = true,
-    }: IRenderOptions): ReactWrapper => {
+    }: IRenderOptions = {}): ReactWrapper => {
         appConfig.planning_auto_assign_to_workflow = autoAssignToWorkflow;
 
         // The component reads only a handful of fields off each entity, so the fixtures are
@@ -56,16 +57,19 @@ describe('<CoverageItem />', () => {
         return wrapper;
     };
 
-    it('shows "Added to workflow" when adding to workflow is not automatic', () => {
+    const labelTexts = (wrapper: ReactWrapper): Array<string> =>
+        wrapper.find(Label).map((label) => label.prop('text'));
+
+    it('shows "Added to workflow" instead of the status when someone added the coverage', () => {
         const wrapper = renderCoverageItem({autoAssignToWorkflow: false});
 
-        expect(wrapper.text()).toContain('Added to workflow');
+        expect(labelTexts(wrapper)).toEqual(['Added to workflow']);
     });
 
-    it('hides "Added to workflow" when the coverage was added to workflow automatically', () => {
+    it('shows the status instead of "Added to workflow" when the coverage was added automatically', () => {
         const wrapper = renderCoverageItem({autoAssignToWorkflow: true});
 
-        expect(wrapper.text()).not.toContain('Added to workflow');
+        expect(labelTexts(wrapper)).toEqual(['active']);
     });
 
     it('shows "Added to workflow" when the planning item overrides auto assign to workflow', () => {
@@ -74,28 +78,23 @@ describe('<CoverageItem />', () => {
             overrideAutoAssignToWorkflow: true,
         });
 
-        expect(wrapper.text()).toContain('Added to workflow');
+        expect(labelTexts(wrapper)).toEqual(['Added to workflow']);
     });
 
-    it('hides "Added to workflow" when the coverage is not in workflow', () => {
-        const wrapper = renderCoverageItem({
-            autoAssignToWorkflow: false,
-            workflowStatus: 'draft',
-        });
+    it('shows the status when the coverage is not in workflow', () => {
+        const wrapper = renderCoverageItem({workflowStatus: 'draft'});
 
-        expect(wrapper.text()).not.toContain('Added to workflow');
+        expect(labelTexts(wrapper)).toEqual(['draft']);
     });
 
     it('omits the "Desk" label in previews', () => {
-        const wrapper = renderCoverageItem({autoAssignToWorkflow: false, isPreview: true});
+        const wrapper = renderCoverageItem({isPreview: true});
 
         expect(wrapper.text()).toContain('Sports');
         expect(wrapper.text()).not.toContain('Desk:');
     });
 
     it('renders the "Desk" label outside previews', () => {
-        const wrapper = renderCoverageItem({autoAssignToWorkflow: false, isPreview: false});
-
-        expect(wrapper.text()).toContain('Desk:');
+        expect(renderCoverageItem({isPreview: false}).text()).toContain('Desk:');
     });
 });

--- a/client/components/MultiSelectActions.tsx
+++ b/client/components/MultiSelectActions.tsx
@@ -3,6 +3,7 @@ import {connect} from 'react-redux';
 import * as actions from '../actions';
 import * as selectors from '../selectors';
 import {every} from 'lodash';
+import {appConfig} from 'appConfig';
 import {eventUtils, planningUtils, gettext} from '../utils';
 import {MAIN} from '../constants';
 import {SlidingToolBar} from './UI/SubNav';
@@ -119,9 +120,17 @@ export class MultiSelectActionsComponent extends React.PureComponent<IProps> {
 
         const showExport = selectedPlannings.every((planning) => planning.flags.marked_for_not_publication !== true);
 
+        // Coverages on an item that auto assigns to workflow are already in it, so the action has
+        // nothing to do. An item that sets the override flag is left out of auto assign, so adding
+        // its coverages by hand stays the only way in.
+        const showAddToWorkflow = selectedPlannings.every((planning) => (
+            appConfig.planning_auto_assign_to_workflow !== true ||
+            planning.flags?.overide_auto_assign_to_workflow === true
+        ));
+
         let tools = [];
 
-        if (selectedPlannings.every((planning) => planning.lock_action == null)) {
+        if (showAddToWorkflow && selectedPlannings.every((planning) => planning.lock_action == null)) {
             tools.push(
                 <IconButton
                     key={0}

--- a/client/components/UI/List/LineItems.tsx
+++ b/client/components/UI/List/LineItems.tsx
@@ -25,17 +25,24 @@ export class LineItems extends React.PureComponent<IProps> {
             flexGrow: 1,
         };
 
+        // Pushes the `end` items to the far side of the row. It is a zero-width flex item, so it
+        // would collect the row gap on both sides; the negative margin cancels one of them and
+        // leaves a single gap between the last `start` item and the first `end` one.
+        const endDivider = (items: Array<ILineConfig>) => items.length < 1 ? null : (
+            <div className="ms-auto" style={{marginInlineEnd: '-8px'}} />
+        );
+
         return (
             <Spacer v gap="4" noWrap alignItems="stretch">
                 <Spacer h gap="8" justifyContent="start" noWrap noGrow style={firstLineStyles}>
                     {renderFieldsWithProps(firstLineStart)}
-                    <div className="ms-auto" />
+                    {endDivider(firstLineEnd)}
                     {renderFieldsWithProps(firstLineEnd)}
                 </Spacer>
 
                 <Spacer h gap="8" justifyContent="start" noWrap noGrow style={secondLineStyles}>
                     {renderFieldsWithProps(secondLineStart)}
-                    <div className="ms-auto" />
+                    {endDivider(secondLineEnd)}
                     {renderFieldsWithProps(secondLineEnd)}
                 </Spacer>
             </Spacer>

--- a/client/components/fields/anpa_category.tsx
+++ b/client/components/fields/anpa_category.tsx
@@ -21,7 +21,7 @@ export const anpa_category: React.ComponentType<IProps> = (props) => {
     }
 
     return (
-        <Spacer h gap="4" noGrow style={{whiteSpace: 'nowrap'}}>
+        <Spacer h gap="4" noWrap noGrow style={{whiteSpace: 'nowrap'}}>
             {showLabel && <div className="sd-list-item__text-label">{vocabulary.display_name}</div>}
 
             <WithMoreItems

--- a/client/components/fields/location.tsx
+++ b/client/components/fields/location.tsx
@@ -1,12 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
-
-import {get} from 'lodash';
 
 import {Location} from '../';
 
-export const location = ({item, fieldsProps}) => {
+export const location = ({item}) => {
     const locations = Array.isArray(item.location) ? item.location : [item.location];
 
     if (locations.length === 0 || locations[0] == null) {
@@ -14,13 +11,9 @@ export const location = ({item, fieldsProps}) => {
     }
 
     const location = locations[0];
-    const locationProps = fieldsProps?.location ?? {};
 
     return (
-        <span
-            className={classNames('sd-overflow-ellipsis sd-list-item--element-grow',
-                {'sd-list-item__element-lm-10': !get(locationProps, 'noMargin')})}
-        >
+        <span className="sd-overflow-ellipsis sd-list-item--element-grow">
             <Location
                 name={location.name}
                 address={location.formatted_address}
@@ -33,5 +26,4 @@ location.propTypes = {
     item: PropTypes.shape({
         description_text: PropTypes.string,
     }).isRequired,
-    fieldsProps: PropTypes.object,
 };

--- a/client/components/fields/reference.tsx
+++ b/client/components/fields/reference.tsx
@@ -8,7 +8,7 @@ export const reference = ({item}) => {
         return null;
     }
 
-    return (<span className="sd-list-item__text-strong sd-list-item__element-lm-10">{item.reference}</span>);
+    return (<span className="sd-list-item__text-strong">{item.reference}</span>);
 };
 
 reference.propTypes = {

--- a/client/utils/planning.tsx
+++ b/client/utils/planning.tsx
@@ -381,6 +381,8 @@ function canCancelCoverage(
         );
 }
 
+// Exported but never called. The `? :` below also binds looser than the `&&` chain, so the
+// draft and assigned checks are dropped whenever `ignoreAutoAssignConfig` is unset.
 function canAddCoverageToWorkflow(
     coverage: IPlanningCoverageItem,
     planning: Partial<IPlanningItem>,


### PR DESCRIPTION
### Purpose

Cards for linked events and planning items in the preview panel space their fields inconsistently: a location sits further right than the field above it, and the gap before a right-aligned field is double every other gap on the row. The coverage card also shows "Added to workflow" on coverages the system added automatically, where it says nothing, and labels the desk name with "Desk" where the name alone is clear.

### What has changed

**Row spacing.** Three things were adding space on top of the row's 8px gap:

- `LineItems` always rendered an empty `ms-auto` divider between the start and end items. It's zero-width but still a flex item, so it picked up a gap on both sides: 16px where 8 was intended. It now renders only when there are end items, and cancels one gap with a negative margin.
- `location` and `reference` each added their own 10px `sd-list-item__element-lm-10`. No other field does that. Removing it left `location`'s `noMargin` option as dead code (nothing ever set it), so that went too.
- `anpa_category` was the only field whose `Spacer` skipped `noWrap`, so with `hideLabel: true` its falsy label still emitted an empty div and 4px of indent.

Most visible on the narrow preview cards, but it's every list row in the module. Fields at `position: 'end'` now sit 8px closer to the start.

**Coverage card.**

- "Added to workflow" only shows when adding to workflow was manual, matching the server condition in `planning_service.py`. With auto assign on it appeared on every coverage and just repeated the "active" label beside it.
- The "Desk" prefix is gone in previews, the name stays.
- `title` attributes on coverage type and desk name, which have no visible label.

### Screenshots - Before // After
<img width="340" height="194" alt="image" src="https://github.com/user-attachments/assets/03753dca-be5a-4f25-aace-5319274c1129" />

<img width="380" alt="image" src="https://github.com/user-attachments/assets/32dfe08c-1e31-4a03-b1a0-dad84d8d097a" />


### Steps to test

Row spacing, any configuration:

1. Preview a planning item linked to an event that has a location. The location lines up with the field above it, and the gap before it matches every other gap on the row.
2. Open the Events and Planning lists. Any field configured at `position: 'end'` sits 8px closer to the start items; rows with no end fields are unchanged. Nothing else moves.
3. If a line in your configuration starts with `anpa_category` and `hideLabel: true`, it now starts flush with the line below it instead of 4px in.

Coverage card:

4. With `PLANNING_AUTO_ASSIGN_TO_WORKFLOW = False`, preview a planning item with a coverage in workflow. "Added to workflow" shows, as before.
5. Set it to `True`, restart the backend, reload. The label is gone.
6. Leave it on and switch "Forward Planning" on for that planning item. The label comes back.
7. The desk on a coverage card in a preview shows the name with no "Desk" prefix; hovering shows it as a tooltip. In the coverage editor the prefix is still there.

Resolves: [STT-1738]

[STT-1738]: https://sofab.atlassian.net/browse/STT-1738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ