### PR TITLE
fix all-day planning items not visible in lists

### DIFF
--- a/server/features/search_planning.feature
+++ b/server/features/search_planning.feature
@@ -586,6 +586,48 @@ Feature: Planning Search
         Then we get list with 0 items
 
     @auth
+    Scenario: All day coverage without scheduled date defaults to local midnight
+        When we set config DEFAULT_TIMEZONE to "Europe/Prague"
+        Given empty "planning"
+        When we post to "/planning"
+        """
+        [{
+            "guid": "planning_all_day_no_coverage",
+            "slugline": "slug123",
+            "name": "name123",
+            "planning_date": "2025-11-06T00:00:00+0000",
+            "all_day": true
+        }]
+        """
+        Then we get OK response
+        When we patch "/planning/planning_all_day_no_coverage"
+        """
+        {
+            "coverages": [
+                {
+                    "planning": {"g2_content_type": "text"},
+                    "workflow_status": "draft",
+                    "news_coverage_status": {"qcode": "ncostat:int"}
+                }
+            ]
+        }
+        """
+        Then we get OK response
+        Then we get existing resource
+        """
+        {
+            "_id": "planning_all_day_no_coverage",
+            "coverages": [
+                {"planning": {"scheduled": "2025-11-05T23:00:00+0000"}}
+            ],
+            "_planning_schedule": [
+                {"coverage_id": null, "scheduled": "2025-11-06T00:00:00+0000"},
+                {"scheduled": "2025-11-05T23:00:00+0000"}
+            ]
+        }
+        """
+
+    @auth
     Scenario: Search planning by coverage dates
         Given empty "planning"
         When we post to "/planning"

--- a/server/features/steps/steps.py
+++ b/server/features/steps/steps.py
@@ -423,6 +423,11 @@ def then_set_auto_workflow(context):
     context.app.config["PLANNING_AUTO_ASSIGN_TO_WORKFLOW"] = True
 
 
+@when('we set config DEFAULT_TIMEZONE to "{timezone}"')
+def then_set_default_timezone(context, timezone):
+    context.app.config["DEFAULT_TIMEZONE"] = timezone
+
+
 @when("we set config assignment manual reassignment only to True")
 def then_set_assignment_manual_reassignment_only(context):
     context.app.config["ASSIGNMENT_MANUAL_REASSIGNMENT_ONLY"] = True

--- a/server/planning/planning/planning.py
+++ b/server/planning/planning/planning.py
@@ -31,7 +31,7 @@ from superdesk.flask import request
 from superdesk.resource_fields import ID_FIELD, ITEMS
 from superdesk import get_resource_service, Resource
 from superdesk.errors import SuperdeskApiError
-from superdesk.utc import utcnow, utc_to_local
+from superdesk.utc import utcnow, utc_to_local, local_to_utc
 from superdesk.metadata.utils import generate_guid, item_url
 from superdesk.metadata.item import GUID_NEWSML
 from superdesk.users.services import current_user_has_privilege
@@ -704,6 +704,7 @@ class PlanningService(AsyncBaseService):
             return
 
         planning_date = original.get("planning_date") or updates.get("planning_date")
+        all_day = updates.get("all_day", original.get("all_day"))
         original_coverage_ids = [
             coverage["coverage_id"] for coverage in original.get("coverages") or [] if coverage.get("coverage_id")
         ]
@@ -720,9 +721,14 @@ class PlanningService(AsyncBaseService):
                 coverage["firstcreated"] = utcnow()
 
                 # Make sure the coverage has a ``scheduled`` date
-                # If none was supplied, fallback to to ``planning.planning_date``
+                # If none was supplied, fallback to ``planning.planning_date``
+                # A coverage's ``scheduled`` is always a real datetime with a timezone (stored in UTC),
+                # unlike ``planning_date`` which may be a "floating" date for all day Planning items
                 coverage.setdefault("planning", {})
-                coverage["planning"].setdefault("scheduled", planning_date)
+                if not coverage["planning"].get("scheduled"):
+                    coverage["planning"]["scheduled"] = (
+                        self.get_all_day_scheduled_date(planning_date) if all_day else planning_date
+                    )
 
                 await self.inherit_planning_metadata(coverage, updates, original)
 
@@ -909,6 +915,18 @@ class PlanningService(AsyncBaseService):
 
         return False
 
