### PR TITLE
[SDESK-8009] Preserve coverage expanded state in planning preview on list refresh

### DIFF
--- a/client/components/Planning/PlanningPreviewContent.tsx
+++ b/client/components/Planning/PlanningPreviewContent.tsx
@@ -91,6 +91,33 @@ const mapDispatchToProps = (dispatch): IDispatchProps => ({
 });
 
 export class PlanningPreviewContentComponent extends React.PureComponent<IProps> {
+    // Do not turn this into a component defined inside render(): such a component gets a new type identity on
+    // every render, making React remount the coverage subtree and lose the CollapseBox open state
+    renderCoveragePreview(coverage: IPlanningCoverageItem, index: number) {
+        const {item, users, desks, newsCoverageStatus, inner, files} = this.props;
+        const {profile} = getCoverageFields(coverage.planning.g2_content_type);
+
+        return (
+            <CoveragePreview
+                item={item}
+                key={coverage.coverage_id}
+                index={index}
+                coverage={coverage}
+                users={users}
+                desks={desks}
+                newsCoverageStatus={newsCoverageStatus}
+                formProfile={profile}
+                inner={inner}
+                files={files}
+                createLink={getFileDownloadURL}
+                canScheduleUpdates={
+                    profile.editor.flags && appConfig.planning_allow_scheduled_updates
+                }
+                scrollInView={true}
+            />
+        );
+    }
+
     componentWillMount() {
         // If the planning item is associated with an event, get its files
         if ((this.props.relatedEvents?.length ?? 0) > 0) {
@@ -108,10 +135,7 @@ export class PlanningPreviewContentComponent extends React.PureComponent<IProps>
             users,
             formProfile,
             relatedEvents,
-            desks,
-            newsCoverageStatus,
             onEditEvent,
-            inner,
             noPadding,
             hideRelatedItems,
             hideEditIcon,
@@ -131,30 +155,6 @@ export class PlanningPreviewContentComponent extends React.PureComponent<IProps>
         const otherCoverages: Array<IPlanningCoverageItem> = this.props.currentCoverageId == null ?
             item.coverages ?? [] :
             (item.coverages ?? []).filter((coverage) => coverage.coverage_id !== this.props.currentCoverageId);
-
-        const CoveragesPreview = ({coverage, index}) => {
-            const {profile} = getCoverageFields(coverage.planning.g2_content_type);
-
-            return (
-                <CoveragePreview
-                    item={item}
-                    key={coverage.coverage_id}
-                    index={index}
-                    coverage={coverage}
-                    users= {users}
-                    desks= {desks}
-                    newsCoverageStatus={newsCoverageStatus}
-                    formProfile={profile}
-                    inner={inner}
-                    files={files}
-                    createLink={getFileDownloadURL}
-                    canScheduleUpdates={
-                        profile.editor.flags && appConfig.planning_allow_scheduled_updates
-                    }
-                    scrollInView={true}
-                />
-            );
-        };
 
         const primaryEventId = getRelatedEventIdsForPlanning(this.props.item, 'primary')[0];
         const primaryRelatedEvent = (relatedEvents ?? []).find((relatedEvent) => relatedEvent._id === primaryEventId);
@@ -183,21 +183,17 @@ export class PlanningPreviewContentComponent extends React.PureComponent<IProps>
                         {currentCoverage == null ? (
                             <>
                                 <h3 className="side-panel__heading--big">{gettext('Coverages')}</h3>
-                                {otherCoverages.map((coverage, i) => (
-                                    <CoveragesPreview key={i} coverage={coverage} index={i} />
-                                ))}
+                                {otherCoverages.map((coverage, i) => this.renderCoveragePreview(coverage, i))}
                             </>
                         ) : (
                             <>
                                 <h3 className="side-panel__heading--big">{gettext('This Coverage')}</h3>
-                                <CoveragesPreview coverage={currentCoverage} index={0} />
+                                {this.renderCoveragePreview(currentCoverage, 0)}
 
                                 {(otherCoverages ?? []).length > 0 && (
                                     <>
                                         <h3 className="side-panel__heading--big">{gettext('Other Coverages')}</h3>
-                                        {otherCoverages.map((coverage, i) => (
-                                            <CoveragesPreview key={i} coverage={coverage} index={i} />
-                                        ))}
+                                        {otherCoverages.map((coverage, i) => this.renderCoveragePreview(coverage, i))}
                                     </>
                                 )}
                             </>


### PR DESCRIPTION
### Purpose
In the planning list, previewing an item and expanding one of its coverages didn't stick: any list refresh (navigating dates back and forth, or websocket-driven refetches when other users are active) collapsed the coverage again and made the cards flicker. Reported in SDESK-8009.

### What has changed
`PlanningPreviewContent` defined `CoveragesPreview` as a function component inside `render()`. That gives it a new type identity on every render, so React unmounted and remounted the whole coverage subtree whenever the previewed item object changed identity, wiping the `CollapseBox` open state. It's now a regular class method returning `CoveragePreview` elements, so the subtree reconciles in place and keeps its state. The coverage cards are also keyed by `coverage_id` instead of the array index, so the open state can't shift to a different coverage when the list changes.

### Steps to test
1. Open Planning and preview a planning item that has coverages.
2. Expand one of the coverages in the preview panel.
3. Navigate the date back and forward with the arrows next to the date.
4. The coverage should stay expanded and the cards should not flicker. Same when another user edits planning items so the list refreshes via websocket.

### Front-end checklist
- [x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)
