### PR TITLE
fix assignee change on add to planning

### DIFF
--- a/client/utils/planning.tsx
+++ b/client/utils/planning.tsx
@@ -1114,9 +1114,13 @@ function createCoverageFromNewsItem(
     }
 
     // Add assignment to coverage
+    // Prefer the original journalist/assignee from the assignment if available
+    // Otherwise fall back to the version_creator (last editor/publisher)
+    const assignedUser = addNewsItemToPlanning?.assignment?.user ?? addNewsItemToPlanning?.version_creator;
+
     newCoverage.assigned_to = {
         desk: get(addNewsItemToPlanning, 'task.desk', desk),
-        user: get(addNewsItemToPlanning, 'version_creator'),
+        user: assignedUser,
     };
 
     self.modifyCoverageForClient(newCoverage);

--- a/client/utils/tests/planning_test.ts
+++ b/client/utils/tests/planning_test.ts
@@ -437,6 +437,36 @@ describe('PlanningUtils', () => {
             });
         });
 
+        it('prefers the assignment assignee over version_creator when building coverage', () => {
+            const newsItem = {
+                slugline: 'slug',
+                ednote: 'edit my note',
+                type: 'text',
+                state: 'published',
+                versioncreated: '2017-10-15T14:01:11',
+                version_creator: 'editor-user',
+                assignment: {
+                    user: 'journalist-user',
+                },
+                task: {
+                    desk: 'desk2',
+                    user: 'editor-user',
+                },
+                firstpublished: '2017-10-15T16:00:00',
+            };
+
+            const coverage = planningUtils.createCoverageFromNewsItem(
+                newsItem,
+                newsCoverageStatus,
+                desk,
+                contentTypes,
+                {},
+            );
+
+            expect(coverage.assigned_to.user).toBe('journalist-user');
+            expect(coverage.assigned_to.desk).toBe('desk2');
+        });
+
         it('coverage time is derived from news item\'s published time', () => {
             const newsItem = {
                 slugline: 'slug',


### PR DESCRIPTION
avoid changing assignee on add to planning

SDCP-1220

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

### Front-end checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] This pull request is adding missing TypeScript types to modified code segments where it's easy to do so with confidence
- [ ] This pull request is using TypeScript interfaces instead of prop-types and updates usages where it's quick to do so
- [ ] This pull request is using `memo` or `PureComponent` to define new React components (and updates existing usages in modified code segments)
- [ ] This pull request is replacing `lodash.get` with optional chaining and nullish coalescing for modified code segments
- [ ] This pull request is not importing anything from client-core directly (use `superdeskApi`)
- [ ] This pull request is importing UI components from `superdesk-ui-framework` and `superdeskApi` when possible instead of using ones defined in this repository.
- [ ] This pull request is not using `planningApi` where it is possible to use `superdeskApi`
- [ ] This pull request is not adding redux based modals
- [ ] In this pull request, properties of redux state are not being passed as props to components; instead, we connect it to the component that needs them. Except components where using a react key is required - do not connect those due to performance reasons.
- [ ] This pull request is not adding redux actions that do not modify state (e.g. only calling angular services; those should be moved to `planningApi`)

Resolves: #[issue-number]

