### PR TITLE
avoid resetting assignment state on planning item change

### DIFF
--- a/server/planning/coverage_assignments.py
+++ b/server/planning/coverage_assignments.py
@@ -330,6 +330,13 @@ def _set_assignment_state(updates: dict, coverage: dict, assignment: dict) -> bo
     assign_state = ASSIGNMENT_WORKFLOW_STATE.ASSIGNED
     coverage_assigned_to = coverage.get("assigned_to") or {}
     assignment_assigned_to = (assignment or {}).get("assigned_to") or {}
+    current_assignment_state = assignment_assigned_to.get("state")
+    coverage_assignment_state = coverage_assigned_to.get("state")
+
+    # For existing assignments, preserve current workflow state unless we have an
+    # explicit state transition to apply.
+    if current_assignment_state:
+        assign_state = current_assignment_state
 
     if coverage.get("workflow_status") == WORKFLOW_STATE.DRAFT:
         assign_state = ASSIGNMENT_WORKFLOW_STATE.DRAFT
@@ -342,8 +349,16 @@ def _set_assignment_state(updates: dict, coverage: dict, assignment: dict) -> bo
         if assignee_changed and get_config_assignment_manual_reassignment_only():
             # Reassignment should move the item back to To Do.
             assign_state = ASSIGNMENT_WORKFLOW_STATE.ASSIGNED
-        elif coverage_assigned_to.get("state") and coverage_assigned_to["state"] != ASSIGNMENT_WORKFLOW_STATE.DRAFT:
-            assign_state = coverage_assigned_to["state"]
+        elif (
+            not assignee_changed
+            and current_assignment_state == ASSIGNMENT_WORKFLOW_STATE.IN_PROGRESS
+            and coverage_assignment_state == ASSIGNMENT_WORKFLOW_STATE.ASSIGNED
+        ):
+            # Planning editors can hold stale assigned_to.state values. Do not
+            # downgrade an in-progress assignment to "to do" on planning save.
+            assign_state = ASSIGNMENT_WORKFLOW_STATE.IN_PROGRESS
+        elif coverage_assignment_state and coverage_assignment_state != ASSIGNMENT_WORKFLOW_STATE.DRAFT:
+            assign_state = coverage_assignment_state
 
     if updates["assigned_to"]["state"] != assign_state:
         updates["assigned_to"]["state"] = assign_state

--- a/server/planning/tests/coverage_assignments_sync_test.py
+++ b/server/planning/tests/coverage_assignments_sync_test.py
@@ -354,3 +354,37 @@ def test_reassignment_does_not_reset_state_when_manual_reassignment_disabled():
 
     assert updates["assigned_to"]["user"] is None
     assert updates["assigned_to"]["state"] == "in_progress"
+
+
+def test_stale_planning_assignment_state_does_not_reset_in_progress_assignment():
+    assignment = {
+        "_id": "as1",
+        "assigned_to": {
+            "desk": "desk-1",
+            "user": "user-1",
+            "state": "in_progress",
+        },
+        "planning": {},
+    }
+    planning = {
+        "_id": "plan-1",
+        # Trigger assignment metadata update path without changing assignee fields.
+        "description_text": "Updated from planning editor",
+    }
+    coverage = {
+        "coverage_id": "cov-1",
+        "workflow_status": "active",
+        "assigned_to": {
+            "assignment_id": "as1",
+            "desk": "desk-1",
+            "user": "user-1",
+            # Stale state in planning editor (before "start work" websocket update).
+            "state": "assigned",
+        },
+        "planning": {},
+    }
+
+    with mock.patch("planning.coverage_assignments.get_user", return_value=None):
+        updates = get_metadata_updates_between_entities(assignment, planning, coverage, destination="assignment")
+
+    assert updates["assigned_to"]["state"] == "in_progress"

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -23,4 +23,4 @@ aiomoto[sqs]==0.5.3
 
 -e .
 # Install in editable state so we get feature fixtures
--e git+https://github.com/superdesk/superdesk-core.git@develop#egg=superdesk-core
+-e git+https://github.com/superdesk/superdesk-core.git@release/3.6#egg=superdesk-core


### PR DESCRIPTION
SDESK-7991

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

### Front-end checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)

Resolves: #[issue-number]

