### PR TITLE
[SDESK-8014] - Show Event coverage information in all views

### DIFF
--- a/client/api/editor/item_events.ts
+++ b/client/api/editor/item_events.ts
@@ -19,7 +19,12 @@ import {planningApi, superdeskApi} from '../../superdeskApi';
 import {generateTempId, isTemporaryId} from '../../utils';
 import {getBookmarksFromFormGroups, getEditorFormGroupsFromProfile} from '../../utils/contentProfiles';
 
-import {AddPlanningBookmark, AssociatedPlanningsBookmark} from '../../components/Editor/bookmarks';
+import {
+    AddCoverageBookmark,
+    AddPlanningBookmark,
+    AssociatedPlanningsBookmark,
+    CoveragesBookmark,
+} from '../../components/Editor/bookmarks';
 import {RelatedPlanningItem} from '../../components/fields/editor/EventRelatedPlannings/RelatedPlanningItem';
 import {convertEventToPlanningItem} from '../../actions';
 import {addRelatedPlannings} from '../../utils/planning';
@@ -44,6 +49,18 @@ export function getEventsInstance(type: EDITOR_TYPE): IEditorAPI['item']['events
         const bookmarks = getBookmarksFromFormGroups(groups);
         let index = bookmarks.length;
 
+        const coverageBookmarks: Array<IEditorBookmark> = profile.editor.coverages?.enabled !== true ? [] : [{
+            id: 'add_coverage',
+            type: BOOKMARK_TYPE.custom,
+            index: index++,
+            component: AddCoverageBookmark,
+        }, {
+            id: 'coverage_links',
+            type: BOOKMARK_TYPE.custom,
+            index: index++,
+            component: CoveragesBookmark,
+        }];
+
         return {
             bookmarks: bookmarks.concat([{
                 id: 'divider-1',
@@ -61,7 +78,7 @@ export function getEventsInstance(type: EDITOR_TYPE): IEditorAPI['item']['events
                 index: index++,
                 disabled: !canCreatePlanningItems,
                 component: AssociatedPlanningsBookmark,
-            }]),
+            }], coverageBookmarks),
             groups: Object.values(groups),
         };
     }