+    @staticmethod
+    def get_all_day_scheduled_date(value: datetime) -> datetime:
+        """Resolve ``value`` to the real UTC instant of local midnight on its calendar date
+
+        A coverage's ``scheduled`` date is always a real datetime with a timezone, stored in
+        UTC (see ``field_range``), so a value inherited from a "floating" all day ``planning_date``
+        must be converted to the actual UTC instant of local midnight rather than copied as-is.
+        """
+
+        tz_name = get_app_config("DEFAULT_TIMEZONE")
+        return local_to_utc(tz_name, datetime(value.year, value.month, value.day))
+
     def set_planning_schedule(self, updates, original=None):
         """This set the list of schedule based on the coverage and planning.
 
@@ -926,14 +944,12 @@ class PlanningService(AsyncBaseService):
         coverages = updates.get("coverages", [])
         planning_date = updates.get("planning_date") or (original or {}).get("planning_date") or utcnow()
 
-        add_default_schedule = True
         add_default_updates_schedule = True
-        schedule = []
+        # The planning item's own `planning_date` must always be searchable/sortable via
+        # `_planning_schedule`, even when coverages have their own distinct `scheduled` dates
+        schedule = [{"coverage_id": None, "scheduled": planning_date or utcnow()}]
         updates_schedule = []
         for coverage in coverages:
-            if coverage.get("planning", {}).get("scheduled"):
-                add_default_schedule = False
-
             schedule.append(
                 {
                     "coverage_id": coverage.get("coverage_id"),
@@ -951,9 +967,6 @@ class PlanningService(AsyncBaseService):
                         "scheduled": s.get("planning", {}).get("scheduled"),
                     }
                 )
-
-        if add_default_schedule:
-            schedule.append({"coverage_id": None, "scheduled": planning_date or utcnow()})
 
         if add_default_updates_schedule:
             updates_schedule.append({"scheduled_update_id": None, "scheduled": planning_date or utcnow()})

--- a/server/planning/planning/planning_service.py
+++ b/server/planning/planning/planning_service.py
@@ -12,7 +12,7 @@ from apps.auth import get_user, get_auth
 
 from superdesk.core.types import SearchRequest
 from superdesk.core import get_current_app
-from superdesk.utc import utcnow, utc_to_local
+from superdesk.utc import utcnow, utc_to_local, local_to_utc
 from superdesk.errors import SuperdeskApiError
 from superdesk.resource_fields import ID_FIELD
 from superdesk.metadata.item import GUID_NEWSML
@@ -448,6 +448,18 @@ class PlanningAsyncService(BasePlanningAsyncService[PlanningResourceModel]):
         await self.add_coverages(updated_planning, original)
         await self.update_coverages(updated_planning, original)
 
+    @staticmethod
+    def _get_all_day_date(value: datetime) -> datetime:
+        """Resolve ``value`` to the real UTC instant of local midnight on its calendar date
+
+        A coverage's ``scheduled`` date is always a real datetime with a timezone, stored in
+        UTC (see ``field_range``), so a value inherited from a "floating" all day ``planning_date``
+        must be converted to the actual UTC instant of local midnight rather than copied as-is.
+        """
+
+        tz_name = get_app_config("DEFAULT_TIMEZONE")
+        return local_to_utc(tz_name, datetime(value.year, value.month, value.day))
+
     def set_planning_schedule(
         self, updated_planning: PlanningResourceModel, original_planning: PlanningResourceModel | None = None
     ):
@@ -467,15 +479,13 @@ class PlanningAsyncService(BasePlanningAsyncService[PlanningResourceModel]):
         planning_date = (
             updated_planning.planning_date or (original_planning and original_planning.planning_date) or utcnow()
         )
-        add_default_schedule = True
         add_default_updates_schedule = True
 
-        schedule = []
+        # The planning item's own `planning_date` must always be searchable/sortable via
+        # `_planning_schedule`, even when coverages have their own distinct `scheduled` dates
+        schedule = [{"coverage_id": None, "scheduled": planning_date or utcnow()}]
         updates_schedule = []
         for coverage in updated_planning.coverages:
-            if coverage.planning.scheduled:
-                add_default_schedule = False
-
             schedule.append(
                 {
                     "coverage_id": coverage.coverage_id,
@@ -493,9 +503,6 @@ class PlanningAsyncService(BasePlanningAsyncService[PlanningResourceModel]):
                         "scheduled": s.planning.scheduled,
                     }
                 )
-
-        if add_default_schedule:
-            schedule.append({"coverage_id": None, "scheduled": planning_date or utcnow()})
 
         if add_default_updates_schedule:
             updates_schedule.append({"scheduled_update_id": None, "scheduled": planning_date or utcnow()})
@@ -566,6 +573,10 @@ class PlanningAsyncService(BasePlanningAsyncService[PlanningResourceModel]):
             return
 
         planning_date = original.planning_date or updated_planning.planning_date
+        # `all_day` isn't a declared model field, so it may be entirely absent from either instance
+        all_day = getattr(updated_planning, "all_day", None)
+        if all_day is None:
+            all_day = getattr(original, "all_day", None)
         original_coverage_ids = [coverage.coverage_id for coverage in original.coverages if coverage.coverage_id]
 
         for coverage in updated_planning.coverages:
@@ -587,8 +598,10 @@ class PlanningAsyncService(BasePlanningAsyncService[PlanningResourceModel]):
 
                 # Make sure the coverage has a ``scheduled`` date
                 # If none was supplied, fallback to ``planning.planning_date``
+                # A coverage's ``scheduled`` is always a real datetime with a timezone (stored in UTC),
+                # unlike ``planning_date`` which may be a "floating" date for all day Planning items
                 if not coverage.planning.scheduled:
-                    coverage.planning.scheduled = planning_date
+                    coverage.planning.scheduled = self._get_all_day_date(planning_date) if all_day else planning_date
 
                 coverage.original_creator = get_user().get(ID_FIELD)
 

--- a/server/planning/search/queries/elastic.py
+++ b/server/planning/search/queries/elastic.py
@@ -189,6 +189,19 @@ def field_exists(field: str, query_context: bool = True) -> Dict[str, Any]:
     return query if not query_context else {"constant_score": {"filter": query}}
 
 
+def local_day_start(time_zone: Optional[str], offset_days: int = 0) -> str:
+    """Return the ISO datetime for the start of "today + offset_days" in the given timezone
+
+    We compute this ourselves (instead of relying on elastic date-math such as "now/d")
+    so the resulting value is a concrete datetime that ``field_range`` can convert to a
+    plain local date for all day items, the same way it does for other absolute datetimes.
+    """
+
+    tz = pytz.timezone(time_zone) if time_zone else pytz.utc
+    day = datetime.now(tz).date() + timedelta(days=offset_days)
+    return tz.localize(datetime(day.year, day.month, day.day)).isoformat()
+
+
 def field_range(query: ElasticRangeParams):
     params = {}
 
@@ -211,18 +224,19 @@ def field_range(query: ElasticRangeParams):
         params["time_zone"] = query.time_zone
 
     if query.field in ("dates.start", "dates.end", "_planning_schedule.scheduled", "_updates_schedule.scheduled"):
-        # handle also all day events
-        # there we get value which is in utc,
-        # so we first convert it to local timezone
-        # and then we take only date part of it
+        # All day items are stored as a plain local calendar date (no real time/zone info), so
+        # convert any absolute datetime bounds to that local date too, instead of comparing them
+        # as UTC instants against a timezone-aware boundary.
         local_params = params.copy()
+        tz = pytz.timezone(params["time_zone"]) if params.get("time_zone") else None
+        if tz is not None:
+            for key in ("gt", "gte", "lt", "lte"):
+                value = local_params.get(key)
+                if value and "T" in value:
+                    utc_value = datetime.fromisoformat(value.replace("+0000", "+00:00"))
+                    local_params[key] = utc_value.astimezone(tz).strftime("%Y-%m-%d")
+        # values are now plain dates, so the time_zone param is no longer needed
         local_params.pop("time_zone", None)
-        for key in ("gt", "gte", "lt", "lte"):
-            if local_params.get(key) and "T" in local_params[key] and params.get("time_zone"):
-                tz = pytz.timezone(params["time_zone"])
-                utc_value = datetime.fromisoformat(local_params[key].replace("+0000", "+00:00"))
-                local_value = utc_value.astimezone(tz)
-                local_params[key] = local_value.strftime("%Y-%m-%d")
         if query.field == "dates.start":
             return {
                 "bool": {
@@ -304,11 +318,11 @@ def field_range(query: ElasticRangeParams):
                                             "path": "_planning_schedule",
                                             "query": {
                                                 "bool": {
-                                                    # Currently, only Planning items can be date-only
-                                                    # So split the search query for Planning and Coverages separately
+                                                    # The default Planning date (no coverage) is stored as a
+                                                    # plain local date, but a coverage's `scheduled` date is
+                                                    # always a real datetime with a timezone, stored in UTC
                                                     "should": [
                                                         {
-                                                            # Match Planning date using UTC date params
                                                             "bool": {
                                                                 "must_not": {
                                                                     "exists": {
@@ -323,7 +337,6 @@ def field_range(query: ElasticRangeParams):
                                                             }
                                                         },
                                                         {
-                                                            # Match coverage dates using local date params
                                                             "bool": {
                                                                 "must": [
                                                                     {
@@ -362,8 +375,8 @@ def range_today(query: ElasticRangeParams):
             field=query.field,
             time_zone=query.time_zone,
             value_format=query.value_format,
-            gte="now/d",
-            lt="now+24h/d",
+            gte=local_day_start(query.time_zone),
+            lt=local_day_start(query.time_zone, offset_days=1),
         )
     )
 
@@ -374,20 +387,21 @@ def range_tomorrow(query: ElasticRangeParams):
             field=query.field,
             time_zone=query.time_zone,
             value_format=query.value_format,
-            gte="now+24h/d",
-            lt="now+48h/d",
+            gte=local_day_start(query.time_zone, offset_days=1),
+            lt=local_day_start(query.time_zone, offset_days=2),
         )
     )
 
 
 def range_last_24_hours(query: ElasticRangeParams):
+    now_utc = datetime.now(pytz.utc)
     return field_range(
         ElasticRangeParams(
             field=query.field,
             time_zone=query.time_zone,
             value_format=query.value_format,
-            gte="now-24h",
-            lt="now",
+            gte=(now_utc - timedelta(hours=24)).isoformat(),
+            lt=now_utc.isoformat(),
         )
     )
 

--- a/server/planning/search/queries/elastic.py
+++ b/server/planning/search/queries/elastic.py
@@ -189,6 +189,22 @@ def field_exists(field: str, query_context: bool = True) -> Dict[str, Any]:
     return query if not query_context else {"constant_score": {"filter": query}}
 
 
+def _local_today(time_zone: Optional[str]):
+    """Return the timezone object and today's date in that timezone, computed once
+
+    Computing "now" once and reusing it avoids the boundaries of a range being
+    based on different moments (e.g. if the calls straddle local midnight).
+    """
+
+    tz = pytz.timezone(time_zone) if time_zone else pytz.utc
+    return tz, datetime.now(tz).date()
+
+
+def _local_day_start(tz: Any, day, offset_days: int = 0) -> str:
+    day = day + timedelta(days=offset_days)
+    return tz.localize(datetime(day.year, day.month, day.day)).isoformat()
+
+
 def local_day_start(time_zone: Optional[str], offset_days: int = 0) -> str:
     """Return the ISO datetime for the start of "today + offset_days" in the given timezone
 
