### PR TITLE
fix edit coverages modal opening

### DIFF
--- a/client/components/Planning/PlanningItem.tsx
+++ b/client/components/Planning/PlanningItem.tsx
@@ -61,6 +61,8 @@ class PlanningItemComponent extends React.Component<IProps, IState> {
         this.onAddCoverageButtonClick = this.onAddCoverageButtonClick.bind(this);
         this.onItemHoverOn = this.onItemHoverOn.bind(this);
         this.onItemHoverOff = this.onItemHoverOff.bind(this);
+        this.openCoverageModal = this.openCoverageModal.bind(this);
+        this.closeCoverageModal = this.closeCoverageModal.bind(this);
         this.renderItemActions = this.renderItemActions.bind(this);
     }
 

--- a/e2e/playwright/planning/edit_coverages_from_list.spec.ts
+++ b/e2e/playwright/planning/edit_coverages_from_list.spec.ts
@@ -1,0 +1,48 @@
+import {test, expect} from '@playwright/test';
+
+import {setup, addItems, login, waitForPageLoad} from '../utils/common';
+import {PlanningList} from '../page-object-models/planning';
+import {createPlanningFor} from '../utils/fixtures/planning';
+
+const PLANNING = {
+    slugline: 'Edit coverages from planning list',
+    coverages: [{
+        coverage_id: 'e2e-edit-coverages',
+        workflow_status: 'draft',
+        news_coverage_status: {qcode: 'ncostat:int'},
+        planning: {
+            g2_content_type: 'text',
+            language: null,
+        },
+    }],
+};
+
+test.describe('Planning: edit coverages from the planning list', () => {
+    let list: PlanningList;
+
+    test.beforeEach(async ({page}) => {
+        list = new PlanningList(page);
+
+        await setup(page, 'planning_prepopulate_data', '/#/planning');
+        await addItems(page.request, 'planning', [createPlanningFor.today(PLANNING)]);
+        await login(page);
+        await waitForPageLoad.planning(page);
+
+        await expect(list.item(0)).toContainText(PLANNING.slugline);
+    });
+
+    test('updates a coverage status through Edit Coverages', async ({page}) => {
+        await list.clickAction(0, 'Edit Coverages');
+
+        const modal = page.getByRole('dialog');
+        const status = modal.getByLabel('Status');
+
+        await expect(status).toHaveValue('ncostat:int');
+        await status.selectOption('ncostat:notdec');
+        await modal.getByRole('button', {name: 'Save', exact: true}).click();
+        await expect(modal).not.toBeVisible();
+
+        await list.clickAction(0, 'Edit Coverages');
+        await expect(page.getByRole('dialog').getByLabel('Status')).toHaveValue('ncostat:notdec');
+    });
+});

--- a/e2e/playwright/planning/edit_coverages_from_list.spec.ts
+++ b/e2e/playwright/planning/edit_coverages_from_list.spec.ts
@@ -34,7 +34,8 @@ test.describe('Planning: edit coverages from the planning list', () => {
     test('updates a coverage status through Edit Coverages', async ({page}) => {
         await list.clickAction(0, 'Edit Coverages');
 
-        const modal = page.getByRole('dialog');
+        const modal = page.getByRole('dialog', {name: 'Add Coverages (advanced mode)'});
+        await expect(modal).toBeVisible();
         const status = modal.getByLabel('Status');
 
         await expect(status).toHaveValue('ncostat:int');
@@ -43,6 +44,7 @@ test.describe('Planning: edit coverages from the planning list', () => {
         await expect(modal).not.toBeVisible();
 
         await list.clickAction(0, 'Edit Coverages');
-        await expect(page.getByRole('dialog').getByLabel('Status')).toHaveValue('ncostat:notdec');
+        await expect(modal).toBeVisible();
+        await expect(modal.getByLabel('Status')).toHaveValue('ncostat:notdec');
     });
 });


### PR DESCRIPTION
SDESK-8012

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

### Front-end checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)

Resolves: #[issue-number]