--- a/client/api/editor/item_events.ts
+++ b/client/api/editor/item_events.ts
@@ -49,7 +49,12 @@ export function getEventsInstance(type: EDITOR_TYPE): IEditorAPI['item']['events
         const bookmarks = getBookmarksFromFormGroups(groups);
         let index = bookmarks.length;
 
+        // Coverages belong to the Event itself, so their bookmarks come before the related Planning ones
         const coverageBookmarks: Array<IEditorBookmark> = profile.editor.coverages?.enabled !== true ? [] : [{
+            id: 'divider-coverages',
+            type: BOOKMARK_TYPE.divider,
+            index: index++,
+        }, {
             id: 'add_coverage',
             type: BOOKMARK_TYPE.custom,
             index: index++,
@@ -62,7 +67,7 @@ export function getEventsInstance(type: EDITOR_TYPE): IEditorAPI['item']['events
         }];
 
         return {
-            bookmarks: bookmarks.concat([{
+            bookmarks: bookmarks.concat(coverageBookmarks, [{
                 id: 'divider-1',
                 type: BOOKMARK_TYPE.divider,
                 index: index++,
@@ -78,7 +83,7 @@ export function getEventsInstance(type: EDITOR_TYPE): IEditorAPI['item']['events
                 index: index++,
                 disabled: !canCreatePlanningItems,
                 component: AssociatedPlanningsBookmark,
-            }], coverageBookmarks),
+            }]),
             groups: Object.values(groups),
         };
     }

--- a/client/components/Coverages/CoverageArrayInput.tsx
+++ b/client/components/Coverages/CoverageArrayInput.tsx
@@ -8,12 +8,12 @@ import {
     ICoverageProvider,
     ICoverageType,
     IEventItem,
+    IEventOrPlanningItem,
     IFile,
     IG2ContentType,
     IGenre,
     IInputArrayHocModeOptions,
     IPlanningCoverageItem,
-    IPlanningItem,
     IPlanningNewsCoverageStatus,
 } from '../../interfaces';
 import {IArticle, IDesk, IUser} from 'superdesk-api';
@@ -30,7 +30,7 @@ import planningActions from '../../actions/planning/api';
 interface IOwnProps {
     field: string;
     addButtonText?: string; // defaults to 'Add a coverage'
-    item: IPlanningItem;
+    item: IEventOrPlanningItem;
     value: Array<IPlanningCoverageItem>;
     disabled: boolean;
     addNewsItemToPlanning?: IArticle;

--- a/client/components/Coverages/CoverageEditor/CoverageForm.tsx
+++ b/client/components/Coverages/CoverageEditor/CoverageForm.tsx
@@ -8,8 +8,8 @@ import {Dictionary, IArticle, IDesk, IVocabularyItem} from 'superdesk-api';
 import {
     EDITOR_TYPE,
     ICoverageScheduledUpdate,
+    IEventOrPlanningItem,
     IPlanningCoverageItem,
-    IPlanningItem,
     IPlanningNewsCoverageStatus,
     IG2ContentType,
     IGenre,
@@ -37,8 +37,8 @@ interface IOwnProps {
     value: IPlanningCoverageItem;
     disabled: boolean;
     message: string | {[key: string]: any};
-    item: IPlanningItem;
-    diff: Partial<IPlanningItem>;
+    item: IEventOrPlanningItem;
+    diff: Partial<IEventOrPlanningItem>;
     errors: {[key: string]: any}
     showErrors: boolean;
     hasAssignment: boolean;

--- a/client/components/Coverages/CoverageEditor/index.tsx
+++ b/client/components/Coverages/CoverageEditor/index.tsx
@@ -8,10 +8,10 @@ import {
     ICoverageProvider,
     ICoverageType,
     IEventItem,
+    IEventOrPlanningItem,
     IG2ContentType,
     IPlanningAppState,
     IPlanningCoverageItem,
-    IPlanningItem,
     IPlanningNewsCoverageStatus
 } from '../../../interfaces';
 import {IArticle, IDesk, IUser} from 'superdesk-api';
@@ -22,7 +22,7 @@ import {CoverageItem} from '../CoverageItem';
 import {CoverageForm} from './CoverageForm';
 import {CoverageFormHeader} from './CoverageFormHeader';
 
-import {planningUtils, gettext, editorMenuUtils} from '../../../utils';
+import {planningUtils, gettext, editorMenuUtils, isEvent} from '../../../utils';
 import {getVocabularyItemFieldTranslated} from '../../../utils/vocabularies';
 import {getUserInterfaceLanguageFromCV} from '../../../utils/users';
 import {getRelatedEventIdsForPlanning} from '../../../utils/planning';
@@ -81,18 +81,22 @@ function duplicateCoverage({
     coverage,
     duplicateAs,
 }: {
-    planning: IPlanningItem;
+    planning: IEventOrPlanningItem;
     coverage: IPlanningCoverageItem;
     duplicateAs?: ICoverageType;
 }): Array<DeepPartial<IPlanningCoverageItem>> {
     const state: IPlanningAppState = planningApi.redux.store.getState();
 
-    // TAG: MULTIPLE_PRIMARY_EVENTS
-    const relatedEventId = getRelatedEventIdsForPlanning(planning, 'primary')[0];
+    let relatedEvent: IEventItem | undefined;
 
-    const relatedEvent: IEventItem | undefined = relatedEventId == null
-        ? undefined
-        : state.events.events[relatedEventId];
+    if (isEvent(planning)) {
+        relatedEvent = planning;
+    } else {
+        // TAG: MULTIPLE_PRIMARY_EVENTS
+        const relatedEventId = getRelatedEventIdsForPlanning(planning, 'primary')[0];
+
+        relatedEvent = relatedEventId == null ? undefined : state.events.events[relatedEventId];
+    }
 
     const coverageProfilesMap = selectors.forms.getCoverageProfilesMap(state);
 

--- a/client/components/Coverages/CoverageEditor/index.tsx
+++ b/client/components/Coverages/CoverageEditor/index.tsx
@@ -22,7 +22,7 @@ import {CoverageItem} from '../CoverageItem';
 import {CoverageForm} from './CoverageForm';
 import {CoverageFormHeader} from './CoverageFormHeader';
 
-import {planningUtils, gettext, editorMenuUtils, isEvent} from '../../../utils';
+import {planningUtils, gettext, editorMenuUtils} from '../../../utils';
 import {getVocabularyItemFieldTranslated} from '../../../utils/vocabularies';
 import {getUserInterfaceLanguageFromCV} from '../../../utils/users';
 import {getRelatedEventIdsForPlanning} from '../../../utils/planning';
@@ -89,7 +89,7 @@ function duplicateCoverage({
 
     let relatedEvent: IEventItem | undefined;
 
-    if (isEvent(planning)) {
+    if (planning.type === 'event') {
         relatedEvent = planning;
     } else {
         // TAG: MULTIPLE_PRIMARY_EVENTS

--- a/client/components/Coverages/CoverageItem.tsx
+++ b/client/components/Coverages/CoverageItem.tsx
@@ -6,9 +6,9 @@ import {IDesk, IUser} from 'superdesk-api';
 import {appConfig} from 'appConfig';
 import {
     IContactItem,
+    IEventOrPlanningItem,
     IG2ContentType,
     IPlanningCoverageItem,
-    IPlanningItem,
     IPlanningWorkflowStatus,
 } from '../../interfaces';
 
@@ -37,7 +37,7 @@ interface IProps {
     contentTypes: Array<IG2ContentType>;
     isPreview?: boolean;
     active?: boolean;
-    item: DeepPartial<IPlanningItem>;
+    item: DeepPartial<IEventOrPlanningItem>;
     index: number;
     workflowStateReasonPrefix?: string;
     showBackground?: boolean;

--- a/client/components/Coverages/CoveragePreview/index.tsx
+++ b/client/components/Coverages/CoveragePreview/index.tsx
@@ -5,9 +5,9 @@ import {IDesk, IUser} from 'superdesk-api';
 import {superdeskApi} from '../../../superdeskApi';
 import {
     IEditorProfile,
+    IEventOrPlanningItem,
     IFile,
     IPlanningCoverageItem,
-    IPlanningItem,
     IPlanningNewsCoverageStatus,
 } from '../../../interfaces';
 
@@ -38,7 +38,7 @@ interface IProps {
     onClick?(): void;
     inner: boolean;
     index: number;
-    item: IPlanningItem;
+    item: IEventOrPlanningItem;
     canScheduleUpdates: boolean;
     createLink(file: IFile): string;
     files: {[key: string]: IFile};

--- a/client/components/Coverages/CoveragesPreview.tsx
+++ b/client/components/Coverages/CoveragesPreview.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+
+import {IDesk, IUser} from 'superdesk-api';
+import {appConfig} from 'appConfig';
+import {superdeskApi} from '../../superdeskApi';
+import {
+    IEventOrPlanningItem,
+    IFile,
+    IPlanningCoverageItem,
+    IPlanningNewsCoverageStatus,
+} from '../../interfaces';
+
+import {getFileDownloadURL} from '../../utils';
+import {getCoverageFields} from '../../api/editor/item_planning';
+import {CoveragePreview} from './CoveragePreview';
+
+interface IProps {
+    item: IEventOrPlanningItem;
+    users: Array<IUser>;
+    desks: Array<IDesk>;
+    newsCoverageStatus: Array<IPlanningNewsCoverageStatus>;
+    files: {[key: string]: IFile};
+    inner?: boolean;
+    currentCoverageId?: IPlanningCoverageItem['coverage_id'];
+}
+
+export class CoveragesPreview extends React.PureComponent<IProps> {
+    // Kept as a method rather than a component defined in render(), so the coverage
+    // subtree is not remounted (and its CollapseBox state lost) on every render
+    renderCoveragePreview(coverage: IPlanningCoverageItem, index: number) {
+        const {item, users, desks, newsCoverageStatus, inner, files} = this.props;
+        const {profile} = getCoverageFields(coverage.planning.g2_content_type);
+
+        return (
+            <CoveragePreview
+                item={item}
+                key={coverage.coverage_id}
+                index={index}
+                coverage={coverage}
+                users={users}
+                desks={desks}
+                newsCoverageStatus={newsCoverageStatus}
+                formProfile={profile}
+                inner={inner}
+                files={files}
+                createLink={getFileDownloadURL}
+                canScheduleUpdates={
+                    profile.editor.flags && appConfig.planning_allow_scheduled_updates
+                }
+                scrollInView={true}
+            />
+        );
+    }
+
+    render() {
+        const {gettext} = superdeskApi.localization;
+        const coverages = this.props.item.coverages ?? [];
+
+        if (coverages.length === 0) {
+            return null;
+        }
+
+        const currentCoverage = this.props.currentCoverageId == null ?
+            null :
+            coverages.find((coverage) => coverage.coverage_id === this.props.currentCoverageId);
+        const otherCoverages = currentCoverage == null ?
+            coverages :
+            coverages.filter((coverage) => coverage.coverage_id !== this.props.currentCoverageId);
+
+        if (currentCoverage == null) {
+            return (
+                <>
+                    <h3 className="side-panel__heading--big">{gettext('Coverages')}</h3>
+                    {otherCoverages.map((coverage, i) => this.renderCoveragePreview(coverage, i))}
+                </>
+            );
+        }
+
+        return (
+            <>
+                <h3 className="side-panel__heading--big">{gettext('This Coverage')}</h3>
+                {this.renderCoveragePreview(currentCoverage, 0)}
+
+                {otherCoverages.length > 0 && (
+                    <>
+                        <h3 className="side-panel__heading--big">{gettext('Other Coverages')}</h3>
+                        {otherCoverages.map((coverage, i) => this.renderCoveragePreview(coverage, i))}
+                    </>
+                )}
+            </>
+        );
+    }
+}

--- a/client/components/Coverages/index.ts
+++ b/client/components/Coverages/index.ts
@@ -2,6 +2,7 @@ export {CoverageArrayInput} from './CoverageArrayInput';
 export {CoverageEditor} from './CoverageEditor';
 export {CoverageItem} from './CoverageItem';
 export {CoveragePreview} from './CoveragePreview/index';
+export {CoveragesPreview} from './CoveragesPreview';
 export {CoverageAddButton} from './CoverageAddButton';
 export {CoverageHistory} from './CoverageHistory';
 export {ScheduledUpdate} from './ScheduledUpdate';

--- a/client/components/Events/EventEditor/index.tsx
+++ b/client/components/Events/EventEditor/index.tsx
@@ -5,6 +5,7 @@ import {
     IEventItem,
     IEventFormProfile,
     IFile,
+    IPlanningCoverageItem,
     IPlanningItem,
     IFormItemManager,
     EDITOR_TYPE,
@@ -37,8 +38,16 @@ interface IProps {
     editorType: EDITOR_TYPE;
     showAllLanguages: boolean;
     language: IVocabularyItem['qcode'];
+    files: Array<IFile>;
+    message?: string | {[key: string]: any};
+    navigation?: any;
 
-    onChangeHandler(field: string | {[key: string]: any}, value?: any): void;
+    onChangeHandler(
+        field: string | {[key: string]: any},
+        value?: any,
+        updateDirtyFlag?: boolean,
+        saveAutosave?: boolean,
+    ): void;
     onPopupOpen(): void;
     onPopupClose(): void;
     fetchEventFiles(event: IEventItem): void;
@@ -49,6 +58,7 @@ interface IProps {
 
 const mapStateToProps = (state) => ({
     formProfile: selectors.forms.eventProfile(state),
+    files: selectors.general.files(state),
 });
 
 const mapDispatchToProps = (dispatch) => ({
@@ -64,6 +74,15 @@ class EventEditorComponent extends React.PureComponent<IProps> {
         super(props);
 
         this.onDatesChanged = this.onDatesChanged.bind(this);
+        this.onCoverageChange = this.onCoverageChange.bind(this);
+    }
+
+    onCoverageChange(field: string, value: any, updateDirtyFlag: boolean = true, saveAutosave: boolean = true) {
+        this.props.onChangeHandler(field, value, updateDirtyFlag, saveAutosave);
+
+        if (field === 'coverages') {
+            planningApi.editor(this.props.editorType).autosave.flushAutosave();
+        }
     }
 
     componentDidMount() {
@@ -211,6 +230,27 @@ class EventEditorComponent extends React.PureComponent<IProps> {
                         addPlanningItem: editor.item.events.addPlanningItem,
                         unlinkPlanning: editor.item.events.unlinkPlanning,
                         updatePlanningItem: editor.item.events.updatePlanningItem,
+                    },
+                    coverages: {
+                        onChange: this.onCoverageChange,
+                        useLocalNavigation: !this.props.inModalView,
+                        navigation: this.props.navigation,
+                        disabled: this.props.readOnly,
+                        originalCount: this.props.item?.coverages?.length ?? 0,
+                        message: this.props.message,
+                        event: this.props.item,
+                        defaultValue: [],
+                        files: this.props.files,
+                        uploadFiles: this.props.uploadFiles,
+                        removeFile: this.props.removeFile,
+                        notifyValidationErrors: this.props.notifyValidationErrors,
+                        onPopupOpen: this.props.onPopupOpen,
+                        onPopupClose: this.props.onPopupClose,
+                        getRef: (field, value: IPlanningCoverageItem) => (
+                            editor.item.planning.getCoverageFieldDomRef(value.coverage_id)
+                        ),
+                        includeScheduledUpdates: true,
+                        language: this.props.language,
                     },
                 }}
             />

--- a/client/components/Events/EventHistory.tsx
+++ b/client/components/Events/EventHistory.tsx
@@ -5,6 +5,7 @@ import {gettext, historyUtils} from '../../utils';
 import {get} from 'lodash';
 import {AbsoluteDate} from '../index';
 import {ContentBlock} from '../UI/SidePanel';
+import {CoverageHistory} from '../Coverages';
 
 export class EventHistory extends React.Component {
     closeAndOpenDuplicate(duplicateId) {
@@ -109,10 +110,13 @@ export class EventHistory extends React.Component {
     }
 
     render() {
+        const itemHistory = historyUtils.getPlanningItemHistory(this.props.historyItems);
+        const groupedCoverageHistory = historyUtils.getGroupedCoverageHistory(this.props.historyItems);
+
         return (
             <ContentBlock>
                 <ul className="history-list history-list--no-padding">
-                    {get(this.props, 'historyItems', []).map((historyItem, index) => {
+                    {itemHistory.map((historyItem, index) => {
                         const postElement = historyUtils.getPostedHistoryElement(
                             index, this.props.historyItems, this.props.users);
                         const historyElement = this.getHistoryActionElement(historyItem);
@@ -215,6 +219,15 @@ export class EventHistory extends React.Component {
                         return null;
                     })}
                 </ul>
+                {Object.keys(groupedCoverageHistory).map((historyKey) => (
+                    <CoverageHistory
+                        key={historyKey}
+                        historyData={groupedCoverageHistory[historyKey]}
+                        users={this.props.users}
+                        desks={this.props.desks}
+                        contentTypes={this.props.contentTypes}
+                    />
+                ))}
             </ContentBlock>
         );
     }
@@ -223,5 +236,7 @@ export class EventHistory extends React.Component {
 EventHistory.propTypes = {
     historyItems: PropTypes.array,
     users: PropTypes.array,
+    desks: PropTypes.array,
+    contentTypes: PropTypes.array,
     openItemPreview: PropTypes.func,
 };

--- a/client/components/Events/EventItem.tsx
+++ b/client/components/Events/EventItem.tsx
@@ -16,6 +16,7 @@ import {
     isItemExpired,
     isItemPosted,
     lockUtils,
+    planningUtils,
 } from '../../utils';
 import {renderFields} from '../fields';
 import {CreatedUpdatedColumn} from '../UI/List/CreatedUpdatedColumn';
@@ -189,6 +190,17 @@ class EventItemComponent extends React.Component<IProps, IState> {
                     event_datetime: {
                         hasStartDateContext: this.props.planningProps?.date != null
                             && isSameDay(eventStartDate, moment(this.props.planningProps.date)),
+                    },
+                    coverages: {
+                        prepare: (coverages) => planningUtils.filterCoveragesForList(
+                            item,
+                            coverages,
+                            {
+                                date: this.props.planningProps?.date,
+                                activeFilter: activeFilter,
+                                filterLanguage: filterLanguage,
+                            },
+                        ),
                     },
                 },
             },

--- a/client/components/Events/EventPreviewContent.tsx
+++ b/client/components/Events/EventPreviewContent.tsx
@@ -4,7 +4,7 @@ import {get} from 'lodash';
 
 import {IDesk, IUser} from 'superdesk-api';
 import {superdeskApi} from '../../superdeskApi';
-import {IEventFormProfile, IEventItem} from '../../interfaces';
+import {IEventFormProfile, IEventItem, IFile, IPlanningNewsCoverageStatus} from '../../interfaces';
 
 import {getCreator} from '../../utils';
 import {getUserInterfaceLanguageFromCV} from '../../utils/users';
@@ -15,8 +15,10 @@ import {
     RelatedPlannings,
     StateLabel,
 } from '../index';
+import {CoveragesPreview} from '../Coverages';
 import {ContentBlock} from '../UI/SidePanel';
 import * as actions from '../../actions';
+import planningActions from '../../actions/planning/api';
 
 import {renderProfileGroupedFields} from '../fields';
 
@@ -25,7 +27,10 @@ interface IProps {
     users: Array<IUser>;
     desks: Array<IDesk>;
     formProfile: IEventFormProfile;
+    newsCoverageStatus: Array<IPlanningNewsCoverageStatus>;
+    files: {[key: string]: IFile};
     fetchEventFiles(event: IEventItem): Promise<void>;
+    fetchPlanningFiles(item: IEventItem): Promise<void>;
     hideRelatedItems?: boolean;
 }
 
@@ -36,15 +41,19 @@ const mapStateToProps = (state, ownProps) => ({
     desks: selectors.general.desks(state),
     formProfile: selectors.forms.eventProfile(state),
     contacts: selectors.general.contacts(state),
+    newsCoverageStatus: selectors.general.newsCoverageStatus(state),
+    files: selectors.general.files(state),
 });
 
 const mapDispatchToProps = (dispatch) => ({
     fetchEventFiles: (event) => dispatch(actions.events.api.fetchEventFiles(event)),
+    fetchPlanningFiles: (item) => dispatch(planningActions.fetchPlanningFiles(item)),
 });
 
 export class EventPreviewContentComponent extends React.PureComponent<IProps> {
     componentWillMount() {
         this.props.fetchEventFiles(this.props.item);
+        this.props.fetchPlanningFiles(this.props.item);
     }
 
     render() {
@@ -55,6 +64,8 @@ export class EventPreviewContentComponent extends React.PureComponent<IProps> {
             desks,
             formProfile,
             hideRelatedItems,
+            newsCoverageStatus,
+            files,
         } = this.props;
         const createdBy = getCreator(item, 'original_creator', users);
         const updatedBy = getCreator(item, 'version_creator', users);
@@ -87,6 +98,18 @@ export class EventPreviewContentComponent extends React.PureComponent<IProps> {
                 }
             </>
         );
+
+        // Rendered at the profile position of the `coverages` group when the profile has one
+        const coveragesNode = (
+            <CoveragesPreview
+                item={item}
+                users={users}
+                desks={desks}
+                newsCoverageStatus={newsCoverageStatus}
+                files={files}
+            />
+        );
+        const hasCoveragesGroup = formProfile.groups?.coverages != null;
 
         return (
             <ContentBlock>
@@ -122,9 +145,10 @@ export class EventPreviewContentComponent extends React.PureComponent<IProps> {
                         profile: formProfile,
                     },
                     {},
-                    ['recurring_rules', 'related_plannings'],
-                    {related_plannings: relatedPlanningsNode},
+                    ['recurring_rules', 'related_plannings', 'coverages'],
+                    {related_plannings: relatedPlanningsNode, coverages: coveragesNode},
                 )}
+                {hasCoveragesGroup ? null : coveragesNode}
             </ContentBlock>
         );
     }

--- a/client/components/Events/tests/EventHistory_test.tsx
+++ b/client/components/Events/tests/EventHistory_test.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import {mount} from 'enzyme';
+import {noop} from 'lodash';
+
+import '../../../utils/testUtils';
+import {users, desks} from '../../../utils/testData';
+import {EventHistory} from '../EventHistory';
+import {CoverageHistory} from '../../Coverages';
+
+describe('<EventHistory />', () => {
+    const historyItems = [
+        {
+            _id: 'h1',
+            item_id: 'e1',
+            item_type: 'event',
+            operation: 'create',
+            _created: '2026-07-16T09:39:57+0000',
+            user_id: 'ident1',
+            update: {name: 'Event 1'},
+        },
+        {
+            _id: 'h2',
+            item_id: 'e1',
+            item_type: 'event',
+            operation: 'coverage_created',
+            _created: '2026-07-16T09:40:00+0000',
+            user_id: 'ident1',
+            update: {
+                coverage_id: 'c1',
+                assigned_to: {desk: 123, user: 'ident1'},
+                planning: {g2_content_type: 'text', scheduled: '2026-07-17T09:00:00+0000'},
+            },
+        },
+        {
+            _id: 'h3',
+            item_id: 'e1',
+            item_type: 'event',
+            operation: 'reassigned',
+            _created: '2026-07-16T09:41:00+0000',
+            user_id: 'ident1',
+            update: {
+                coverage_id: 'c1',
+                assigned_to: {desk: 123, user: 'ident1'},
+            },
+        },
+    ];
+
+    const getWrapper = () => mount(
+        <EventHistory
+            historyItems={historyItems}
+            users={users}
+            desks={desks}
+            contentTypes={[]}
+            openItemPreview={noop}
+        />
+    );
+
+    it('renders event operations in the list and coverage operations grouped per coverage', () => {
+        const wrapper = getWrapper();
+
+        expect(wrapper.find('ul.history-list--no-padding > li.item').length).toBe(1);
+        expect(wrapper.find('ul.history-list--no-padding > li.item').text()).toContain('Created');
+
+        expect(wrapper.find(CoverageHistory).length).toBe(1);
+
+        wrapper.find('.sd-collapse-box').simulate('click');
+        wrapper.update();
+
+        const coverageRows = wrapper.find(CoverageHistory).find('.history-list .item');
+
+        expect(coverageRows.length).toBe(2);
+        expect(coverageRows.at(0).text()).toContain('Politic Desk');
+    });
+});

--- a/client/components/Events/tests/EventItem_test.tsx
+++ b/client/components/Events/tests/EventItem_test.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import {mount} from 'enzyme';
+import {Provider} from 'react-redux';
+import {noop} from 'lodash';
+
+import {GROUP_LIST_BY, SORT_FIELD} from '../../../interfaces';
+import {MAIN} from '../../../constants';
+import {getTestActionStore} from '../../../utils/testUtils';
+import {createTestStore} from '../../../utils';
+import {EventItem} from '../EventItem';
+import {CoverageIcons} from '../../Coverages/CoverageIcons';
+
+describe('<EventItem />', () => {
+    const coverages = [
+        {
+            coverage_id: 'c1',
+            planning: {g2_content_type: 'text', scheduled: '2016-10-15T12:00:00+0000', language: 'fi'},
+        },
+        {
+            coverage_id: 'c2',
+            planning: {g2_content_type: 'picture', scheduled: '2016-10-16T12:00:00+0000', language: 'en'},
+        },
+    ];
+
+    const getWrapper = (props = {}) => {
+        const astore = getTestActionStore();
+
+        astore.init();
+        const store = createTestStore({initialState: astore.initialState});
+        const item = {...astore.initialState.events.events.e1, coverages};
+
+        return mount(
+            <Provider store={store}>
+                <EventItem
+                    item={item}
+                    lockedItems={astore.initialState.locks}
+                    session={astore.initialState.session}
+                    privileges={astore.initialState.privileges}
+                    activeFilter={MAIN.FILTERS.EVENTS}
+                    multiSelected={false}
+                    active={false}
+                    groupListBy={GROUP_LIST_BY.DATE}
+                    sortField={SORT_FIELD.SCHEDULE}
+                    minTimeWidth="100px"
+                    onItemClick={noop}
+                    onMultiSelectClick={noop}
+                    refNode={noop}
+                    calendars={[]}
+                    relatedPlanningsCount={0}
+                    planningProps={{date: '2016-10-15'}}
+                    {...props}
+                />
+            </Provider>
+        );
+    };
+
+    const renderedCoverageIds = (wrapper) => wrapper.find(CoverageIcons)
+        .prop('coverages')
+        .map((coverage) => coverage.coverage_id);
+
+    it('shows every coverage regardless of the day group', () => {
+        expect(renderedCoverageIds(getWrapper())).toEqual(['c1', 'c2']);
+        expect(renderedCoverageIds(getWrapper({planningProps: {date: '2016-10-16'}}))).toEqual(['c1', 'c2']);
+    });
+
+    it('filters coverages by the list language filter', () => {
+        expect(renderedCoverageIds(getWrapper({filterLanguage: 'en'}))).toEqual(['c2']);
+    });
+});

--- a/client/components/Events/tests/EventItem_test.tsx
+++ b/client/components/Events/tests/EventItem_test.tsx
@@ -58,12 +58,14 @@ describe('<EventItem />', () => {
         .prop('coverages')
         .map((coverage) => coverage.coverage_id);
 
-    it('shows every coverage regardless of the day group', () => {
-        expect(renderedCoverageIds(getWrapper())).toEqual(['c1', 'c2']);
-        expect(renderedCoverageIds(getWrapper({planningProps: {date: '2016-10-16'}}))).toEqual(['c1', 'c2']);
+    it('shows the coverages scheduled on the day group', () => {
+        expect(renderedCoverageIds(getWrapper())).toEqual(['c1']);
+        expect(renderedCoverageIds(getWrapper({planningProps: {date: '2016-10-16'}}))).toEqual(['c2']);
     });
 
     it('filters coverages by the list language filter', () => {
-        expect(renderedCoverageIds(getWrapper({filterLanguage: 'en'}))).toEqual(['c2']);
+        expect(renderedCoverageIds(getWrapper({filterLanguage: 'en'}))).toEqual([]);
+        expect(renderedCoverageIds(getWrapper({filterLanguage: 'en', planningProps: {date: '2016-10-16'}})))
+            .toEqual(['c2']);
     });
 });

--- a/client/components/Events/tests/EventPreviewContent_test.tsx
+++ b/client/components/Events/tests/EventPreviewContent_test.tsx
@@ -11,6 +11,7 @@ import {getTestActionStore, restoreSinonStub} from '../../../utils/testUtils';
 import {createTestStore, eventUtils, timeUtils} from '../../../utils';
 
 import {FileInput, LinkInput} from '../../UI/Form';
+import {CoveragePreview, CoveragesPreview} from '../../Coverages';
 
 describe('<EventPreviewContent />', () => {
     let astore = getTestActionStore();
@@ -202,5 +203,100 @@ describe('<EventPreviewContent />', () => {
         const relPlan = relatedPlannings.find('span.sd-list-item__slugline').first();
 
         expect(relPlan.text()).toBe('Planning2'); // expect to display slugline (i.e. Planning2)
+    });
+});
+
+describe('<EventPreviewContent /> coverages', () => {
+    const coverages = [{
+        coverage_id: 'ec1',
+        planning: {
+            g2_content_type: 'text',
+            slugline: 'Event text coverage',
+            scheduled: '2016-10-15T13:01:11+0000',
+        },
+        news_coverage_status: {qcode: 'ncostat:int'},
+        workflow_status: 'draft',
+    }];
+    const editor = {
+        name: {enabled: true, group: 'main', index: 0},
+        related_plannings: {enabled: true, group: 'related_plannings', index: 0},
+    };
+    const groups = {
+        main: {_id: 'main', name: 'Main', index: 0},
+        related_plannings: {_id: 'related_plannings', name: 'Related Plannings', index: 1},
+    };
+
+    const getWrapper = (eventCoverages, profile) => {
+        const astore = getTestActionStore();
+
+        astore.init();
+        astore.initialState.events.events.e1 = {
+            ...astore.initialState.events.events.e1,
+            coverages: eventCoverages,
+        };
+        astore.initialState.forms.profiles.event = {
+            ...astore.initialState.forms.profiles.event,
+            ...profile,
+        };
+        astore.initialState.main.previewId = 'e1';
+        astore.initialState.main.previewType = 'event';
+
+        const store = createTestStore({initialState: astore.initialState});
+
+        return mount(
+            <Provider store={store}>
+                <EventPreviewContent />
+            </Provider>
+        );
+    };
+
+    const getPositions = (wrapper) => {
+        const html = wrapper.html();
+
+        return {
+            coverages: html.indexOf('Coverages'),
+            relatedPlannings: html.indexOf('Related Plannings'),
+        };
+    };
+
+    beforeEach(() => {
+        sinon.stub(timeUtils, 'localTimeZone').returns(appConfig.default_timezone);
+    });
+
+    afterEach(() => {
+        restoreSinonStub(timeUtils.localTimeZone);
+    });
+
+    it('renders no coverages section for an event without coverages', () => {
+        const wrapper = getWrapper([], {editor, groups});
+
+        expect(wrapper.find(CoveragesPreview).length).toBe(1);
+        expect(wrapper.find(CoveragePreview).length).toBe(0);
+        expect(getPositions(wrapper).coverages).toBe(-1);
+    });
+
+    it('renders coverages after the other sections when the profile has no coverages group', () => {
+        const wrapper = getWrapper(coverages, {editor, groups});
+        const positions = getPositions(wrapper);
+
+        expect(wrapper.find(CoveragePreview).length).toBe(1);
+        expect(positions.relatedPlannings).toBeGreaterThan(-1);
+        expect(positions.coverages).toBeGreaterThan(positions.relatedPlannings);
+    });
+
+    it('renders coverages at the profile group position', () => {
+        const wrapper = getWrapper(coverages, {
+            editor: {...editor, coverages: {enabled: true, group: 'coverages', index: 0}},
+            groups: {
+                ...groups,
+                related_plannings: {...groups.related_plannings, index: 2},
+                coverages: {_id: 'coverages', name: 'Coverages', index: 1},
+            },
+        });
+        const positions = getPositions(wrapper);
+
+        expect(wrapper.find(CoveragePreview).length).toBe(1);
+        expect(positions.coverages).toBeGreaterThan(-1);
+        expect(positions.relatedPlannings).toBeGreaterThan(positions.coverages);
     });
 });

--- a/client/components/Planning/PlanningItem.tsx
+++ b/client/components/Planning/PlanningItem.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import {connect} from 'react-redux';
 import {get, isEqual} from 'lodash';
-import moment from 'moment';
 import {Menu, Tooltip} from 'superdesk-ui-framework/react';
 
 import {superdeskApi, planningApi} from '../../superdeskApi';
@@ -35,7 +34,6 @@ import planningApis from '../../actions/planning/api';
 import {getUserInterfaceLanguageFromCV} from '../../utils/users';
 import {LineItems} from '../../components/UI/List/LineItems';
 import {getPlanningSecondLineConfig, planningFirstLineConfig} from '../../config';
-import {getRelatedEventIdsForPlanning} from '../../utils/planning';
 import {ILineConfig} from 'globals';
 
 interface IState {
@@ -334,41 +332,11 @@ class PlanningItemComponent extends React.Component<IProps, IState> {
                         relatedEventsUI: this.props.relatedEventsUI,
                     },
                     coverages: {
-                        prepare: (coverages) => { // removing coverages that do not match page filters
-                            const coveragesMapped = planningUtils.mapCoverageByDate(coverages);
-                            const hasAssociatedEvent = getRelatedEventIdsForPlanning(item).length > 0;
-
-                            const isSameDay = (scheduled) =>
-                                scheduled && (date == null || moment(scheduled).format('YYYY-MM-DD') === date);
-
-                            const coverageToDisplay = coveragesMapped.filter((coverage) => {
-                                const scheduled = get(coverage, 'planning.scheduled');
-
-                                // Display only the coverages that match the active filter language
-                                if (
-                                    filterLanguage !== ''
-                                    && filterLanguage != null
-                                    && coverage.planning.language != filterLanguage
-                                ) {
-                                    return false;
-                                }
-
-                                if (activeFilter === MAIN.FILTERS.COMBINED) {
-                                    // Display if it has an associated event
-                                    // or if adhoc planning has coverage on that date
-                                    if (hasAssociatedEvent || isSameDay(scheduled)) {
-                                        return true;
-                                    }
-                                } else if (scheduled && isSameDay(scheduled)) {
-                                    // Planning-only view - display only coverage of the particular date
-                                    return true;
-                                }
-
-                                return false;
-                            });
-
-                            return coverageToDisplay;
-                        },
+                        prepare: (coverages) => planningUtils.filterCoveragesForList(
+                            item,
+                            coverages,
+                            {date, activeFilter, filterLanguage},
+                        ),
                     },
                 },
             },

--- a/client/components/Planning/PlanningPreviewContent.tsx
+++ b/client/components/Planning/PlanningPreviewContent.tsx
@@ -27,7 +27,7 @@ import {
     StateLabel,
     Label,
 } from '../index';
-import {CoveragePreview} from '../Coverages';
+import {CoveragesPreview} from '../Coverages';
 import {ContentBlock} from '../UI/SidePanel';
 import {EventMetadata} from '../Events';
 import {FeatureLabel} from './FeaturedPlanning';
@@ -36,8 +36,6 @@ import {PreviewFieldFiles} from '../fields/preview/Files';
 import {getRelatedEventIdsForPlanning, pickRelatedEventIdsForPlanning} from '../../utils/planning';
 import {RelatedEventsFilesFetcher} from './RelatedEventsFilesFetcher';
 import {coverageProfiles} from '../../selectors/forms';
-import {getCoverageFields} from '../../api/editor/item_planning';
-import {appConfig} from 'appConfig';
 
 interface IOwnProps {
     inner?: boolean;
@@ -90,33 +88,6 @@ const mapDispatchToProps = (dispatch): IDispatchProps => ({
 });
 
 export class PlanningPreviewContentComponent extends React.PureComponent<IProps> {
-    // Do not turn this into a component defined inside render(): such a component gets a new type identity on
-    // every render, making React remount the coverage subtree and lose the CollapseBox open state
-    renderCoveragePreview(coverage: IPlanningCoverageItem, index: number) {
-        const {item, users, desks, newsCoverageStatus, inner, files} = this.props;
-        const {profile} = getCoverageFields(coverage.planning.g2_content_type);
-
-        return (
-            <CoveragePreview
-                item={item}
-                key={coverage.coverage_id}
-                index={index}
-                coverage={coverage}
-                users={users}
-                desks={desks}
-                newsCoverageStatus={newsCoverageStatus}
-                formProfile={profile}
-                inner={inner}
-                files={files}
-                createLink={getFileDownloadURL}
-                canScheduleUpdates={
-                    profile.editor.flags && appConfig.planning_allow_scheduled_updates
-                }
-                scrollInView={true}
-            />
-        );
-    }
-
     componentWillMount() {
         // Related event files are fetched by RelatedEventsFilesFetcher from the live
         // event data, so only the planning item's own files are needed here
@@ -159,12 +130,15 @@ export class PlanningPreviewContentComponent extends React.PureComponent<IProps>
         const {gettext} = superdeskApi.localization;
         const {item,
             users,
+            desks,
             formProfile,
             onEditEvent,
             noPadding,
             hideRelatedItems,
             hideEditIcon,
             files,
+            newsCoverageStatus,
+            inner,
         } = this.props;
 
         const createdBy = getCreator(item, 'original_creator', users);
@@ -173,13 +147,6 @@ export class PlanningPreviewContentComponent extends React.PureComponent<IProps>
         const updatedDate = get(item, '_updated');
         const versionCreator = get(updatedBy, 'display_name') ? updatedBy :
             users.find((user) => user._id === updatedBy);
-        const hasCoverage = get(item, 'coverages.length', 0) > 0;
-        const currentCoverage: IPlanningCoverageItem | null = this.props.currentCoverageId == null ?
-            null :
-            (item.coverages ?? []).find((coverage) => coverage.coverage_id === this.props.currentCoverageId);
-        const otherCoverages: Array<IPlanningCoverageItem> = this.props.currentCoverageId == null ?
-            item.coverages ?? [] :
-            (item.coverages ?? []).filter((coverage) => coverage.coverage_id !== this.props.currentCoverageId);
 
         const primaryEventId = getRelatedEventIdsForPlanning(this.props.item, 'primary')[0];
         const primaryRelatedEvent = (relatedEvents ?? []).find((relatedEvent) => relatedEvent._id === primaryEventId);
@@ -203,27 +170,16 @@ export class PlanningPreviewContentComponent extends React.PureComponent<IProps>
             },
             {
                 id: 'coverages' as const,
-                node: !hasCoverage ? null : (
-                    <>
-                        {currentCoverage == null ? (
-                            <>
-                                <h3 className="side-panel__heading--big">{gettext('Coverages')}</h3>
-                                {otherCoverages.map((coverage, i) => this.renderCoveragePreview(coverage, i))}
-                            </>
-                        ) : (
-                            <>
-                                <h3 className="side-panel__heading--big">{gettext('This Coverage')}</h3>
-                                {this.renderCoveragePreview(currentCoverage, 0)}
-
-                                {(otherCoverages ?? []).length > 0 && (
-                                    <>
-                                        <h3 className="side-panel__heading--big">{gettext('Other Coverages')}</h3>
-                                        {otherCoverages.map((coverage, i) => this.renderCoveragePreview(coverage, i))}
-                                    </>
-                                )}
-                            </>
-                        )}
-                    </>
+                node: (
+                    <CoveragesPreview
+                        item={item}
+                        users={users}
+                        desks={desks}
+                        newsCoverageStatus={newsCoverageStatus}
+                        files={files}
+                        inner={inner}
+                        currentCoverageId={this.props.currentCoverageId}
+                    />
                 ),
             },
             {

--- a/client/components/fields/coverages.tsx
+++ b/client/components/fields/coverages.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import {connect} from 'react-redux';
 import {IDesk, IUser} from 'superdesk-api';
 import {IFieldsProps, IG2ContentType, IPlanningAppState, IPlanningCoverageItem} from 'interfaces';
-import {isPlanning} from '../../utils';
 import * as selectors from '../../selectors';
 import {CoverageIcons} from '../../components/Coverages/CoverageIcons';
 
@@ -34,10 +33,6 @@ const CoveragesComponent: React.FunctionComponent<IProps> = (props) => {
         item,
         fieldsProps,
     } = props;
-
-    if (!isPlanning(item)) {
-        return null;
-    }
 
     const coverages = item?.coverages ?? [];
     const prepare = fieldsProps?.coverages?.prepare ?? ((_items) => _items);

--- a/client/components/fields/editor/coverages.interface.ts
+++ b/client/components/fields/editor/coverages.interface.ts
@@ -1,9 +1,9 @@
 import {
     IEditorFieldProps,
     IEventItem,
+    IEventOrPlanningItem,
     IInputArrayHocModeOptions,
     IPlanningCoverageItem,
-    IPlanningItem
 } from '../../../interfaces';
 import {IArticle} from 'superdesk-api';
 
@@ -12,7 +12,7 @@ import {IArticle} from 'superdesk-api';
 type CoverageEditor = any;
 
 export interface IPropsEditorFieldCoverages extends IEditorFieldProps {
-    item: IPlanningItem;
+    item: IEventOrPlanningItem;
     addButtonText?: string; // defaults to 'Add a coverage'
     addNewsItemToPlanning?: IArticle;
     useLocalNavigation?: boolean;

--- a/client/config.ts
+++ b/client/config.ts
@@ -125,6 +125,7 @@ const eventSecondLineConfigDefaults: Array<ILineConfig> = [
     {fieldId: 'state'},
     {fieldId: 'related_plannings'},
     {fieldId: 'location'},
+    {fieldId: 'coverages', position: 'end'},
 ];
 
 export const eventFirstLineConfig: Array<ILineConfig> =

--- a/client/interfaces.ts
+++ b/client/interfaces.ts
@@ -470,6 +470,7 @@ export interface IEventItem extends IBaseRestApiResponse {
     invitation_details?: string;
     anpa_category?: Array<IANPACategory>;
     files?: Array<string>;
+    coverages?: Array<IPlanningCoverageItem>;
     relationships?: {
         broader?: string;
         narrower?: string;
@@ -1222,8 +1223,10 @@ export interface IEventFormProfile {
         slugline: IProfileEditorField;
         subject: IProfileEditorField;
         related_plannings: IProfileEditorField;
+        coverages: IProfileEditorField;
     };
     name: 'event';
+    groups?: {[key: string]: IEditorProfileGroup};
     schema: {
         anpa_category: IProfileSchemaTypeList;
         calendars: IProfileSchemaTypeList;
@@ -1246,6 +1249,7 @@ export interface IEventFormProfile {
         slugline: IProfileSchemaTypeString;
         subject: IProfileSchemaTypeList;
         related_plannings: IProfileSchemaTypeList;
+        coverages: IProfileSchemaTypeList;
     };
 }
 

--- a/client/utils/events.tsx
+++ b/client/utils/events.tsx
@@ -1,6 +1,6 @@
 import moment from 'moment-timezone';
 import RRule from 'rrule';
-import {get, isNil, sortBy, cloneDeep, omitBy, find, isEqual, pickBy, flatten} from 'lodash';
+import {get, isNil, sortBy, cloneDeep, omitBy, find, isEqual, pickBy, flatten, uniqBy} from 'lodash';
 import {IMenuItem} from 'superdesk-ui-framework/react/components/Menu';
 
 import {IVocabularyItem} from 'superdesk-api';
@@ -1128,6 +1128,21 @@ function getEventsByDate(
         for (const day = displayStartDate.clone(); day.isSameOrBefore(displayEndDate, 'day'); day.add(1, 'days')) {
             addEventToDate(event, day, eventStartDate);
         }
+
+        // Also show the event under the day of each coverage scheduled outside its own dates
+        const coverageDays = uniqBy(
+            (event.coverages ?? [])
+                .filter((coverage) => coverage.planning?.scheduled != null)
+                .map((coverage) => moment(coverage.planning.scheduled))
+                .filter((coverageDate) => (
+                    !coverageDate.isBetween(eventStartDate, eventEndDate, 'day', '[]')
+                    && (startDate == null || !coverageDate.isBefore(startDate, 'day'))
+                    && (endDate == null || !coverageDate.isAfter(endDate, 'day'))
+                )),
+            (coverageDate) => coverageDate.format('YYYY-MM-DD'),
+        );
+
+        coverageDays.forEach((coverageDate) => addEventToDate(event, coverageDate, coverageDate));
     });
 
     return sortBasedOnTBC(days);

--- a/client/utils/events.tsx
+++ b/client/utils/events.tsx
@@ -56,7 +56,12 @@ import {
     sortBasedOnTBC,
     sanitizeItemFields,
 } from './index';
-import {toUIFrameworkInterface, getRelatedEventIdsForPlanning} from './planning';
+import {
+    toUIFrameworkInterface,
+    getRelatedEventIdsForPlanning,
+    modifyCoverageForClient,
+    modifyCoverageForServer,
+} from './planning';
 import {confirmAddingRelatedItems} from './confirmAddingRelatedItems';
 import {isSameDay} from './../helpers';
 import {getOpenEditorType} from './editor';
@@ -1223,6 +1228,8 @@ function modifyForClient(event: Partial<IEventItem>): Partial<IEventItem> {
         event.actioned_date = moment(event.actioned_date);
     }
 
+    (event.coverages ?? []).forEach((coverage) => modifyCoverageForClient(coverage));
+
     return event;
 }
 
@@ -1290,6 +1297,8 @@ function modifyForServer(event: IEventItem, removeNullLinks: boolean = false) {
     if (until) {
         event.dates.recurring_rule.until = until.endOf('day').toISOString();
     }
+
+    (event.coverages ?? []).forEach((coverage) => modifyCoverageForServer(coverage));
 
     return event;
 }

--- a/client/utils/planning.tsx
+++ b/client/utils/planning.tsx
@@ -45,7 +45,6 @@ import {
 import {
     getItemWorkflowState,
     lockUtils,
-    isEvent,
     isItemPublic,
     isItemKilled,
     isItemSpiked,
@@ -460,8 +459,9 @@ export function mapCoverageByDate(coverages: Array<IPlanningCoverageItem> = []):
 }
 
 /**
- * Coverages to show on a list row: filtered by the list language filter, and for
- * ad-hoc planning items by the day group the row is rendered under
+ * Coverages to show on a list row: filtered by the list language filter and by the
+ * day group the row is rendered under (planning items linked to an event show all
+ * their coverages in the combined view)
  */
 export function filterCoveragesForList(
     item: IEventOrPlanningItem,
@@ -469,9 +469,9 @@ export function filterCoveragesForList(
     options: {date?: string; activeFilter: PLANNING_VIEW; filterLanguage?: string},
 ): Array<IPlanningCoverageItem> {
     const {date, activeFilter, filterLanguage} = options;
-    const showAllDates = isEvent(item) || (
-        activeFilter === MAIN.FILTERS.COMBINED && getRelatedEventIdsForPlanning(item).length > 0
-    );
+    const showAllDates = item.type === 'planning'
+        && activeFilter === MAIN.FILTERS.COMBINED
+        && getRelatedEventIdsForPlanning(item).length > 0;
     const isSameDay = (scheduled) => scheduled && (date == null || moment(scheduled).format('YYYY-MM-DD') === date);
 
     return mapCoverageByDate(coverages).filter((coverage) => {
@@ -1615,7 +1615,7 @@ function defaultCoverageValues(
 ): DeepPartial<IPlanningCoverageItem> {
     const {contentProfiles} = planningApi;
     const profile = coverageProfile ?? contentProfiles.get('coverage');
-    const eventItem = relatedEvent ?? (isEvent(planningItem) ? planningItem as IEventItem : undefined);
+    const eventItem = relatedEvent ?? (planningItem?.type === 'event' ? planningItem as IEventItem : undefined);
     const defaultValues = contentProfiles.getDefaultValues(profile) as DeepPartial<IPlanningCoverageItem>;
 
     // if new profile hasn't been created for the type don't set to anything, backend also accepts objectid only
@@ -1719,7 +1719,7 @@ function getDefaultCoverageDueDate(
 ): moment.Moment | null {
     let coverageTime: moment.Moment;
 
-    if (isEvent(planningItem)) {
+    if (planningItem.type === 'event') {
         coverageTime = getCoverageTimeFromEvent(planningItem);
     } else if (getRelatedEventIdsForPlanning(planningItem, 'primary').length === 0) {
         if (planningItem.all_day && appConfig.planning?.all_day) {

--- a/client/utils/planning.tsx
+++ b/client/utils/planning.tsx
@@ -25,6 +25,8 @@ import {
     ICoverageType,
     IAssignmentItem,
     IPlanningContentProfile,
+    IEventOrPlanningItem,
+    PLANNING_VIEW,
 } from '../interfaces';
 
 import {stripHtmlRaw} from 'superdesk-core/scripts/apps/authoring/authoring/helpers';
@@ -38,10 +40,12 @@ import {
     POST_STATE,
     COVERAGES,
     TIME_COMPARISON_GRANULARITY,
+    MAIN,
 } from '../constants';
 import {
     getItemWorkflowState,
     lockUtils,
+    isEvent,
     isItemPublic,
     isItemKilled,
     isItemSpiked,
@@ -453,6 +457,30 @@ export function mapCoverageByDate(coverages: Array<IPlanningCoverageItem> = []):
         g2_content_type: c.planning.g2_content_type || '',
         assigned_to: get(c, 'assigned_to'),
     }));
+}
+
+/**
+ * Coverages to show on a list row: filtered by the list language filter, and for
+ * ad-hoc planning items by the day group the row is rendered under
+ */
+export function filterCoveragesForList(
+    item: IEventOrPlanningItem,
+    coverages: Array<IPlanningCoverageItem>,
+    options: {date?: string; activeFilter: PLANNING_VIEW; filterLanguage?: string},
+): Array<IPlanningCoverageItem> {
+    const {date, activeFilter, filterLanguage} = options;
+    const showAllDates = isEvent(item) || (
+        activeFilter === MAIN.FILTERS.COMBINED && getRelatedEventIdsForPlanning(item).length > 0
+    );
+    const isSameDay = (scheduled) => scheduled && (date == null || moment(scheduled).format('YYYY-MM-DD') === date);
+
+    return mapCoverageByDate(coverages).filter((coverage) => {
+        if (filterLanguage && coverage.planning.language != filterLanguage) {
+            return false;
+        }
+
+        return showAllDates || isSameDay(coverage.planning?.scheduled);
+    });
 }
 
 // ad hoc plan created directly from planning list and not from an event
@@ -941,29 +969,29 @@ export function modifyForClient<T extends IPlanningItem | Partial<IPlanningItem>
     return plan;
 }
 
-function modifyForServer(plan: Partial<IPlanningItem>): Partial<IPlanningItem> {
-    delete plan?.event;
-
-    const modifyGenre = (coverage) => {
-        if (!get(coverage, 'planning.genre', null)) {
-            coverage.planning.genre = null;
-        } else if (!isArray(coverage.planning.genre)) {
-            coverage.planning.genre = [coverage.planning.genre];
+export function modifyCoverageForServer(coverage: DeepPartial<IPlanningCoverageItem>): void {
+    const modifyGenre = (item) => {
+        if (!get(item, 'planning.genre', null)) {
+            item.planning.genre = null;
+        } else if (!isArray(item.planning.genre)) {
+            item.planning.genre = [item.planning.genre];
         }
     };
 
+    modifyGenre(coverage);
+    delete coverage.planning._scheduledTime;
+
+    get(coverage, 'scheduled_updates', []).forEach((s) => {
+        delete s.planning._scheduledTime;
+        modifyGenre(s);
+    });
+}
+
+function modifyForServer(plan: Partial<IPlanningItem>): Partial<IPlanningItem> {
+    delete plan?.event;
     delete plan._agendas;
 
-    get(plan, 'coverages', []).forEach((coverage, i) => {
-        modifyGenre(coverage);
-
-        delete coverage.planning._scheduledTime;
-
-        get(coverage, 'scheduled_updates', []).forEach((s) => {
-            delete s.planning._scheduledTime;
-            modifyGenre(s);
-        });
-    });
+    get(plan, 'coverages', []).forEach((coverage) => modifyCoverageForServer(coverage));
 
     return plan;
 }
@@ -1578,8 +1606,8 @@ function getDefaultCoverageStatus(
 
 function defaultCoverageValues(
     newsCoverageStatus: Array<IPlanningNewsCoverageStatus>,
-    planningItem?: DeepPartial<IPlanningItem>,
-    eventItem?: IEventItem, // TAG: MULTIPLE_PRIMARY_EVENTS
+    planningItem?: DeepPartial<IEventOrPlanningItem>,
+    relatedEvent?: IEventItem, // TAG: MULTIPLE_PRIMARY_EVENTS
     g2contentType?: ICoverageType,
     defaultDesk?: IDesk,
     preferredCoverageDesks?: {[key: string]: IDesk['_id']},
@@ -1587,6 +1615,7 @@ function defaultCoverageValues(
 ): DeepPartial<IPlanningCoverageItem> {
     const {contentProfiles} = planningApi;
     const profile = coverageProfile ?? contentProfiles.get('coverage');
+    const eventItem = relatedEvent ?? (isEvent(planningItem) ? planningItem as IEventItem : undefined);
     const defaultValues = contentProfiles.getDefaultValues(profile) as DeepPartial<IPlanningCoverageItem>;
 
     // if new profile hasn't been created for the type don't set to anything, backend also accepts objectid only
@@ -1617,7 +1646,9 @@ function defaultCoverageValues(
                     'ednote',
                     planningItem?.ednote
                 ),
-                scheduled: planningItem?.planning_date || moment(),
+                scheduled: (planningItem as DeepPartial<IPlanningItem>)?.planning_date
+                    || eventItem?.dates?.start
+                    || moment(),
                 g2_content_type: g2contentType,
                 language: planningItem?.language ?? eventItem?.language,
             },
@@ -1642,7 +1673,7 @@ function defaultCoverageValues(
 
     if (planningItem) {
         const getCoverageDueDateStrategy = appConfig.coverage?.getDueDateStrategy || getDefaultCoverageDueDate;
-        const coverageTime = getCoverageDueDateStrategy(planningItem as IPlanningItem, eventItem);
+        const coverageTime = getCoverageDueDateStrategy(planningItem as IEventOrPlanningItem, eventItem);
 
         if (coverageTime) {
             newCoverage.planning.scheduled = coverageTime;
@@ -1683,13 +1714,14 @@ function getCoverageTimeFromEvent(eventItem: IEventItem): moment.Moment {
 }
 
 function getDefaultCoverageDueDate(
-    planningItem: IPlanningItem,
+    planningItem: IEventOrPlanningItem,
     eventItem?: IEventItem,
 ): moment.Moment | null {
     let coverageTime: moment.Moment;
-    const primaryEventIds = getRelatedEventIdsForPlanning(planningItem, 'primary');
 
-    if (primaryEventIds.length === 0) {
+    if (isEvent(planningItem)) {
+        coverageTime = getCoverageTimeFromEvent(planningItem);
+    } else if (getRelatedEventIdsForPlanning(planningItem, 'primary').length === 0) {
         if (planningItem.all_day && appConfig.planning?.all_day) {
             coverageTime = getCoverageTimeForAllDay(planningItem.planning_date);
         } else if (planningItem.planning_date) {
@@ -2031,6 +2063,7 @@ const self = {
     canEditPlanning,
     canUpdatePlanning,
     mapCoverageByDate,
+    filterCoveragesForList,
     isPlanAdHoc,
     modifyCoverageForClient,
     isCoverageCancelled,

--- a/client/utils/tests/events_test.ts
+++ b/client/utils/tests/events_test.ts
@@ -556,6 +556,37 @@ describe('EventUtils', () => {
             });
         });
 
+        it('also shows the event under the day of a coverage scheduled outside its dates', () => {
+            const event = {
+                _id: 'e1',
+                dates: {
+                    start: moment('2014-10-15T14:01:11+0000'),
+                    end: moment('2014-10-15T15:01:11+0000'),
+                    tz: 'Australia/Sydney',
+                },
+                coverages: [
+                    {coverage_id: 'c1', planning: {scheduled: '2014-10-15T14:01:11+0000'}},
+                    {coverage_id: 'c2', planning: {scheduled: '2014-10-18T10:00:00+0000'}},
+                    {coverage_id: 'c3', planning: {scheduled: '2014-10-18T12:00:00+0000'}},
+                    {coverage_id: 'c4', planning: {scheduled: '2014-10-30T12:00:00+0000'}},
+                    {coverage_id: 'c5', planning: {}},
+                ],
+            };
+
+            const eventsDateGroup = eventUtils.getEventsByDate([event],
+                moment('2014-10-10T14:01:11+0000'), moment('2014-10-25T14:01:11+0000'));
+            const groups = Object.values(eventsDateGroup);
+            const expectedDays = [
+                moment('2014-10-15T14:01:11+0000').format('YYYY-MM-DD'),
+                moment('2014-10-18T10:00:00+0000').format('YYYY-MM-DD'),
+            ];
+
+            expect(groups.map((group) => group.date).sort()).toEqual(expectedDays);
+            groups.forEach((group) => {
+                expect(group.events.length).toBe(1);
+            });
+        });
+
         it('shows a no_end_time event when raw end date is before local start day after conversion', () => {
             const event = eventUtils.modifyForClient({
                 _id: 'e1',

--- a/client/utils/tests/events_test.ts
+++ b/client/utils/tests/events_test.ts
@@ -678,5 +678,52 @@ describe('EventUtils', () => {
                 unique_id: 12345,
             });
         });
+
+        it('normalises coverages the same way as planning items', () => {
+            const event = {
+                coverages: [{
+                    coverage_id: 'c1',
+                    planning: {
+                        scheduled: '2014-08-15T04:00:00+0000',
+                        genre: [{name: 'foo', qcode: 'bar'}],
+                    },
+                }],
+            };
+
+            eventUtils.modifyForClient(event);
+
+            const planning = event.coverages[0].planning;
+
+            expect(moment.isMoment(planning.scheduled)).toBe(true);
+            expect(moment.isMoment(planning._scheduledTime)).toBe(true);
+            expect(planning.genre).toEqual({name: 'foo', qcode: 'bar'});
+        });
+    });
+
+    describe('modifyForServer', () => {
+        it('normalises coverages the same way as planning items', () => {
+            const event = {
+                dates: {
+                    start: moment('2014-08-15T04:00:00+0000'),
+                    end: moment('2014-08-15T07:00:00+0000'),
+                    tz: 'Australia/Sydney',
+                },
+                coverages: [{
+                    coverage_id: 'c1',
+                    planning: {
+                        scheduled: moment('2014-08-15T04:00:00+0000'),
+                        _scheduledTime: moment('2014-08-15T04:00:00+0000'),
+                        genre: {name: 'foo', qcode: 'bar'},
+                    },
+                }],
+            };
+
+            eventUtils.modifyForServer(event);
+
+            const planning = event.coverages[0].planning;
+
+            expect(planning.genre).toEqual([{name: 'foo', qcode: 'bar'}]);
+            expect(planning._scheduledTime).toBeUndefined();
+        });
     });
 });

--- a/client/utils/tests/planning_test.ts
+++ b/client/utils/tests/planning_test.ts
@@ -6,7 +6,7 @@ import {ILockedItems} from '../../interfaces';
 
 import {lockUtils, planningUtils} from '../index';
 import lockReducer from '../../reducers/locks';
-import {EVENTS, PLANNING, ASSIGNMENTS, PRIVILEGES} from '../../constants';
+import {EVENTS, PLANNING, ASSIGNMENTS, PRIVILEGES, MAIN} from '../../constants';
 import {expectActions} from '../testUtils';
 import {sessions} from '../testData';
 
@@ -1093,7 +1093,67 @@ describe('PlanningUtils', () => {
         });
     });
 
+    describe('filterCoveragesForList', () => {
+        const coverages = [
+            {coverage_id: 'c1', planning: {scheduled: '2026-09-07T12:00:00+0000', language: 'fi'}},
+            {coverage_id: 'c2', planning: {scheduled: '2026-09-08T12:00:00+0000', language: 'en'}},
+            {coverage_id: 'c3', planning: {language: 'fi'}},
+        ];
+        const adHocPlanning = {type: 'planning', _id: 'p1'};
+        const linkedPlanning = {type: 'planning', _id: 'p2', related_events: [{_id: 'e1', link_type: 'primary'}]};
+        const event = {type: 'event', _id: 'e1'};
+        const ids = (result) => result.map((coverage) => coverage.coverage_id);
+        const filter = (item, options) => ids(planningUtils.filterCoveragesForList(item, coverages, options));
+
+        it('ad-hoc planning items only show coverages scheduled on the day group', () => {
+            expect(filter(adHocPlanning, {date: '2026-09-07', activeFilter: MAIN.FILTERS.PLANNING})).toEqual(['c1']);
+            expect(filter(adHocPlanning, {date: '2026-09-07', activeFilter: MAIN.FILTERS.COMBINED})).toEqual(['c1']);
+        });
+
+        it('planning items linked to an event show all coverages in the combined view only', () => {
+            expect(filter(linkedPlanning, {date: '2026-09-07', activeFilter: MAIN.FILTERS.PLANNING}))
+                .toEqual(['c1']);
+            expect(filter(linkedPlanning, {date: '2026-09-07', activeFilter: MAIN.FILTERS.COMBINED}))
+                .toEqual(['c1', 'c2', 'c3']);
+        });
+
+        it('events show all coverages on every day group', () => {
+            expect(filter(event, {date: '2026-09-07', activeFilter: MAIN.FILTERS.EVENTS}))
+                .toEqual(['c1', 'c2', 'c3']);
+            expect(filter(event, {date: '2026-09-09', activeFilter: MAIN.FILTERS.COMBINED}))
+                .toEqual(['c1', 'c2', 'c3']);
+        });
+
+        it('filters by the list language filter', () => {
+            expect(filter(event, {date: '2026-09-07', activeFilter: MAIN.FILTERS.EVENTS, filterLanguage: 'en'}))
+                .toEqual(['c2']);
+            expect(filter(adHocPlanning, {
+                date: '2026-09-07',
+                activeFilter: MAIN.FILTERS.PLANNING,
+                filterLanguage: 'en',
+            })).toEqual([]);
+        });
+    });
+
     describe('defaultCoverageValues', () => {
+        it('set coverage time from the event itself', () => {
+            const newsCoverageStatus = [{qcode: 'ncostat:int'}];
+            const eventEnd = moment('2119-03-17T09:00:00+11:00');
+            const event = {
+                type: 'event',
+                name: 'Event',
+                language: 'fi',
+                dates: {start: moment('2119-03-17T08:00:00+11:00'), end: eventEnd},
+            };
+
+            const coverage = planningUtils.defaultCoverageValues(newsCoverageStatus, event);
+
+            const expected = eventEnd.clone().add(1, 'hour');
+
+            expect(coverage.planning.scheduled.toISOString()).toBe(expected.toISOString());
+            expect(coverage.planning.language).toBe('fi');
+        });
+
         it('set coverage time for adhock planning', () => {
             const newsCoverageStatus = [{qcode: 'ncostat:int'}];
             let planned = moment('2119-03-15T09:00:00+11:00');

--- a/client/utils/tests/planning_test.ts
+++ b/client/utils/tests/planning_test.ts
@@ -1117,15 +1117,14 @@ describe('PlanningUtils', () => {
                 .toEqual(['c1', 'c2', 'c3']);
         });
 
-        it('events show all coverages on every day group', () => {
-            expect(filter(event, {date: '2026-09-07', activeFilter: MAIN.FILTERS.EVENTS}))
-                .toEqual(['c1', 'c2', 'c3']);
-            expect(filter(event, {date: '2026-09-09', activeFilter: MAIN.FILTERS.COMBINED}))
-                .toEqual(['c1', 'c2', 'c3']);
+        it('events only show coverages scheduled on the day group', () => {
+            expect(filter(event, {date: '2026-09-07', activeFilter: MAIN.FILTERS.EVENTS})).toEqual(['c1']);
+            expect(filter(event, {date: '2026-09-08', activeFilter: MAIN.FILTERS.COMBINED})).toEqual(['c2']);
+            expect(filter(event, {date: '2026-09-09', activeFilter: MAIN.FILTERS.EVENTS})).toEqual([]);
         });
 
         it('filters by the list language filter', () => {
-            expect(filter(event, {date: '2026-09-07', activeFilter: MAIN.FILTERS.EVENTS, filterLanguage: 'en'}))
+            expect(filter(event, {date: '2026-09-08', activeFilter: MAIN.FILTERS.EVENTS, filterLanguage: 'en'}))
                 .toEqual(['c2']);
             expect(filter(adHocPlanning, {
                 date: '2026-09-07',

--- a/client/validators/index.ts
+++ b/client/validators/index.ts
@@ -171,6 +171,7 @@ export const validators = {
         place: [formProfile],
         reference: [formProfile],
         related_plannings: [formProfile],
+        coverages: [planningValidators.validateCoverages],
     },
     planning: {
         planning_date: [formProfile, planningValidators.validatePlanningScheduleDate],

--- a/server/features/content_profiles_event.feature
+++ b/server/features/content_profiles_event.feature
@@ -336,7 +336,7 @@ Feature: Event Content Profiles
             "related_plannings": {
                 "_id": "related_plannings",
                 "name": "Related Plannings",
-                "index": 7,
+                "index": 8,
                 "showBookmark": true,
                 "icon": "calendar-list",
                 "useToggleBox": false,
@@ -345,7 +345,7 @@ Feature: Event Content Profiles
             "coverages": {
                 "_id": "coverages",
                 "name": "Coverages",
-                "index": 8,
+                "index": 7,
                 "showBookmark": true,
                 "icon": "calendar-list",
                 "useToggleBox": false,

--- a/server/features/content_profiles_event.feature
+++ b/server/features/content_profiles_event.feature
@@ -117,6 +117,11 @@ Feature: Event Content Profiles
                 "group": "related_plannings",
                 "index": 1
             },
+            "coverages": {
+                "enabled": true,
+                "group": "coverages",
+                "index": 1
+            },
             "registration_details": {"enabled": false},
             "invitation_details": {"enabled": false},
             "accreditation_info": {"enabled": false},
@@ -124,7 +129,6 @@ Feature: Event Content Profiles
             "marked_for_not_publication": {"enabled": false},
             "overide_auto_assign_to_workflow": {"enabled": false},
             "headline": {"enabled": false},
-            "coverages": {"enabled": false},
             "agendas": {"enabled": false},
             "priority": {
                 "enabled": false,
@@ -333,6 +337,15 @@ Feature: Event Content Profiles
                 "_id": "related_plannings",
                 "name": "Related Plannings",
                 "index": 7,
+                "showBookmark": true,
+                "icon": "calendar-list",
+                "useToggleBox": false,
+                "translations": {"name": {}}
+            },
+            "coverages": {
+                "_id": "coverages",
+                "name": "Coverages",
+                "index": 8,
                 "showBookmark": true,
                 "icon": "calendar-list",
                 "useToggleBox": false,

--- a/server/planning/content_profiles/profiles/event.py
+++ b/server/planning/content_profiles/profiles/event.py
@@ -158,6 +158,12 @@ DEFAULT_EVENT_PROFILE = PlanningProfileResource(
             "group": "related_plannings",
             "index": 1,
         },
+        # Coverages group
+        "coverages": {
+            "enabled": True,
+            "group": "coverages",
+            "index": 1,
+        },
         "registration_details": {"enabled": False},
         "invitation_details": {"enabled": False},
         "accreditation_info": {"enabled": False},
@@ -166,7 +172,6 @@ DEFAULT_EVENT_PROFILE = PlanningProfileResource(
         "marked_for_not_publication": {"enabled": False},
         "overide_auto_assign_to_workflow": {"enabled": False},
         "headline": {"enabled": False},
-        "coverages": {"enabled": False},
         "agendas": {"enabled": False},
     },
     schema=dict(EventSchema),  # type: ignore
@@ -241,6 +246,17 @@ DEFAULT_EVENT_PROFILE = PlanningProfileResource(
             "_id": "related_plannings",
             "name": "Related Plannings",
             "index": 7,
+            "showBookmark": True,
+            "icon": "calendar-list",
+            "useToggleBox": False,
+            "translations": {
+                "name": {},
+            },
+        },
+        "coverages": {
+            "_id": "coverages",
+            "name": "Coverages",
+            "index": 8,
             "showBookmark": True,
             "icon": "calendar-list",
             "useToggleBox": False,

--- a/server/planning/content_profiles/profiles/event.py
+++ b/server/planning/content_profiles/profiles/event.py
@@ -245,7 +245,7 @@ DEFAULT_EVENT_PROFILE = PlanningProfileResource(
         "related_plannings": {
             "_id": "related_plannings",
             "name": "Related Plannings",
-            "index": 7,
+            "index": 8,
             "showBookmark": True,
             "icon": "calendar-list",
             "useToggleBox": False,
@@ -256,7 +256,7 @@ DEFAULT_EVENT_PROFILE = PlanningProfileResource(
         "coverages": {
             "_id": "coverages",
             "name": "Coverages",
-            "index": 8,
+            "index": 7,
             "showBookmark": True,
             "icon": "calendar-list",
             "useToggleBox": False,

--- a/server/planning/planning_article_export.py
+++ b/server/planning/planning_article_export.py
@@ -99,7 +99,14 @@ async def get_items(ids, resource_type):
                 [model.id], RelatedEventLinkType.PRIMARY, max_results=EXPORT_FETCH_PAGE_SIZE
             )
             item["plannings"] = [plan.to_dict() async for plan in plannings]
-            item["coverages"] = [coverage for plan in item["plannings"] for coverage in plan.get("coverages") or []]
+            coverages = list(item.get("coverages") or [])
+            coverage_ids = {coverage.get("coverage_id") for coverage in coverages}
+            for plan in item["plannings"]:
+                for coverage in plan.get("coverages") or []:
+                    if coverage.get("coverage_id") not in coverage_ids:
+                        coverages.append(coverage)
+                        coverage_ids.add(coverage.get("coverage_id"))
+            item["coverages"] = coverages
 
         items.append(item)
 
@@ -292,9 +299,8 @@ async def generate_text_item(items, template_name, resource_type):
         users = []
         desks = []
 
-        if item["type"] == "planning":
-            await enhance_coverage(item, item, users, desks, text_users, text_desks)
-        else:
+        await enhance_coverage(item, item, users, desks, text_users, text_desks)
+        if item["type"] == "event":
             for p in item.get("plannings") or []:
                 await enhance_coverage(p, item, users, desks, text_users, text_desks)
 

--- a/server/planning/tests/unified_resource/article_export_test.py
+++ b/server/planning/tests/unified_resource/article_export_test.py
@@ -65,14 +65,17 @@ class ArticleExportTestCase(TestCase):
         self.desk = await get_resource_service("desks").find_one_async(req=None, _id=self.desk_id)
 
     # helpers
-    def _coverage(self, content_type: str) -> dict:
-        return {
+    def _coverage(self, content_type: str, assigned_to: dict | None = None) -> dict:
+        coverage = {
             "coverage_id": str(ObjectId()),
             "original_creator": g.user["_id"],
             "workflow_status": "draft",
             "news_coverage_status": COVERAGE_STATUS,
             "planning": {"g2_content_type": content_type, "slugline": "story"},
         }
+        if assigned_to:
+            coverage["assigned_to"] = assigned_to
+        return coverage
 
     async def _create_event(self, **overrides) -> str:
         data = dict(
@@ -137,6 +140,53 @@ class ArticleExportTestCase(TestCase):
             ["text", "picture"],
             [coverage["planning"]["g2_content_type"] for coverage in event["coverages"]],
         )
+
+    async def test_get_items_merges_event_coverages_with_related_plannings(self):
+        shared = self._coverage("video")
+        event_id = await self._create_event(coverages=[self._coverage("text"), shared])
+        plan_id = await self._create_planning(
+            related_events=[{"_id": event_id, "link_type": "primary"}],
+            coverages=[shared, self._coverage("picture")],
+        )
+
+        (event,) = await get_items([event_id], "event")
+        self.assertEqual([plan_id], [plan["_id"] for plan in event["plannings"]])
+        # the Event's own coverages come first, related ones are appended and deduped by ``coverage_id``
+        self.assertEqual(
+            ["text", "video", "picture"],
+            [coverage["planning"]["g2_content_type"] for coverage in event["coverages"]],
+        )
+
+    async def test_export_renders_event_own_coverages(self):
+        reporter_id = ObjectId()
+        await test_utils.post_items(
+            "users",
+            [
+                {
+                    "_id": reporter_id,
+                    "username": "reporter",
+                    "email": "reporter@example.org",
+                    "display_name": "Coverage Reporter",
+                    "is_active": True,
+                }
+            ],
+        )
+        event_id = await self._create_event(
+            name="Solo Event",
+            coverages=[
+                self._coverage("text", assigned_to={"desk": self.desk_id, "user": reporter_id}),
+                self._coverage("picture"),
+            ],
+        )
+
+        item = await export_items_to_article(
+            ArticleExportRequest(items=[event_id], desk=str(self.desk_id), type="event")
+        )
+
+        self.assertIn("<b>Solo Event</b>", item["body_html"])
+        self.assertIn("<b>Planned coverage:</b> Text, Picture", item["body_html"])
+        # the assignee of the Event's own text coverage is listed on the Event line
+        self.assertIn(" - Coverage Reporter</p>", item["body_html"])
 
     async def test_export_creates_archive_item_on_desk(self):
         event_id = await self._create_event(name="Big Match")


### PR DESCRIPTION
### Purpose
Events on the unified resource can carry `coverages`, but the client only rendered coverages for Planning items. This PR shows Event coverages in every view where Planning coverages already appear: list row, preview, editor, history and article export.

### What has changed
- `IEventItem` gains `coverages`; the Event form profile interface gains the `coverages` editor field, schema entry and `groups`.
- List row: the `coverages` list field is no longer gated on Planning items and is added to the default event second line (`config.ts`). The date/language filtering previously inlined in `PlanningItem` is extracted to `planningUtils.filterCoveragesForList` and used by both `PlanningItem` and `EventItem`. Event rows show all their coverages on every day group; the language filter still applies.
- Preview: new `CoveragesPreview` component extracted from `PlanningPreviewContent` and reused in `EventPreviewContent`, rendered at the profile `coverages` group position (after the other sections when the profile has no such group). `EventPreviewContent` now also fetches planning files for coverage attachments.
- Editor: the existing `coverages` editor field is wired into `EventEditor` (change handler with autosave flush, files, popups, field refs) together with the add-coverage and coverage-links bookmarks, enabled when `profile.editor.coverages.enabled` is set. `validators.event` gains `validateCoverages`; `eventUtils.modifyForClient` / `modifyForServer` normalise coverages via the shared `modifyCoverageForClient` / `modifyCoverageForServer` helpers. `defaultCoverageValues` and `getDefaultCoverageDueDate` accept an Event as the parent item, defaulting the due date from the event end.
- History: `EventHistory` splits item and coverage operations the same way as `PlanningHistory` and renders `CoverageHistory` cards.
- Default Event content profile enables `coverages` in a new `Coverages` group.
- Article export: `get_items` merges an Event's own coverages with its related Planning coverages, deduplicated by `coverage_id`, instead of overwriting them; `generate_text_item` enhances the Event's own coverages too.
- Tests: karma for `EventItem`, `EventPreviewContent`, `EventHistory`, `filterCoveragesForList`, `defaultCoverageValues` and event coverage normalisation; pytest for the export merge; `content_profiles_event.feature` updated for the new default profile.

### How to test
1. Create an Event and add coverages in the Event editor (the Coverages group and bookmarks appear when the field is enabled in the Event profile).
2. Events list / combined list: the event row shows the coverage icons on every day it appears under; switch the language filter and confirm only matching coverages remain.
3. Preview the Event: a Coverages section lists each coverage with the same card as a Planning item.
4. History tab of the Event: coverage cards appear for coverage operations.
5. Export the Event as an article: the body lists the Event's own coverages plus those of linked Planning items, without duplicates.

### Notes for review
- Instances that override `planning.event_list_item.secondLine` in `superdesk.config.js` need to add `{fieldId: 'coverages', position: 'end'}` to see coverages on event rows.

Resolves: [SDESK-8014](https://sofab.atlassian.net/browse/SDESK-8014)

[SDESK-8014]: https://sofab.atlassian.net/browse/SDESK-8014