@@ -197,9 +213,8 @@ def local_day_start(time_zone: Optional[str], offset_days: int = 0) -> str:
     plain local date for all day items, the same way it does for other absolute datetimes.
     """
 
-    tz = pytz.timezone(time_zone) if time_zone else pytz.utc
-    day = datetime.now(tz).date() + timedelta(days=offset_days)
-    return tz.localize(datetime(day.year, day.month, day.day)).isoformat()
+    tz, day = _local_today(time_zone)
+    return _local_day_start(tz, day, offset_days)
 
 
 def field_range(query: ElasticRangeParams):
@@ -370,25 +385,29 @@ def field_range(query: ElasticRangeParams):
 
 
 def range_today(query: ElasticRangeParams):
+    tz, day = _local_today(query.time_zone)
+
     return field_range(
         ElasticRangeParams(
             field=query.field,
             time_zone=query.time_zone,
             value_format=query.value_format,
-            gte=local_day_start(query.time_zone),
-            lt=local_day_start(query.time_zone, offset_days=1),
+            gte=_local_day_start(tz, day),
+            lt=_local_day_start(tz, day, offset_days=1),
         )
     )
 
 
 def range_tomorrow(query: ElasticRangeParams):
+    tz, day = _local_today(query.time_zone)
+
     return field_range(
         ElasticRangeParams(
             field=query.field,
             time_zone=query.time_zone,
             value_format=query.value_format,
-            gte=local_day_start(query.time_zone, offset_days=1),
-            lt=local_day_start(query.time_zone, offset_days=2),
+            gte=_local_day_start(tz, day, offset_days=1),
+            lt=_local_day_start(tz, day, offset_days=2),
         )
     )
 

--- a/server/planning/search/queries/planning.py
+++ b/server/planning/search/queries/planning.py
@@ -211,7 +211,7 @@ def search_date_default(params: Dict[str, Any], query: elastic.ElasticQuery):
         query_range = elastic.date_range(
             elastic.ElasticRangeParams(
                 field=field_name,
-                gte="now/d",
+                gte=elastic.local_day_start(time_zone),
                 time_zone=time_zone,
             )
         )

--- a/server/planning/tests/search_queries_elastic_test.py
+++ b/server/planning/tests/search_queries_elastic_test.py
@@ -27,8 +27,9 @@ def test_field_range_resolves_today_to_local_date_for_all_day_items():
     """
 
     tz = pytz.timezone("America/Toronto")
