### PR TITLE
[SDBELGA-1125] - Update Production API to use unified resources as datasources

### DIFF
--- a/server/planning/prod_api/events/resource.py
+++ b/server/planning/prod_api/events/resource.py
@@ -21,9 +21,11 @@ class EventsResource(Resource):
     resource_methods = ["GET"]
     allow_unknown = True
     datasource = {
-        "source": "events",
+        "source": "unified_planning",
         "search_backend": "elastic",
         "default_sort": [("dates.start", 1)],
+        "filter": {"type": "event"},
+        "elastic_filter": {"term": {"type": "event"}},
     }
     privileges = {"GET": Scope.EVENTS_READ.name}
 
@@ -34,7 +36,11 @@ class EventsHistoryResource(Resource):
     item_methods = ["GET"]
     resource_methods = ["GET"]
     allow_unknown = True
-    datasource = {"source": "events_history", "default_sort": [("_updated", -1)]}
+    datasource = {
+        "source": "planning_history",
+        "default_sort": [("_updated", -1)],
+        "filter": {"item_type": "event"},
+    }
     privileges = {"GET": Scope.EVENTS_READ.name}
 
 

--- a/server/planning/prod_api/events/service.py
+++ b/server/planning/prod_api/events/service.py
@@ -32,7 +32,7 @@ from planning.prod_api.planning.utils import (
     extract_coverage_summaries,
     str_to_bool,
 )
-from planning.utils import get_related_planning_for_events_async
+from planning.utils import get_related_planning_for_events_async, get_related_event_ids_for_planning
 
 
 class EventsService(ProdApiService):
@@ -98,7 +98,7 @@ class EventsService(ProdApiService):
             raise SuperdeskApiError.badRequestError("planning_source must be an object")
 
         query.setdefault("sort", [{"_created": "asc"}, {"_updated": "asc"}, {"guid": "asc"}])
-        query.setdefault("_source", ["_id", "_resource", "event_item"])
+        query.setdefault("_source", ["_id", "_resource", "related_events"])
 
         return query
 
@@ -125,8 +125,7 @@ class EventsService(ProdApiService):
 
     def _extract_event_items(self, results: Iterable[dict]) -> Iterable[str]:
         for item in results:
-            if item.get("event_item"):
-                yield item["event_item"]
+            yield from get_related_event_ids_for_planning(item, "primary")
 
     async def _process_fetched_object(self, doc):
         super()._process_fetched_object(doc)

--- a/server/planning/prod_api/planning/resource.py
+++ b/server/planning/prod_api/planning/resource.py
@@ -21,8 +21,10 @@ class PlanningResource(Resource):
     resource_methods = ["GET"]
     allow_unknown = True
     datasource = {
-        "source": "planning",
+        "source": "unified_planning",
         "search_backend": "elastic",
         "default_sort": [("_updated", -1)],
+        "filter": {"type": "planning"},
+        "elastic_filter": {"term": {"type": "planning"}},
     }
     privileges = {"GET": Scope.PLANNING_READ.name}

--- a/server/planning/prod_api/planning/service.py
+++ b/server/planning/prod_api/planning/service.py
@@ -12,6 +12,7 @@ from superdesk.resource_fields import LINKS
 from prod_api.service import ProdApiService
 
 from planning.types import Planning
