### PR TITLE
[STT-1738] Fix list row spacing and show a single status label on coverage cards (backport of #2948)

### DIFF
--- a/client/components/Coverages/CoverageItem.tsx
+++ b/client/components/Coverages/CoverageItem.tsx
@@ -3,7 +3,14 @@ import {connect} from 'react-redux';
 import {get, isEqual} from 'lodash';
 
 import {IDesk, IUser} from 'superdesk-api';
-import {IContactItem, IG2ContentType, IPlanningCoverageItem, IPlanningItem} from '../../interfaces';
+import {appConfig} from 'appConfig';
+import {
+    IContactItem,
+    IG2ContentType,
+    IPlanningCoverageItem,
+    IPlanningItem,
+    IPlanningWorkflowStatus,
+} from '../../interfaces';
 
 import * as selectors from '../../selectors';
 import * as actions from '../../actions';
@@ -48,6 +55,16 @@ interface IState {
     coverageDateText?: string;
     internalNoteFieldPrefix?: string;
 }
+
+type ILabelType = React.ComponentProps<typeof Label>['type'];
+
+// Statuses without an entry fall back to 'warning'
+const WORKFLOW_STATUS_LABEL_TYPES: Partial<Record<IPlanningWorkflowStatus, ILabelType>> = {
+    draft: 'default',
+    assigned: 'primary',
+    active: 'success',
+    spiked: 'alert',
+};
 
 const mapStateToProps = (state) => ({
     users: selectors.general.users(state),
@@ -179,7 +196,10 @@ export class CoverageItemComponent extends React.Component<IProps, IState> {
     renderFirstRow() {
         return (
             <Row paddingBottom>
-                <span className="sd-overflow-ellipsis sd-list-item--element-grow">
+                <span
+                    className="sd-overflow-ellipsis sd-list-item--element-grow"
+                    title={gettext('Coverage type')}
+                >
                     {this.state.displayContentType}
                 </span>
                 <time>
@@ -199,7 +219,14 @@ export class CoverageItemComponent extends React.Component<IProps, IState> {
         const {
             coverage,
             item,
+            isPreview,
         } = this.props;
+
+        // Nobody chose to add this coverage to workflow: the server did it on creation, and the
+        // action that would have done it by hand is hidden in this state. The status label says
+        // "active" instead, which is all there is to say.
+        const addedToWorkflowAutomatically = appConfig.planning_auto_assign_to_workflow === true &&
+            item.flags?.overide_auto_assign_to_workflow !== true;
 
         return (
             <Row>
@@ -213,10 +240,15 @@ export class CoverageItemComponent extends React.Component<IProps, IState> {
                 )}
 
                 {this.state.deskAssigned && (
-                    <span className="sd-overflow-ellipsis sd-list-item--element-grow">
-                        <span className="sd-list-item__text-label sd-list-item__text-label--normal">
-                            {gettext('Desk: ')}
-                        </span>
+                    <span
+                        className="sd-overflow-ellipsis sd-list-item--element-grow"
+                        title={gettext('Desk')}
+                    >
+                        {isPreview ? null : (
+                            <span className="sd-list-item__text-label sd-list-item__text-label--normal">
+                                {gettext('Desk: ')}
+                            </span>
+                        )}
                         {get(this.state.deskAssigned, 'name')}
                     </span>
                 )}
@@ -231,31 +263,18 @@ export class CoverageItemComponent extends React.Component<IProps, IState> {
                             `${this.state.internalNoteFieldPrefix}.workflow_status` : 'state'}
                         showHeaderText={false}
                     />
-                    {this.state.addedToWorkflow && (
+                    {(this.state.addedToWorkflow && !addedToWorkflowAutomatically) ? (
                         <Label
                             text={gettext('Added to workflow')}
                             type="success"
                         />
+                    ) : (
+                        <Label
+                            text={coverage.workflow_status}
+                            style="hollow"
+                            type={WORKFLOW_STATUS_LABEL_TYPES[coverage.workflow_status] ?? 'warning'}
+                        />
                     )}
-                    <Label
-                        text={this.props.coverage.workflow_status}
-                        style="hollow"
-                        type={(() => {
-                            const {coverage} = this.props;
-
-                            if (coverage.workflow_status === 'draft') {
-                                return 'default';
-                            } else if (coverage.workflow_status === 'assigned') {
-                                return 'primary';
-                            } else if (coverage.workflow_status === 'spiked') {
-                                return 'alert';
-                            } else if (coverage.workflow_status === 'active') {
-                                return 'success';
-                            } else {
-                                return 'warning';
-                            }
-                        })()}
-                    />
                 </span>
             </Row>
         );
@@ -291,6 +310,7 @@ export class CoverageItemComponent extends React.Component<IProps, IState> {
 
         return (
             <Item
+                testId="coverage-item"
                 noBg={!showBackground && !active}
                 activated={active}
                 shadow={shadow}

--- a/client/components/Coverages/CoverageItem_test.tsx
+++ b/client/components/Coverages/CoverageItem_test.tsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import {mount, ReactWrapper} from 'enzyme';
+import {Label} from 'superdesk-ui-framework/react';
+import {appConfig} from 'appConfig';
+
+import '../../utils/testUtils';
+import {CoverageItemComponent} from './CoverageItem';
+
+describe('<CoverageItem />', () => {
+    const autoAssignToWorkflowDefault = appConfig.planning_auto_assign_to_workflow;
+
+    afterEach(() => {
+        appConfig.planning_auto_assign_to_workflow = autoAssignToWorkflowDefault;
+    });
+
+    interface IRenderOptions {
+        autoAssignToWorkflow?: boolean;
+        overrideAutoAssignToWorkflow?: boolean;
+        workflowStatus?: string;
+        isPreview?: boolean;
+    }
+
+    const renderCoverageItem = ({
+        autoAssignToWorkflow = false,
+        overrideAutoAssignToWorkflow,
+        workflowStatus = 'active',
+        isPreview = true,
+    }: IRenderOptions = {}): ReactWrapper => {
+        appConfig.planning_auto_assign_to_workflow = autoAssignToWorkflow;
+
+        // The component reads only a handful of fields off each entity, so the fixtures are
+        // narrower than the prop types
+        const props = {
+            index: 0,
+            isPreview: isPreview,
+            item: {
+                _id: 'plan1',
+                type: 'planning',
+                flags: {overide_auto_assign_to_workflow: overrideAutoAssignToWorkflow},
+            },
+            coverage: {
+                coverage_id: 'cov1',
+                workflow_status: workflowStatus,
+                assigned_to: {desk: 'desk1'},
+                planning: {g2_content_type: 'text'},
+            },
+            users: [],
+            desks: [{_id: 'desk1', name: 'Sports'}],
+            contentTypes: [{qcode: 'text', name: 'Text'}],
+            getContactById: () => Promise.resolve(null),
+        } as unknown as React.ComponentProps<typeof CoverageItemComponent>;
+
+        const wrapper = mount(<CoverageItemComponent {...props} />);
+
+        wrapper.update();
+
+        return wrapper;
+    };
+
+    const labelTexts = (wrapper: ReactWrapper): Array<string> =>
+        wrapper.find(Label).map((label) => label.prop('text'));
+
+    it('shows "Added to workflow" instead of the status when someone added the coverage', () => {
+        const wrapper = renderCoverageItem({autoAssignToWorkflow: false});
+
+        expect(labelTexts(wrapper)).toEqual(['Added to workflow']);
+    });
+
+    it('shows the status instead of "Added to workflow" when the coverage was added automatically', () => {
+        const wrapper = renderCoverageItem({autoAssignToWorkflow: true});
+
+        expect(labelTexts(wrapper)).toEqual(['active']);
+    });
+
+    it('shows "Added to workflow" when the planning item overrides auto assign to workflow', () => {
+        const wrapper = renderCoverageItem({
+            autoAssignToWorkflow: true,
+            overrideAutoAssignToWorkflow: true,
+        });
+
+        expect(labelTexts(wrapper)).toEqual(['Added to workflow']);
+    });
+
+    it('shows the status when the coverage is not in workflow', () => {
+        const wrapper = renderCoverageItem({workflowStatus: 'draft'});
+
+        expect(labelTexts(wrapper)).toEqual(['draft']);
+    });
+
+    it('colours the status label by workflow status, falling back for unmapped ones', () => {
+        const labelType = (workflowStatus: string) => renderCoverageItem({workflowStatus})
+            .find(Label)
+            .first()
+            .prop('type');
+
+        expect(labelType('draft')).toBe('default');
+        expect(labelType('spiked')).toBe('alert');
+        expect(labelType('cancelled')).toBe('warning');
+    });
+
+    it('omits the "Desk" label in previews', () => {
+        const wrapper = renderCoverageItem({isPreview: true});
+
+        expect(wrapper.text()).toContain('Sports');
+        expect(wrapper.text()).not.toContain('Desk:');
+    });
+
+    it('renders the "Desk" label outside previews', () => {
+        expect(renderCoverageItem({isPreview: false}).text()).toContain('Desk:');
+    });
+});

--- a/client/components/MultiSelectActions.tsx
+++ b/client/components/MultiSelectActions.tsx
@@ -3,6 +3,7 @@ import {connect} from 'react-redux';
 import * as actions from '../actions';
 import * as selectors from '../selectors';
 import {every} from 'lodash';
+import {appConfig} from 'appConfig';
 import {eventUtils, planningUtils, gettext} from '../utils';
 import {MAIN} from '../constants';
 import {SlidingToolBar} from './UI/SubNav';
@@ -119,9 +120,17 @@ export class MultiSelectActionsComponent extends React.PureComponent<IProps> {
 
         const showExport = selectedPlannings.every((planning) => planning.flags.marked_for_not_publication !== true);
 
+        // Coverages on an item that auto assigns to workflow are already in it, so the action has
+        // nothing to do. An item that sets the override flag is left out of auto assign, so adding
+        // its coverages by hand stays the only way in.
+        const showAddToWorkflow = selectedPlannings.every((planning) => (
+            appConfig.planning_auto_assign_to_workflow !== true ||
+            planning.flags?.overide_auto_assign_to_workflow === true
+        ));
+
         let tools = [];
 
-        if (selectedPlannings.every((planning) => planning.lock_action == null)) {
+        if (showAddToWorkflow && selectedPlannings.every((planning) => planning.lock_action == null)) {
             tools.push(
                 <IconButton
                     key={0}

--- a/client/components/UI/List/ItemType.tsx
+++ b/client/components/UI/List/ItemType.tsx
@@ -16,7 +16,7 @@ import {Checkbox} from '../Form';
 export const ItemType = ({hasCheck, checked, onCheckToggle, item, color}) => (
     <Column hasCheck={hasCheck} checked={checked} >
         {hasCheck && (
-            <div className="sd-list-item__checkbox-container">
+            <div className="sd-list-item__checkbox-container" data-test-id="multi-select-checkbox">
                 <Checkbox
                     value={checked}
                     onChange={(field, value, shiftKey) => {

--- a/client/components/UI/List/LineItems.tsx
+++ b/client/components/UI/List/LineItems.tsx
@@ -25,17 +25,24 @@ export class LineItems extends React.PureComponent<IProps> {
             flexGrow: 1,
         };
 
+        // Pushes the `end` items to the far side of the row. It is a zero-width flex item, so it
+        // would collect the row gap on both sides; the negative margin cancels one of them and
+        // leaves a single gap between the last `start` item and the first `end` one.
+        const endDivider = (items: Array<ILineConfig>) => items.length < 1 ? null : (
+            <div className="ms-auto" style={{marginInlineEnd: '-8px'}} />
+        );
+
         return (
             <Spacer v gap="4" noWrap alignItems="stretch">
                 <Spacer h gap="8" justifyContent="start" noWrap noGrow style={firstLineStyles}>
                     {renderFieldsWithProps(firstLineStart)}
-                    <div className="ms-auto" />
+                    {endDivider(firstLineEnd)}
                     {renderFieldsWithProps(firstLineEnd)}
                 </Spacer>
 
                 <Spacer h gap="8" justifyContent="start" noWrap noGrow style={secondLineStyles}>
                     {renderFieldsWithProps(secondLineStart)}
-                    <div className="ms-auto" />
+                    {endDivider(secondLineEnd)}
                     {renderFieldsWithProps(secondLineEnd)}
                 </Spacer>
             </Spacer>

--- a/client/components/fields/anpa_category.tsx
+++ b/client/components/fields/anpa_category.tsx
@@ -21,7 +21,7 @@ export const anpa_category: React.ComponentType<IProps> = (props) => {
     }
 
     return (
-        <Spacer h gap="4" noGrow style={{whiteSpace: 'nowrap'}}>
+        <Spacer h gap="4" noWrap noGrow style={{whiteSpace: 'nowrap'}}>
             {showLabel && <div className="sd-list-item__text-label">{vocabulary.display_name}</div>}
 
             <WithMoreItems

--- a/client/components/fields/location.tsx
+++ b/client/components/fields/location.tsx
@@ -1,12 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
-
-import {get} from 'lodash';
 
 import {Location} from '../';
 
-export const location = ({item, fieldsProps}) => {
+export const location = ({item}) => {
     const locations = Array.isArray(item.location) ? item.location : [item.location];
 
     if (locations.length === 0 || locations[0] == null) {
@@ -14,13 +11,9 @@ export const location = ({item, fieldsProps}) => {
     }
 
     const location = locations[0];
-    const locationProps = fieldsProps?.location ?? {};
 
     return (
-        <span
-            className={classNames('sd-overflow-ellipsis sd-list-item--element-grow',
-                {'sd-list-item__element-lm-10': !get(locationProps, 'noMargin')})}
-        >
+        <span className="sd-overflow-ellipsis sd-list-item--element-grow">
             <Location
                 name={location.name}
                 address={location.formatted_address}
@@ -33,5 +26,4 @@ location.propTypes = {
     item: PropTypes.shape({
         description_text: PropTypes.string,
     }).isRequired,
-    fieldsProps: PropTypes.object,
 };

--- a/client/components/fields/reference.tsx
+++ b/client/components/fields/reference.tsx
@@ -8,7 +8,7 @@ export const reference = ({item}) => {
         return null;
     }
 
-    return (<span className="sd-list-item__text-strong sd-list-item__element-lm-10">{item.reference}</span>);
+    return (<span className="sd-list-item__text-strong">{item.reference}</span>);
 };
 
 reference.propTypes = {

--- a/client/utils/planning.tsx
+++ b/client/utils/planning.tsx
@@ -381,6 +381,8 @@ function canCancelCoverage(
         );
 }
 
+// Exported but never called. The `? :` below also binds looser than the `&&` chain, so the
+// draft and assigned checks are dropped whenever `ignoreAutoAssignConfig` is unset.
 function canAddCoverageToWorkflow(
     coverage: IPlanningCoverageItem,
     planning: Partial<IPlanningItem>,

--- a/e2e/playwright/planning/coverage_card_labels.spec.ts
+++ b/e2e/playwright/planning/coverage_card_labels.spec.ts
@@ -1,7 +1,7 @@
 import {test, expect} from '@playwright/test';
 
 import {setup, login, waitForPageLoad, addItems} from '../utils/common';
-import {AdvancedSearch, PlanningList, PlanningPreview} from '../page-object-models/planning';
+import {AdvancedSearch, PlanningList, PlanningPreview} from '../utils/planning';
 import {createPlanningFor} from '../utils/fixtures/planning';
 
 const PLANNING = {

--- a/e2e/playwright/planning/coverage_card_labels.spec.ts
+++ b/e2e/playwright/planning/coverage_card_labels.spec.ts
@@ -1,0 +1,78 @@
+import {test, expect} from '@playwright/test';
+
+import {setup, login, waitForPageLoad, addItems} from '../utils/common';
+import {AdvancedSearch, PlanningList, PlanningPreview} from '../page-object-models/planning';
+import {createPlanningFor} from '../utils/fixtures/planning';
+
+const PLANNING = {
+    slugline: 'Coverage card labels',
+    coverages: [{
+        coverage_id: 'e2e-coverage-card',
+        workflow_status: 'draft',
+        news_coverage_status: {qcode: 'ncostat:int', name: 'coverage intended', label: 'Planned'},
+        planning: {
+            g2_content_type: 'text',
+        },
+    }],
+};
+
+test.describe('Planning: coverage card status labels', () => {
+    let list: PlanningList;
+    let preview: PlanningPreview;
+    let search: AdvancedSearch;
+
+    test.beforeEach(async ({page}) => {
+        list = new PlanningList(page);
+        preview = new PlanningPreview(page);
+        search = new AdvancedSearch(page);
+
+        await setup(page, 'planning_prepopulate_data', '/#/planning');
+        await addItems(page.request, 'planning', [createPlanningFor.today(PLANNING)]);
+
+        await login(page);
+        await waitForPageLoad.planning(page);
+
+        // The multi-select checkbox is only rendered outside the combined view
+        await search.viewPlanningOnly();
+        await list.expectItemCount(1);
+    });
+
+    const openPreview = async () => {
+        await list.item(0).click();
+        await preview.waitTillOpen();
+        await expect(preview.coverageCards).toHaveCount(1);
+    };
+
+    test('a coverage that is not in workflow shows its status', async () => {
+        await openPreview();
+
+        await expect(preview.coverageCard(0)).toContainText('draft');
+        await expect(preview.coverageCard(0)).not.toContainText('Added to workflow');
+    });
+
+    test('a coverage added to workflow shows "Added to workflow" instead of its status', async () => {
+        await list.addSelectedToWorkflow(0);
+        await openPreview();
+
+        await expect(preview.coverageCard(0)).toContainText('Added to workflow');
+        await expect(preview.coverageCard(0)).not.toContainText('active');
+    });
+
+    test('a coverage added automatically shows its status instead of "Added to workflow"', async ({page}) => {
+        await list.addSelectedToWorkflow(0);
+
+        await page.addInitScript(() => {
+            window.localStorage.setItem(
+                'TEST_APP_CONFIG',
+                JSON.stringify({planning_auto_assign_to_workflow: true}),
+            );
+        });
+        await page.reload();
+        await waitForPageLoad.planning(page);
+
+        await openPreview();
+
+        await expect(preview.coverageCard(0)).toContainText('active');
+        await expect(preview.coverageCard(0)).not.toContainText('Added to workflow');
+    });
+});

--- a/e2e/playwright/utils/planning/planningList.ts
+++ b/e2e/playwright/utils/planning/planningList.ts
@@ -65,6 +65,24 @@ export class PlanningList {
             .click();
     }
 
+    /**
+     * The multi-select toolbar renders its actions as icon buttons carrying only an aria-label,
+     * so this is a role lookup rather than a test id.
+     */
+    async addSelectedToWorkflow(index: number): Promise<void> {
+        await this.item(index).hover();
+        await this.item(index).getByTestId('multi-select-checkbox').click();
+
+        // The action patches each selected item; without waiting for that response a reload
+        // straight afterwards races the in-flight request and sees the coverage still in draft
+        const patched = this.page.waitForResponse((response) => (
+            response.request().method() === 'PATCH' && response.url().includes('/planning/')
+        ));
+
+        await this.page.getByRole('button', {name: 'Add to workflow'}).click();
+        await patched;
+    }
+
     async setDateInterval(interval: 'Day' | 'Week' | 'Month') {
         await this.page.getByTestId('planning-list-panel')
             .getByTestId('interval-dropdown-toggle')

--- a/e2e/playwright/utils/planning/planningPreview.ts
+++ b/e2e/playwright/utils/planning/planningPreview.ts
@@ -31,6 +31,14 @@ export class PlanningPreview {
         return this.entityCards.nth(index);
     }
 
+    get coverageCards(): Locator {
+        return this.element.getByTestId('coverage-item');
+    }
+
+    coverageCard(index: number): Locator {
+        return this.coverageCards.nth(index);
+    }
+
     // The column wrapping `ItemIcon` on a related event / planning item
     itemTypeIcons(scope?: Locator): Locator {
         return (scope ?? this.element).locator('[data-test-id="item-type-icon"]');


### PR DESCRIPTION
Backport of #2948, so STT picks these up.

### Difference from #2948

One commit on top of the cherry-pick: this branch keeps Playwright page objects under `e2e/playwright/utils/planning`, so the new spec imports from there rather than `page-object-models/planning`. Everything else is identical.

Resolves: [STT-1738]


[STT-1738]: https://sofab.atlassian.net/browse/STT-1738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