-    today = datetime.now(tz).strftime("%Y-%m-%d")
-    tomorrow = (datetime.now(tz) + timedelta(hours=24)).strftime("%Y-%m-%d")
+    now = datetime.now(tz)
+    today = now.strftime("%Y-%m-%d")
+    tomorrow = (now + timedelta(days=1)).strftime("%Y-%m-%d")
 
     query = range_today(ElasticRangeParams(field="dates.start", time_zone="America/Toronto"))
 

--- a/server/planning/tests/search_queries_elastic_test.py
+++ b/server/planning/tests/search_queries_elastic_test.py
@@ -1,0 +1,61 @@
+from datetime import datetime, timedelta
+
+import pytz
+
+from planning.search.queries.elastic import ElasticRangeParams, field_range, range_today
+
+
+def _get_all_day_range(query):
+    """Extract the range params used for `dates.all_day: True` items from a `dates.start` query."""
+
+    should_clauses = query["bool"]["should"]
+    for clause in should_clauses:
+        must = clause["bool"]["must"]
+        if {"term": {"dates.all_day": True}} in must:
+            for item in must:
+                if "range" in item:
+                    return item["range"]["dates.start"]
+    raise AssertionError("Could not find all_day range clause")
+
+
+def test_field_range_resolves_today_to_local_date_for_all_day_items():
+    """Regression test: relative date filters (e.g. "Today") must be resolved to a plain
+    local calendar date (and drop `time_zone`) for all-day items. All-day items are stored
+    as a literal date, so comparing them against a timezone-aware UTC instant boundary
+    can exclude/include the wrong day depending on the time of day and the newsroom's UTC
+    offset (e.g. Toronto, UTC-4/5).
+    """
+
+    tz = pytz.timezone("America/Toronto")
+    today = datetime.now(tz).strftime("%Y-%m-%d")
+    tomorrow = (datetime.now(tz) + timedelta(hours=24)).strftime("%Y-%m-%d")
+
+    query = range_today(ElasticRangeParams(field="dates.start", time_zone="America/Toronto"))
+
+    all_day_range = _get_all_day_range(query)
+
+    assert "time_zone" not in all_day_range
+    assert all_day_range["gte"] == today
+    assert all_day_range["lt"] == tomorrow
+
+
+def test_field_range_converts_explicit_datetime_to_local_date():
+    """Explicit UTC datetime values should still be converted to a local date-only
+    value for all-day items, without the (now unnecessary) `time_zone` param.
+    """
+
+    query = field_range(
+        ElasticRangeParams(
+            field="dates.start",
+            time_zone="America/Toronto",
+            value_format="date_optional_time",
+            gte="2026-08-25T00:00:00+0000",
+            lt="2026-08-26T00:00:00+0000",
+        )
+    )
+
+    all_day_range = _get_all_day_range(query)
+
+    assert "time_zone" not in all_day_range
+    assert all_day_range["gte"] == "2026-08-24"
+    assert all_day_range["lt"] == "2026-08-25"


### PR DESCRIPTION
this was happening when using timezone with negative offset, those items were only visible on previous day.

SDESK-8012

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

### Front-end checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)

Resolves: #[issue-number]