+from planning.unified.common import convert_unified_planning_to_legacy_format
 from planning.prod_api.common import excluded_lock_fields
 from planning.prod_api.assignments.utils import (
     get_assignment_ids_from_planning,
@@ -29,6 +30,7 @@ class PlanningService(ProdApiService):
 
     async def _process_fetched_object(self, doc: Planning):
         super()._process_fetched_object(doc)
+        convert_unified_planning_to_legacy_format(doc)
 
         if doc.get(LINKS):
             add_related_event_links(doc, doc)

--- a/server/tests/prod_api/conftest.py
+++ b/server/tests/prod_api/conftest.py
@@ -17,10 +17,28 @@ from planning.assignments.assignments import assignments_schema
 from planning.prod_api.assignments.resource import AssignmentsResource
 
 
+# DOMAIN entries for the repointed sources so fixture writes' notification lookup resolves
+# (ProdAPI is read-only in production, so this write path never runs there).
+UNIFIED_SOURCES = ("unified_planning", "planning_history")
+
+
+def _init_unified_planning_index(app):
+    # eve_elastic's init_index skips resources whose source != endpoint, so the repointed
+    # Events/Planning resources never get their unified_planning index. In production the
+    # main app creates it; here we build it from the Events + Planning schemas.
+    elastic = app.data.elastic
+    alias = elastic._resource_index("events")
+    mapping = elastic._resource_mapping("events")
+    mapping.setdefault("properties", {}).update(elastic._resource_mapping("planning").get("properties", {}))
+    settings = elastic._resource_config("events", "SETTINGS")
+    elastic._init_index(elastic.elastic("events"), alias, settings, mapping)
+
+
 @pytest.fixture(scope="function")
 async def prodapi_app(request):
     extra_config = getattr(request, "param", {})
     extra_config["PRODAPI_AUTH_ENABLED"] = False
+    extra_config["ELASTICSEARCH_FORCE_REFRESH"] = True
 
     # Copy schemas onto ProdAPI resources so elastic mapping is correct, otherwise certain queries will fail
     # This will not happen in a production environment, as the index/types should already be created
@@ -29,6 +47,12 @@ async def prodapi_app(request):
     PlanningResource.schema = deepcopy(planning_schema)
 
     app = await get_test_prodapi_app(extra_config)
+
+    for source in UNIFIED_SOURCES:
+        app.config["DOMAIN"].setdefault(source, {"notifications": False})
+
+    async with app.app_context():
+        _init_unified_planning_index(app)
 
     def test_app_teardown():
         teardown_app(app)

--- a/server/tests/prod_api/tests/fixtures/events_history.json
+++ b/server/tests/prod_api/tests/fixtures/events_history.json
@@ -1,7 +1,8 @@
 [
     {
         "_id": "5d77a8724c3b49675964b095",
-        "event_id": "urn:newsml:localhost:5000:2019-09-10T15:43:13.722490:5dcea683-fb9b-42ca-a77f-ce1216aef8b1",
+        "item_id": "urn:newsml:localhost:5000:2019-09-10T15:43:13.722490:5dcea683-fb9b-42ca-a77f-ce1216aef8b1",
+        "item_type": "event",
         "user_id": "5d385f31fe985ec67a0ca583",
         "operation": "create",
         "update": {
@@ -67,7 +68,8 @@
     },
     {
         "_id": "5d77b1aa4c3b49675964b0f9",
-        "event_id": "urn:newsml:localhost:5000:2019-09-10T16:22:34.066960:6b2d9c79-08b9-456f-b890-9b2154ee997a",
+        "item_id": "urn:newsml:localhost:5000:2019-09-10T16:22:34.066960:6b2d9c79-08b9-456f-b890-9b2154ee997a",
+        "item_type": "event",
         "user_id": "5d385f31fe985ec67a0ca583",
         "operation": "create",
         "update": {

--- a/server/tests/prod_api/tests/fixtures/planning.json
+++ b/server/tests/prod_api/tests/fixtures/planning.json
@@ -2,7 +2,6 @@
     {
         "_id": "urn:newsml:localhost:5000:2019-09-10T15:47:04.367097:714ceeb4-c366-48af-b360-e7aefdf9941a",
         "type": "planning",
-        "event_item": "urn:newsml:localhost:5000:2019-09-10T15:43:13.722490:5dcea683-fb9b-42ca-a77f-ce1216aef8b1",
         "planning_date": "2019-09-10T13:46:38.000Z",
         "agendas": [],
         "state": "draft",
@@ -124,7 +123,12 @@
     {
         "_id": "urn:newsml:localhost:5000:2019-09-10T16:22:02.020996:dd01be40-e401-407f-a2f4-f6532c3f907c",
         "type": "planning",
-        "event_item": "urn:newsml:localhost:5000:2019-09-10T16:22:34.066960:6b2d9c79-08b9-456f-b890-9b2154ee997a",
+        "related_events": [
+            {
+                "_id": "urn:newsml:localhost:5000:2019-09-10T16:22:34.066960:6b2d9c79-08b9-456f-b890-9b2154ee997a",
+                "link_type": "primary"
+            }
+        ],
         "planning_date": "2019-09-10T14:21:45.000Z",
         "agendas": [],
         "state": "draft",
@@ -191,7 +195,12 @@
     {
         "_id": "urn:newsml:localhost:5000:2019-10-21T11:48:10.807263:c61d74ec-fb22-4665-98e1-f773f618826d",
         "type": "planning",
-        "event_item": "urn:newsml:localhost:5000:2019-08-22T15:50:04.270524:86da81f0-c3fa-4b93-9e28-ed21ad2f1ed9",
+        "related_events": [
+            {
+                "_id": "urn:newsml:localhost:5000:2019-08-22T15:50:04.270524:86da81f0-c3fa-4b93-9e28-ed21ad2f1ed9",
+                "link_type": "primary"
+            }
+        ],
         "planning_date": "2019-10-21T09:47:59.000Z",
         "agendas": [],
         "state": "draft",

--- a/server/tests/prod_api/tests/test_events.py
+++ b/server/tests/prod_api/tests/test_events.py
@@ -310,7 +310,7 @@ async def test_planning_source_pagination(prodapi_app, prodapi_app_with_data_cli
                     "_id": f"planning--{i}",
                     "guid": f"planning--{i}",
                     "name": f"Test Planning {i}",
-                    "event_item": event_id,
+                    "related_events": [{"_id": event_id, "link_type": "primary"}],
                 }
                 if i % 4 == 0:
                     # Planning item's will alternate between text and picture coverages


### PR DESCRIPTION
### Purpose
This PR repoints the Production API Events & Planning to the unified collections

### What has changed
- `prod_api/events` and `prod_api/planning` datasources point at `unified_planning`, filtered by `type` (Mongo `filter` + `elastic_filter`).
- `events_history` points at the merged `planning_history` (`item_type=event`); `events_files` and `assignments` are unchanged.
- The `planning_source` filter reads the event link from `related_events` instead of the legacy `event_item`.
- Planning output is converted back to the legacy field shape (`planning_date`, `description_text`), so the API contract is unchanged.
- Tests seed the unified collections in the `prod_api` conftest and update the fixtures to the unified shape.

Depends on superdesk/superdesk-core#3308; without it the repointed resources fall back to Mongo and search does not filter.

Resolves: [SDBELGA-1125](https://sofab.atlassian.net/browse/SDBELGA-1125)

[SDBELGA-1125]: https://sofab.atlassian.net/browse/SDBELGA-1125
