### PR TITLE
[SDESK-7993] Reflect related event changes in the open planning preview

### DIFF
--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -58,8 +58,36 @@ jobs:
         run: npm run start-client-server
 
       # playwright start
-      - name: Install Playwright Browsers
+      - name: Resolve Playwright version
+        id: playwright-version
+        run: echo "version=$(node -p "require('@playwright/test/package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v5.0.5
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+
+      # `--with-deps` runs apt-get, which hangs for the full job timeout when a
+      # mirror stalls or a package prompts; the env vars keep it non-interactive
+      # and the timeout turns a stall into a fast failure instead of a 6h job
+      - name: Install Playwright browsers and system deps
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        timeout-minutes: 15
+        env:
+          DEBIAN_FRONTEND: noninteractive
+          NEEDRESTART_MODE: a
         run: npx playwright install --with-deps chromium
+
+      - name: Install Playwright system deps only
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        timeout-minutes: 15
+        env:
+          DEBIAN_FRONTEND: noninteractive
+          NEEDRESTART_MODE: a
+        run: npx playwright install-deps chromium
+
       - name: Run Playwright tests
         run: npm run playwright -- --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
       - uses: actions/upload-artifact@v6

--- a/client/components/Planning/PlanningPreviewContent.tsx
+++ b/client/components/Planning/PlanningPreviewContent.tsx
@@ -33,7 +33,7 @@ import {EventMetadata} from '../Events';
 import {FeatureLabel} from './FeaturedPlanning';
 import {renderProfileGroupedFields} from '../fields';
 import {PreviewFieldFiles} from '../fields/preview/Files';
-import {getRelatedEventIdsForPlanning} from '../../utils/planning';
+import {getRelatedEventIdsForPlanning, pickRelatedEventIdsForPlanning} from '../../utils/planning';
 import {coverageProfiles} from '../../selectors/coverageProfiles';
 import {getCoverageFields} from '../../api/editor/item_planning';
 import {appConfig} from 'appConfig';
@@ -130,11 +130,33 @@ export class PlanningPreviewContentComponent extends React.PureComponent<IProps>
     }
 
     render() {
+        const eventIds = pickRelatedEventIdsForPlanning(this.props.item, 'display');
+
+        if (eventIds.length < 1) {
+            return this.renderContent(null);
+        }
+
+        const {WithLiveResources} = superdeskApi.components;
+
+        // Related events are rendered from live resources rather than the redux store: the store
+        // copy is not refreshed on `events:updated` notifications outside the Events view, so it
+        // goes stale when an event changes while the preview is open
+        return (
+            <WithLiveResources resources={[{resource: 'events', ids: eventIds}]}>
+                {([res]) => this.renderContent(
+                    (res._items as Array<IEventItem>)
+                        .filter((event) => event != null)
+                        .map((event) => eventUtils.modifyForClient(event))
+                )}
+            </WithLiveResources>
+        );
+    }
+
+    renderContent(relatedEvents: Array<IEventItem> | null) {
         const {gettext} = superdeskApi.localization;
         const {item,
             users,
             formProfile,
-            relatedEvents,
             onEditEvent,
             noPadding,
             hideRelatedItems,

--- a/client/components/Planning/PlanningPreviewContent.tsx
+++ b/client/components/Planning/PlanningPreviewContent.tsx
@@ -34,6 +34,7 @@ import {FeatureLabel} from './FeaturedPlanning';
 import {renderProfileGroupedFields} from '../fields';
 import {PreviewFieldFiles} from '../fields/preview/Files';
 import {getRelatedEventIdsForPlanning, pickRelatedEventIdsForPlanning} from '../../utils/planning';
+import {RelatedEventsFilesFetcher} from './RelatedEventsFilesFetcher';
 import {coverageProfiles} from '../../selectors/coverageProfiles';
 import {getCoverageFields} from '../../api/editor/item_planning';
 import {appConfig} from 'appConfig';
@@ -48,7 +49,6 @@ interface IOwnProps {
 
 interface IReduxProps {
     item: IPlanningItem;
-    relatedEvents: Array<IEventItem> | null;
     session: ISession;
     privileges: any;
     users: Array<IUser>;
@@ -72,7 +72,6 @@ type IProps = IOwnProps & IReduxProps & IDispatchProps;
 
 const mapStateToProps = (state, ownProps): IReduxProps => ({
     item: selectors.planning.currentPlanning(state) || ownProps.item,
-    relatedEvents: selectors.events.getRelatedEventsForPlanning(state),
     session: selectors.general.session(state),
     privileges: selectors.general.privileges(state),
     users: selectors.general.users(state),
@@ -119,13 +118,8 @@ export class PlanningPreviewContentComponent extends React.PureComponent<IProps>
     }
 
     componentWillMount() {
-        // If the planning item is associated with an event, get its files
-        if ((this.props.relatedEvents?.length ?? 0) > 0) {
-            this.props.relatedEvents.forEach((relatedEvent) => (
-                this.props.fetchEventFiles(relatedEvent)
-            ));
-        }
-
+        // Related event files are fetched by RelatedEventsFilesFetcher from the live
+        // event data, so only the planning item's own files are needed here
         this.props.fetchPlanningFiles(this.props.item);
     }
 
@@ -143,11 +137,20 @@ export class PlanningPreviewContentComponent extends React.PureComponent<IProps>
         // goes stale when an event changes while the preview is open
         return (
             <WithLiveResources resources={[{resource: 'events', ids: eventIds}]}>
-                {([res]) => this.renderContent(
-                    (res._items as Array<IEventItem>)
+                {([res]) => {
+                    const relatedEvents = (res._items as Array<IEventItem>)
                         .filter((event) => event != null)
-                        .map((event) => eventUtils.modifyForClient(event))
-                )}
+                        .map((event) => eventUtils.modifyForClient(event));
+
+                    return (
+                        <RelatedEventsFilesFetcher
+                            events={relatedEvents}
+                            fetchEventFiles={this.props.fetchEventFiles}
+                        >
+                            {this.renderContent(relatedEvents)}
+                        </RelatedEventsFilesFetcher>
+                    );
+                }}
             </WithLiveResources>
         );
     }

--- a/client/components/Planning/RelatedEventsFilesFetcher.tsx
+++ b/client/components/Planning/RelatedEventsFilesFetcher.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import {isEqual} from 'lodash';
+
+import {IEventItem} from '../../interfaces';
+
+interface IProps {
+    events: Array<IEventItem>;
+    fetchEventFiles(event: IEventItem): void;
+    children: React.ReactNode;
+}
+
+/**
+ * Live event updates can add attachments whose file resources are not in the store yet,
+ * leaving their rows in the preview without name and size. Fetch the resources whenever an
+ * event's file list changes (`fetchEventFiles` is a no-op for files already in the store).
+ */
+export class RelatedEventsFilesFetcher extends React.PureComponent<IProps> {
+    componentDidMount() {
+        this.props.events.forEach((event) => this.props.fetchEventFiles(event));
+    }
+
+    componentDidUpdate(prevProps: Readonly<IProps>) {
+        this.props.events.forEach((event) => {
+            const previous = prevProps.events.find(({_id}) => _id === event._id);
+
+            if (!isEqual(previous?.files, event.files)) {
+                this.props.fetchEventFiles(event);
+            }
+        });
+    }
+
+    render() {
+        return this.props.children;
+    }
+}

--- a/client/components/UI/IconButton.tsx
+++ b/client/components/UI/IconButton.tsx
@@ -75,7 +75,8 @@ IconButton.propTypes = {
     tooltip: PropTypes.string,
     tooltipDirection: PropTypes.string,
     testId: PropTypes.string,
-    refNode: PropTypes.object,
+    // A React ref: either a callback ref (function) or a ref object
+    refNode: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
 };
 
 IconButton.defaultProps = {

--- a/client/controllers/PlanningController.tsx
+++ b/client/controllers/PlanningController.tsx
@@ -66,16 +66,18 @@ export class PlanningController {
     }
 
     renderLoader() {
+        const container = document.getElementById(PLANNING_CONTAINER_ID);
+
         ReactDOM.render(
             <div id="planning-loader">
                 <Loader overlay />
             </div>,
-            document.getElementById(PLANNING_CONTAINER_ID)
+            container
         );
 
-        const loaderElement = document.getElementById('planning-loader');
-
-        return () => ReactDOM.unmountComponentAtNode(loaderElement);
+        // Unmounting must target the container React rendered into, not the
+        // rendered `#planning-loader` node itself
+        return () => ReactDOM.unmountComponentAtNode(container);
     }
 
     render() {

--- a/client/utils/testApi.ts
+++ b/client/utils/testApi.ts
@@ -5,6 +5,7 @@ import {querySelectorParent} from 'superdesk-core/scripts/core/helpers/dom/query
 import {superdeskApi, planningApi} from '../superdeskApi';
 
 
+import * as testData from './testData';
 import {initialState, privileges} from './testData';
 Object.assign(superdeskApi, {
     localization: {
@@ -43,8 +44,25 @@ Object.assign(superdeskApi, {
             error: sinon.stub().returns(undefined),
         }
     },
+    helpers: {
+        assertNever: (value: never) => {
+            throw new Error(`assertNever: unexpected value ${JSON.stringify(value)}`);
+        },
+    },
     components: {
         SelectUser: sinon.stub().returns('<div>Stubbed SelectUser Component</div>'),
+
+        // Synchronous stand-in for the live-resources component: resolves the requested ids
+        // from test data (events only) instead of querying the server. Items are cloned
+        // because consumers may modify them in place (e.g. `eventUtils.modifyForClient`)
+        WithLiveResources: ({resources, children}) => children(
+            resources.map(({resource, ids}) => ({
+                _items: resource !== 'events' ? [] : ids
+                    .map((id) => testData.events.find((event) => event._id === id))
+                    .filter((event) => event != null)
+                    .map(cloneDeep),
+            }))
+        ),
     },
     entities: {
         contentProfile: {

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -12,8 +12,8 @@
                 "superdesk-planning": "file:../"
             },
             "devDependencies": {
-                "@playwright/test": "~1.58.2",
-                "@superdesk/build-tools": "^1.0.14",
+                "@playwright/test": "^1.61.0",
+                "@superdesk/build-tools": "^1.2.0",
                 "http-server": "14.1.1",
                 "lodash": "^4.17.15",
                 "moment": "^2.29.4",
@@ -1870,19 +1870,19 @@
             }
         },
         "node_modules/@playwright/test": {
-            "version": "1.58.2",
-            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
-            "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+            "version": "1.62.1",
+            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+            "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "playwright": "1.58.2"
+                "playwright": "1.62.1"
             },
             "bin": {
                 "playwright": "cli.js"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=20"
             }
         },
         "node_modules/@popperjs/core": {
@@ -12044,35 +12044,35 @@
             }
         },
         "node_modules/playwright": {
-            "version": "1.58.2",
-            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
-            "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+            "version": "1.62.1",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+            "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "playwright-core": "1.58.2"
+                "playwright-core": "1.62.1"
             },
             "bin": {
                 "playwright": "cli.js"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=20"
             },
             "optionalDependencies": {
                 "fsevents": "2.3.2"
             }
         },
         "node_modules/playwright-core": {
-            "version": "1.58.2",
-            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
-            "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+            "version": "1.62.1",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+            "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
                 "playwright-core": "cli.js"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=20"
             }
         },
         "node_modules/pluralize": {

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -8,8 +8,8 @@
         "superdesk-planning": "file:../"
     },
     "devDependencies": {
-        "@playwright/test": "~1.58.2",
-        "@superdesk/build-tools": "^1.0.14",
+        "@playwright/test": "^1.61.0",
+        "@superdesk/build-tools": "^1.2.0",
         "http-server": "14.1.1",
         "lodash": "^4.17.15",
         "moment": "^2.29.4",

--- a/e2e/playwright/page-object-models/planning/planning/embeddedEventEditor.ts
+++ b/e2e/playwright/page-object-models/planning/planning/embeddedEventEditor.ts
@@ -1,0 +1,81 @@
+import {expect} from '@playwright/test';
+import type {Locator} from '@playwright/test';
+
+import {PlanningEditor} from './planningEditor';
+
+export class EmbeddedEventEditor {
+    editor: PlanningEditor;
+
+    constructor(editor: PlanningEditor) {
+        this.editor = editor;
+    }
+
+    get element(): Locator {
+        return this.editor.element;
+    }
+
+    getEventItem(index: number): Locator {
+        return this.element.getByTestId(`editor--event-item__${index}`);
+    }
+
+    // An embedded event renders collapsed with its fields present but not
+    // interactable; expand it before touching any field. The editor can
+    // remount the card while it finishes loading, collapsing it again, so
+    // retry until the expanded state sticks and the embedded form is reachable.
+    async expand(index: number): Promise<void> {
+        const eventItem = this.getEventItem(index);
+        const toggle = eventItem.getByRole('button', {name: /Show (more|less)/});
+
+        await toggle.waitFor({state: 'visible'});
+
+        await expect(async () => {
+            // A DOM-level click: the toggle animates on state change, which makes
+            // pointer clicks unstable for Playwright
+            await eventItem.evaluate((el) => {
+                const divider = el.querySelector<HTMLElement>('.new-collapse-box__divider');
+
+                if (divider?.textContent?.includes('Show more')) {
+                    divider.click();
+                }
+            });
+
+            await expect(eventItem.getByRole('button', {name: 'Show less'})).toBeVisible({timeout: 2000});
+            await expect(eventItem.getByRole('button', {name: 'Save', exact: true})).toBeVisible({timeout: 2000});
+        }).toPass({timeout: 30000});
+    }
+
+    field(index: number, fieldId: string): Locator {
+        return this.getEventItem(index)
+            .locator(`[data-test-id="authoring-field"][data-test-value="${fieldId}"]`);
+    }
+
+    name(index: number): Locator {
+        return this.field(index, 'name').locator('[contenteditable="true"]').first();
+    }
+
+    // Drives the field via focus and keyboard: the collapse box header is
+    // sticky and intercepts pointer clicks on fields that land underneath it
+    async setName(index: number, text: string): Promise<void> {
+        await this.expand(index);
+
+        const field = this.name(index);
+        const keyboard = field.page().keyboard;
+
+        await field.focus();
+        await keyboard.press('ControlOrMeta+a');
+        await keyboard.type(text);
+    }
+
+    async save(index: number): Promise<void> {
+        const eventItem = this.getEventItem(index);
+
+        // The box can re-collapse while fields are being edited (the form stays
+        // mounted and keeps the changes); make sure the Save button is visible
+        await this.expand(index);
+
+        await eventItem.getByRole('button', {name: 'Save', exact: true}).first().click();
+
+        // Done once no enabled Save button remains: a successful save greys it out
+        await expect(eventItem.locator('button:enabled', {hasText: 'Save'})).toHaveCount(0, {timeout: 20000});
+    }
+}

--- a/e2e/playwright/page-object-models/planning/planning/index.ts
+++ b/e2e/playwright/page-object-models/planning/planning/index.ts
@@ -1,3 +1,4 @@
 export {CoverageEditor} from './coverageEditor';
 export {PlanningEditor} from './planningEditor';
 export {FeaturedModal} from './featuredModal';
+export {EmbeddedEventEditor} from './embeddedEventEditor';

--- a/e2e/playwright/page-object-models/planning/planningList.ts
+++ b/e2e/playwright/page-object-models/planning/planningList.ts
@@ -65,6 +65,12 @@ export class PlanningList {
             .click();
     }
 
+    async toggleAssociatedEvents(index: number): Promise<void> {
+        await this.nestedItem(index)
+            .getByTestId('toggle-related-events')
+            .click();
+    }
+
     /**
      * The multi-select toolbar renders its actions as icon buttons carrying only an aria-label,
      * so this is a role lookup rather than a test id.

--- a/e2e/playwright/planning/related_event_refresh.spec.ts
+++ b/e2e/playwright/planning/related_event_refresh.spec.ts
@@ -1,0 +1,79 @@
+import {test, expect} from '@playwright/test';
+
+import {setup, login, waitForPageLoad, addItems} from '../utils/common';
+import {
+    AdvancedSearch,
+    EmbeddedEventEditor,
+    PlanningEditor,
+    PlanningList,
+    PlanningPreview,
+} from '../page-object-models/planning';
+import {createEventFor} from '../utils/fixtures/events';
+import {createPlanningFor} from '../utils/fixtures/planning';
+
+const EVENT_NAME = 'Related Refresh Event';
+
+test.describe('Planning: related event changes refresh open views', () => {
+    let list: PlanningList;
+    let preview: PlanningPreview;
+    let search: AdvancedSearch;
+    let editor: PlanningEditor;
+    let embedded: EmbeddedEventEditor;
+
+    test.beforeEach(async ({page}, testInfo) => {
+        // Unique per run so repeats stay independent of leftovers from a
+        // previous instance of this test
+        const EVENT_ID = `e2e-related-event-refresh-${testInfo.repeatEachIndex}-${Date.now()}`;
+
+        list = new PlanningList(page);
+        preview = new PlanningPreview(page);
+        search = new AdvancedSearch(page);
+        editor = new PlanningEditor(page);
+        embedded = new EmbeddedEventEditor(editor);
+
+        await setup(page, 'planning_prepopulate_data', '/#/planning');
+        await addItems(page.request, 'events', [createEventFor.today({
+            guid: EVENT_ID,
+            name: EVENT_NAME,
+            slugline: 'related-refresh',
+        })]);
+        await addItems(page.request, 'planning', [createPlanningFor.today({
+            slugline: 'RELATED-REFRESH-PLAN',
+            related_events: [{_id: EVENT_ID, link_type: 'primary'}],
+        })]);
+
+        await login(page);
+        await waitForPageLoad.planning(page);
+    });
+
+    test('saving the embedded event updates the preview card and the nested list row', async () => {
+        await search.viewPlanningOnly();
+        await list.expectItemCount(1);
+
+        await list.toggleAssociatedEvents(0);
+        await expect(list.nestedPlanningItems(0)).toHaveCount(1);
+        await expect(list.nestedPlanningItem(0, 0)).toContainText(EVENT_NAME);
+
+        await list.item(0).dblclick();
+        await editor.waitTillOpen();
+        await editor.waitLoadingComplete();
+
+        // Preview after opening the editor: previewing an item closes on
+        // opening it for edit, but not the other way around
+        // TODO: verify this is the intended product behaviour; if preview and
+        // editor are supposed to stay open in either order, drop the ordering
+        // constraint here
+        await list.item(0).click();
+        await preview.waitTillOpen();
+        await expect(preview.entityCards).toHaveCount(1);
+        await expect(preview.entityCard(0)).toContainText(EVENT_NAME);
+
+        await embedded.setName(0, `${EVENT_NAME} updated`);
+        await embedded.save(0);
+
+        // The preview card and the nested list row must pick up the change without
+        // being closed and reopened
+        await expect(preview.entityCard(0)).toContainText(`${EVENT_NAME} updated`);
+        await expect(list.nestedPlanningItem(0, 0)).toContainText(`${EVENT_NAME} updated`);
+    });
+});

--- a/e2e/playwright/planning/related_event_refresh.spec.ts
+++ b/e2e/playwright/planning/related_event_refresh.spec.ts
@@ -1,6 +1,6 @@
-import {test, expect} from '@playwright/test';
+import {test, expect, APIRequestContext} from '@playwright/test';
 
-import {setup, login, waitForPageLoad, addItems} from '../utils/common';
+import {setup, login, waitForPageLoad, addItems, baseBackendUrl} from '../utils/common';
 import {
     AdvancedSearch,
     EmbeddedEventEditor,
@@ -12,6 +12,28 @@ import {createEventFor} from '../utils/fixtures/events';
 import {createPlanningFor} from '../utils/fixtures/planning';
 
 const EVENT_NAME = 'Related Refresh Event';
+const FILE_NAME = 'attachment-refresh.txt';
+
+const attachFileToEvent = async(request: APIRequestContext, eventId: string): Promise<void> => {
+    const uploaded = await request.post(`${baseBackendUrl}/events_files`, {
+        failOnStatusCode: true,
+        multipart: {
+            media: {
+                name: FILE_NAME,
+                mimeType: 'text/plain',
+                buffer: Buffer.from('e2e attachment body'),
+            },
+        },
+    });
+    const fileId = (await uploaded.json())._id;
+    const event = await request.get(`${baseBackendUrl}/events/${eventId}`, {failOnStatusCode: true});
+
+    await request.patch(`${baseBackendUrl}/events/${eventId}`, {
+        failOnStatusCode: true,
+        headers: {'If-Match': (await event.json())._etag},
+        data: {files: [fileId]},
+    });
+};
 
 test.describe('Planning: related event changes refresh open views', () => {
     let list: PlanningList;
@@ -19,11 +41,12 @@ test.describe('Planning: related event changes refresh open views', () => {
     let search: AdvancedSearch;
     let editor: PlanningEditor;
     let embedded: EmbeddedEventEditor;
+    let eventId: string;
 
-    test.beforeEach(async ({page}, testInfo) => {
+    test.beforeEach(async({page}, testInfo) => {
         // Unique per run so repeats stay independent of leftovers from a
         // previous instance of this test
-        const EVENT_ID = `e2e-related-event-refresh-${testInfo.repeatEachIndex}-${Date.now()}`;
+        eventId = `e2e-related-event-refresh-${testInfo.repeatEachIndex}-${Date.now()}`;
 
         list = new PlanningList(page);
         preview = new PlanningPreview(page);
@@ -33,20 +56,20 @@ test.describe('Planning: related event changes refresh open views', () => {
 
         await setup(page, 'planning_prepopulate_data', '/#/planning');
         await addItems(page.request, 'events', [createEventFor.today({
-            guid: EVENT_ID,
+            guid: eventId,
             name: EVENT_NAME,
             slugline: 'related-refresh',
         })]);
         await addItems(page.request, 'planning', [createPlanningFor.today({
             slugline: 'RELATED-REFRESH-PLAN',
-            related_events: [{_id: EVENT_ID, link_type: 'primary'}],
+            related_events: [{_id: eventId, link_type: 'primary'}],
         })]);
 
         await login(page);
         await waitForPageLoad.planning(page);
     });
 
-    test('saving the embedded event updates the preview card and the nested list row', async () => {
+    test('saving the embedded event updates the preview card and the nested list row', async() => {
         await search.viewPlanningOnly();
         await list.expectItemCount(1);
 
@@ -75,5 +98,27 @@ test.describe('Planning: related event changes refresh open views', () => {
         // being closed and reopened
         await expect(preview.entityCard(0)).toContainText(`${EVENT_NAME} updated`);
         await expect(list.nestedPlanningItem(0, 0)).toContainText(`${EVENT_NAME} updated`);
+    });
+
+    test('an attachment added to the related event resolves in the open preview', async({page}) => {
+        await search.viewPlanningOnly();
+        await list.expectItemCount(1);
+        await list.item(0).click();
+        await preview.waitTillOpen();
+        await expect(preview.entityCard(0)).toContainText(EVENT_NAME);
+
+        await attachFileToEvent(page.request, eventId);
+
+        await preview.entityCard(0).click();
+
+        // Scoped to the expanded card: the planning item renders its own
+        // "Attached Files" toggle in the same panel
+        const expandedCard = preview.element.locator('.sd-collapse-box--open');
+
+        await expandedCard.getByRole('button', {name: /Attached Files/}).click();
+
+        // The file name only renders when the file resource was fetched after the
+        // live update; an unresolved attachment shows as an empty row
+        await expect(expandedCard).toContainText(FILE_NAME);
     });
 });


### PR DESCRIPTION
### Purpose
When a related event is edited (e.g. renamed through the embedded editor inside the planning editor), an open planning preview kept showing the old values until it was closed and reopened. The list rows and the editor cards updated fine, only the preview lagged behind.

### What has changed
- The preview's Related Events section now renders through `WithLiveResources` instead of the redux events store. The store copy is not refreshed on `events:updated` notifications outside the Events view, which is the root cause of the staleness; the nested list rows already use `WithLiveResources`, so this brings the preview in line with them.
- New e2e spec covering the flow end to end: rename the related event in the embedded form, save, and both the preview card and the nested list row update without reopening anything. Comes with a new `EmbeddedEventEditor` page object.
- Two small console noise fixes: `IconButton`'s `refNode` prop type now accepts callback refs, and the planning loader is unmounted at the container it was rendered into.
- `@playwright/test` and `@superdesk/build-tools` bumped in e2e.

### Steps to test
1. In the Planning view, have a planning item linked to an event.
2. Open the planning item in the editor, then click it in the list so the preview opens next to it.
3. Expand the related event in the editor ("Show more"), change its name and save.
4. The Related Events card in the preview and the nested event row in the list should both show the new name within a second or so, without closing or reopening anything.

### Front-end checklist
- [x] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [x] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [x] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [x] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [x] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [x] This pull request is not adding redux based modals
- [x] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [x] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)
