### PR TITLE
[SDBELGA-1130] - Update Export as Article to use unified resource

### DIFF
--- a/server/features/combined_export.feature
+++ b/server/features/combined_export.feature
@@ -64,12 +64,14 @@ Feature: Export combined Planning and Event items with default template
             "ednote": "Ed. note 1",
             "coverages": [{
                 "coverage_id": "123",
+                "news_coverage_status": {"qcode": "ncostat:int", "name": "coverage intended", "label": "Planned"},
                 "planning": {
                     "g2_content_type": "text"
                 }
             },
             {
                 "coverage_id": "456",
+                "news_coverage_status": {"qcode": "ncostat:int", "name": "coverage intended", "label": "Planned"},
                 "planning": {
                     "g2_content_type": "photo"
                 }
@@ -84,12 +86,14 @@ Feature: Export combined Planning and Event items with default template
             "ednote": "Ed. note 2",
             "coverages": [{
                 "coverage_id": "789",
+                "news_coverage_status": {"qcode": "ncostat:int", "name": "coverage intended", "label": "Planned"},
                 "planning": {
                     "g2_content_type": "text"
                 }
             },
             {
                 "coverage_id": "012",
+                "news_coverage_status": {"qcode": "ncostat:int", "name": "coverage intended", "label": "Planned"},
                 "planning": {
                     "g2_content_type": "photo"
                 }

--- a/server/features/planning_export.feature
+++ b/server/features/planning_export.feature
@@ -46,12 +46,14 @@ Feature: Export planning items with default template
             "ednote": "Ed. note 1",
             "coverages": [{
                 "coverage_id": "123",
+                "news_coverage_status": {"qcode": "ncostat:int", "name": "coverage intended", "label": "Planned"},
                 "planning": {
                     "g2_content_type": "text"
                 }
             },
             {
                 "coverage_id": "456",
+                "news_coverage_status": {"qcode": "ncostat:int", "name": "coverage intended", "label": "Planned"},
                 "planning": {
                     "g2_content_type": "photo"
                 }

--- a/server/planning/__init__.py
+++ b/server/planning/__init__.py
@@ -63,10 +63,6 @@ from .planning_export_templates import (
     PlanningExportTemplatesResource,
     PlanningExportTemplatesService,
 )
-from .planning_article_export import (
-    PlanningArticleExportResource,
-    PlanningArticleExportService,
-)
 from .locks.unlock import unlock_session
 from .publish.module import init_publish_module
 
@@ -103,14 +99,6 @@ def init_app(app):
     init_search_app(app)
     init_planning_autocomplete_app(app)
     init_publish_module(app)
-
-    superdesk.register_resource(
-        "planning_article_export",
-        PlanningArticleExportResource,
-        PlanningArticleExportService,
-        privilege="planning",
-        _app=app,
-    )
 
     superdesk.privilege(
         name="planning",

--- a/server/planning/assignments/assignments_content.py
+++ b/server/planning/assignments/assignments_content.py
@@ -70,7 +70,7 @@ async def get_item_from_assignment(assignment, template=None):
     if template is not None:
         template = get_resource_service("content_templates").find_one(req=None, template_name=template)
     else:
-        template = get_desk_template(desk)
+        template = await get_desk_template(desk or {})
     item = get_item_from_template(template)
 
     planning_data = assignment.get("planning") or {}

--- a/server/planning/commands/export_scheduled_filters.py
+++ b/server/planning/commands/export_scheduled_filters.py
@@ -18,6 +18,7 @@ from superdesk.lock import lock, unlock
 from superdesk.celery_task_utils import get_lock_id
 
 from planning.search import EventsPlanningFiltersAsyncService
+from planning.planning_article_export import export_items_to_article, ArticleExportRequest
 
 logger = logging.getLogger(__name__)
 
@@ -197,14 +198,12 @@ class ExportScheduledFilters:
             logger.info(f"No items found for filter {search_filter_id}")
             return
 
-        await get_resource_service("planning_article_export").post_async(
-            [
-                {
-                    "items": [item["_id"] async for item in items],
-                    "desk": schedule.get("desk"),
-                    "template": schedule.get("template"),
-                    "article_template": schedule.get("article_template"),
-                    "type": "event" if search_filter["item_type"] == "events" else search_filter["item_type"],
-                }
-            ]
+        await export_items_to_article(
+            ArticleExportRequest(
+                items=[str(item["_id"]) async for item in items],
+                desk=schedule.get("desk"),
+                template=schedule.get("template"),
+                article_template=schedule.get("article_template"),
+                type="event" if search_filter["item_type"] == "events" else search_filter["item_type"],
+            )
         )

--- a/server/planning/module.py
+++ b/server/planning/module.py
@@ -32,6 +32,7 @@ from planning.search import (
 )
 
 from .planning_download import planning_download_endpoint
+from .planning_article_export import planning_article_export_endpoints
 from .unified.module import unified_planning_resource_config, template_endpoints, planning_templates_resource_config
 from .unified.signals import connect_signals
 from .unified.docs import unified_resource_docs_endpoints
@@ -74,6 +75,7 @@ module = Module(
         planning_endpoint_group,
         events_endpoints_group,
         planning_download_endpoint,
+        planning_article_export_endpoints,
         content_api_docs_endpoints,
         unified_resource_docs_endpoints,
         planning_lock_endpoints,

--- a/server/planning/planning_article_export.py
+++ b/server/planning/planning_article_export.py
@@ -7,26 +7,32 @@
 # at https://www.sourcefabric.org/superdesk/license
 
 import logging
+from typing import Literal
 from dateutil import tz, parser
 from bson import ObjectId
+from bson.errors import InvalidId
+from pydantic import BaseModel, ValidationError
 
 from superdesk.core import get_app_config
-from superdesk.core.types import ItemId
-from superdesk.eve_async.service import AsyncBaseService
+from superdesk.core.auth.privilege_rules import required_privilege_rule
+from superdesk.core.resources import fields
+from superdesk.core.resources.validators import convert_pydantic_validation_error_for_response
+from superdesk.core.types import Request, Response
+from superdesk.core.web import EndpointGroup
 from superdesk.resource_fields import VERSION
 from superdesk.flask import render_template_string, render_template
 
 from quart_babel import gettext as _
 
 from superdesk.utc import utc_to_local, get_timezone_offset, utcnow
-from superdesk import get_resource_service, Resource
+from superdesk import get_resource_service
 from superdesk.errors import SuperdeskApiError
-from superdesk.metadata.item import get_schema
 
 from apps.auth import get_user_id
 from apps.templates.content_templates import get_item_from_template
 
-from planning.types import UnifiedPlanningResource, SearchItemType
+from planning.types import UnifiedPlanningResource, SearchItemType, PlanningItemType
+from planning.types.unified import RelatedEventLinkType
 from planning.common import (
     WORKFLOW_STATE,
     format_address,
@@ -35,8 +41,9 @@ from planning.common import (
     get_first_paragraph_text,
 )
 from planning.unified.agenda import AgendasAsyncService
-from planning.utils import get_related_planning_for_events_async, get_first_related_event_id_for_planning
+from planning.unified.common import get_related_planning_for_events, get_first_related_event_id
 from planning.archive import create_item_from_template
+from planning.utils import get_json_or_400_async
 
 
 logger = logging.getLogger(__name__)
@@ -45,27 +52,17 @@ PLACEHOLDER_HTML = "<p>%s</p>" % PLACEHOLDER_TEXT
 EXPORT_FETCH_PAGE_SIZE = 1000
 
 
-class PlanningArticleExportResource(Resource):
-    schema = get_schema(versioning=True)
-    schema.update(
-        {
-            "items": {
-                "type": "list",
-                "required": True,
-            },
-            "desk": Resource.rel("desks", nullable=True),
-            "template": {"type": "string"},
-            "type": {
-                "type": "string",
-                "default": "planning",
-            },
-            "article_template": Resource.rel("content_templates", nullable=True),
-        }
-    )
+planning_article_export_endpoints = EndpointGroup("planning_article_export", __name__)
 
-    item_methods = []
-    resource_methods = ["POST"]
-    privileges = {"POST": "planning"}
+
+class ArticleExportRequest(BaseModel):
+    """Request body for exporting Event and/or Planning items as an Article"""
+
+    items: list[str]
+    desk: fields.ObjectId | None = None
+    template: str | None = None
+    type: Literal["planning", "event", "combined"] = "planning"
+    article_template: fields.ObjectId | None = None
 
 
 async def get_items(ids, resource_type):
@@ -77,30 +74,34 @@ async def get_items(ids, resource_type):
         query["type"] = "event" if resource_type == SearchItemType.EVENT.value else resource_type
 
     cursor = await service.find(query, use_mongo=True, max_results=EXPORT_FETCH_PAGE_SIZE)
-    items = sorted([item.to_dict() async for item in cursor], key=lambda item: ids_string.index(str(item["_id"])))
+    models = sorted([item async for item in cursor], key=lambda item: ids_string.index(str(item.id)))
 
-    for item in items:
-        item_type = item.get("type")
+    items = []
+    for model in models:
+        item = model.to_dict()
 
-        if item_type == "planning":
-            event_id = get_first_related_event_id_for_planning(item, "primary")
+        if model.item_type == PlanningItemType.PLANNING:
+            event_id = get_first_related_event_id(model, RelatedEventLinkType.PRIMARY)
             if event_id:
                 event = await service.find_by_id(event_id)
                 if not event:
                     logger.error(
                         "Failed to find Event linked to the Planning item",
                         extra=dict(
-                            planning_id=item["_id"],
+                            planning_id=model.id,
                             event_id=event_id,
                         ),
                     )
                 else:
                     item["event"] = event.to_dict()
-        elif item_type == "event":
-            item["plannings"] = await get_related_planning_for_events_async([item["_id"]], "primary")
-            item["coverages"] = []
-            for plan in item["plannings"]:
-                item["coverages"].extend(plan.get("coverages") or [])
+        elif model.item_type == PlanningItemType.EVENT:
+            plannings = await get_related_planning_for_events(
+                [model.id], RelatedEventLinkType.PRIMARY, max_results=EXPORT_FETCH_PAGE_SIZE
+            )
+            item["plannings"] = [plan.to_dict() async for plan in plannings]
+            item["coverages"] = [coverage for plan in item["plannings"] for coverage in plan.get("coverages") or []]
+
+        items.append(item)
 
     return items
 
@@ -178,13 +179,15 @@ async def inject_internal_coverages(items):
                     item["internal_coverages"].append({"type": label})
 
 
-def _enhance_assigned_provider(coverage, item, assigned_to):
+async def _enhance_assigned_provider(coverage, item, assigned_to):
     """
     Enhances the text_assignees with the contact details if it's assigned to an external provider
     """
 
     if assigned_to.get("contact"):
-        provider_contact = get_resource_service("contacts").find_one(req=None, _id=assigned_to.get("contact"))
+        provider_contact = await get_resource_service("contacts").find_one_async(
+            req=None, _id=assigned_to.get("contact")
+        )
 
         if (coverage.get("planning", {})).get("slugline", ""):
             slug_str = "({0}) - ".format((coverage.get("planning", {})).get("slugline", ""))
@@ -225,7 +228,7 @@ async def enhance_coverage(planning, item, users, desks, text_users, text_desks)
         if assigned_to.get("coverage_provider"):
             item["assignees"].append(assigned_to["coverage_provider"]["name"])
             if is_text and not completed:
-                _enhance_assigned_provider(c, item, assigned_to)
+                await _enhance_assigned_provider(c, item, assigned_to)
         elif assigned_to.get("user"):
             user = assigned_to["user"]
             users.append(user)
@@ -320,13 +323,16 @@ async def generate_text_item(items, template_name, resource_type):
 
         set_item_place(item)
 
-        item["description_text"] = item.get("description_text") or (item.get("event") or {}).get("definition_short")
-        item["slugline"] = item.get("slugline") or (item.get("event") or {}).get("name")
+        event = item.get("event") or {}
+        item["description_text"] = (
+            item.get("description_text") or item.get("definition_long") or event.get("definition_short")
+        )
+        item["slugline"] = item.get("slugline") or event.get("name")
 
-        # Handle dates and remote time-zones
-        if item.get("dates") or (item.get("event") or {}).get("dates"):
+        # Handle dates and remote time-zones (Planning items linked to an Event use the Event's dates)
+        dates = event.get("dates") or item.get("dates")
+        if dates:
             default_timezone = get_app_config("DEFAULT_TIMEZONE")
-            dates = item.get("dates") or item.get("event").get("dates")
             start = dates.get("start")
             utc_dt = parser.parse(start) if isinstance(start, str) else start
             item["schedule"] = utc_to_local(default_timezone, utc_dt)
@@ -365,10 +371,10 @@ async def generate_text_item(items, template_name, resource_type):
     return article
 
 
-def get_desk_template(desk):
+async def get_desk_template(desk):
     default_content_template = desk.get("default_content_template")
     if default_content_template:
-        return get_resource_service("content_templates").find_one(req=None, _id=default_content_template)
+        return await get_resource_service("content_templates").find_one_async(req=None, _id=default_content_template)
 
     return {}
 
@@ -378,118 +384,144 @@ def set_item_place(item):
     item["place"] = [p.get("name") for p in item["place"]] if item.get("place") else None
 
 
-class PlanningArticleExportService(AsyncBaseService):
-    async def create_async(self, docs: list[dict], **kwargs) -> list[ItemId]:
-        ids = []
-        for doc in docs:
-            item_type = doc.pop("type")
-            item_list = await get_items(doc.pop("items", []), item_type)
-            desk = await get_resource_service("desks").find_one_async(req=None, _id=doc.pop("desk")) or {}
-            article_template = doc.pop("article_template", None)
-            if article_template:
-                content_template = (
-                    get_resource_service("content_templates").find_one(req=None, _id=article_template) or {}
-                )
+async def export_items_to_article(export_request: ArticleExportRequest) -> dict:
+    """Creates a text Archive item on the given desk, rendering the requested items through an export template"""
+
+    item_type = export_request.type
+    item_list = await get_items(export_request.items, item_type)
+
+    desk = {}
+    if export_request.desk:
+        desk = await get_resource_service("desks").find_one_async(req=None, _id=export_request.desk)
+        if not desk:
+            raise SuperdeskApiError.badRequestError(_("Desk not found"))
+
+    if export_request.article_template:
+        content_template = await get_resource_service("content_templates").find_one_async(
+            req=None, _id=export_request.article_template
+        )
+        if not content_template:
+            raise SuperdeskApiError.badRequestError(_("Article template not found"))
+    else:
+        content_template = await get_desk_template(desk)
+
+    item = get_item_from_template(content_template)
+    item[VERSION] = 1
+    item.setdefault("type", "text")
+
+    if item_type == "planning":
+        item.setdefault("slugline", "Planning")
+    elif item_type == "event":
+        item.setdefault("slugline", "Event")
+    else:
+        item.setdefault("slugline", "Events and Planning")
+
+    item["task"] = {
+        "desk": desk.get("_id"),
+        "user": get_user_id(),
+        "stage": desk.get("working_stage"),
+    }
+    item_from_template = await generate_text_item(item_list, export_request.template, item_type)
+    fields_to_override = []
+    for key, val in item_from_template.items():
+        if item.get(key):
+            fields_to_override.append(key)
+
+            placeholder = PLACEHOLDER_HTML if "_html" in key else PLACEHOLDER_TEXT
+            if placeholder in item[key]:
+                # The placeholder is found in the current field
+                # So replace {{content}} with the generated text
+                item[key] = item[key].replace(placeholder, val)
             else:
-                content_template = get_desk_template(desk)
+                # Otherwise append the generated text to the field
+                item[key] += val
+        else:
+            item[key] = val
 
-            item = get_item_from_template(content_template)
-            item[VERSION] = 1
-            item.setdefault("type", "text")
+    return await create_item_from_template(item, fields_to_override)
 
-            if item_type == "planning":
-                item.setdefault("slugline", "Planning")
-            elif item_type == "event":
-                item.setdefault("slugline", "Event")
-            else:
-                item.setdefault("slugline", "Events and Planning")
 
-            item["task"] = {
-                "desk": desk.get("_id"),
-                "user": get_user_id(),
-                "stage": desk.get("working_stage"),
-            }
-            item_from_template = await generate_text_item(item_list, doc.pop("template", None), item_type)
-            fields_to_override = []
-            for key, val in item_from_template.items():
-                if item.get(key):
-                    fields_to_override.append(key)
+@planning_article_export_endpoints.endpoint(
+    "planning_article_export",
+    name="planning_article_export",
+    methods=["POST"],
+    auth=[required_privilege_rule("planning")],
+)
+async def export_as_article_endpoint(request: Request) -> Response:
+    data = await get_json_or_400_async(request)
+    try:
+        export_request = ArticleExportRequest.model_validate(data)
+    except ValidationError as error:
+        return Response(convert_pydantic_validation_error_for_response(error), 400)
+    except InvalidId as error:
+        # ``fields.ObjectId`` raises bson's InvalidId for malformed ids instead of a pydantic error
+        raise SuperdeskApiError.badRequestError(str(error))
 
-                    placeholder = PLACEHOLDER_HTML if "_html" in key else PLACEHOLDER_TEXT
-                    if placeholder in item[key]:
-                        # The placeholder is found in the current field
-                        # So replace {{content}} with the generated text
-                        item[key] = item[key].replace(placeholder, val)
-                    else:
-                        # Otherwise append the generated text to the field
-                        item[key] += val
-                else:
-                    item[key] = val
+    item = await export_items_to_article(export_request)
+    item["_status"] = "OK"
+    item["_links"] = {"self": {"title": "Archive", "href": f"archive/{item['_id']}"}}
+    return Response(item, 201)
 
-            item = await create_item_from_template(item, fields_to_override)
-            doc.update(item)
-            ids.append(doc["_id"])
-        return ids
 
-    async def export_events_to_text(self, items, format="utf-8", template="", tz_offset=None):
-        for item in items:
-            item["formatted_state"] = (
-                item["state"]
-                if item.get("state")
-                in [
-                    WORKFLOW_STATE.CANCELLED,
-                    WORKFLOW_STATE.RESCHEDULED,
-                    WORKFLOW_STATE.POSTPONED,
-                ]
-                else None
+async def export_events_to_text(items, template, tz_offset=None):
+    for item in items:
+        item["formatted_state"] = (
+            item["state"]
+            if item.get("state")
+            in [
+                WORKFLOW_STATE.CANCELLED,
+                WORKFLOW_STATE.RESCHEDULED,
+                WORKFLOW_STATE.POSTPONED,
+            ]
+            else None
+        )
+        location = item["location"][0] if len(item.get("location") or []) > 0 else None
+        if location:
+            format_address(location)
+            item["formatted_location"] = (
+                location.get("name")
+                if not location.get("formatted_address")
+                else "{0}, {1}".format(location.get("name"), location["formatted_address"])
             )
-            location = item["location"][0] if len(item.get("location") or []) > 0 else None
-            if location:
-                format_address(location)
-                item["formatted_location"] = (
-                    location.get("name")
-                    if not location.get("formatted_address")
-                    else "{0}, {1}".format(location.get("name"), location["formatted_address"])
-                )
 
-            item["contacts"] = []
-            async for contact in await get_contacts_from_item(item):
-                contact_info = ["{0} {1}".format(contact.get("first_name"), contact.get("last_name"))]
-                phone = None
-                if contact.get("job_title"):
-                    contact_info[0] = contact_info[0] + " ({})".format(contact["job_title"])
-                if (len(contact.get("contact_email") or [])) > 0:
-                    contact_info.append(contact["contact_email"][0])
+        item["contacts"] = []
+        async for contact in await get_contacts_from_item(item):
+            contact_info = ["{0} {1}".format(contact.get("first_name"), contact.get("last_name"))]
+            phone = None
+            if contact.get("job_title"):
+                contact_info[0] = contact_info[0] + " ({})".format(contact["job_title"])
+            if (len(contact.get("contact_email") or [])) > 0:
+                contact_info.append(contact["contact_email"][0])
 
-                if (len(contact.get("contact_phone") or [])) > 0:
-                    phone = next((p for p in contact["contact_phone"] if p.get("public")), None)
-                elif len(contact.get("mobile") or []) > 0:
-                    phone = next((m for m in contact["mobile"] if m.get("public")), None)
+            if (len(contact.get("contact_phone") or [])) > 0:
+                phone = next((p for p in contact["contact_phone"] if p.get("public")), None)
+            elif len(contact.get("mobile") or []) > 0:
+                phone = next((m for m in contact["mobile"] if m.get("public")), None)
 
-                if phone:
-                    contact_info.append(phone.get("number"))
+            if phone:
+                contact_info.append(phone.get("number"))
 
-                item["contacts"].append(", ".join(contact_info))
+            item["contacts"].append(", ".join(contact_info))
 
-            date_time_format = "%a %d %b %Y, %H:%M"
-            default_timezone = get_app_config("DEFAULT_TIMEZONE")
-            item["dates"]["start"] = utc_to_local(default_timezone, item["dates"]["start"])
-            item["dates"]["end"] = utc_to_local(default_timezone, item["dates"]["end"])
-            item["schedule"] = "{0}-{1}".format(
+        date_time_format = "%a %d %b %Y, %H:%M"
+        default_timezone = get_app_config("DEFAULT_TIMEZONE")
+        item["dates"]["start"] = utc_to_local(default_timezone, item["dates"]["start"])
+        item["dates"]["end"] = utc_to_local(default_timezone, item["dates"]["end"])
+        item["schedule"] = "{0}-{1}".format(
+            item["dates"]["start"].strftime(date_time_format),
+            item["dates"]["end"].strftime("%H:%M"),
+        )
+        if ((item["dates"]["end"] - item["dates"]["start"]).total_seconds() / 60) >= (24 * 60):
+            item["schedule"] = "{0} to {1}".format(
                 item["dates"]["start"].strftime(date_time_format),
-                item["dates"]["end"].strftime("%H:%M"),
+                item["dates"]["end"].strftime(date_time_format),
             )
-            if ((item["dates"]["end"] - item["dates"]["start"]).total_seconds() / 60) >= (24 * 60):
-                item["schedule"] = "{0} to {1}".format(
-                    item["dates"]["start"].strftime(date_time_format),
-                    item["dates"]["end"].strftime(date_time_format),
-                )
 
-            if tz_offset:
-                tz_browser = tz.tzoffset("", int(tz_offset))
-                item["browser_start"] = (item["dates"]["start"]).astimezone(tz_browser)
-                item["browser_end"] = (item["dates"]["end"]).astimezone(tz_browser)
+        if tz_offset:
+            tz_browser = tz.tzoffset("", int(tz_offset))
+            item["browser_start"] = (item["dates"]["start"]).astimezone(tz_browser)
+            item["browser_end"] = (item["dates"]["end"]).astimezone(tz_browser)
 
-            set_item_place(item)
+        set_item_place(item)
 
-        return str.encode(await render_template(template, items=items), format)
+    return (await render_template(template, items=items)).encode()

--- a/server/planning/planning_download.py
+++ b/server/planning/planning_download.py
@@ -17,7 +17,7 @@ from superdesk.core.web import EndpointGroup
 from werkzeug.utils import secure_filename
 from superdesk.flask import send_file, request, make_response
 from superdesk.utc import utcnow
-from .planning_article_export import get_items
+from .planning_article_export import get_items, export_events_to_text
 import json
 
 
@@ -39,7 +39,6 @@ async def planning_download_file() -> Response:
         response.headers.add("Access-Control-Allow-Methods", "POST")
         return response
 
-    export_service = superdesk.get_resource_service("planning_article_export")
     raw_data = await request.get_data()
     decoded_data = raw_data.decode("utf-8")
     items = await get_items(json.loads(decoded_data), "events")
@@ -49,9 +48,7 @@ async def planning_download_file() -> Response:
     if not template:
         await request.abort(400, "Template not available")
 
-    exported_text = await export_service.export_events_to_text(
-        items, template=template, tz_offset=request.args.get("tz")
-    )
+    exported_text = await export_events_to_text(items, template=template, tz_offset=request.args.get("tz"))
     if exported_text:
         try:
             temp_file = io.BytesIO()

--- a/server/planning/templates/test_combined_export_template.html
+++ b/server/planning/templates/test_combined_export_template.html
@@ -1,7 +1,7 @@
 <h1>Planned Coverages</h1>
 <p></p>
 {% for item in items if item.coverages %}
-{% if item._type == 'events' %}
+{% if item.type == 'event' %}
 <p><b>Event:</b> {{ item.name }}</p>
 {% else %}
 <p><b>Planning:</b> {{item.headline}}</p>

--- a/server/planning/tests/planning_article_export_test.py
+++ b/server/planning/tests/planning_article_export_test.py
@@ -1,112 +1,28 @@
 from unittest import mock
 
 from planning.tests import TestCase
+from planning.types.unified import UnifiedPlanningResource
 from planning.planning_article_export import get_items, EXPORT_FETCH_PAGE_SIZE
 
 
 class PlanningArticleExportTest(TestCase):
-    planning_items = [
-        {
-            "_id": "plan1",
-            "planning_date": "2016-01-02T14:00:00+0000",
-            "type": "planning",
-        },
-        {
-            "_id": "plan2",
-            "planning_date": "2016-01-03T14:00:00+0000",
-            "type": "planning",
-        },
-        {
-            "_id": "plan3",
-            "planning_date": "2016-01-04T14:00:00+0000",
-            "type": "planning",
-        },
-    ]
-
-    event_items = [
-        {
-            "_id": "event1",
-            "dates": {
-                "start": "2016-01-02T14:00:00+0000",
-                "end": "2016-01-03T14:00:00+0000",
-            },
-            "type": "event",
-        },
-        {
-            "_id": "event2",
-            "dates": {
-                "start": "2016-01-04T14:00:00+0000",
-                "end": "2016-01-05T14:00:00+0000",
-            },
-            "type": "event",
-        },
-        {
-            "_id": "event3",
-            "dates": {
-                "start": "2016-01-06T14:00:00+0000",
-                "end": "2016-01-07T14:00:00+0000",
-            },
-            "type": "event",
-        },
-    ]
-
-    async def test_get_items_in_supplied_order(self):
-        async with self.app.app_context():
-            await self.app.data.insert_async("planning", self.planning_items)
-            await self.app.data.insert_async("events", self.event_items)
-
-            items = await get_items(["plan1", "plan2", "plan3"], "planning")
-            assert items[0]["_id"] == "plan1"
-            assert items[1]["_id"] == "plan2"
-            assert items[2]["_id"] == "plan3"
-
-            items = await get_items(["plan3", "plan2", "plan1"], "planning")
-            assert items[0]["_id"] == "plan3"
-            assert items[1]["_id"] == "plan2"
-            assert items[2]["_id"] == "plan1"
-
-            items = await get_items(["plan2", "plan1", "plan3"], "planning")
-            assert items[0]["_id"] == "plan2"
-            assert items[1]["_id"] == "plan1"
-            assert items[2]["_id"] == "plan3"
-
-            items = await get_items(["event1", "event2", "event3"], "event")
-            assert items[0]["_id"] == "event1"
-            assert items[1]["_id"] == "event2"
-            assert items[2]["_id"] == "event3"
-
-            items = await get_items(["event3", "event2", "event1"], "event")
-            assert items[0]["_id"] == "event3"
-            assert items[1]["_id"] == "event2"
-            assert items[2]["_id"] == "event1"
-
-            items = await get_items(["event2", "event1", "event3"], "event")
-            assert items[0]["_id"] == "event2"
-            assert items[1]["_id"] == "event1"
-            assert items[2]["_id"] == "event3"
-
     async def test_get_items_uses_export_page_size(self):
-        search_service = mock.AsyncMock()
+        planning = UnifiedPlanningResource.from_dict(
+            {"_id": "plan1", "type": "planning", "slugline": "plan", "dates": {"start": "2026-06-30T15:30:55+0000"}}
+        )
 
         async def async_iterator():
-            yield {"_id": "plan1", "type": "planning"}
+            yield planning
 
-        search_service.search_repos.return_value = async_iterator()
-        events_service = mock.AsyncMock()
+        service = mock.MagicMock()
+        service.find = mock.AsyncMock(return_value=async_iterator())
 
-        def get_service(name):
-            if name == "events_planning_search":
-                return search_service
-            if name == "events":
-                return events_service
-            raise AssertionError("Unexpected service requested: {}".format(name))
-
-        with mock.patch("planning.planning_article_export.get_resource_service", side_effect=get_service):
+        with mock.patch.object(UnifiedPlanningResource, "get_service", return_value=service):
             items = await get_items(["plan1"], "planning")
 
-        assert items == [{"_id": "plan1", "type": "planning"}]
-        search_service.search_repos.assert_called_once_with(
-            "planning",
-            {"item_ids": "plan1", "only_future": False},
-            page_size=EXPORT_FETCH_PAGE_SIZE,
+        self.assertEqual(["plan1"], [item["_id"] for item in items])
+        service.find.assert_awaited_once_with(
+            {"_id": {"$in": ["plan1"]}, "type": "planning"},
+            use_mongo=True,
+            max_results=EXPORT_FETCH_PAGE_SIZE,
         )

--- a/server/planning/tests/unified_resource/article_export_test.py
+++ b/server/planning/tests/unified_resource/article_export_test.py
@@ -20,10 +20,7 @@ COVERAGE_STATUS = {"qcode": "ncostat:int", "name": "coverage intended", "label":
 
 
 class ArticleExportTestCase(TestCase):
-    """Export as Article reads Event & Planning items from the single ``unified_planning``
-    resource (SDBELGA-1130): related items are resolved through the unified helpers, and
-    the export is served by a native async endpoint instead of the Eve resource.
-    """
+    """Exporting Event & Planning items as an Article from the unified resource"""
 
     app_config = {
         **TestCase.app_config.copy(),
@@ -96,7 +93,6 @@ class ArticleExportTestCase(TestCase):
         data.update(overrides)
         return (await self.service.create([UnifiedPlanningResource.from_dict(data)]))[0].id
 
-    # ------------------------------------------------------------- get_items
     async def test_get_items_preserves_supplied_order(self):
         plan_ids = [await self._create_planning(headline=f"Planning {i}") for i in range(3)]
         event_ids = [await self._create_event(name=f"Event {i}") for i in range(3)]
@@ -142,7 +138,6 @@ class ArticleExportTestCase(TestCase):
             [coverage["planning"]["g2_content_type"] for coverage in event["coverages"]],
         )
 
-    # ------------------------------------------------- export_items_to_article
     async def test_export_creates_archive_item_on_desk(self):
         event_id = await self._create_event(name="Big Match")
         plan_id = await self._create_planning(
@@ -242,7 +237,6 @@ class ArticleExportTestCase(TestCase):
 
         self.assertIsNone(await get_resource_service("archive").find_one_async(req=None, type="text"))
 
-    # ------------------------------------------------- export_events_to_text
     async def test_export_events_to_text(self):
         event_id = await self._create_event(name="Downloaded Event")
         items = await get_items([event_id], "events")

--- a/server/planning/tests/unified_resource/article_export_test.py
+++ b/server/planning/tests/unified_resource/article_export_test.py
@@ -1,0 +1,253 @@
+from bson import ObjectId
+from bson.errors import InvalidId
+
+from superdesk import get_resource_service
+from superdesk.errors import SuperdeskApiError
+from superdesk.flask import g
+from superdesk.tests import utils as test_utils, fixtures
+
+from planning.types.unified import UnifiedPlanningResource, PlanningItemType
+from planning.planning_article_export import (
+    get_items,
+    export_items_to_article,
+    export_events_to_text,
+    ArticleExportRequest,
+)
+from planning.tests import TestCase, fixtures as planning_fixtures
+
+
+COVERAGE_STATUS = {"qcode": "ncostat:int", "name": "coverage intended", "label": "Planned"}
+
+
+class ArticleExportTestCase(TestCase):
+    """Export as Article reads Event & Planning items from the single ``unified_planning``
+    resource (SDBELGA-1130): related items are resolved through the unified helpers, and
+    the export is served by a native async endpoint instead of the Eve resource.
+    """
+
+    app_config = {
+        **TestCase.app_config.copy(),
+        "ELASTICSEARCH_FORCE_REFRESH": True,
+    }
+
+    async def asyncSetUp(self):
+        await super().asyncSetUp()
+        self.service = UnifiedPlanningResource.get_service()
+
+        await test_utils.post_items("users", fixtures.users.all_users())
+        admin = fixtures.users.admin().to_dict()
+        admin["_id"] = ObjectId()
+        admin["username"] = "export_tester"
+        admin["email"] = "export_tester@example.org"
+        await test_utils.post_items("users", [admin])
+        g.user = admin
+        g.auth = {"_id": ObjectId(), "user": g.user["_id"]}
+        await test_utils.post_items("vocabularies", planning_fixtures.cvs.all_cvs())
+
+        self.content_template_id = ObjectId()
+        await test_utils.post_items(
+            "content_templates",
+            [
+                {
+                    "_id": self.content_template_id,
+                    "template_name": "Planning export",
+                    "template_type": "planning_export",
+                    "data": {"slugline": "Foo"},
+                }
+            ],
+        )
+        self.desk_id = ObjectId()
+        self.plain_desk_id = ObjectId()
+        await test_utils.post_items(
+            "desks",
+            [
+                {"_id": self.desk_id, "name": "Sports", "default_content_template": self.content_template_id},
+                {"_id": self.plain_desk_id, "name": "Plain"},
+            ],
+        )
+        self.desk = await get_resource_service("desks").find_one_async(req=None, _id=self.desk_id)
+
+    # helpers
+    def _coverage(self, content_type: str) -> dict:
+        return {
+            "coverage_id": str(ObjectId()),
+            "original_creator": g.user["_id"],
+            "workflow_status": "draft",
+            "news_coverage_status": COVERAGE_STATUS,
+            "planning": {"g2_content_type": content_type, "slugline": "story"},
+        }
+
+    async def _create_event(self, **overrides) -> str:
+        data = dict(
+            type=PlanningItemType.EVENT,
+            name="Test Event",
+            dates={"start": "2026-06-30T15:30:55+0000", "end": "2026-06-30T17:30:55+0000", "tz": "UTC"},
+        )
+        data.update(overrides)
+        return (await self.service.create([UnifiedPlanningResource.from_dict(data)]))[0].id
+
+    async def _create_planning(self, **overrides) -> str:
+        data = dict(
+            type=PlanningItemType.PLANNING,
+            headline="Test Planning",
+            slugline="test-planning",
+            dates={"start": "2026-06-30T15:30:55+0000"},
+        )
+        data.update(overrides)
+        return (await self.service.create([UnifiedPlanningResource.from_dict(data)]))[0].id
+
+    # ------------------------------------------------------------- get_items
+    async def test_get_items_preserves_supplied_order(self):
+        plan_ids = [await self._create_planning(headline=f"Planning {i}") for i in range(3)]
+        event_ids = [await self._create_event(name=f"Event {i}") for i in range(3)]
+
+        for ids, item_type in (
+            (plan_ids, "planning"),
+            (list(reversed(plan_ids)), "planning"),
+            (event_ids, "event"),
+            (list(reversed(event_ids)), "event"),
+            ([event_ids[1], plan_ids[2], event_ids[0], plan_ids[0]], "combined"),
+        ):
+            items = await get_items(ids, item_type)
+            self.assertEqual(ids, [item["_id"] for item in items])
+
+    async def test_get_items_scopes_by_type(self):
+        event_id = await self._create_event()
+        plan_id = await self._create_planning()
+        ids = [event_id, plan_id]
+
+        self.assertEqual([plan_id], [item["_id"] for item in await get_items(ids, "planning")])
+        self.assertEqual([event_id], [item["_id"] for item in await get_items(ids, "event")])
+        # legacy search repo name used by the download endpoint
+        self.assertEqual([event_id], [item["_id"] for item in await get_items(ids, "events")])
+        self.assertEqual(ids, [item["_id"] for item in await get_items(ids, "combined")])
+
+    async def test_get_items_embeds_related_items_from_unified_resource(self):
+        event_id = await self._create_event(name="Linked Event")
+        plan_id = await self._create_planning(
+            related_events=[{"_id": event_id, "link_type": "primary"}],
+            coverages=[self._coverage("text"), self._coverage("picture")],
+        )
+        # unrelated planning items are not part of the event export
+        await self._create_planning(coverages=[self._coverage("video")])
+
+        (planning,) = await get_items([plan_id], "planning")
+        self.assertEqual(event_id, planning["event"]["_id"])
+        self.assertEqual("Linked Event", planning["event"]["name"])
+
+        (event,) = await get_items([event_id], "event")
+        self.assertEqual([plan_id], [plan["_id"] for plan in event["plannings"]])
+        self.assertEqual(
+            ["text", "picture"],
+            [coverage["planning"]["g2_content_type"] for coverage in event["coverages"]],
+        )
+
+    # ------------------------------------------------- export_items_to_article
+    async def test_export_creates_archive_item_on_desk(self):
+        event_id = await self._create_event(name="Big Match")
+        plan_id = await self._create_planning(
+            headline="Match Report",
+            definition_long="Who won",
+            related_events=[{"_id": event_id, "link_type": "primary"}],
+            coverages=[self._coverage("text"), self._coverage("picture")],
+        )
+
+        item = await export_items_to_article(
+            ArticleExportRequest(items=[event_id, plan_id], desk=str(self.desk_id), type="combined")
+        )
+
+        self.assertEqual("text", item["type"])
+        self.assertEqual("Foo", item["slugline"])
+        self.assertEqual(self.desk_id, item["task"]["desk"])
+        self.assertEqual(self.desk["working_stage"], item["task"]["stage"])
+        self.assertIn("<h2>Events</h2>", item["body_html"])
+        self.assertIn("<b>Big Match</b>", item["body_html"])
+        self.assertIn("<b>Match Report</b>", item["body_html"])
+        # unified ``definition_long`` is exposed to templates as ``description_text``
+        self.assertIn("<p>Who won</p>", item["body_html"])
+        # coverage labels rendered for the Event (via its related Planning) and the Planning itself
+        self.assertEqual(2, item["body_html"].count("Text, Picture"))
+
+        archived = await get_resource_service("archive").find_one_async(req=None, _id=item["_id"])
+        self.assertIsNotNone(archived)
+        self.assertEqual("Foo", archived["slugline"])
+
+    async def test_export_default_sluglines_per_type(self):
+        event_id = await self._create_event()
+        plan_id = await self._create_planning()
+
+        for item_type, ids, slugline in (
+            ("planning", [plan_id], "Planning"),
+            ("event", [event_id], "Event"),
+            ("combined", [event_id, plan_id], "Events and Planning"),
+        ):
+            item = await export_items_to_article(
+                ArticleExportRequest(items=ids, desk=str(self.plain_desk_id), type=item_type)
+            )
+            self.assertEqual(slugline, item["slugline"])
+
+    async def test_export_uses_article_template_over_desk_template(self):
+        plan_id = await self._create_planning()
+        template_id = ObjectId()
+        await test_utils.post_items(
+            "content_templates",
+            [
+                {
+                    "_id": template_id,
+                    "template_name": "editor_template",
+                    "template_type": "editor_template",
+                    "data": {"slugline": "Bar", "body_html": "<p>Intro</p><p>{{content}}</p>"},
+                }
+            ],
+        )
+
+        item = await export_items_to_article(
+            ArticleExportRequest(items=[plan_id], desk=str(self.desk_id), article_template=str(template_id))
+        )
+
+        self.assertEqual("Bar", item["slugline"])
+        self.assertTrue(item["body_html"].startswith("<p>Intro</p>"))
+        self.assertIn("<b>Test Planning</b>", item["body_html"])
+
+    def test_export_request_validation(self):
+        request = ArticleExportRequest.model_validate({"items": ["a"]})
+        self.assertEqual("planning", request.type)
+        self.assertIsNone(request.desk)
+
+        with self.assertRaises(ValueError):
+            ArticleExportRequest.model_validate({"template": "missing-items"})
+        with self.assertRaises(ValueError):
+            ArticleExportRequest.model_validate({"items": ["a"], "type": "assignment"})
+        # core's ``fields.ObjectId`` surfaces malformed ids as bson's InvalidId (the endpoint maps it to a 400)
+        with self.assertRaises(InvalidId):
+            ArticleExportRequest.model_validate({"items": ["a"], "desk": "not-an-object-id"})
+
+        # ObjectId fields accept both bson ObjectIds (internal callers) and their string form (HTTP)
+        desk_id = ObjectId()
+        self.assertEqual(desk_id, ArticleExportRequest(items=["a"], desk=desk_id).desk)
+        self.assertEqual(desk_id, ArticleExportRequest.model_validate({"items": ["a"], "desk": str(desk_id)}).desk)
+
+    async def test_export_rejects_unknown_desk_and_article_template(self):
+        plan_id = await self._create_planning()
+
+        with self.assertRaises(SuperdeskApiError) as context:
+            await export_items_to_article(ArticleExportRequest(items=[plan_id], desk=ObjectId()))
+        self.assertEqual(400, context.exception.status_code)
+
+        with self.assertRaises(SuperdeskApiError) as context:
+            await export_items_to_article(
+                ArticleExportRequest(items=[plan_id], desk=self.desk_id, article_template=ObjectId())
+            )
+        self.assertEqual(400, context.exception.status_code)
+
+        self.assertIsNone(await get_resource_service("archive").find_one_async(req=None, type="text"))
+
+    # ------------------------------------------------- export_events_to_text
+    async def test_export_events_to_text(self):
+        event_id = await self._create_event(name="Downloaded Event")
+        items = await get_items([event_id], "events")
+
+        exported = await export_events_to_text(items, template="event_download_default.html", tz_offset="3600")
+
+        self.assertIsInstance(exported, bytes)
+        self.assertIn(b"Downloaded Event", exported)

--- a/server/planning/unified/common.py
+++ b/server/planning/unified/common.py
@@ -130,6 +130,7 @@ async def get_related_planning_for_events(
     link_type: RelatedEventLinkType | None = None,
     exclude_planning_ids: list[str] | None = None,
     projection: ProjectedFieldArg | None = None,
+    max_results: int | None = None,
 ) -> ResourceCursorAsync[UnifiedPlanningResource]:
     related_events_filters: list[dict] = [{"terms": {"related_events._id": event_ids}}]
     if link_type is not None:
@@ -147,8 +148,12 @@ async def get_related_planning_for_events(
     if len(exclude_planning_ids or []) > 0:
         bool_query["must_not"] = {"terms": {"_id": exclude_planning_ids}}
 
+    query: dict = {"query": {"bool": bool_query}}
+    if max_results is not None:
+        query["size"] = max_results
+
     service = UnifiedPlanningResource.get_service()
-    return await service.search({"query": {"bool": bool_query}}, projection=projection)
+    return await service.search(query, projection=projection)
 
 
 async def event_has_planning_items(


### PR DESCRIPTION
### Purpose
Move Export as Article off the Eve `planning_article_export` resource onto the unified resource and a native async endpoint.

### What has changed
- `planning_article_export` is a native async POST endpoint (same name, URL and `planning` privilege; the client needs no change). The request body is validated by a Pydantic model; unknown `desk` / `article_template` ids return 400 as the Eve schema did.
- Export logic is now module functions (`export_items_to_article`, `export_events_to_text`) shared by the endpoint, the events download endpoint and the scheduled-filters export. No `get_resource_service("planning_article_export")` remains.
- `get_items` resolves related Events/Planning via the `unified.common` helpers; the legacy `planning.utils` Eve reads are gone. This also fixes combined exports rendering Events with no coverages (the old helper searched the now-empty legacy planning index).
- `get_related_planning_for_events` gained `max_results`; the export passes its page size instead of hitting Elasticsearch's default 10-hit cap.
- Templates: unified planning `definition_long` is exposed as `description_text`; planning items linked to an Event keep using the Event's dates for `schedule`.
- Blocking `find_one` calls in the module made async.
- Fixtures for `planning_export.feature` / `combined_export.feature` gained the required `news_coverage_status`; 9 scenarios that died at setup on `feature/unified` now run. New `tests/unified_resource/article_export_test.py`.

### Notes for review
- `test_combined_export_template.html` switched from `item._type == 'events'` to `item.type == 'event'`; customer export templates using `_type` would need the same change.
- Core's `fields.ObjectId` raises bson `InvalidId` rather than a pydantic error on malformed ids; the endpoint maps it to a 400. Probably worth a small core fix.
- The per-item lookups in `get_items` (one fetch per planning, one search per event) are pre-existing and left for a follow-up.

Resolves: [SDBELGA-1130](https://sofab.atlassian.net/browse/SDBELGA-1130)

[SDBELGA-1130]: https://sofab.atlassian.net/browse/SDBELGA-1130
